### PR TITLE
fix: クロスウィンドウ同期時にprofilesCacheを無効化

### DIFF
--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -582,7 +582,7 @@ export const useDeckStore = defineStore('deck', () => {
       // Ignore events from this window; only reload if same profile
       if (sourceWindowId === myWindowId) return
       if (profileId !== profileStore.windowProfileId) return
-      const data = profileStore.initWindowProfile(profileId)
+      const data = profileStore.reloadProfile(profileId)
       columns.value = data.columns
       layout.value = data.layout
     })

--- a/src/stores/deckProfile.ts
+++ b/src/stores/deckProfile.ts
@@ -342,6 +342,16 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     return { columns: [], layout: [] }
   }
 
+  /** Invalidate in-memory cache and reload profile from localStorage.
+   *  Used by cross-window sync to pick up changes written by another window. */
+  function reloadProfile(profileId: string): {
+    columns: DeckColumn[]
+    layout: string[][]
+  } {
+    profilesCache = null
+    return initWindowProfile(profileId)
+  }
+
   /** Save window layout (position/size) to the current profile */
   function saveWindowLayout(windowLayout: DeckWindowLayout) {
     if (!windowProfileId.value) return
@@ -501,6 +511,7 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     deleteProfile,
     renameProfile,
     initWindowProfile,
+    reloadProfile,
     saveWindowLayout,
     removeWindowLayout,
     getWindowLayouts,


### PR DESCRIPTION
## Summary

- `reloadProfile()` を追加: キャッシュ無効化 + プロファイル再読み込み
- sync リスナーで `initWindowProfile` → `reloadProfile` に変更
- 他ウィンドウが localStorage に書いた最新データを確実に読めるように

🤖 Generated with [Claude Code](https://claude.com/claude-code)