### PR TITLE
feat: ランディングページにMisStoreリンクを追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -35,6 +35,7 @@
           <a href="#features">機能</a>
           <a href="#architecture">アーキテクチャ</a>
           <a href="#download">ダウンロード</a>
+          <a href="https://misstore.hital.in">Store</a>
         </div>
         <div class="nav-right">
           <button class="nav-right-button" id="color-mode-toggle" aria-label="カラーモード切り替え">
@@ -54,6 +55,7 @@
       <a href="#features" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">機能</a>
       <a href="#architecture" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">アーキテクチャ</a>
       <a href="#download" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">ダウンロード</a>
+      <a href="https://misstore.hital.in" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">Store</a>
       <a href="https://github.com/hitalin/notedeck" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">GitHub</a>
     </div>
   </div>
@@ -368,6 +370,7 @@
       <a href="https://github.com/hitalin/notedeck">GitHub</a>
       <a href="https://github.com/hitalin/notedeck/issues">Issues</a>
       <a href="https://github.com/hitalin/notedeck/blob/main/ROADMAP.md">Roadmap</a>
+      <a href="https://misstore.hital.in">Store</a>
       <a href="https://github.com/sponsors/hitalin">Sponsor</a>
     </div>
     <p>&copy; 2026 NoteDeck &mdash; <a href="https://github.com/hitalin/notedeck/blob/main/LICENSE">AGPL-3.0</a></p>


### PR DESCRIPTION
ナビ・モバイルドロワー・フッターにプラグイン・テーマストア
(misstore.hital.in) へのリンクを追加。

## What

<!-- 変更内容を簡潔に -->

## Why

<!-- なぜこの変更が必要か -->

## Test

- [ ] `pnpm test` パス
- [ ] `pnpm typecheck` パス
- [ ] 手動確認済み

## Screenshots

<!-- UI 変更がある場合のみ -->
