### PR TITLE
chore: CLAUDE.md追加とmainブランチ保護設定

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# NoteDeck — Claude Code 設定
+
+Misskey 系マルチサーバー対応デッキクライアント。Tauri v2 + Vue 3 + TypeScript + Pinia。
+
+## 開発コマンド
+
+```bash
+task dev          # Vite dev server（ブラウザ確認用）
+task dev:tauri    # Tauri デスクトップ開発
+task test         # vitest run
+task lint         # biome check
+task lint:fix     # biome check --write
+task typecheck    # vue-tsc --noEmit
+```
+
+## Git ワークフロー
+
+- **main への直接 push 禁止** — 必ずブランチを切って PR 経由でマージする
+- ブランチ命名: `feat/*`, `fix/*`, `refactor/*`, `chore/*`, `docs/*`
+- コミット: Conventional Commits 形式
+- pre-commit hook (lefthook): biome check + vue-tsc --noEmit
+
+## スタイリング
+
+- `<style module lang="scss">` + `$style.xxx` で参照（CSS Modules）
+- グローバル CSS 変数: `src/styles/global.css`
+- モバイル/デスクトップ切り替えは `v-if`（CSS display ではない）
+
+## アーキテクチャ要点
+
+- API クライアント・DB・ストリーミングは全て **notecli** クレート側（`src-tauri/` は薄いラッパー）
+- フォーク対応は adapter パターン（`src/adapters/`）
+- 詳細は [DEVELOPMENT.md](DEVELOPMENT.md) 参照


### PR DESCRIPTION
## Summary
- Claude Code用のプロジェクト設定ファイル（CLAUDE.md）を追加
- mainブランチにブランチ保護ルールを設定（PR必須、force push禁止、レビュー承認数0）

Closes #25, Closes #26

## Test plan
- [ ] CLAUDE.md の内容がプロジェクトの実態と一致していることを確認
- [ ] mainへの直接pushが拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)