### PR TITLE
ランディングページ: 比較テーブル削除・機能ハイライトカード化

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -119,35 +119,6 @@
       </div>
     </div>
   </section>
-
-  <!-- Performance comparison -->
-  <section class="section-default">
-    <div class="section-inner section-narrow">
-      <h2 class="section-title fade-in" data-direction="up">ブラウザを超えるパフォーマンス</h2>
-      <p class="section-sub fade-in" data-direction="up">同じサーバーに接続した状態での比較（参考値）</p>
-      <div class="comparison-table-wrapper glass fade-in" data-direction="up">
-        <table class="comparison-table">
-          <thead>
-            <tr>
-              <th></th>
-              <th>Misskey Web UI</th>
-              <th>Aria（Flutter）</th>
-              <th class="highlight">NoteDeck</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr><td class="row-label">メモリ使用量</td><td>ブラウザタブ依存で重い</td><td>Flutter ランタイム分の負荷</td><td class="highlight"><strong>ネイティブで圧倒的に軽量</strong></td></tr>
-            <tr><td class="row-label">起動時間</td><td>ブラウザ依存</td><td>ランタイム初期化あり</td><td class="highlight"><strong>一瞬で起動</strong></td></tr>
-            <tr><td class="row-label">オフライン閲覧</td><td>不可</td><td>不可</td><td class="highlight"><strong>可能</strong></td></tr>
-            <tr><td class="row-label">ローカル全文検索</td><td>なし</td><td>なし</td><td class="highlight"><strong>FTS5</strong></td></tr>
-            <tr><td class="row-label">トークン保管</td><td>localStorage</td><td>localStorage</td><td class="highlight"><strong>OS キーチェーン</strong></td></tr>
-            <tr><td class="row-label">外部ツール連携</td><td>なし</td><td>なし</td><td class="highlight"><strong>REST API</strong></td></tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </section>
-
   <!-- Guest mode CTA -->
   <section class="section-alt">
     <div class="section-inner section-narrow">
@@ -171,7 +142,7 @@
 
       <!-- Highlight: Deck UI -->
       <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text">
+        <div class="highlight-text glass">
           <span class="highlight-badge">デッキ UI</span>
           <h3>自由に並べる、自分だけのレイアウト</h3>
           <p>HTL・LTL・通知・検索・リスト・アンテナ・チャンネル・チャット — あらゆるカラムを横に並べて一覧。カラム幅はドラッグで自由に調整、プロファイルとして保存すればワンクリックで切り替え。</p>
@@ -186,7 +157,7 @@
 
       <!-- Highlight: Offline -->
       <div class="highlight-row fade-in" data-direction="right">
-        <div class="highlight-text">
+        <div class="highlight-text glass">
           <span class="highlight-badge">オフライン &amp; ローカル DB</span>
           <h3>流れたノートも、ここに残る</h3>
           <p>タイムラインに流れてきたノートは自動でローカル SQLite に蓄積。サーバーからノートが消えても、連合が切れても、手元のデータは残り続けます。</p>
@@ -201,7 +172,7 @@
 
       <!-- Highlight: Security -->
       <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text">
+        <div class="highlight-text glass">
           <span class="highlight-badge">セキュリティ</span>
           <h3>トークンは OS が守る</h3>
           <p>ブラウザの localStorage にトークンを保存する Web クライアントとは設計が違います。NoteDeck はアクセストークンを OS のキーチェーン（macOS Keychain / Windows Credential Manager / Linux Secret Service）に暗号化保存。ブラウザ拡張や XSS によるトークン窃取は構造的に不可能です。</p>
@@ -216,7 +187,7 @@
 
       <!-- Highlight: API -->
       <div class="highlight-row fade-in" data-direction="right">
-        <div class="highlight-text">
+        <div class="highlight-text glass">
           <span class="highlight-badge">拡張性</span>
           <h3>外部ツールからデッキを操作</h3>
           <p>NoteDeck はバックグラウンドで REST API サーバー（localhost:19820）を起動。ノート投稿、タイムライン取得、カラム操作、コマンド実行 — すべてを HTTP で制御可能。Raycast、Obsidian、StreamDeck、自作ボットとの連携が、OAuth なしで実現します。</p>
@@ -231,7 +202,7 @@
 
       <!-- Highlight: Hackable -->
       <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text">
+        <div class="highlight-text glass">
           <span class="highlight-badge">Hackable</span>
           <h3>Misskey 開発者なら、すぐ貢献できる</h3>
           <p>フロントエンドは Misskey 本家と同じ <strong>Vue 3 + TypeScript</strong>。Misskey のコードが読める人なら、NoteDeck のコードもすぐに読めます。バックエンドの notecli は独立した Rust クレートとして分離設計されており、フロントエンドとバックエンドを独立して開発・テスト可能。</p>

--- a/site/style.css
+++ b/site/style.css
@@ -181,17 +181,6 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .pillar .pillar-lead{font-size:1rem;font-weight:700;margin-bottom:.5rem;color:var(--text)}
 .pillar p{color:var(--text-muted);font-size:.9rem;line-height:1.7}
 
-/* ===== Comparison table ===== */
-.comparison-table-wrapper{padding:1.5rem;overflow-x:auto}
-.comparison-table{width:100%;border-collapse:collapse;font-size:.9rem}
-.comparison-table th,.comparison-table td{padding:.65rem 1rem;text-align:center;border-bottom:1px solid var(--border)}
-.comparison-table thead th{font-weight:700;color:var(--text-muted);font-size:.85rem;padding-bottom:.75rem}
-.comparison-table thead th.highlight{color:var(--accent);font-size:.95rem}
-.comparison-table .row-label{text-align:left;font-weight:700;color:var(--text);white-space:nowrap}
-.comparison-table td.highlight{color:var(--accent)}
-.comparison-table tbody tr:last-child td{border-bottom:none}
-@media(max-width:640px){.comparison-table{font-size:.8rem}.comparison-table th,.comparison-table td{padding:.5rem .6rem}}
-
 /* ===== Guest CTA ===== */
 .guest-cta{display:flex;align-items:center;gap:1.5rem;padding:1.5rem 2rem}
 .guest-cta-icon{display:flex;align-items:center;justify-content:center;flex-shrink:0;width:52px;height:52px;border-radius:14px;background:linear-gradient(135deg,rgba(134,179,0,0.15),rgba(74,179,0,0.1));color:var(--accent)}
@@ -201,10 +190,11 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .guest-cta .btn{flex-shrink:0;white-space:nowrap}
 @media(max-width:640px){.guest-cta{flex-direction:column;text-align:center}.guest-cta .btn{align-self:center}}
 
+
 /* ===== Highlight rows (alternating left/right) ===== */
 .highlight-row{margin-bottom:3.5rem}
 .highlight-row:last-child{margin-bottom:0}
-.highlight-text{max-width:720px}
+.highlight-text{max-width:720px;padding:2rem;border-radius:var(--radius)}
 .highlight-row:nth-child(odd) .highlight-text{margin-right:auto}
 .highlight-row:nth-child(even) .highlight-text{margin-left:auto}
 .highlight-badge{display:inline-block;font-size:.75rem;font-weight:700;color:var(--accent);background:var(--accent-soft);padding:.2em .7em;border-radius:var(--radius-pill);margin-bottom:.75rem;letter-spacing:.03em}


### PR DESCRIPTION
## Summary
- パフォーマンス比較テーブル（「ブラウザを超えるパフォーマンス」セクション）を削除
- 機能ハイライトセクションに glass 背景を追加してカード風に変更
- 不要になった comparison-table の CSS を削除

## Test plan
- [ ] ランディングページをブラウザで開き、比較テーブルが消えていることを確認
- [ ] 機能ハイライトが左右交互にカード風背景で表示されることを確認
- [ ] モバイル幅でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)