### PR TITLE
Release v0.8.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notedeck",
   "private": true,
-  "version": "0.8.17",
+  "version": "0.8.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.8.17"
+version = "0.8.18"
 edition = "2021"
 
 [dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.8.17",
+  "version": "0.8.18",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Changes

- chore: bump version to 0.8.18

> **Note**: v0.8.17 のホットフィックスリリース、またはバージョンバンプのみ。