### PR TITLE
feat(renote): RN/引用のUI/UXをMisskey本家に合わせる

### DIFF
--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -100,6 +100,7 @@ const instanceTickerStyle = computed(() => {
 })
 
 const renoteMenuPos = ref<{ x: number; y: number } | null>(null)
+const renoteMenuTheme = ref<Record<string, string>>({})
 const myRenoteId = ref<string | null>(null)
 const isRenoted = ref(false)
 
@@ -109,6 +110,8 @@ function openRenoteMenu(e: MouseEvent) {
     return
   }
   const el = e.currentTarget as HTMLElement
+  const column = el.closest('.deck-column') as HTMLElement | null
+  if (column) renoteMenuTheme.value = extractThemeVars(column)
   const rect = el.getBoundingClientRect()
   let x = rect.left
   let y = rect.bottom + 4
@@ -599,7 +602,7 @@ function closeMentionPopup() {
         <div
           :class="$style.renotePopup"
           class="_popup nd-popup-content popup-menu"
-          :style="{ top: renoteMenuPos.y + 'px', left: renoteMenuPos.x + 'px' }"
+          :style="{ ...renoteMenuTheme, top: renoteMenuPos.y + 'px', left: renoteMenuPos.x + 'px' }"
           @click.stop
         >
           <button v-if="myRenoteId" :class="[$style.renotePopupItem, $style.renotePopupItemActive]" @click="handleUnrenote()">

--- a/src/components/common/NoteMoreMenu.vue
+++ b/src/components/common/NoteMoreMenu.vue
@@ -6,6 +6,7 @@ import {
   getPluginHandlers,
   setPluginAccountContext,
 } from '@/aiscript/plugin-api'
+import { extractThemeVars } from '@/utils/themeVars'
 import { isSafeUrl } from '@/utils/url'
 
 const props = defineProps<{
@@ -25,6 +26,7 @@ const emit = defineEmits<{
 const showMenu = ref(false)
 const showDeleteConfirm = ref(false)
 const menuPos = ref({ x: 0, y: 0 })
+const menuTheme = ref<Record<string, string>>({})
 const localIsFavorited = ref(props.isFavorited)
 const localIsPinned = ref(props.isPinned)
 
@@ -50,6 +52,11 @@ const noteWebUrl = computed(() => {
 })
 
 function open(e: MouseEvent) {
+  const el = e.currentTarget as HTMLElement | null
+  const column = (el ?? (e.target as HTMLElement))?.closest(
+    '.deck-column',
+  ) as HTMLElement | null
+  if (column) menuTheme.value = extractThemeVars(column)
   let x = e.clientX
   let y = e.clientY
   // 画面外に出ないよう調整
@@ -94,7 +101,7 @@ defineExpose({ open })
         <div
           :class="$style.popupMenu"
           class="_popup nd-popup-content popup-menu"
-          :style="{ top: menuPos.y + 'px', left: menuPos.x + 'px' }"
+          :style="{ ...menuTheme, top: menuPos.y + 'px', left: menuPos.x + 'px' }"
           @click.stop
         >
           <template v-if="showDeleteConfirm">


### PR DESCRIPTION
## Summary

- リノートメニューをインラインボタンからポップアップメニューに変更（Misskey本家と同じUI）
- ラベルを日本語化（リノート / 引用 / リノート解除）
- リノート解除機能を追加（メニュー表示時に自分のリノートを検出、削除可能に）
- リノート済みのボタンをハイライト表示
- ポップアップメニュー（リノート・右クリック）にカラムテーマ変数を適用

Closes #42

## Test plan

- [ ] タイムラインでリノートボタンをクリック → ポップアップメニューが表示される
- [ ] 「リノート」選択 → リノートが実行され、ボタンが緑色にハイライト
- [ ] 再度メニューを開く → 「リノート解除」が表示される
- [ ] 「リノート解除」選択 → リノートが削除される
- [ ] 「引用」選択 → 投稿フォームが開く
- [ ] メニュー外クリックで閉じる
- [ ] 異なるサーバーテーマのカラムでポップアップの色が正しい
- [ ] PiPウィンドウ等の狭いカラムでも正常表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)