### PR TITLE
fix: DeckTimelineColumn の reconnect 呼び出しから不要な引数を削除

### DIFF
--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -279,7 +279,7 @@ async function switchTl(type: TimelineType) {
   if (snapshot && snapshot.notes.length > 0) {
     await col?.switchWithSnapshot(snapshot.notes, snapshot.scrollTop)
   } else {
-    await reconnect(true)
+    await reconnect()
   }
 }
 


### PR DESCRIPTION
## What

<!-- 変更内容を簡潔に -->

## Why

<!-- なぜこの変更が必要か -->

## Test

- [ ] `pnpm test` パス
- [ ] `pnpm typecheck` パス
- [ ] 手動確認済み

## Screenshots

<!-- UI 変更がある場合のみ -->
