### PR TITLE
refactor: プロファイルストアをSingle Source of Truthに統合

### DIFF
--- a/src/components/window/ProfileEditorContent.vue
+++ b/src/components/window/ProfileEditorContent.vue
@@ -295,9 +295,18 @@ function syncVisualFromCode() {
     if (parsed.name && profileStore.windowProfileId) {
       profileStore.renameProfile(profileStore.windowProfileId, parsed.name)
     }
-    if (Array.isArray(parsed.columns)) deckStore.columns = parsed.columns
-    if (Array.isArray(parsed.layout)) deckStore.applyLayout(parsed.layout)
-    deckStore.flushSave()
+    const newColumns = Array.isArray(parsed.columns)
+      ? parsed.columns
+      : undefined
+    const newLayout = Array.isArray(parsed.layout) ? parsed.layout : undefined
+    if (newColumns && newLayout) {
+      profileStore.setColumnsAndLayout(newColumns, newLayout)
+    } else if (newColumns) {
+      profileStore.setColumns(newColumns)
+    } else if (newLayout) {
+      profileStore.setLayout(newLayout)
+    }
+    profileStore.flushPersist()
     codeError.value = null
   } catch (e) {
     codeError.value = e instanceof Error ? e.message : 'JSON5パースエラー'

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -1,4 +1,3 @@
-import { emit, listen } from '@tauri-apps/api/event'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import type { TimelineFilter, TimelineType } from '@/adapters/types'
@@ -102,8 +101,10 @@ export const useDeckStore = defineStore('deck', () => {
   const profileStore = useDeckProfileStore()
   const wallpaperStore = useDeckWallpaperStore()
 
-  const columns = ref<DeckColumn[]>([])
-  const layout = ref<string[][]>([])
+  // columns and layout are derived from the profile store (single source of truth)
+  const columns = computed(() => profileStore.columns)
+  const layout = computed(() => profileStore.layout)
+
   const navCollapsed = ref(false)
   const activeColumnId = ref<string | null>(null)
   /** This window's sub-window ID (null = main window) */
@@ -190,26 +191,29 @@ export const useDeckStore = defineStore('deck', () => {
 
   function addColumn(partial: Omit<DeckColumn, 'id'>) {
     const col: DeckColumn = { ...partial, id: genColumnId() }
-    columns.value.push(col)
-    layout.value.push([col.id])
-    save()
+    profileStore.mutateProfile((p) => {
+      p.columns.push(col)
+      p.layout.push([col.id])
+    })
     activeColumnId.value = col.id
     return col
   }
 
   function removeColumn(id: string) {
-    columns.value = columns.value.filter((c) => c.id !== id)
-    layout.value = layout.value
-      .map((ids) => ids.filter((_id) => _id !== id))
-      .filter((ids) => ids.length > 0)
-    flushSave()
+    profileStore.mutateProfile((p) => {
+      p.columns = p.columns.filter((c) => c.id !== id)
+      p.layout = p.layout
+        .map((ids) => ids.filter((_id) => _id !== id))
+        .filter((ids) => ids.length > 0)
+    })
+    profileStore.flushPersist()
   }
 
   function updateColumn(id: string, updates: Partial<DeckColumn>) {
     const col = getColumn(id)
     if (col) {
       Object.assign(col, updates)
-      save()
+      profileStore.schedulePersist()
     }
   }
 
@@ -223,8 +227,7 @@ export const useDeckStore = defineStore('deck', () => {
   }
 
   function applyLayout(newLayout: string[][]) {
-    layout.value = newLayout
-    save()
+    profileStore.setLayout(newLayout)
   }
 
   function swapColumns(aIdx: number, bIdx: number) {
@@ -254,26 +257,22 @@ export const useDeckStore = defineStore('deck', () => {
     const toGroupIdx = groupIndexOf(toId)
     if (fromGroupIdx < 0 || toGroupIdx < 0) return
 
-    // Remove fromId from its current group
     const fromGroup = layout.value[fromGroupIdx]
     if (!fromGroup) return
     const newFromGroup = fromGroup.filter((id) => id !== fromId)
 
     const newLayout = [...layout.value]
-    // Update or remove the source group
     if (newFromGroup.length === 0) {
       newLayout.splice(fromGroupIdx, 1)
     } else {
       newLayout[fromGroupIdx] = newFromGroup
     }
 
-    // Find target group in updated layout (index may have shifted)
     const targetIdx = groupIndexOf(toId, newLayout)
     if (targetIdx < 0) return
     const targetGroup = newLayout[targetIdx]
     if (!targetGroup) return
 
-    // Insert into target group
     const toPos = targetGroup.indexOf(toId)
     const insertAt = position === 'above' ? toPos : toPos + 1
     const newTargetGroup = [...targetGroup]
@@ -306,10 +305,8 @@ export const useDeckStore = defineStore('deck', () => {
     const group = layout.value[groupIdx]
     if (!group) return
 
-    // Solo column already at this position — nothing to do
     if (group.length === 1 && groupIdx === targetIndex) return
 
-    // Remove from current group
     const newGroup = group.filter((colId) => colId !== id)
     const newLayout = [...layout.value]
     if (newGroup.length === 0) {
@@ -318,7 +315,6 @@ export const useDeckStore = defineStore('deck', () => {
       newLayout[groupIdx] = newGroup
     }
 
-    // Adjust target index if removal shifted it
     const adjustedIndex =
       newGroup.length === 0 && targetIndex > groupIdx
         ? targetIndex - 1
@@ -337,7 +333,6 @@ export const useDeckStore = defineStore('deck', () => {
     const newGroup = group.filter((colId) => colId !== id)
     const newLayout = [...layout.value]
     newLayout[groupIdx] = newGroup
-    // Insert as new solo group right after
     newLayout.splice(groupIdx + 1, 0, [id])
     applyLayout(newLayout)
   }
@@ -356,46 +351,14 @@ export const useDeckStore = defineStore('deck', () => {
     return columnMap.value.get(id)
   }
 
-  let saveTimer: ReturnType<typeof setTimeout> | null = null
-
-  function flushSave() {
-    if (saveTimer) {
-      clearTimeout(saveTimer)
-      saveTimer = null
-    }
-    try {
-      if (profileStore.windowProfileId) {
-        profileStore.syncColumnsToProfile(
-          profileStore.windowProfileId,
-          columns.value,
-          layout.value,
-        )
-      }
-      // Always keep nd-deck in sync for backward compatibility
-      setStorageJson(STORAGE_KEYS.deck, {
-        columns: columns.value,
-        layout: layout.value,
-      })
-      // Notify other windows viewing the same profile
-      if (profileStore.windowProfileId) {
-        emit('deck:profile-updated', {
-          profileId: profileStore.windowProfileId,
-          sourceWindowId: currentWindowId.value ?? '__main__',
-        }).catch(() => {
-          // Not running in Tauri (browser dev mode)
-        })
-      }
-    } catch (e) {
-      console.warn('[deck] failed to save:', e)
-    }
-  }
+  // --- save / flushSave facades (backward compat for external callers) ---
 
   function save() {
-    if (saveTimer) clearTimeout(saveTimer)
-    saveTimer = setTimeout(() => {
-      saveTimer = null
-      flushSave()
-    }, 100)
+    profileStore.schedulePersist()
+  }
+
+  function flushSave() {
+    profileStore.flushPersist()
   }
 
   function load() {
@@ -404,28 +367,24 @@ export const useDeckStore = defineStore('deck', () => {
       columns?: DeckColumn[]
       layout?: string[][]
     } | null>(STORAGE_KEYS.deck, null)
-    if (data?.columns && data?.layout) {
-      columns.value = data.columns
-      layout.value = data.layout
-    }
 
-    profileStore.ensureDefaults(columns.value, layout.value)
+    const fallbackColumns = data?.columns ?? []
+    const fallbackLayout = data?.layout ?? []
 
-    // All windows use windowProfileId — set it from query or activeProfileId
+    profileStore.ensureDefaults(fallbackColumns, fallbackLayout)
+
+    // Set window identity from query params
     const params = new URLSearchParams(window.location.search)
     const profileId = params.get('profile')
     const windowId = params.get('window')
     if (windowId) {
       currentWindowId.value = windowId
     }
-    if (profileId) {
-      const data = profileStore.initWindowProfile(profileId)
-      columns.value = data.columns
-      layout.value = data.layout
-    } else if (profileStore.activeProfileId) {
-      const data = profileStore.initWindowProfile(profileStore.activeProfileId)
-      columns.value = data.columns
-      layout.value = data.layout
+
+    // Initialize this window's profile view
+    const targetProfileId = profileId ?? profileStore.activeProfileId
+    if (targetProfileId) {
+      profileStore.initWindowProfile(targetProfileId)
     }
   }
 
@@ -467,47 +426,31 @@ export const useDeckStore = defineStore('deck', () => {
   }
 
   function clear() {
-    columns.value = []
-    layout.value = []
-    save()
+    profileStore.setColumnsAndLayout([], [])
   }
 
   // --- Profile facade (delegates to profileStore) ---
 
   function syncCurrentToActiveProfile() {
-    if (!profileStore.windowProfileId) return
-    profileStore.syncColumnsToProfile(
-      profileStore.windowProfileId,
-      columns.value,
-      layout.value,
-    )
+    // No-op: profileStore is already the source of truth
+    profileStore.flushPersist()
   }
 
   function saveAsProfile(name?: string) {
-    const profile = profileStore.saveAsProfile(
-      name,
-      columns.value,
-      layout.value,
-    )
-    columns.value = []
-    layout.value = []
-    flushSave()
+    // Flush current state first
+    profileStore.flushPersist()
+    const profile = profileStore.saveAsProfile(name)
     return profile
   }
 
   function applyProfile(profileId: string) {
-    const result = profileStore.switchProfile(
-      profileId,
-      columns.value,
-      layout.value,
-    )
+    profileStore.flushPersist()
+    const result = profileStore.switchProfile(profileId)
     if (!result) return
-    columns.value = result.columns
-    layout.value = result.layout
-    // Only sync nd-deck localStorage for backward compat (skip profile re-save)
+    // Backward compat: keep nd-deck in sync
     setStorageJson(STORAGE_KEYS.deck, {
-      columns: columns.value,
-      layout: layout.value,
+      columns: result.columns,
+      layout: result.layout,
     })
   }
 
@@ -521,15 +464,12 @@ export const useDeckStore = defineStore('deck', () => {
       group.some((colId) => {
         const col = colMap.get(colId)
         if (!col) return false
-        // Main window shows columns without windowId
         if (!wid) return !col.windowId
-        // Sub-windows show their assigned columns
         return col.windowId === wid
       }),
     )
   })
 
-  /** Pop out a column to a sub-window. Unstacks first if needed. */
   function popOutColumn(columnId: string, windowId: string) {
     unstackColumn(columnId)
     const col = getColumn(columnId)
@@ -539,7 +479,6 @@ export const useDeckStore = defineStore('deck', () => {
     }
   }
 
-  /** Recall a column from a sub-window back to main */
   function recallColumn(columnId: string) {
     const col = getColumn(columnId)
     if (col) {
@@ -548,7 +487,6 @@ export const useDeckStore = defineStore('deck', () => {
     }
   }
 
-  /** Recall all columns from a specific sub-window (e.g. when window closes) */
   function recallColumnsFromWindow(windowId: string) {
     let changed = false
     for (const col of columns.value) {
@@ -560,7 +498,6 @@ export const useDeckStore = defineStore('deck', () => {
     if (changed) save()
   }
 
-  /** Move a column between windows */
   function moveColumnToWindow(columnId: string, targetWindowId: string | null) {
     const col = getColumn(columnId)
     if (!col) return
@@ -568,29 +505,14 @@ export const useDeckStore = defineStore('deck', () => {
     save()
   }
 
-  /** Listen for sync events from other windows */
-  let unlistenSync: (() => void) | null = null
+  // --- Sync (delegates to profileStore) ---
 
-  async function startSync() {
-    unlistenSync?.()
-    unlistenSync = await listen<{
-      profileId: string
-      sourceWindowId: string
-    }>('deck:profile-updated', (event) => {
-      const { profileId, sourceWindowId } = event.payload
-      const myWindowId = currentWindowId.value ?? '__main__'
-      // Ignore events from this window; only reload if same profile
-      if (sourceWindowId === myWindowId) return
-      if (profileId !== profileStore.windowProfileId) return
-      const data = profileStore.reloadProfile(profileId)
-      columns.value = data.columns
-      layout.value = data.layout
-    })
+  function startSync() {
+    return profileStore.startSync()
   }
 
   function stopSync() {
-    unlistenSync?.()
-    unlistenSync = null
+    profileStore.stopSync()
   }
 
   return {

--- a/src/stores/deckProfile.ts
+++ b/src/stores/deckProfile.ts
@@ -1,6 +1,6 @@
 import JSON5 from 'json5'
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 import type { DeckColumn, DeckProfile, DeckWindowLayout } from '@/stores/deck'
 import * as settingsFs from '@/utils/settingsFs'
@@ -43,7 +43,7 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   const activeProfileId = ref<string | null>(null)
   /** Per-window profile ID (set via ?profile= query). Isolates this window from deck:sync. */
   const windowProfileId = ref<string | null>(null)
-  /** Bumped on every saveProfiles() to make profile-derived computeds reactive */
+  /** Bumped on every persist to make profile-derived computeds reactive */
   const profileVersion = ref(0)
   /** Whether file-based storage has been initialized */
   const initialized = ref(false)
@@ -51,44 +51,155 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   /** Cached profile name, kept in sync imperatively to avoid localStorage dependency. */
   const currentProfileName = ref<string | null>(null)
 
-  /** In-memory cache of profiles to avoid repeated localStorage JSON.parse. */
-  let profilesCache: DeckProfile[] | null = null
+  /** In-memory cache of profiles. Serves as the reactive single source of truth
+   *  within a window. All reads go through this; writes update it + persist. */
+  const profilesData = ref<DeckProfile[]>([])
+
+  // --- Profile data access (reactive) ---
+
+  /** The profile this window is currently viewing. */
+  const currentProfile = computed(
+    () =>
+      profilesData.value.find((p) => p.id === windowProfileId.value) ?? null,
+  )
+
+  /** Columns of the current profile (reactive, read-only from outside). */
+  const columns = computed<DeckColumn[]>(
+    () => currentProfile.value?.columns ?? [],
+  )
+
+  /** Layout of the current profile (reactive, read-only from outside). */
+  const layout = computed<string[][]>(() => currentProfile.value?.layout ?? [])
+
+  // --- Profile mutation ---
+
+  /** Mutate the current profile's data and schedule persistence. */
+  function mutateProfile(fn: (profile: DeckProfile) => void) {
+    const profile = currentProfile.value
+    if (!profile) return
+    fn(profile)
+    // Trigger reactivity by bumping version (Vue tracks the ref)
+    profileVersion.value++
+    schedulePersist()
+  }
+
+  function setColumns(newColumns: DeckColumn[]) {
+    mutateProfile((p) => {
+      p.columns = newColumns
+    })
+  }
+
+  function setLayout(newLayout: string[][]) {
+    mutateProfile((p) => {
+      p.layout = newLayout
+    })
+  }
+
+  function setColumnsAndLayout(
+    newColumns: DeckColumn[],
+    newLayout: string[][],
+  ) {
+    mutateProfile((p) => {
+      p.columns = newColumns
+      p.layout = newLayout
+    })
+  }
+
+  // --- Persistence (debounced) ---
+
+  let persistTimer: ReturnType<typeof setTimeout> | null = null
+
+  function schedulePersist() {
+    if (persistTimer) clearTimeout(persistTimer)
+    persistTimer = setTimeout(() => {
+      persistTimer = null
+      flushPersist()
+    }, 100)
+  }
+
+  function flushPersist() {
+    if (persistTimer) {
+      clearTimeout(persistTimer)
+      persistTimer = null
+    }
+    try {
+      const profiles = profilesData.value
+      // Sync: localStorage + bump version
+      setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
+      // Backward compat: keep nd-deck in sync
+      const profile = currentProfile.value
+      if (profile) {
+        setStorageJson(STORAGE_KEYS.deck, {
+          columns: profile.columns,
+          layout: profile.layout,
+        })
+      }
+      // Async: write changed profile to file
+      if (initialized.value && profile) {
+        persistSingleProfile(profile).catch((e) =>
+          console.warn('[deckProfile] failed to persist profile:', e),
+        )
+      }
+      // Notify other windows
+      if (windowProfileId.value) {
+        import('@tauri-apps/api/event')
+          .then(({ emit }) =>
+            emit('deck:profile-updated', {
+              profileId: windowProfileId.value,
+            }),
+          )
+          .catch(() => {
+            // Not running in Tauri (browser dev mode)
+          })
+      }
+    } catch (e) {
+      console.warn('[deckProfile] failed to persist:', e)
+    }
+  }
+
+  // --- Cross-window sync ---
+
+  let unlistenSync: (() => void) | null = null
+
+  async function startSync() {
+    unlistenSync?.()
+    const { listen } = await import('@tauri-apps/api/event')
+    unlistenSync = await listen<{ profileId: string }>(
+      'deck:profile-updated',
+      (event) => {
+        const { profileId } = event.payload
+        if (profileId !== windowProfileId.value) return
+        // Reload from localStorage to pick up changes from the other window
+        profilesData.value = getStorageJson<DeckProfile[]>(
+          STORAGE_KEYS.deckProfiles,
+          [],
+        )
+        profileVersion.value++
+      },
+    )
+  }
+
+  function stopSync() {
+    unlistenSync?.()
+    unlistenSync = null
+  }
+
+  // --- Internal helpers ---
 
   /** Update currentProfileName from current windowProfileId. */
   function refreshProfileName() {
-    if (!windowProfileId.value) {
-      currentProfileName.value = null
-      return
-    }
-    const { profile } = loadProfileById(windowProfileId.value)
-    currentProfileName.value = profile?.name ?? null
+    currentProfileName.value = currentProfile.value?.name ?? null
   }
 
-  // --- localStorage cache (sync access) ---
-
-  function loadProfiles(): DeckProfile[] {
-    if (profilesCache) return profilesCache
-    profilesCache = getStorageJson<DeckProfile[]>(STORAGE_KEYS.deckProfiles, [])
-    return profilesCache
+  function loadProfilesFromStorage(): DeckProfile[] {
+    return getStorageJson<DeckProfile[]>(STORAGE_KEYS.deckProfiles, [])
   }
 
-  /** Load profiles and find one by ID in a single pass. */
-  function loadProfileById(id: string): {
-    profiles: DeckProfile[]
-    profile: DeckProfile | undefined
-  } {
-    const profiles = loadProfiles()
-    return { profiles, profile: profiles.find((p) => p.id === id) }
-  }
-
-  /** Persist profiles and invalidate in-memory cache. */
+  /** Persist profiles: write profilesData to localStorage + files. */
   function saveProfiles(profiles: DeckProfile[]) {
-    // Sync: localStorage + in-memory cache
+    profilesData.value = profiles
     setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
     profileVersion.value++
-
-    // Async: write each profile to file (fire-and-forget)
     if (initialized.value) {
       persistProfilesToFiles(profiles).catch((e) =>
         console.warn('[deckProfile] failed to persist to files:', e),
@@ -103,7 +214,7 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     await settingsFs.writeProfile(filename, content)
   }
 
-  /** Write all profiles to files (used for initial migration / full sync). */
+  /** Write all profiles to files. */
   async function persistProfilesToFiles(
     profiles: DeckProfile[],
   ): Promise<void> {
@@ -128,21 +239,19 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /** Save current deck state into the specified profile */
+  // --- Profile CRUD ---
+
   function syncColumnsToProfile(
     profileId: string,
-    columns: DeckColumn[],
-    layout: string[][],
+    cols: DeckColumn[],
+    lay: string[][],
   ) {
-    const { profiles, profile } = loadProfileById(profileId)
+    const profile = profilesData.value.find((p) => p.id === profileId)
     if (!profile) return
-    profile.columns = deepClone(columns)
-    profile.layout = deepClone(layout)
-    // Sync: update localStorage + in-memory cache
-    setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
+    profile.columns = deepClone(cols)
+    profile.layout = deepClone(lay)
+    setStorageJson(STORAGE_KEYS.deckProfiles, profilesData.value)
     profileVersion.value++
-    // Async: write only this profile to file
     if (initialized.value) {
       persistSingleProfile(profile).catch((e) =>
         console.warn('[deckProfile] failed to persist profile:', e),
@@ -150,50 +259,28 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /**
-   * Save current deck state and apply a new profile in one pass.
-   * Avoids redundant localStorage round-trips compared to separate
-   * syncColumnsToProfile() + applyProfile() calls.
-   */
   function switchProfile(
     newProfileId: string,
-    currentColumns: DeckColumn[],
-    currentLayout: string[][],
   ): { columns: DeckColumn[]; layout: string[][] } | null {
-    const profiles = loadProfiles()
-
-    // 1. Save current state to old profile (in-memory)
-    if (windowProfileId.value) {
-      const oldProfile = profiles.find((p) => p.id === windowProfileId.value)
-      if (oldProfile) {
-        oldProfile.columns = deepClone(currentColumns)
-        oldProfile.layout = deepClone(currentLayout)
-      }
-    }
-
-    // 2. Find new profile
+    const profiles = profilesData.value
     const newProfile = profiles.find((p) => p.id === newProfileId)
     if (!newProfile) return null
 
-    // 3. Single localStorage write for both changes
+    // Single localStorage write
     setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
     profileVersion.value++
 
-    // 4. Capture old profile ID before updating state
     const oldProfileId = windowProfileId.value
 
-    // 5. Update active state
     windowProfileId.value = newProfileId
     saveActiveProfileId(newProfileId)
     refreshProfileName()
 
-    // 6. Async: persist only the changed profiles to files
+    // Async: persist only changed profiles
     if (initialized.value) {
       const toWrite = oldProfileId
         ? profiles.filter((p) => p.id === oldProfileId || p.id === newProfileId)
         : [newProfile]
-      // Deduplicate if same profile
       const unique = [...new Map(toWrite.map((p) => [p.id, p])).values()]
       Promise.all(unique.map((p) => persistSingleProfile(p))).catch((e) =>
         console.warn('[deckProfile] failed to persist profiles:', e),
@@ -201,22 +288,13 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
 
     return {
-      columns: structuredClone(newProfile.columns),
-      layout: structuredClone(newProfile.layout),
+      columns: newProfile.columns,
+      layout: newProfile.layout,
     }
   }
 
-  function saveAsProfile(
-    name: string | undefined,
-    currentColumns: DeckColumn[],
-    currentLayout: string[][],
-  ): DeckProfile {
-    // Save current state to the active profile before creating a new one
-    if (windowProfileId.value) {
-      syncColumnsToProfile(windowProfileId.value, currentColumns, currentLayout)
-    }
-
-    const profiles = loadProfiles()
+  function saveAsProfile(name?: string): DeckProfile {
+    const profiles = profilesData.value
     const autoName = name || nextProfileName(profiles)
 
     const profile: DeckProfile = {
@@ -235,9 +313,8 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     return profile
   }
 
-  /** Create an empty profile without switching the current window to it */
   function createEmptyProfile(name?: string): DeckProfile {
-    const profiles = loadProfiles()
+    const profiles = profilesData.value
     const autoName = name || nextProfileName(profiles)
     const profile: DeckProfile = {
       id: settingsFs.profileFilename(autoName),
@@ -252,43 +329,33 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   }
 
   function getProfiles(): DeckProfile[] {
-    return loadProfiles()
+    return profilesData.value
   }
 
-  /** Apply a profile, returning its columns and layout. Caller must set deck state. */
   function applyProfile(
     profileId: string,
-    currentColumns: DeckColumn[],
-    currentLayout: string[][],
   ): { columns: DeckColumn[]; layout: string[][] } | null {
-    // Save current state before switching
-    if (windowProfileId.value) {
-      syncColumnsToProfile(windowProfileId.value, currentColumns, currentLayout)
-    }
-
-    const { profile } = loadProfileById(profileId)
+    const profile = profilesData.value.find((p) => p.id === profileId)
     if (!profile) return null
     windowProfileId.value = profileId
     saveActiveProfileId(profileId)
     refreshProfileName()
     return {
-      columns: structuredClone(profile.columns),
-      layout: structuredClone(profile.layout),
+      columns: profile.columns,
+      layout: profile.layout,
     }
   }
 
   function deleteProfile(profileId: string) {
-    const profiles = loadProfiles().filter((p) => p.id !== profileId)
-    // Sync: localStorage + in-memory cache only (no file write for remaining profiles)
+    const profiles = profilesData.value.filter((p) => p.id !== profileId)
+    profilesData.value = profiles
     setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
     profileVersion.value++
 
     if (activeProfileId.value === profileId) {
       saveActiveProfileId(profiles[0]?.id ?? null)
     }
 
-    // Async: delete only the removed profile's file
     if (initialized.value) {
       settingsFs
         .deleteProfile(profileId)
@@ -297,7 +364,7 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   }
 
   function renameProfile(profileId: string, newName: string) {
-    const { profiles, profile } = loadProfileById(profileId)
+    const profile = profilesData.value.find((p) => p.id === profileId)
     if (!profile) return
 
     const oldFilename = profile.id
@@ -306,7 +373,6 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     profile.name = newName
     profile.id = newFilename
 
-    // Update activeProfileId if it was pointing to the old ID
     if (activeProfileId.value === oldFilename) {
       saveActiveProfileId(newFilename)
     }
@@ -314,10 +380,9 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
       windowProfileId.value = newFilename
     }
 
-    saveProfiles(profiles)
+    saveProfiles(profilesData.value)
     refreshProfileName()
 
-    // Rename file on disk
     if (initialized.value && oldFilename !== newFilename) {
       settingsFs
         .renameProfile(oldFilename, newFilename)
@@ -325,37 +390,16 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /** Initialize this window with an isolated profile */
-  function initWindowProfile(profileId: string): {
-    columns: DeckColumn[]
-    layout: string[][]
-  } {
+  /** Initialize this window with a profile */
+  function initWindowProfile(profileId: string) {
     windowProfileId.value = profileId
     refreshProfileName()
-    const { profile } = loadProfileById(profileId)
-    if (profile) {
-      return {
-        columns: structuredClone(profile.columns),
-        layout: structuredClone(profile.layout),
-      }
-    }
-    return { columns: [], layout: [] }
-  }
-
-  /** Invalidate in-memory cache and reload profile from localStorage.
-   *  Used by cross-window sync to pick up changes written by another window. */
-  function reloadProfile(profileId: string): {
-    columns: DeckColumn[]
-    layout: string[][]
-  } {
-    profilesCache = null
-    return initWindowProfile(profileId)
   }
 
   /** Save window layout (position/size) to the current profile */
   function saveWindowLayout(windowLayout: DeckWindowLayout) {
     if (!windowProfileId.value) return
-    const { profiles, profile } = loadProfileById(windowProfileId.value)
+    const profile = currentProfile.value
     if (!profile) return
     if (!profile.windows) profile.windows = []
     const existing = profile.windows.findIndex((w) => w.id === windowLayout.id)
@@ -364,11 +408,8 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     } else {
       profile.windows.push(windowLayout)
     }
-    // Sync: update localStorage + in-memory cache
-    setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
+    setStorageJson(STORAGE_KEYS.deckProfiles, profilesData.value)
     profileVersion.value++
-    // Async: write only this profile to file
     if (initialized.value) {
       persistSingleProfile(profile).catch((e) =>
         console.warn('[deckProfile] failed to persist profile:', e),
@@ -376,17 +417,13 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /** Remove a window layout entry from the current profile */
   function removeWindowLayout(windowId: string) {
     if (!windowProfileId.value) return
-    const { profiles, profile } = loadProfileById(windowProfileId.value)
+    const profile = currentProfile.value
     if (!profile?.windows) return
     profile.windows = profile.windows.filter((w) => w.id !== windowId)
-    // Sync: update localStorage + in-memory cache
-    setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
-    profilesCache = profiles
+    setStorageJson(STORAGE_KEYS.deckProfiles, profilesData.value)
     profileVersion.value++
-    // Async: write only this profile to file
     if (initialized.value) {
       persistSingleProfile(profile).catch((e) =>
         console.warn('[deckProfile] failed to persist profile:', e),
@@ -394,20 +431,16 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /** Get saved window layouts for the current profile */
   function getWindowLayouts(): DeckWindowLayout[] {
-    if (!windowProfileId.value) return []
-    return loadProfileById(windowProfileId.value).profile?.windows ?? []
+    return currentProfile.value?.windows ?? []
   }
 
   // --- File-based initialization ---
 
-  /** Check if a profile ID is in the new filename-based format. */
   function isNewFormatId(id: string): boolean {
     return id.endsWith('.ndprofile.json5')
   }
 
-  /** Load profiles from files (Tauri only). */
   async function loadProfilesFromFiles(): Promise<DeckProfile[]> {
     const filenames = await settingsFs.listProfiles()
     if (filenames.length === 0) return []
@@ -428,8 +461,13 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   }
 
   /** Ensure profiles exist on first load. Discards legacy format profiles. */
-  function ensureDefaults(columns: DeckColumn[], layout: string[][]) {
-    let profiles = loadProfiles()
+  function ensureDefaults(
+    fallbackColumns: DeckColumn[],
+    fallbackLayout: string[][],
+  ) {
+    // Load from localStorage into reactive state
+    profilesData.value = loadProfilesFromStorage()
+    let profiles = profilesData.value
 
     // Discard legacy profiles (old ID format like "profile-xxx")
     const legacyCount = profiles.filter((p) => !isNewFormatId(p.id)).length
@@ -453,8 +491,8 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
       const profile: DeckProfile = {
         id: settingsFs.profileFilename('プロファイル 1'),
         name: 'プロファイル 1',
-        columns: deepClone(columns),
-        layout: deepClone(layout),
+        columns: deepClone(fallbackColumns),
+        layout: deepClone(fallbackLayout),
         createdAt: Date.now(),
       }
       profiles.push(profile)
@@ -462,7 +500,6 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
       saveActiveProfileId(profile.id)
     } else {
       loadActiveProfileId()
-      // If activeProfileId points to a non-existent profile, reset to first
       const first = profiles[0]
       if (first && !profiles.find((p) => p.id === activeProfileId.value)) {
         saveActiveProfileId(first.id)
@@ -479,30 +516,38 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     }
   }
 
-  /** Initialize file-based storage: load from files and sync localStorage cache. */
   async function initFileStorage(): Promise<void> {
     const fileProfiles = await loadProfilesFromFiles()
 
     if (fileProfiles.length > 0) {
-      // Files are source of truth — update localStorage + in-memory cache
+      profilesData.value = fileProfiles
       setStorageJson(STORAGE_KEYS.deckProfiles, fileProfiles)
-      profilesCache = fileProfiles
       profileVersion.value++
     }
     initialized.value = true
   }
 
   return {
+    // Reactive state
     activeProfileId,
     windowProfileId,
     profileVersion,
     currentProfileName,
     initialized,
-    loadProfiles,
-    loadProfileById,
-    saveProfiles,
-    saveActiveProfileId,
-    loadActiveProfileId,
+    columns,
+    layout,
+    currentProfile,
+    // Mutation
+    mutateProfile,
+    setColumns,
+    setLayout,
+    setColumnsAndLayout,
+    // Persistence
+    flushPersist,
+    schedulePersist,
+    startSync,
+    stopSync,
+    // Profile CRUD
     syncColumnsToProfile,
     saveAsProfile,
     createEmptyProfile,
@@ -511,11 +556,15 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     deleteProfile,
     renameProfile,
     initWindowProfile,
-    reloadProfile,
+    switchProfile,
+    ensureDefaults,
+    // Window layout
     saveWindowLayout,
     removeWindowLayout,
     getWindowLayouts,
-    switchProfile,
-    ensureDefaults,
+    // Legacy compat
+    saveActiveProfileId,
+    loadActiveProfileId,
+    saveProfiles,
   }
 })

--- a/tests/stores/deck.test.ts
+++ b/tests/stores/deck.test.ts
@@ -15,6 +15,8 @@ describe('deck store', () => {
     vi.useFakeTimers()
     setActivePinia(createPinia())
     storage.clear()
+    // Initialize profile store (creates default profile)
+    useDeckStore().load()
   })
 
   afterEach(() => {
@@ -276,16 +278,19 @@ describe('deck store', () => {
 
     it('deleteProfile removes a profile', () => {
       const deck = useDeckStore()
+      const initialCount = deck.getProfiles().length
       const profile = deck.saveAsProfile('Temp')
+      expect(deck.getProfiles()).toHaveLength(initialCount + 1)
       deck.deleteProfile(profile.id)
-      expect(deck.getProfiles()).toHaveLength(0)
+      expect(deck.getProfiles()).toHaveLength(initialCount)
     })
 
     it('renameProfile updates profile name', () => {
       const deck = useDeckStore()
       const profile = deck.saveAsProfile('Old Name')
       deck.renameProfile(profile.id, 'New Name')
-      expect(deck.getProfiles()[0]?.name).toBe('New Name')
+      const renamed = deck.getProfiles().find((p) => p.name === 'New Name')
+      expect(renamed).toBeDefined()
     })
 
     it('applyProfile does not mutate the other profile', () => {
@@ -424,14 +429,17 @@ describe('deck store', () => {
       expect(savedP1?.columns).toHaveLength(2)
     })
 
-    it('deleteProfile clears activeProfileId when deleting active profile', () => {
+    it('deleteProfile falls back to first profile when deleting active profile', () => {
       const deck = useDeckStore()
+      const defaultProfiles = deck.getProfiles()
+      const firstId = defaultProfiles[0]?.id
       const profile = deck.saveAsProfile('Temp')
       expect(deck.activeProfileId).toBe(profile.id)
 
       deck.deleteProfile(profile.id)
 
-      expect(deck.activeProfileId).toBeNull()
+      // Falls back to the default profile
+      expect(deck.activeProfileId).toBe(firstId)
     })
   })
 


### PR DESCRIPTION
## Summary

- `deckProfile.ts` を columns/layout の唯一のデータ所有者に変更
- `deck.ts` のローカル `columns`/`layout` ref を削除し、profileStore の computed に
- 永続化・cross-window sync を profileStore に一本化
- 全ウィンドウが同じプロファイルデータを直接参照するため、編集が自動反映

## Breaking Changes (internal)

- `deck.ts` の `columns`/`layout` は readonly computed（直接代入不可）
- `save()`/`flushSave()` は profileStore facade に変更
- `switchProfile`/`applyProfile`/`saveAsProfile` の引数変更

## Test plan

- [x] 全237テスト通過
- [x] typecheck OK
- [x] lint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)