### PR TITLE
docs: 未署名によるセキュリティ警告の注記を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ yay -S misskey-notedeck-bin
 nix run github:hitalin/notedeck
 ```
 
+> [!NOTE]
+> Windows / Android ではインストール時にセキュリティ警告が表示されることがあります。
+> これはアプリがコード署名されていないためで、マルウェアではありません。
+> ソースコードは公開されており、ビルドは GitHub Actions で自動化されています。
+> プロジェクトの成長に伴い、正式なコード署名の導入を予定しています。
+
 ## 貢献する
 
 - **フォーク対応の追加** — [DEVELOPMENT.md](DEVELOPMENT.md) を参照


### PR DESCRIPTION
## Summary
- Windows/Androidでインストール時にセキュリティ警告が表示される理由をREADMEに注記追加
- コード署名未導入であること、マルウェアではないこと、将来的な署名導入予定を明示

🤖 Generated with [Claude Code](https://claude.com/claude-code)