### PR TITLE
refactor: プロファイルメニューのreactive化とクロスウィンドウ同期

### DIFF
--- a/src/components/deck/DeckProfileMenu.vue
+++ b/src/components/deck/DeckProfileMenu.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import type { CSSProperties } from 'vue'
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { refreshProfileCommands } from '@/commands/definitions'
 import { switchProfileWithWindows } from '@/composables/useDeckWindow'
-import type { DeckProfile } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { useDeckProfileStore } from '@/stores/deckProfile'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 
@@ -18,10 +18,11 @@ const emit = defineEmits<{
 }>()
 
 const deckStore = useDeckStore()
+const profileStore = useDeckProfileStore()
 const windowsStore = useWindowsStore()
 const isCompact = useIsCompactLayout()
 
-const profiles = ref<DeckProfile[]>([])
+const profiles = computed(() => profileStore.getProfiles())
 const menuEl = ref<HTMLElement | null>(null)
 const fixedStyle = ref<CSSProperties | undefined>()
 
@@ -39,7 +40,6 @@ watch(
       } else {
         fixedStyle.value = undefined
       }
-      profiles.value = deckStore.getProfiles()
     }
   },
   { immediate: true },
@@ -47,7 +47,6 @@ watch(
 
 function createProfile() {
   deckStore.saveAsProfile()
-  profiles.value = deckStore.getProfiles()
   refreshProfileCommands()
 }
 
@@ -63,12 +62,10 @@ async function apply(id: string) {
   } finally {
     switching = false
   }
-  profiles.value = deckStore.getProfiles()
 }
 
 function remove(id: string) {
   deckStore.deleteProfile(id)
-  profiles.value = deckStore.getProfiles()
   refreshProfileCommands()
 }
 

--- a/src/stores/deckProfile.ts
+++ b/src/stores/deckProfile.ts
@@ -142,15 +142,9 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
       }
       // Notify other windows
       if (windowProfileId.value) {
-        import('@tauri-apps/api/event')
-          .then(({ emit }) =>
-            emit('deck:profile-updated', {
-              profileId: windowProfileId.value,
-            }),
-          )
-          .catch(() => {
-            // Not running in Tauri (browser dev mode)
-          })
+        emitSync('deck:profile-updated', {
+          profileId: windowProfileId.value,
+        })
       }
     } catch (e) {
       console.warn('[deckProfile] failed to persist:', e)
@@ -159,29 +153,48 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
 
   // --- Cross-window sync ---
 
-  let unlistenSync: (() => void) | null = null
+  function emitSync(event: string, payload?: Record<string, unknown>) {
+    import('@tauri-apps/api/event')
+      .then(({ emit }) => emit(event, payload))
+      .catch(() => {
+        // Not running in Tauri (browser dev mode)
+      })
+  }
+
+  function reloadFromStorage() {
+    profilesData.value = getStorageJson<DeckProfile[]>(
+      STORAGE_KEYS.deckProfiles,
+      [],
+    )
+    profileVersion.value++
+    refreshProfileName()
+  }
+
+  const unlistenFns: (() => void)[] = []
 
   async function startSync() {
-    unlistenSync?.()
+    stopSync()
     const { listen } = await import('@tauri-apps/api/event')
-    unlistenSync = await listen<{ profileId: string }>(
-      'deck:profile-updated',
-      (event) => {
-        const { profileId } = event.payload
-        if (profileId !== windowProfileId.value) return
-        // Reload from localStorage to pick up changes from the other window
-        profilesData.value = getStorageJson<DeckProfile[]>(
-          STORAGE_KEYS.deckProfiles,
-          [],
-        )
-        profileVersion.value++
-      },
+
+    // Profile content changed (columns/layout)
+    unlistenFns.push(
+      await listen<{ profileId: string }>('deck:profile-updated', (event) => {
+        if (event.payload.profileId !== windowProfileId.value) return
+        reloadFromStorage()
+      }),
+    )
+
+    // Profile list changed (add/delete/rename)
+    unlistenFns.push(
+      await listen('deck:profiles-changed', () => {
+        reloadFromStorage()
+      }),
     )
   }
 
   function stopSync() {
-    unlistenSync?.()
-    unlistenSync = null
+    for (const fn of unlistenFns) fn()
+    unlistenFns.length = 0
   }
 
   // --- Internal helpers ---
@@ -195,7 +208,7 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     return getStorageJson<DeckProfile[]>(STORAGE_KEYS.deckProfiles, [])
   }
 
-  /** Persist profiles: write profilesData to localStorage + files. */
+  /** Persist profiles: write profilesData to localStorage + files + notify other windows. */
   function saveProfiles(profiles: DeckProfile[]) {
     profilesData.value = profiles
     setStorageJson(STORAGE_KEYS.deckProfiles, profiles)
@@ -205,6 +218,8 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
         console.warn('[deckProfile] failed to persist to files:', e),
       )
     }
+    // Notify all windows that the profile list changed
+    emitSync('deck:profiles-changed')
   }
 
   /** Write only the given profile to its file. */


### PR DESCRIPTION
## Summary

- プロファイルメニューをローカル ref → computed に変更し reactive 化
- プロファイルリスト変更時に `deck:profiles-changed` イベントを全ウィンドウに通知
- `startSync` で content 変更とリスト変更の両イベントを listen

NOTE: 現在は localStorage + イベントによるキャッシュ同期方式。将来的に Rust AppState を SSoT とする設計に移行予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)