### PR TITLE
fix: TS2532エラーとbiome lint警告を修正

### DIFF
--- a/src/components/deck/widgets/WidgetAiScriptApp.vue
+++ b/src/components/deck/widgets/WidgetAiScriptApp.vue
@@ -129,7 +129,9 @@ async function run() {
   })
 
   const ioOpts = createInterpreterOptions({
-    onOutput: () => {},
+    onOutput: () => {
+      /* noop */
+    },
     onError: (err) => {
       error.value = err.message
     },

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -22,7 +22,7 @@ function parseOS(ua: string): string {
   const win = ua.match(/Windows NT ([\d.]+)/)
   if (win) return `Windows NT ${win[1]}`
   const mac = ua.match(/Mac OS X ([\d_]+)/)
-  if (mac) return `macOS ${mac[1].replace(/_/g, '.')}`
+  if (mac?.[1]) return `macOS ${mac[1].replace(/_/g, '.')}`
   return navigator.platform || 'N/A'
 }
 

--- a/src/composables/useScrollDirection.ts
+++ b/src/composables/useScrollDirection.ts
@@ -42,6 +42,10 @@ export function provideScrollDirection() {
 export function useScrollDirection() {
   const ctx = inject(SCROLL_DIR_KEY, null)
   return {
-    reportScroll: ctx?.reportScroll ?? (() => {}),
+    reportScroll:
+      ctx?.reportScroll ??
+      (() => {
+        /* noop */
+      }),
   }
 }

--- a/tests/adapters/misskey/streaming.test.ts
+++ b/tests/adapters/misskey/streaming.test.ts
@@ -228,7 +228,9 @@ describe('MisskeyStream', () => {
       })
 
       vi.mocked(invoke).mockResolvedValue('sub-123')
-      const sub = stream.subscribeTimeline('home', () => {})
+      const sub = stream.subscribeTimeline('home', () => {
+        /* noop */
+      })
       await vi.waitFor(() => {
         expect(invoke).toHaveBeenCalledWith(
           'stream_connect_and_subscribe_timeline',
@@ -328,7 +330,9 @@ describe('MisskeyStream', () => {
       })
 
       vi.mocked(invoke).mockResolvedValue('sub-456')
-      const sub = stream.subscribeMain(() => {})
+      const sub = stream.subscribeMain(() => {
+        /* noop */
+      })
       await vi.waitFor(() => {
         expect(invoke).toHaveBeenCalledWith(
           'stream_subscribe_main',
@@ -408,7 +412,9 @@ describe('MisskeyStream', () => {
       })
 
       vi.mocked(invoke).mockResolvedValue('sub-ant-1')
-      const sub = stream.subscribeAntenna('antenna-1', () => {})
+      const sub = stream.subscribeAntenna('antenna-1', () => {
+        /* noop */
+      })
       await vi.waitFor(() => {
         expect(invoke).toHaveBeenCalledWith(
           'stream_connect_and_subscribe_antenna',
@@ -464,7 +470,9 @@ describe('MisskeyStream', () => {
       })
 
       vi.mocked(invoke).mockResolvedValue('sub-chat-1')
-      const sub = stream.subscribeChatUser('other-user-1', () => {})
+      const sub = stream.subscribeChatUser('other-user-1', () => {
+        /* noop */
+      })
       await vi.waitFor(() => {
         expect(invoke).toHaveBeenCalledWith(
           'stream_subscribe_chat_user',

--- a/tests/composables/useNoteList.test.ts
+++ b/tests/composables/useNoteList.test.ts
@@ -22,7 +22,9 @@ function createNoteList(maxNotes?: number) {
     getMyUserId: () => 'u1',
     getAdapter: () => null,
     deleteHandler: async () => true,
-    closePostForm: () => {},
+    closePostForm: () => {
+      /* noop */
+    },
     maxNotes,
   })
 }
@@ -83,7 +85,9 @@ describe('useNoteList', () => {
       getMyUserId: () => 'u1',
       getAdapter: () => null,
       deleteHandler: async () => true,
-      closePostForm: () => {},
+      closePostForm: () => {
+        /* noop */
+      },
       onNotesChanged: callback,
       maxNotes: 5,
     })

--- a/tests/utils/logger.test.ts
+++ b/tests/utils/logger.test.ts
@@ -9,14 +9,18 @@ import {
 
 describe('logger', () => {
   it('logWarn outputs to console.warn in dev', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* noop */
+    })
     logWarn('test-context', new Error('boom'))
     expect(spy).toHaveBeenCalledWith('[test-context]', 'UNKNOWN', 'boom')
     spy.mockRestore()
   })
 
   it('logError outputs to console.error in dev', () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {
+      /* noop */
+    })
     logError('test-context', 'string error')
     expect(spy).toHaveBeenCalledWith(
       '[test-context]',
@@ -27,7 +31,9 @@ describe('logger', () => {
   })
 
   it('logIgnored outputs to console.debug in dev', () => {
-    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {
+      /* noop */
+    })
     logIgnored('test-context', { code: 'NETWORK', message: 'offline' })
     expect(spy).toHaveBeenCalledWith(
       '[test-context] ignored:',
@@ -38,7 +44,9 @@ describe('logger', () => {
   })
 
   it('catchLog returns a function that calls logWarn', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* noop */
+    })
     const handler = catchLog('my-op')
     handler(new Error('fail'))
     expect(spy).toHaveBeenCalledWith('[my-op]', 'UNKNOWN', 'fail')
@@ -46,7 +54,9 @@ describe('logger', () => {
   })
 
   it('catchIgnore returns a function that calls logIgnored', () => {
-    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+    const spy = vi.spyOn(console, 'debug').mockImplementation(() => {
+      /* noop */
+    })
     const handler = catchIgnore('my-op')
     handler('ignored error')
     expect(spy).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- `AboutContent.vue` の TS2532 エラー修正（`mac[1]` が `undefined` の可能性）
- `noEmptyBlockStatements` lint警告をすべて修正（`() => {}` → `() => { /* noop */ }`）

## Checks
- [x] biome check: エラー・警告なし
- [x] vue-tsc --noEmit: パス
- [x] vitest: 237テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)