### PR TITLE
ランディングページ: オープンソースカードを削除

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -287,13 +287,6 @@
           <h4>パフォーマンスチューニング</h4>
           <p>省メモリ〜高パフォーマンスのプリセット。Adaptive Quality でフレームレート自動最適化。3 段階画像キャッシュ。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-          </div>
-          <h4>オープンソース</h4>
-          <p>AGPL-3.0 で全コード公開。バグ報告・PR 歓迎。<a href="https://github.com/sponsors/hitalin">Sponsors</a> で開発を支援。</p>
-        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Misskeyエコシステムでは OSS が前提であり差別化にならないため、オープンソースカードを削除

## Test plan
- [ ] ランディングページの「さらに」セクションからオープンソースカードが消えていることを確認
- [ ] カードグリッドのレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)