### PR TITLE
fix: 新規ウィンドウを同じプロファイルで開くように変更

### DIFF
--- a/src/components/common/TitleBar.vue
+++ b/src/components/common/TitleBar.vue
@@ -116,8 +116,8 @@ async function toggleMobileSize() {
 }
 
 function openNewWindow() {
-  const profile = deckStore.createEmptyProfile()
-  openDeckWindow(profile.id)
+  if (!deckStore.windowProfileId) return
+  openDeckWindow(deckStore.windowProfileId)
 }
 
 async function onPipClick() {


### PR DESCRIPTION
## Summary

- 新規ウィンドウボタンで空プロファイルを作成する代わりに、現在のプロファイルで開く
- プロファイルとウィンドウの直交性を維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)