### PR TITLE
Fix: v0.6.4 CIビルドエラー修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -188,12 +188,6 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         commands::get_notecli_version,
         commands::open_devtools,
         commands::export_db,
-        commands::list_settings_files,
-        commands::read_settings_file,
-        commands::write_settings_file,
-        commands::delete_settings_file,
-        commands::rename_settings_file,
-        commands::get_settings_dir,
     ]);
 
     builder = builder.setup(|app| {


### PR DESCRIPTION
## Summary
- 未実装の settings コマンド登録を lib.rs から除外しCIビルドエラーを修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)