### PR TITLE
chore: update Cargo.lock for v0.7.1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "async-trait",
  "axum",


### PR DESCRIPTION
## Summary
- Cargo.lock のバージョンを 0.7.1 に同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)