### PR TITLE
fix: AddColumnDialogの型エラー修正

### DIFF
--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -88,7 +88,7 @@ function selectColumnType(type: ColumnType) {
 function addColumnForAccount(accountId: string | null) {
   const type = addColumnType.value || 'timeline'
   const config = SELECTABLE_CONFIGS.find((c) => c.type === type)
-  if (config) {
+  if (config && accountId) {
     fetchSelectItems(config, accountId)
     return
   }


### PR DESCRIPTION
## Summary
- `fetchSelectItems(config, accountId)` で `accountId: string | null` を `string` 引数に渡していた型エラーを修正
- null チェックを追加


🤖 Generated with [Claude Code](https://claude.com/claude-code)