### PR TITLE
fix: add missing Win32_System_Threading for GetCurrentThreadId

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,7 @@ tauri-plugin-os = "2"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ] }
 

--- a/src-tauri/src/hwheel_hook.rs
+++ b/src-tauri/src/hwheel_hook.rs
@@ -10,6 +10,7 @@
 use std::sync::OnceLock;
 use tauri::WebviewWindow;
 use windows::Win32::Foundation::*;
+use windows::Win32::System::Threading::GetCurrentThreadId;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
 const WM_MOUSEHWHEEL: u32 = 0x020E;


### PR DESCRIPTION
## Summary
- Windows ビルドで `GetCurrentThreadId` が見つからないエラーを修正
- `windows` クレートの features に `Win32_System_Threading` を追加
- `hwheel_hook.rs` に対応する use 文を追加

## Context
v0.2.11 の Release CI で Windows ビルドが失敗したため

🤖 Generated with [Claude Code](https://claude.com/claude-code)