### PR TITLE
fix: プロファイルエディタのレイアウト書き戻しを現ウィンドウ分に限定

### DIFF
--- a/src/components/window/ProfileEditorContent.vue
+++ b/src/components/window/ProfileEditorContent.vue
@@ -296,7 +296,7 @@ function syncVisualFromCode() {
       profileStore.renameProfile(profileStore.windowProfileId, parsed.name)
     }
     if (Array.isArray(parsed.columns)) deckStore.columns = parsed.columns
-    if (Array.isArray(parsed.layout)) deckStore.applyLayout(parsed.layout)
+    if (Array.isArray(parsed.layout)) deckStore.applyWindowLayout(parsed.layout)
     deckStore.flushSave()
     codeError.value = null
   } catch (e) {

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -227,6 +227,16 @@ export const useDeckStore = defineStore('deck', () => {
     save()
   }
 
+  /** Replace only the current window's portion of the layout, preserving other windows' groups. */
+  function applyWindowLayout(newWindowLayout: string[][]) {
+    const windowColIds = new Set(windowLayout.value.flat())
+    const otherGroups = layout.value.filter(
+      (group) => !group.some((id) => windowColIds.has(id)),
+    )
+    layout.value = [...otherGroups, ...newWindowLayout]
+    save()
+  }
+
   function swapColumns(aIdx: number, bIdx: number) {
     if (
       aIdx < 0 ||
@@ -592,6 +602,7 @@ export const useDeckStore = defineStore('deck', () => {
     stackColumn,
     insertColumnAt,
     applyLayout,
+    applyWindowLayout,
     unstackColumn,
     moveLeft,
     moveRight,


### PR DESCRIPTION
## Summary

- `applyWindowLayout()` を追加し、エディタからのレイアウト書き戻しを現ウィンドウ分のみに限定
- `applyLayout()` での全体上書きによる他ウィンドウのカラム配置消失を防止

## Test plan

- [x] typecheck OK
- [x] lint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)