### PR TITLE
perf: リリースCIの高速化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: Install frontend dependencies
+        run: pnpm install
+
+      - name: Lint (Biome)
+        run: pnpm biome check
+
+      - name: Lint (Clippy)
+        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+
+      - name: Type check
+        run: pnpm vue-tsc --noEmit
+
+      - name: Test
+        run: pnpm vitest run
+
   build:
+    needs: check
     permissions:
       contents: write
     strategy:
@@ -47,7 +89,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.rust_targets }}
-          components: clippy
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -63,18 +104,6 @@ jobs:
 
       - name: Install frontend dependencies
         run: pnpm install
-
-      - name: Lint (Biome)
-        run: pnpm biome check
-
-      - name: Lint (Clippy)
-        run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
-
-      - name: Type check
-        run: pnpm vue-tsc --noEmit
-
-      - name: Test
-        run: pnpm vitest run
 
       - name: Build
         run: pnpm tauri build ${{ matrix.tauri_args }}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,8 +54,7 @@ tempfile = "3"
 tauri-build = { version = "2", features = [] }
 
 [profile.release]
-lto = true
-codegen-units = 1
+lto = "thin"
 strip = true
 
 [lib]


### PR DESCRIPTION
## Summary
- lint/typecheck/test を `check` ジョブに分離し、3プラットフォームでの重複実行を解消
- Rust リリースプロファイルを `lto = "thin"` に変更しリンク時間を短縮
- `codegen-units` をデフォルト（16）に戻しコンパイル並列度を向上

## Test plan
- [ ] 次回タグ push 時にリリースビルドが正常完了すること
- [ ] 生成されるバイナリサイズが大幅に増加していないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)