### PR TITLE
fix(type): inject の型エラーを修正

### DIFF
--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
 }>()
 
 const isPipMode = window.location.pathname === '/pip'
-const pipColumnConfig = inject<() => DeckColumnType | null>(
+const pipColumnConfig = inject<(() => DeckColumnType | null) | undefined>(
   'pipColumnConfig',
   undefined,
 )


### PR DESCRIPTION
## Summary
- `DeckColumn.vue` の `inject` でデフォルト値 `undefined` を指定した際、型パラメータに `undefined` を含めていなかったため TS2345 エラーが発生していた
- CI (Android/macOS) のビルドが失敗していた問題を修正

## Test plan
- [x] `vue-tsc --noEmit` で型チェック通過を確認
- [x] lefthook pre-commit (biome + typecheck) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)