### PR TITLE
feat(site): ダウンロードセクションに最新バージョンを表示

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -123,6 +123,7 @@
   <section class="download fade-in" id="download">
     <h2 class="section-title">ダウンロード</h2>
     <p class="sub">お使いの環境に合わせてインストール</p>
+    <p class="version-badge" id="latest-version"></p>
     <div class="platforms">
       <a href="https://github.com/hitalin/notedeck/releases/latest" data-platform="windows" class="platform glass">
         <svg viewBox="0 0 24 24"><path d="M3 12V6.75l8-1.25V12H3zm0 .5h8v6.5l-8-1.25V12.5zM11.5 5.34l9.5-1.34v8h-9.5V5.34zM11.5 12.5H21v7.5l-9.5-1.34V12.5z"/></svg>

--- a/site/main.js
+++ b/site/main.js
@@ -49,6 +49,10 @@ fetch('https://api.github.com/repos/hitalin/notedeck/releases/latest')
       linux:   a => a.name.endsWith('.deb'),
       android: a => a.name.endsWith('.apk'),
     };
+    const badge = document.getElementById('latest-version');
+    if (badge && release.tag_name) {
+      badge.textContent = release.tag_name;
+    }
     document.querySelectorAll('.platform[data-platform]').forEach(el => {
       const fn = match[el.dataset.platform];
       const asset = fn && assets.find(fn);

--- a/site/style.css
+++ b/site/style.css
@@ -346,7 +346,9 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 
 /* Download */
 .download{max-width:700px;margin:0 auto 5rem;padding:0 1.5rem;text-align:center}
-.download .sub{color:var(--text-muted);margin-bottom:1.5rem}
+.download .sub{color:var(--text-muted);margin-bottom:.75rem}
+.version-badge{display:inline-block;font-size:.85rem;color:var(--accent);border:1px solid var(--accent);border-radius:var(--radius-pill);padding:.15em .7em;margin-bottom:1.5rem;opacity:0;transition:opacity .3s var(--ease)}
+.version-badge:not(:empty){opacity:1}
 .platforms{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:.75rem}
 .platform{
   display:flex;flex-direction:column;align-items:center;


### PR DESCRIPTION
## Summary
- サイトのダウンロードセクションにGitHub Releasesから取得した最新バージョンタグを表示

## Test plan
- [ ] サイトのダウンロードセクションにバージョンバッジが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)