### PR TITLE
fix: Cargo.lock のバージョンを 0.3.4 に同期

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "axum",


### PR DESCRIPTION
## Summary
- バンプ PR で Cargo.lock が含まれていなかったため、バージョンを 0.3.4 に同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)