### PR TITLE
Release v0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.10.3",
+  "version": "0.10.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.10.3"
+version = "0.10.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -10,7 +10,7 @@ use super::Result;
 const SETTINGS_DIR: &str = "notedeck";
 
 /// Allowed subdirectory names for settings files.
-const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins"];
+const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets"];
 
 /// Validate a subdirectory name against the whitelist.
 fn validate_subdir(subdir: &str) -> Result<()> {
@@ -251,7 +251,7 @@ pub fn write_notedeck_json(app: tauri::AppHandle, content: &str) -> Result<()> {
 }
 
 /// Directories and root files to include in settings backup.
-const BACKUP_SUBDIRS: &[&str] = &["profiles", "themes", "plugins"];
+const BACKUP_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets"];
 
 /// Export all settings files to a JSON bundle via save dialog.
 #[tauri::command]
@@ -389,6 +389,7 @@ mod tests {
         assert!(validate_subdir("profiles").is_ok());
         assert!(validate_subdir("themes").is_ok());
         assert!(validate_subdir("plugins").is_ok());
+        assert!(validate_subdir("snippets").is_ok());
     }
 
     #[test]
@@ -459,6 +460,14 @@ mod tests {
         )
         .unwrap();
 
+        let snippets_dir = base.join("snippets");
+        fs::create_dir_all(&snippets_dir).unwrap();
+        fs::write(
+            snippets_dir.join("aiscript.json5"),
+            r#"{ hello: { prefix: "hi", body: ["<: \"hi\""] } }"#,
+        )
+        .unwrap();
+
         fs::write(base.join("custom.css"), "body { color: red; }").unwrap();
         fs::write(base.join("keybinds.json5"), r#"{ "search": [] }"#).unwrap();
 
@@ -495,6 +504,7 @@ mod tests {
         // Clear original files
         fs::remove_dir_all(&profiles_dir).unwrap();
         fs::remove_dir_all(&themes_dir).unwrap();
+        fs::remove_dir_all(&snippets_dir).unwrap();
         fs::remove_file(base.join("custom.css")).unwrap();
         fs::remove_file(base.join("keybinds.json5")).unwrap();
 
@@ -529,6 +539,10 @@ mod tests {
         assert_eq!(
             fs::read_to_string(themes_dir.join("dark.ndtheme.json5")).unwrap(),
             r#"{ name: "dark" }"#
+        );
+        assert_eq!(
+            fs::read_to_string(snippets_dir.join("aiscript.json5")).unwrap(),
+            r#"{ hello: { prefix: "hi", body: ["<: \"hi\""] } }"#
         );
         assert_eq!(
             fs::read_to_string(base.join("custom.css")).unwrap(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/codemirror/completions.ts
+++ b/src/aiscript/codemirror/completions.ts
@@ -3,6 +3,7 @@ import type {
   CompletionContext,
   CompletionResult,
 } from '@codemirror/autocomplete'
+import { getSnippetCompletions } from '@/aiscript/snippets/cache'
 
 const keywordCompletions: Completion[] = [
   'let',
@@ -224,13 +225,17 @@ export function aiscriptCompletions(
     }
   }
 
-  // General word completion
+  // General word completion (keywords + namespaces + user snippets)
   const word = context.matchBefore(/\w+/)
   if (!word || (word.from === word.to && !context.explicit)) return null
 
   return {
     from: word.from,
-    options: [...keywordCompletions, ...namespaceCompletions],
+    options: [
+      ...keywordCompletions,
+      ...namespaceCompletions,
+      ...getSnippetCompletions(),
+    ],
     validFor: /^\w*$/,
   }
 }

--- a/src/aiscript/snippets/cache.ts
+++ b/src/aiscript/snippets/cache.ts
@@ -1,0 +1,37 @@
+import type { Completion } from '@codemirror/autocomplete'
+import { loadSnippetCompletions } from './loader'
+
+let cached: Completion[] = []
+let initialLoad: Promise<void> | null = null
+
+function kickInitialLoad(): Promise<void> {
+  if (!initialLoad) {
+    initialLoad = loadSnippetCompletions()
+      .then((arr) => {
+        cached = arr
+      })
+      .catch((e) => {
+        console.warn('[snippets] initial load failed:', e)
+      })
+  }
+  return initialLoad
+}
+
+// Kick off an initial load at module import time so that CodeMirror
+// completions see snippets as soon as possible.
+void kickInitialLoad()
+
+/** Synchronous read — returns whatever is currently loaded (may be empty on first paint). */
+export function getSnippetCompletions(): Completion[] {
+  return cached
+}
+
+/** Force a reload from disk and update the cache. */
+export async function reloadSnippets(): Promise<Completion[]> {
+  try {
+    cached = await loadSnippetCompletions()
+  } catch (e) {
+    console.warn('[snippets] reload failed:', e)
+  }
+  return cached
+}

--- a/src/aiscript/snippets/defaultSnippets.ts
+++ b/src/aiscript/snippets/defaultSnippets.ts
@@ -1,0 +1,28 @@
+// 初回生成用テンプレ。TypeScript のテンプレートリテラル補間と衝突するので
+// 全ての ${...} は \${...} でエスケープしている。
+export const DEFAULT_AISCRIPT_SNIPPETS = `// AiScript スニペット — VSCode の *.code-snippets と同じスキーマ
+// prefix: 補完トリガ文字列  body: 展開後のコード  description: 説明（任意）
+// \${1:default} でタブストップ、$0 で終了位置。
+{
+  "Dialog": {
+    "prefix": "dlg",
+    "body": ["Mk:dialog(\\"$1\\", \\"\${2:message}\\")$0"],
+    "description": "ダイアログを表示"
+  },
+  "For loop": {
+    "prefix": "for",
+    "body": ["for let \${1:i}, \${2:10} {", "\\t$0", "}"],
+    "description": "for ループ"
+  },
+  "Each loop": {
+    "prefix": "each",
+    "body": ["each let \${1:item}, \${2:arr} {", "\\t$0", "}"],
+    "description": "配列を each で走査"
+  },
+  "API call": {
+    "prefix": "api",
+    "body": ["Mk:api(\\"\${1:endpoint}\\", {$2})$0"],
+    "description": "Misskey API 呼び出し"
+  }
+}
+`

--- a/src/aiscript/snippets/loader.ts
+++ b/src/aiscript/snippets/loader.ts
@@ -1,0 +1,36 @@
+import type { Completion } from '@codemirror/autocomplete'
+import { snippetCompletion } from '@codemirror/autocomplete'
+import { listSnippetFiles, readSnippetFile } from '@/utils/settingsFs'
+import { parseSnippetFile } from './parse'
+import type { ParsedSnippet } from './types'
+
+export const DEFAULT_SNIPPETS_FILE = 'aiscript.json5'
+
+export async function loadAllSnippets(): Promise<ParsedSnippet[]> {
+  const files = await listSnippetFiles()
+  const all: ParsedSnippet[] = []
+  for (const file of files) {
+    try {
+      const raw = await readSnippetFile(file)
+      all.push(...parseSnippetFile(raw, file))
+    } catch (e) {
+      console.warn(`[snippets] failed to read ${file}:`, e)
+    }
+  }
+  return all
+}
+
+export function toCompletion(snippet: ParsedSnippet): Completion {
+  return snippetCompletion(snippet.body, {
+    label: snippet.prefix,
+    type: 'snippet',
+    detail: snippet.name,
+    info: snippet.description,
+    boost: 50,
+  })
+}
+
+export async function loadSnippetCompletions(): Promise<Completion[]> {
+  const all = await loadAllSnippets()
+  return all.map(toCompletion)
+}

--- a/src/aiscript/snippets/parse.ts
+++ b/src/aiscript/snippets/parse.ts
@@ -1,0 +1,113 @@
+import JSON5 from 'json5'
+import type { ParsedSnippet, SnippetFile, VSCodeSnippet } from './types'
+
+/**
+ * VSCode スニペットの body を CodeMirror snippet テンプレート構文へ変換する。
+ *
+ * サポート：
+ * - `$1`, `$2`, ... → `#{1}`, `#{2}` （番号付きタブストップ）
+ * - `${1:default}` → `#{1:default}`
+ * - `$0` / `${0}` / `${0:...}` → `#{}` （終了位置）
+ * - `${1|a,b,c|}` → `#{1:a}` + console.warn（choice は未対応なので先頭候補を採用）
+ * - `$TM_FILENAME` 等 VSCode 変数 → 空文字に落とす
+ *
+ * CodeMirror は `#{name}` と `#{name:default}` を解釈する
+ * （`$` ではなく `#` に置換しているのは @codemirror/autocomplete の仕様）。
+ */
+export function vscodeBodyToCmTemplate(body: string | string[]): string {
+  const raw = Array.isArray(body) ? body.join('\n') : body
+
+  let text = raw
+
+  // 1) ${N|a,b,c|} choice → #{N:firstChoice}
+  text = text.replace(
+    /\$\{(\d+)\|([^|}]*)(?:,[^|}]*)*\|\}/g,
+    (_m, n: string, first: string) => {
+      console.warn(
+        `[snippets] choice syntax \${${n}|...|} is not supported; using first option "${first}"`,
+      )
+      return `#{${n}:${first}}`
+    },
+  )
+
+  // 2) $0 / ${0} / ${0:...} → #{} （終了位置）
+  text = text.replace(/\$\{0(?::[^}]*)?\}/g, '#{}')
+  text = text.replace(/\$0(?!\d)/g, '#{}')
+
+  // 3) ${N:default} → #{N:default}
+  text = text.replace(
+    /\$\{(\d+):([^}]*)\}/g,
+    (_m, n: string, def: string) => `#{${n}:${def}}`,
+  )
+
+  // 4) ${N} → #{N}
+  text = text.replace(/\$\{(\d+)\}/g, (_m, n: string) => `#{${n}}`)
+
+  // 5) $N → #{N} （先頭に数字、後続は非数字）
+  text = text.replace(/\$(\d+)(?!\d)/g, (_m, n: string) => `#{${n}}`)
+
+  // 6) ${VAR} / $VAR （VSCode 変数）→ 空文字
+  text = text.replace(/\$\{[A-Z_][A-Z0-9_]*(?::[^}]*)?\}/g, '')
+  text = text.replace(/\$[A-Z_][A-Z0-9_]*/g, '')
+
+  return text
+}
+
+/**
+ * スニペットファイルの JSON5 をパースし、検証済みスニペット配列を返す。
+ * 個別エントリの不正は console.warn でスキップし、他のエントリは採用する。
+ */
+export function parseSnippetFile(
+  raw: string,
+  sourceName: string,
+): ParsedSnippet[] {
+  if (!raw.trim()) return []
+
+  let data: unknown
+  try {
+    data = JSON5.parse(raw)
+  } catch (e) {
+    console.warn(`[snippets] failed to parse ${sourceName}:`, e)
+    return []
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    console.warn(`[snippets] ${sourceName}: top-level must be an object`)
+    return []
+  }
+
+  const result: ParsedSnippet[] = []
+  const file = data as SnippetFile
+
+  for (const [name, entry] of Object.entries(file)) {
+    if (!entry || typeof entry !== 'object') {
+      console.warn(`[snippets] ${sourceName}: "${name}" is not an object`)
+      continue
+    }
+    const snippet = entry as VSCodeSnippet
+    if (snippet.prefix == null || snippet.body == null) {
+      console.warn(`[snippets] ${sourceName}: "${name}" missing prefix or body`)
+      continue
+    }
+    const prefixes = Array.isArray(snippet.prefix)
+      ? snippet.prefix
+      : [snippet.prefix]
+    const bodyTemplate = vscodeBodyToCmTemplate(snippet.body)
+
+    for (const prefix of prefixes) {
+      if (typeof prefix !== 'string' || !prefix) continue
+      result.push({
+        name,
+        prefix,
+        body: bodyTemplate,
+        description:
+          typeof snippet.description === 'string'
+            ? snippet.description
+            : undefined,
+        source: sourceName,
+      })
+    }
+  }
+
+  return result
+}

--- a/src/aiscript/snippets/types.ts
+++ b/src/aiscript/snippets/types.ts
@@ -1,0 +1,16 @@
+export interface VSCodeSnippet {
+  prefix: string | string[]
+  body: string | string[]
+  description?: string
+  scope?: string
+}
+
+export type SnippetFile = Record<string, VSCodeSnippet>
+
+export interface ParsedSnippet {
+  name: string
+  prefix: string
+  body: string
+  description?: string
+  source: string
+}

--- a/src/commands/definitions.ts
+++ b/src/commands/definitions.ts
@@ -608,6 +608,15 @@ export function registerDefaultCommands(handlers: CommandHandlers) {
   })
 
   commandStore.register({
+    id: 'snippets-editor',
+    label: 'スニペット',
+    icon: 'code-plus',
+    category: 'general',
+    shortcuts: keybindsStore.getShortcuts('snippets-editor'),
+    execute: () => useWindowsStore().open('snippetsEditor'),
+  })
+
+  commandStore.register({
     id: 'tasks.run-default',
     label: 'デフォルトタスクを実行',
     icon: 'player-play-filled',

--- a/src/commands/definitions.ts
+++ b/src/commands/definitions.ts
@@ -12,6 +12,7 @@ import { useDeckStore } from '@/stores/deck'
 import { useKeybindsStore } from '@/stores/keybinds'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { useRealtimeModeStore } from '@/stores/realtimeMode'
+import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useThemeStore } from '@/stores/theme'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
@@ -604,6 +605,17 @@ export function registerDefaultCommands(handlers: CommandHandlers) {
     category: 'general',
     shortcuts: keybindsStore.getShortcuts('tasks-editor'),
     execute: () => useWindowsStore().open('tasksEditor'),
+  })
+
+  commandStore.register({
+    id: 'tasks.run-default',
+    label: 'デフォルトタスクを実行',
+    icon: 'player-play-filled',
+    category: 'general',
+    shortcuts: keybindsStore.getShortcuts('tasks.run-default'),
+    execute: () => {
+      void useTaskRunnerStore().runDefault()
+    },
   })
 
   commandStore.register({

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -124,6 +124,13 @@ export function getSettingsItems(): QuickPickItem[] {
       group: '環境設定',
       action: () => useWindowsStore().open('tasksEditor'),
     },
+    {
+      id: 'snippets-editor',
+      label: 'スニペット',
+      icon: 'code-plus',
+      group: '環境設定',
+      action: () => useWindowsStore().open('snippetsEditor'),
+    },
     // Cache
     {
       id: 'clear-all-cache',

--- a/src/commands/taskCommandPrefix.ts
+++ b/src/commands/taskCommandPrefix.ts
@@ -1,0 +1,1 @@
+export const TASK_COMMAND_PREFIX = 'task.'

--- a/src/components/deck/ColumnTabs.vue
+++ b/src/components/deck/ColumnTabs.vue
@@ -173,25 +173,19 @@ watch(
   gap: 4px;
   padding: 8px 12px;
   flex: 0 0 auto;
-  opacity: 0.5;
-  color: var(--nd-fg);
-  font-size: 0.85em;
-  font-weight: 600;
+  opacity: 0.4;
   transition:
     opacity var(--nd-duration-base),
-    background var(--nd-duration-base),
-    color var(--nd-duration-base);
+    background var(--nd-duration-base);
   position: relative;
-  white-space: nowrap;
 
   &:hover {
-    opacity: 0.8;
+    opacity: 0.7;
     background: var(--nd-buttonHoverBg);
   }
 
   &.active {
     opacity: 1;
-    color: var(--nd-accent);
   }
 }
 
@@ -200,6 +194,8 @@ watch(
 }
 
 .tabLabel {
+  font-size: 0.85em;
+  font-weight: bold;
   white-space: nowrap;
 }
 

--- a/src/components/deck/DeckSettingsMenu.vue
+++ b/src/components/deck/DeckSettingsMenu.vue
@@ -165,7 +165,8 @@ function openToolWindow(
     | 'performanceEditor'
     | 'appearanceEditor'
     | 'backup'
-    | 'tasksEditor',
+    | 'tasksEditor'
+    | 'snippetsEditor',
   props: Record<string, unknown> = {},
 ) {
   windowsStore.open(type, props)
@@ -384,6 +385,13 @@ usePortal(settingsMenuPortalRef)
             <i class="ti ti-chevron-right" :class="$style.chevronNav" />
           </button>
         </div>
+        <div :class="$style.categorySection">
+          <button :class="$style.categoryHeader" @click="openToolWindow('snippetsEditor')">
+            <i class="ti ti-code-plus" />
+            <span>スニペット</span>
+            <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+          </button>
+        </div>
       </template>
       <!-- 環境設定 (デスクトップ: アコーディオン) -->
       <div v-else :class="$style.categorySection">
@@ -415,6 +423,10 @@ usePortal(settingsMenuPortalRef)
           <button :class="$style.settingsMenuItem" @click="openToolWindow('tasksEditor')">
             <i class="ti ti-player-play" />
             <span :class="$style.settingsMenuLabel">タスク</span>
+          </button>
+          <button :class="$style.settingsMenuItem" @click="openToolWindow('snippetsEditor')">
+            <i class="ti ti-code-plus" />
+            <span :class="$style.settingsMenuLabel">スニペット</span>
           </button>
         </div>
       </div>

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
 import { computed, onUnmounted, ref } from 'vue'
+import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import RawJsonView from '@/components/common/RawJsonView.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useSensitiveMask } from '@/composables/useSensitiveMask'
+import { useServerImages } from '@/composables/useServerImages'
+import { useVerticalResize } from '@/composables/useVerticalResize'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useTasksStore } from '@/stores/tasks'
@@ -14,6 +17,7 @@ const props = defineProps<{
 }>()
 
 const { columnThemeVars } = useColumnTheme(() => props.column)
+const { serverInfoImageUrl } = useServerImages(() => props.column)
 const tasksStore = useTasksStore()
 const runnerStore = useTaskRunnerStore()
 const windowsStore = useWindowsStore()
@@ -30,7 +34,6 @@ const { showSensitive, formatJson } = useSensitiveMask(SENSITIVE_RAW_KEYS)
 const query = ref('')
 const selectedId = ref<number | null>(null)
 
-// Tick to keep relative timestamps fresh
 const now = ref(Date.now())
 const tickTimer = setInterval(() => {
   now.value = Date.now()
@@ -99,9 +102,23 @@ function runFromList(taskId: string) {
   void runnerStore.runTask(taskId)
 }
 
+function clearHistory() {
+  runnerStore.clear()
+  selectedId.value = null
+}
+
 function openEditor() {
   windowsStore.open('tasksEditor')
 }
+
+const wrapperRef = ref<HTMLElement | null>(null)
+const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
+  containerRef: wrapperRef,
+  mode: 'bottom-px',
+  initial: 320,
+  min: 80,
+  topMargin: 120,
+})
 </script>
 
 <template>
@@ -110,7 +127,31 @@ function openEditor() {
     title="タスク"
     :theme-vars="columnThemeVars"
   >
-    <div :class="$style.body">
+    <template #header-icon>
+      <i class="ti ti-list-check" :class="$style.headerIcon" />
+    </template>
+
+    <template #header-meta>
+      <button
+        v-if="runnerStore.runs.length > 0"
+        class="_button"
+        :class="$style.headerBtn"
+        title="履歴をクリア"
+        @click.stop="clearHistory()"
+      >
+        <i class="ti ti-trash" />
+      </button>
+      <button
+        class="_button"
+        :class="$style.headerBtn"
+        title="tasks.json5 を編集"
+        @click.stop="openEditor()"
+      >
+        <i class="ti ti-pencil" />
+      </button>
+    </template>
+
+    <div ref="wrapperRef" :class="$style.wrapper">
       <div :class="$style.toolbar">
         <div :class="$style.searchWrap">
           <i class="ti ti-search" :class="$style.searchIcon" />
@@ -129,110 +170,104 @@ function openEditor() {
             <i class="ti ti-x" />
           </button>
         </div>
-        <button
-          class="_button"
-          :class="$style.iconBtn"
-          title="tasks.json5 を編集"
-          @click="openEditor"
-        >
-          <i class="ti ti-pencil" />
-        </button>
       </div>
 
-      <section :class="$style.section">
-        <div :class="$style.sectionHeader">
-          <span>タスク ({{ filteredDefinitions.length }})</span>
-          <span v-if="tasksStore.lastError" :class="$style.errorBadge" :title="tasksStore.lastError">
-            <i class="ti ti-alert-triangle" /> エラー
-          </span>
-        </div>
-        <div
+      <div :class="$style.scroll">
+        <ColumnEmptyState
           v-if="tasksStore.definitions.length === 0"
-          :class="$style.empty"
-        >
-          <i class="ti ti-player-play" :class="$style.emptyIcon" />
-          <div :class="$style.emptyTitle">タスクがまだありません</div>
-          <div :class="$style.emptyHint">
-            tasks.json5 を編集してタスクを定義すると、ここから 1-click で実行できます。
-          </div>
-          <button class="_button" :class="$style.emptyBtn" @click="openEditor">
-            <i class="ti ti-pencil" />
-            tasks.json5 を編集
-          </button>
-        </div>
-        <div
+          message="tasks.json5 を編集してタスクを定義すると、ここから 1-click で実行できます。"
+          :image-url="serverInfoImageUrl"
+          cta-label="tasks.json5 を編集"
+          cta-icon="ti-pencil"
+          @cta="openEditor()"
+        />
+        <ColumnEmptyState
           v-else-if="filteredDefinitions.length === 0"
-          :class="$style.empty"
-        >
-          <div :class="$style.emptyHint">
-            "{{ query }}" に一致するタスクはありません
-          </div>
-        </div>
-        <button
-          v-for="def in filteredDefinitions"
-          :key="def.id"
-          class="_button"
-          :class="$style.runBtn"
-          :title="def.description || def.label"
-          @click="runFromList(def.id)"
-        >
-          <i class="ti ti-player-play" :class="$style.runIcon" />
-          <div :class="$style.runBody">
-            <span :class="$style.runLabel">{{ def.label }}</span>
-            <span v-if="def.description" :class="$style.runDesc">{{ def.description }}</span>
-          </div>
-          <span v-if="def.inputs?.length" :class="$style.runBadge" title="入力を求める">
-            <i class="ti ti-keyboard" />{{ def.inputs.length }}
-          </span>
-        </button>
-      </section>
+          :message="`&quot;${query}&quot; に一致するタスクはありません`"
+        />
+        <template v-else>
+          <section :class="$style.section">
+            <div :class="$style.sectionHeader">
+              <span :class="$style.sectionTitle">
+                タスク
+                <span :class="$style.countSub">{{ filteredDefinitions.length }}</span>
+              </span>
+              <span
+                v-if="tasksStore.lastError"
+                :class="$style.errorBadge"
+                :title="tasksStore.lastError"
+              >
+                <i class="ti ti-alert-triangle" /> エラー
+              </span>
+            </div>
+            <button
+              v-for="def in filteredDefinitions"
+              :key="def.id"
+              class="_button"
+              :class="$style.runBtn"
+              :title="def.description || def.label"
+              @click="runFromList(def.id)"
+            >
+              <i class="ti ti-player-play" :class="$style.runIcon" />
+              <div :class="$style.runBody">
+                <span :class="$style.runLabel">{{ def.label }}</span>
+                <span v-if="def.description" :class="$style.runDesc">{{ def.description }}</span>
+              </div>
+              <span v-if="def.inputs?.length" :class="$style.runBadge" title="入力を求める">
+                <i class="ti ti-keyboard" />{{ def.inputs.length }}
+              </span>
+            </button>
+          </section>
 
-      <section :class="$style.section">
-        <div :class="$style.sectionHeader">
-          <span>
-            履歴
-            <span :class="$style.countSub">{{ runnerStore.runs.length }}</span>
-            <span v-if="runningCount > 0" :class="$style.runningPill">
-              <i class="ti ti-loader-2 nd-spin" />{{ runningCount }} 実行中
-            </span>
-          </span>
-          <button
-            v-if="runnerStore.runs.length > 0"
-            class="_button"
-            :class="$style.clearBtn"
-            @click="runnerStore.clear(); selectedId = null"
-          >
-            クリア
-          </button>
-        </div>
-        <div v-if="runnerStore.runs.length === 0" :class="$style.empty">
-          <div :class="$style.emptyHint">実行履歴はまだありません</div>
-        </div>
-        <button
-          v-for="run in runnerStore.runs"
-          :key="run.id"
-          class="_button"
-          :class="[$style.runItem, {
-            [$style.selected]: run.id === selectedId,
-            [$style.statusOk]: run.status === 'ok',
-            [$style.statusError]: run.status === 'error',
-            [$style.statusRunning]: run.status === 'running',
-          }]"
-          @click="selectedId = run.id === selectedId ? null : run.id"
-        >
-          <i :class="['ti', statusIcon(run.status), $style.runItemIcon]" />
-          <div :class="$style.runItemBody">
-            <span :class="$style.runItemLabel">{{ run.label }}</span>
-            <span :class="$style.runItemMeta">
-              <code :class="$style.method">{{ run.method }}</code>
-              <span>{{ runDuration(run) }}</span>
-            </span>
-          </div>
-          <span :class="$style.runItemTime">{{ formatAgo(run.startedAt) }}</span>
-        </button>
-      </section>
+          <section :class="$style.section">
+            <div :class="$style.sectionHeader">
+              <span :class="$style.sectionTitle">
+                履歴
+                <span :class="$style.countSub">{{ runnerStore.runs.length }}</span>
+                <span v-if="runningCount > 0" :class="$style.runningPill">
+                  <i class="ti ti-loader-2 nd-spin" />{{ runningCount }} 実行中
+                </span>
+              </span>
+            </div>
+            <div v-if="runnerStore.runs.length === 0" :class="$style.emptyHint">
+              実行履歴はまだありません
+            </div>
+            <button
+              v-for="run in runnerStore.runs"
+              :key="run.id"
+              class="_button"
+              :class="[$style.runItem, {
+                [$style.selected]: run.id === selectedId,
+                [$style.statusOk]: run.status === 'ok',
+                [$style.statusError]: run.status === 'error',
+                [$style.statusRunning]: run.status === 'running',
+              }]"
+              @click="selectedId = run.id === selectedId ? null : run.id"
+            >
+              <i :class="['ti', statusIcon(run.status), $style.runItemIcon]" />
+              <div :class="$style.runItemBody">
+                <span :class="$style.runItemLabel">{{ run.label }}</span>
+                <span :class="$style.runItemMeta">
+                  <code :class="$style.method">{{ run.method }}</code>
+                  <span>{{ runDuration(run) }}</span>
+                </span>
+              </div>
+              <span :class="$style.runItemTime">{{ formatAgo(run.startedAt) }}</span>
+            </button>
+          </section>
+        </template>
+      </div>
 
-      <section v-if="selectedRun" :class="$style.preview">
+      <div
+        v-if="selectedRun"
+        :class="$style.divider"
+        @pointerdown="onDividerPointerDown"
+      />
+      <div
+        v-if="selectedRun"
+        :class="$style.detail"
+        :style="{ height: detailHeight + 'px' }"
+      >
         <RawJsonView
           :json="previewJson"
           :can-reveal="true"
@@ -248,30 +283,51 @@ function openEditor() {
             <span>{{ runDuration(selectedRun) }}</span>
           </template>
         </RawJsonView>
-      </section>
+      </div>
     </div>
   </DeckColumn>
 </template>
 
 <style lang="scss" module>
-.body {
+@use './column-common.module.scss';
+
+.headerIcon {
+  font-size: 1em;
+}
+
+.headerBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  opacity: 0.6;
+  transition:
+    background var(--nd-duration-fast),
+    opacity var(--nd-duration-fast);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+    opacity: 1;
+  }
+}
+
+.wrapper {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-height: 0;
-  height: 100%;
-  overflow-y: auto;
 }
 
 .toolbar {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 10px;
+  padding: 6px 8px;
   border-bottom: 1px solid var(--nd-divider);
-  background: var(--nd-panelHeaderBg, var(--nd-panel));
-  position: sticky;
-  top: 0;
-  z-index: 1;
+  flex-shrink: 0;
 }
 
 .searchWrap {
@@ -289,6 +345,7 @@ function openEditor() {
 }
 
 .searchIcon { opacity: 0.45; flex-shrink: 0; }
+
 .search {
   flex: 1;
   min-width: 0;
@@ -304,17 +361,12 @@ function openEditor() {
   &:hover { opacity: 1; }
 }
 
-.iconBtn {
-  flex-shrink: 0;
-  width: 30px;
-  height: 30px;
+.scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--nd-radius-sm);
-  opacity: 0.7;
-
-  &:hover { opacity: 1; background: var(--nd-buttonHoverBg); }
+  flex-direction: column;
 }
 
 .section { flex-shrink: 0; }
@@ -330,8 +382,13 @@ function openEditor() {
   text-transform: uppercase;
   letter-spacing: 0.04em;
   opacity: 0.6;
+}
 
-  & > :first-child { flex: 1; display: flex; align-items: center; gap: 6px; }
+.sectionTitle {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .countSub {
@@ -362,60 +419,12 @@ function openEditor() {
   opacity: 1;
 }
 
-.clearBtn {
-  padding: 2px 10px;
-  font-size: 1.1em;
-  text-transform: none;
-  letter-spacing: 0;
-  font-weight: normal;
-  color: var(--nd-fg);
-  opacity: 0.7;
-  border-radius: var(--nd-radius-sm);
-
-  &:hover { opacity: 1; background: var(--nd-buttonHoverBg); }
-}
-
-.empty {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-  padding: 24px 14px;
-  color: var(--nd-fg);
-  text-align: center;
-}
-
-.emptyIcon {
-  font-size: 32px;
-  opacity: 0.3;
-  margin-bottom: 4px;
-}
-
-.emptyTitle {
-  font-weight: 600;
-  opacity: 0.75;
-  font-size: 0.9em;
-}
-
 .emptyHint {
+  padding: 10px 14px 14px;
+  color: var(--nd-fg);
   opacity: 0.55;
   font-size: 0.8em;
-  line-height: 1.5;
-  max-width: 260px;
-}
-
-.emptyBtn {
-  margin-top: 6px;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 6px 14px;
-  border-radius: var(--nd-radius-sm);
-  background: var(--nd-accent);
-  color: var(--nd-fgOnAccent);
-  font-size: 0.8em;
-
-  &:hover { opacity: 0.9; }
+  text-align: center;
 }
 
 .runBtn {
@@ -549,11 +558,23 @@ function openEditor() {
 
 .selected { /* modifier */ }
 
-.preview {
-  flex: 1;
-  min-height: 240px;
+.divider {
+  height: 5px;
+  flex-shrink: 0;
+  cursor: row-resize;
+  background: var(--nd-divider);
+  transition: background var(--nd-duration-fast);
+
+  &:hover,
+  &:active {
+    background: var(--nd-accent);
+  }
+}
+
+.detail {
+  flex-shrink: 0;
+  overflow: auto;
   display: flex;
   flex-direction: column;
-  border-top: 1px solid var(--nd-divider);
 }
 </style>

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from 'vue'
+import { computed, onUnmounted, ref, watch } from 'vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import RawJsonView from '@/components/common/RawJsonView.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
@@ -46,6 +46,15 @@ const tickTimer = setInterval(() => {
   now.value = Date.now()
 }, 15_000)
 onUnmounted(() => clearInterval(tickTimer))
+
+// presentation.revealOnRun の反映: runner が run を実行したらこのカラムで
+// 自動的にその行を選択して詳細パネルを開く。
+watch(
+  () => runnerStore.autoSelectedRunId,
+  (id) => {
+    if (id != null) selectedId.value = id
+  },
+)
 
 const filteredDefinitions = computed(() => {
   const q = query.value.trim().toLowerCase()

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -7,10 +7,12 @@ import { useSensitiveMask } from '@/composables/useSensitiveMask'
 import { useServerImages } from '@/composables/useServerImages'
 import { useVerticalResize } from '@/composables/useVerticalResize'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { useKeybindsStore } from '@/stores/keybinds'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useTasksStore } from '@/stores/tasks'
 import { useWindowsStore } from '@/stores/windows'
 import type { TaskDefinition, TaskRun } from '@/tasks/types'
+import { shortcutLabel } from '@/utils/shortcutLabel'
 import DeckColumn from './DeckColumn.vue'
 
 const UNGROUPED_KEY = '__ungrouped__'
@@ -25,6 +27,7 @@ const { serverInfoImageUrl } = useServerImages(() => props.column)
 const tasksStore = useTasksStore()
 const runnerStore = useTaskRunnerStore()
 const windowsStore = useWindowsStore()
+const keybindsStore = useKeybindsStore()
 
 const SENSITIVE_RAW_KEYS = new Set<string>([
   'i',
@@ -165,6 +168,19 @@ function runFromList(taskId: string) {
   void runnerStore.runTask(taskId)
 }
 
+const defaultTask = computed<TaskDefinition | null>(
+  () => tasksStore.definitions.find((d) => d.isDefault) ?? null,
+)
+
+const defaultShortcutLabel = computed(() => {
+  const shortcut = keybindsStore.getShortcuts('tasks.run-default')[0]
+  return shortcut ? shortcutLabel(shortcut) : ''
+})
+
+function runDefault() {
+  void runnerStore.runDefault()
+}
+
 function clearHistory() {
   runnerStore.clear()
   selectedId.value = null
@@ -215,6 +231,24 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
     </template>
 
     <div ref="wrapperRef" :class="$style.wrapper">
+      <button
+        v-if="defaultTask"
+        class="_button"
+        :class="$style.defaultBar"
+        :title="`${defaultTask.label} を実行`"
+        @click="runDefault()"
+      >
+        <i class="ti ti-player-play-filled" :class="$style.defaultBarIcon" />
+        <span :class="$style.defaultBarText">
+          <span :class="$style.defaultBarKicker">デフォルト実行</span>
+          <span :class="$style.defaultBarLabel">{{ defaultTask.label }}</span>
+        </span>
+        <span
+          v-if="defaultShortcutLabel"
+          :class="$style.defaultBarShortcut"
+        >{{ defaultShortcutLabel }}</span>
+      </button>
+
       <div :class="$style.toolbar">
         <div :class="$style.searchWrap">
           <i class="ti ti-search" :class="$style.searchIcon" />
@@ -406,6 +440,74 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
   flex-direction: column;
   flex: 1;
   min-height: 0;
+}
+
+.defaultBar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--nd-divider);
+  background: color-mix(in srgb, var(--nd-accent) 8%, transparent);
+  color: var(--nd-fgHighlighted);
+  text-align: left;
+  transition: background var(--nd-duration-base);
+
+  &:hover {
+    background: color-mix(in srgb, var(--nd-accent) 16%, transparent);
+  }
+}
+
+.defaultBarIcon {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--nd-accent);
+  color: var(--nd-bg);
+  font-size: 13px;
+}
+
+.defaultBarText {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.defaultBarKicker {
+  font-size: 0.65em;
+  font-weight: bold;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.7;
+  color: var(--nd-accent);
+}
+
+.defaultBarLabel {
+  font-size: 0.85em;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.defaultBarShortcut {
+  flex-shrink: 0;
+  font-size: 0.7em;
+  font-family: var(--nd-font-mono, monospace);
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--nd-bg);
+  border: 1px solid var(--nd-divider);
+  color: var(--nd-fg);
+  opacity: 0.7;
 }
 
 .toolbar {

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -10,7 +10,7 @@ import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useTasksStore } from '@/stores/tasks'
 import { useWindowsStore } from '@/stores/windows'
-import type { TaskDefinition } from '@/tasks/types'
+import type { TaskDefinition, TaskRun } from '@/tasks/types'
 import DeckColumn from './DeckColumn.vue'
 
 const UNGROUPED_KEY = '__ungrouped__'
@@ -103,6 +103,16 @@ const groupedDefinitions = computed<TaskSection[]>(() => {
 function iconClass(def: TaskDefinition): string {
   return `ti ti-${def.icon ?? 'player-play'}`
 }
+
+// runnerStore.runs は新しい順 (taskRunner L40: [run, ...runs.value])。
+// 先頭から走査して taskId ごとの最初の出現 = 最新実行。
+const latestRunByTaskId = computed<Map<string, TaskRun>>(() => {
+  const map = new Map<string, TaskRun>()
+  for (const r of runnerStore.runs) {
+    if (!map.has(r.taskId)) map.set(r.taskId, r)
+  }
+  return map
+})
 
 const selectedRun = computed(() =>
   selectedId.value == null
@@ -278,6 +288,18 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
                   :class="$style.runDesc"
                 >{{ def.detail || def.description }}</span>
               </div>
+              <span
+                v-if="latestRunByTaskId.get(def.id)"
+                :class="[$style.statusBadge, {
+                  [$style.statusOk]: latestRunByTaskId.get(def.id)!.status === 'ok',
+                  [$style.statusError]: latestRunByTaskId.get(def.id)!.status === 'error',
+                  [$style.statusRunning]: latestRunByTaskId.get(def.id)!.status === 'running',
+                }]"
+                :title="`最終実行: ${latestRunByTaskId.get(def.id)!.status} · ${runDuration(latestRunByTaskId.get(def.id)!)}`"
+              >
+                <i :class="['ti', statusIcon(latestRunByTaskId.get(def.id)!.status)]" />
+                <span>{{ formatAgo(latestRunByTaskId.get(def.id)!.startedAt) }}</span>
+              </span>
               <span v-if="def.inputs?.length" :class="$style.runBadge" title="入力を求める">
                 <i class="ti ti-keyboard" />{{ def.inputs.length }}
               </span>
@@ -560,6 +582,36 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
   background: var(--nd-buttonBg);
   color: var(--nd-fg);
   opacity: 0.65;
+}
+
+.statusBadge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  font-size: 0.7em;
+  border-radius: 999px;
+  font-variant-numeric: tabular-nums;
+  background: color-mix(in srgb, var(--nd-fg) 8%, transparent);
+  color: var(--nd-fg);
+  opacity: 0.75;
+
+  &.statusOk {
+    background: color-mix(in srgb, var(--nd-mfmSuccess, #4a8) 14%, transparent);
+    color: var(--nd-mfmSuccess, #4a8);
+    opacity: 1;
+  }
+  &.statusError {
+    background: color-mix(in srgb, var(--nd-love, #c66) 14%, transparent);
+    color: var(--nd-love, #c66);
+    opacity: 1;
+  }
+  &.statusRunning {
+    background: color-mix(in srgb, var(--nd-accent) 14%, transparent);
+    color: var(--nd-accent);
+    opacity: 1;
+  }
 }
 
 .runItem {

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -10,7 +10,11 @@ import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useTasksStore } from '@/stores/tasks'
 import { useWindowsStore } from '@/stores/windows'
+import type { TaskDefinition } from '@/tasks/types'
 import DeckColumn from './DeckColumn.vue'
+
+const UNGROUPED_KEY = '__ungrouped__'
+const PINNED_KEY = '__pinned__'
 
 const props = defineProps<{
   column: DeckColumnType
@@ -47,9 +51,58 @@ const filteredDefinitions = computed(() => {
     (d) =>
       d.id.includes(q) ||
       d.label.toLowerCase().includes(q) ||
-      (d.description?.toLowerCase().includes(q) ?? false),
+      (d.detail?.toLowerCase().includes(q) ?? false) ||
+      (d.description?.toLowerCase().includes(q) ?? false) ||
+      (d.group?.toLowerCase().includes(q) ?? false),
   )
 })
+
+interface TaskSection {
+  key: string
+  title: string
+  pinned: boolean
+  items: TaskDefinition[]
+}
+
+const groupedDefinitions = computed<TaskSection[]>(() => {
+  const items = filteredDefinitions.value
+  const pinned = items.filter((d) => d.pinned)
+  const rest = items.filter((d) => !d.pinned)
+
+  const groups = new Map<string, TaskDefinition[]>()
+  for (const d of rest) {
+    const key = d.group ?? UNGROUPED_KEY
+    const arr = groups.get(key)
+    if (arr) arr.push(d)
+    else groups.set(key, [d])
+  }
+
+  const sections: TaskSection[] = []
+  if (pinned.length > 0) {
+    sections.push({
+      key: PINNED_KEY,
+      title: 'Pinned',
+      pinned: true,
+      items: pinned,
+    })
+  }
+  // グループ未指定は最下段の "General" に送る（VSCode の none に相当）
+  const keys = [...groups.keys()].filter((k) => k !== UNGROUPED_KEY)
+  if (groups.has(UNGROUPED_KEY)) keys.push(UNGROUPED_KEY)
+  for (const k of keys) {
+    sections.push({
+      key: k,
+      title: k === UNGROUPED_KEY ? 'General' : k,
+      pinned: false,
+      items: groups.get(k) ?? [],
+    })
+  }
+  return sections
+})
+
+function iconClass(def: TaskDefinition): string {
+  return `ti ti-${def.icon ?? 'player-play'}`
+}
 
 const selectedRun = computed(() =>
   selectedId.value == null
@@ -186,14 +239,23 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
           :message="`&quot;${query}&quot; に一致するタスクはありません`"
         />
         <template v-else>
-          <section :class="$style.section">
+          <section
+            v-for="section in groupedDefinitions"
+            :key="section.key"
+            :class="$style.section"
+          >
             <div :class="$style.sectionHeader">
               <span :class="$style.sectionTitle">
-                タスク
-                <span :class="$style.countSub">{{ filteredDefinitions.length }}</span>
+                <i
+                  v-if="section.pinned"
+                  class="ti ti-pin-filled"
+                  :class="$style.sectionLeadIcon"
+                />
+                {{ section.title }}
+                <span :class="$style.countSub">{{ section.items.length }}</span>
               </span>
               <span
-                v-if="tasksStore.lastError"
+                v-if="section.key === groupedDefinitions[0]?.key && tasksStore.lastError"
                 :class="$style.errorBadge"
                 :title="tasksStore.lastError"
               >
@@ -201,17 +263,20 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
               </span>
             </div>
             <button
-              v-for="def in filteredDefinitions"
+              v-for="def in section.items"
               :key="def.id"
               class="_button"
               :class="$style.runBtn"
-              :title="def.description || def.label"
+              :title="def.description || def.detail || def.label"
               @click="runFromList(def.id)"
             >
-              <i class="ti ti-player-play" :class="$style.runIcon" />
+              <i :class="[iconClass(def), $style.runIcon]" />
               <div :class="$style.runBody">
                 <span :class="$style.runLabel">{{ def.label }}</span>
-                <span v-if="def.description" :class="$style.runDesc">{{ def.description }}</span>
+                <span
+                  v-if="def.detail || def.description"
+                  :class="$style.runDesc"
+                >{{ def.detail || def.description }}</span>
               </div>
               <span v-if="def.inputs?.length" :class="$style.runBadge" title="入力を求める">
                 <i class="ti ti-keyboard" />{{ def.inputs.length }}
@@ -389,6 +454,12 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
   display: flex;
   align-items: center;
   gap: 6px;
+}
+
+.sectionLeadIcon {
+  font-size: 0.95em;
+  color: var(--nd-accent);
+  opacity: 0.9;
 }
 
 .countSub {

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -42,6 +42,7 @@ const BASE_TITLES: Record<string, string> = {
   appearanceEditor: 'アピアランス',
   backup: 'バックアップ',
   tasksEditor: 'タスク設定',
+  snippetsEditor: 'スニペット',
 }
 
 const windowTitle = computed(() => {
@@ -76,6 +77,7 @@ const icons: Record<string, string> = {
   appearanceEditor: 'ti ti-brush',
   backup: 'ti ti-package-export',
   tasksEditor: 'ti ti-player-play',
+  snippetsEditor: 'ti ti-code-plus',
 }
 
 const isMinimized = computed(() => props.window.minimized)

--- a/src/components/deck/DeckWindowLayer.vue
+++ b/src/components/deck/DeckWindowLayer.vue
@@ -65,6 +65,9 @@ const BackupContent = defineAsyncComponent(
 const TasksEditorContent = defineAsyncComponent(
   () => import('@/components/window/TasksEditorContent.vue'),
 )
+const SnippetsEditorContent = defineAsyncComponent(
+  () => import('@/components/window/SnippetsEditorContent.vue'),
+)
 
 const windowsStore = useWindowsStore()
 const themeStore = useThemeStore()
@@ -211,6 +214,9 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
       />
       <TasksEditorContent
         v-if="win.type === 'tasksEditor'"
+      />
+      <SnippetsEditorContent
+        v-if="win.type === 'snippetsEditor'"
       />
     </DeckWindow>
   </div>

--- a/src/components/window/SnippetsEditorContent.vue
+++ b/src/components/window/SnippetsEditorContent.vue
@@ -1,0 +1,403 @@
+<script setup lang="ts">
+import { json as jsonLang } from '@codemirror/lang-json'
+import { type Diagnostic, linter } from '@codemirror/lint'
+import JSON5 from 'json5'
+import { computed, defineAsyncComponent, onMounted, ref, watch } from 'vue'
+import { reloadSnippets } from '@/aiscript/snippets/cache'
+import { DEFAULT_AISCRIPT_SNIPPETS } from '@/aiscript/snippets/defaultSnippets'
+import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
+import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
+import { useToast } from '@/stores/toast'
+import {
+  isTauri,
+  listSnippetFiles,
+  readSnippetFile,
+  writeSnippetFile,
+} from '@/utils/settingsFs'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/deck/widgets/CodeEditor.vue'),
+)
+
+const lang = jsonLang()
+
+const jsonLinter = linter(
+  (view) => {
+    const diagnostics: Diagnostic[] = []
+    const src = view.state.doc.toString()
+    if (!src.trim()) return diagnostics
+    try {
+      JSON5.parse(src)
+    } catch (e) {
+      diagnostics.push({
+        from: 0,
+        to: src.length,
+        severity: 'error',
+        message: e instanceof Error ? e.message : 'JSON5 パースエラー',
+      })
+    }
+    return diagnostics
+  },
+  { delay: 400 },
+)
+
+const DEFAULT_FILE = 'aiscript.json5'
+const toast = useToast()
+
+const files = ref<string[]>([])
+const currentFile = ref<string>(DEFAULT_FILE)
+const code = ref<string>('')
+const dirty = ref(false)
+const saved = ref(false)
+const error = ref<string | null>(null)
+const loaded = ref(false)
+
+const statusText = computed(() => {
+  if (error.value) return error.value
+  if (saved.value) return '保存しました'
+  if (dirty.value) return '編集中...'
+  return ''
+})
+
+const statusClass = computed(() => {
+  if (error.value) return 'statusError'
+  if (saved.value) return 'statusSaved'
+  return ''
+})
+
+async function refreshFiles() {
+  if (!isTauri) {
+    files.value = [DEFAULT_FILE]
+    return
+  }
+  const list = await listSnippetFiles()
+  if (list.length === 0) {
+    await writeSnippetFile(DEFAULT_FILE, DEFAULT_AISCRIPT_SNIPPETS)
+    files.value = [DEFAULT_FILE]
+  } else {
+    files.value = list
+  }
+}
+
+async function loadCurrent() {
+  if (!isTauri) {
+    code.value = DEFAULT_AISCRIPT_SNIPPETS
+    dirty.value = false
+    return
+  }
+  try {
+    const raw = await readSnippetFile(currentFile.value)
+    code.value = raw || DEFAULT_AISCRIPT_SNIPPETS
+    dirty.value = false
+    error.value = null
+  } catch (e) {
+    toast.show(
+      `${currentFile.value} 読込失敗: ${(e as Error).message}`,
+      'error',
+    )
+  }
+}
+
+onMounted(async () => {
+  await refreshFiles()
+  await loadCurrent()
+  loaded.value = true
+})
+
+async function selectFile(name: string) {
+  if (dirty.value) {
+    await save()
+  }
+  currentFile.value = name
+  await loadCurrent()
+}
+
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+watch(code, () => {
+  if (!loaded.value) return
+  dirty.value = true
+  saved.value = false
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(save, 600)
+})
+
+async function save() {
+  if (!loaded.value || !isTauri) return
+  try {
+    if (code.value.trim()) JSON5.parse(code.value)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : '不正な JSON5'
+    return
+  }
+  try {
+    await writeSnippetFile(currentFile.value, code.value)
+    await reloadSnippets()
+    dirty.value = false
+    saved.value = true
+    error.value = null
+    setTimeout(() => {
+      saved.value = false
+    }, 2000)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : '保存失敗'
+  }
+}
+
+// ── Import / Export ──
+const {
+  copied: copiedMessage,
+  imported: importedMessage,
+  importError,
+  showCopied,
+  showImported,
+  showImportError,
+} = useClipboardFeedback()
+
+function exportSnippets() {
+  navigator.clipboard.writeText(code.value)
+  showCopied()
+}
+
+async function importSnippets() {
+  try {
+    const text = await navigator.clipboard.readText()
+    if (!text.trim()) {
+      showImportError()
+      return
+    }
+    try {
+      JSON5.parse(text)
+    } catch {
+      showImportError()
+      return
+    }
+    code.value = text
+    showImported()
+  } catch {
+    showImportError()
+  }
+}
+
+// ── Reset to defaults ──
+const { confirming: confirmingReset, trigger: triggerReset } =
+  useDoubleConfirm()
+
+function handleReset() {
+  triggerReset(() => {
+    code.value = DEFAULT_AISCRIPT_SNIPPETS
+    error.value = null
+  })
+}
+</script>
+
+<template>
+  <div :class="$style.content">
+    <aside v-if="files.length > 1" :class="$style.fileList">
+      <button
+        v-for="f in files"
+        :key="f"
+        class="_button"
+        :class="[$style.fileItem, { [$style.active]: f === currentFile }]"
+        @click="selectFile(f)"
+      >
+        <i class="ti ti-file-code" />
+        <span>{{ f }}</span>
+      </button>
+    </aside>
+
+    <div :class="$style.editorPanel">
+      <div :class="$style.codePanel">
+        <div :class="$style.codeHint">
+          VSCode 互換のスニペット — prefix で補完に出ます
+        </div>
+
+        <CodeEditor
+          v-model="code"
+          :language="lang"
+          :linter="jsonLinter"
+          :class="[$style.codeEditorWrap, { [$style.hasError]: error }]"
+          auto-height
+        />
+
+        <div v-if="statusText" :class="[$style.status, $style[statusClass]]">
+          <i
+            class="ti"
+            :class="
+              error ? 'ti-alert-triangle' : saved ? 'ti-check' : 'ti-loader-2'
+            "
+          />
+          {{ statusText }}
+        </div>
+      </div>
+
+      <div :class="$style.actions">
+        <div :class="$style.actionGroup">
+          <button
+            class="_button"
+            :class="[$style.actionBtn, $style.secondary, { [$style.feedback]: importedMessage || importError }]"
+            @click="importSnippets"
+          >
+            <i class="ti" :class="importError ? 'ti-alert-circle' : 'ti-clipboard-text'" />
+            {{ importError ? '無効' : importedMessage ? '読込済み' : 'インポート' }}
+          </button>
+          <button
+            class="_button"
+            :class="[$style.actionBtn, $style.secondary, { [$style.feedback]: copiedMessage }]"
+            @click="exportSnippets"
+          >
+            <i class="ti ti-clipboard-copy" />
+            {{ copiedMessage ? 'コピー済み' : 'エクスポート' }}
+          </button>
+        </div>
+        <button
+          class="_button"
+          :class="[$style.actionBtn, $style.danger, { [$style.confirming]: confirmingReset }]"
+          @click="handleReset"
+        >
+          <i class="ti ti-refresh" />
+          {{ confirmingReset ? '本当に戻す？' : 'デフォルトに戻す' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style module lang="scss">
+@use '@/styles/buttons' as *;
+
+.content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.fileList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 160px;
+  padding: 8px 6px;
+  border-right: 1px solid var(--nd-divider);
+  overflow-y: auto;
+  scrollbar-color: var(--nd-scrollbarHandle) transparent;
+  scrollbar-width: thin;
+}
+
+.fileItem {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: var(--nd-radius-sm);
+  font-size: 0.8em;
+  color: var(--nd-fg);
+  text-align: left;
+  transition: background var(--nd-duration-fast);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+
+  &.active {
+    background: var(--nd-accent-hover);
+    color: var(--nd-accent);
+  }
+
+  i {
+    flex-shrink: 0;
+    opacity: 0.7;
+  }
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.active {
+  /* modifier */
+}
+
+.editorPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.codePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.codeHint {
+  font-size: 0.75em;
+  opacity: 0.4;
+}
+
+.codeEditorWrap {
+  &.hasError {
+    box-shadow: 0 0 0 2px var(--nd-love);
+    border-radius: var(--nd-radius-sm);
+  }
+}
+
+.hasError {
+  /* modifier */
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75em;
+  color: var(--nd-fgMuted);
+  min-height: 20px;
+}
+
+.statusError {
+  color: var(--nd-love);
+}
+
+.statusSaved {
+  color: var(--nd-accent);
+}
+
+.actions {
+  @include action-bar;
+}
+.actionGroup {
+  @include action-group;
+}
+
+.actionBtn {
+  &.secondary {
+    @include btn-action;
+  }
+  &.danger {
+    @include btn-danger-ghost;
+  }
+}
+
+.secondary {
+  /* modifier */
+}
+.feedback {
+  /* modifier */
+}
+.danger {
+  /* modifier */
+}
+.confirming {
+  /* modifier */
+}
+</style>

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -125,9 +125,15 @@ async function importTasks() {
 const { confirming: confirmingReset, trigger: triggerReset } =
   useDoubleConfirm()
 
-function handleReset() {
-  triggerReset(() => {
+async function handleReset() {
+  triggerReset(async () => {
     code.value = defaultTasksJson5
+    try {
+      if (isTauri) await writeTasks(defaultTasksJson5)
+      tasksStore.setFromRaw(defaultTasksJson5)
+    } catch (e) {
+      useToast().show(`リセット失敗: ${(e as Error).message}`, 'error')
+    }
   })
 }
 </script>

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -1,15 +1,34 @@
 <script setup lang="ts">
 import { json as jsonLang } from '@codemirror/lang-json'
 import { type Diagnostic, linter } from '@codemirror/lint'
-import { computed, onMounted, ref, watch } from 'vue'
-import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
+import JSON5 from 'json5'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from 'vue'
+import EditorTabs from '@/components/common/EditorTabs.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
+import { useEditorTabs } from '@/composables/useEditorTabs'
 import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTasksStore } from '@/stores/tasks'
 import { useToast } from '@/stores/toast'
 import { parseTasks, TasksParseError } from '@/tasks/schema'
+import type { TaskDefinition, TaskInput } from '@/tasks/types'
 import { isTauri, readTasks, writeTasks } from '@/utils/settingsFs'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/deck/widgets/CodeEditor.vue'),
+)
+
+const props = defineProps<{
+  initialTab?: string
+}>()
 
 const lang = jsonLang()
 
@@ -36,27 +55,58 @@ const tasksLinter = linter(
 )
 
 const tasksStore = useTasksStore()
+
+// ── Tab management ──
+const { tab, containerRef: contentRef } = useEditorTabs(
+  ['visual', 'code'] as const,
+  (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+// ── State ──
 const code = ref('')
 const codeError = ref<string | null>(null)
-const saving = ref(false)
+const visualTasks = ref<TaskDefinition[]>([])
+const expanded = reactive<Record<string, boolean>>({})
 const loaded = ref(false)
+const saving = ref(false)
+let suppressSync = false
+
+function tasksToJson(tasks: TaskDefinition[]): string {
+  return JSON5.stringify({ version: 1, tasks }, null, 2)
+}
+
+function syncVisualFromCode(): boolean {
+  try {
+    const parsed = parseTasks(code.value)
+    suppressSync = true
+    visualTasks.value = parsed.tasks
+    nextTick(() => {
+      suppressSync = false
+    })
+    codeError.value = null
+    return true
+  } catch (e) {
+    codeError.value = e instanceof TasksParseError ? e.message : String(e)
+    return false
+  }
+}
 
 onMounted(async () => {
-  if (!isTauri) {
-    code.value = defaultTasksJson5
-    loaded.value = true
-    return
-  }
-  try {
-    const content = await readTasks()
-    code.value = content || defaultTasksJson5
-  } catch (e) {
-    useToast().show(`tasks.json5 読込失敗: ${(e as Error).message}`, 'error')
-  } finally {
-    loaded.value = true
-  }
+  const initial = isTauri
+    ? await readTasks().catch((e) => {
+        useToast().show(
+          `tasks.json5 読込失敗: ${(e as Error).message}`,
+          'error',
+        )
+        return ''
+      })
+    : ''
+  code.value = initial || defaultTasksJson5
+  syncVisualFromCode()
+  loaded.value = true
 })
 
+// ── Code → Visual: live validation ──
 let validateTimer: ReturnType<typeof setTimeout> | null = null
 watch(code, (v) => {
   if (validateTimer) clearTimeout(validateTimer)
@@ -74,18 +124,28 @@ watch(code, (v) => {
   }, 400)
 })
 
-const taskCount = computed(() => tasksStore.definitions.length)
+// ── Visual → Code + persist (debounced) ──
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+watch(
+  visualTasks,
+  (v) => {
+    if (suppressSync || !loaded.value) return
+    const next = tasksToJson(v)
+    if (next !== code.value) code.value = next
+    if (saveTimer) clearTimeout(saveTimer)
+    saveTimer = setTimeout(() => {
+      void persist()
+    }, 600)
+  },
+  { deep: true },
+)
 
-async function save() {
+async function persist() {
   if (codeError.value) return
   saving.value = true
   try {
-    await writeTasks(code.value)
+    if (isTauri) await writeTasks(code.value)
     tasksStore.setFromRaw(code.value)
-    useToast().show(
-      `tasks.json5 を保存しました (${taskCount.value} タスク)`,
-      'success',
-    )
   } catch (e) {
     useToast().show(`保存失敗: ${(e as Error).message}`, 'error')
   } finally {
@@ -93,6 +153,147 @@ async function save() {
   }
 }
 
+const taskCount = computed(() => visualTasks.value.length)
+
+// ── Visual edit helpers ──
+function uniqueId(base: string): string {
+  const ids = new Set(visualTasks.value.map((t) => t.id))
+  if (!ids.has(base)) return base
+  let i = 2
+  while (ids.has(`${base}-${i}`)) i++
+  return `${base}-${i}`
+}
+
+function addTask() {
+  const id = uniqueId('new-task')
+  visualTasks.value.push({
+    id,
+    label: '新しいタスク',
+    action: { type: 'api', method: 'i' },
+  })
+  expanded[id] = true
+}
+
+function removeTask(index: number) {
+  const t = visualTasks.value[index]
+  if (!t) return
+  visualTasks.value.splice(index, 1)
+  delete expanded[t.id]
+}
+
+function moveTask(index: number, delta: number) {
+  const next = index + delta
+  if (next < 0 || next >= visualTasks.value.length) return
+  const arr = [...visualTasks.value]
+  const [moved] = arr.splice(index, 1)
+  if (moved) arr.splice(next, 0, moved)
+  visualTasks.value = arr
+}
+
+function toggleExpanded(id: string) {
+  expanded[id] = !expanded[id]
+}
+
+function paramsToText(t: TaskDefinition): string {
+  return t.action.params ? JSON5.stringify(t.action.params, null, 2) : ''
+}
+
+function setParamsFromText(t: TaskDefinition, text: string) {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    delete t.action.params
+    return
+  }
+  try {
+    const parsed = JSON5.parse(trimmed)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      t.action.params = parsed as Record<string, unknown>
+    }
+  } catch {
+    /* ignore parse error during edit */
+  }
+}
+
+function paramsErrorOf(text: string): string | null {
+  const trimmed = text.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON5.parse(trimmed)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return 'オブジェクト ({}) が必要です'
+    }
+    return null
+  } catch (e) {
+    return (e as Error).message
+  }
+}
+
+function addInput(t: TaskDefinition) {
+  if (!t.inputs) t.inputs = []
+  t.inputs.push({
+    id: `input${t.inputs.length + 1}`,
+    type: 'text',
+    prompt: '入力してください',
+  })
+}
+
+function removeInput(t: TaskDefinition, idx: number) {
+  if (!t.inputs) return
+  t.inputs.splice(idx, 1)
+  if (t.inputs.length === 0) delete t.inputs
+}
+
+function changeInputType(
+  t: TaskDefinition,
+  idx: number,
+  type: 'text' | 'pick',
+) {
+  if (!t.inputs) return
+  const cur = t.inputs[idx]
+  if (!cur || cur.type === type) return
+  const base = { id: cur.id, prompt: cur.prompt, default: cur.default }
+  t.inputs[idx] =
+    type === 'text'
+      ? ({ ...base, type: 'text' } as TaskInput)
+      : ({ ...base, type: 'pick', options: [] } as TaskInput)
+}
+
+function pickOptionsToText(input: TaskInput): string {
+  if (input.type !== 'pick') return ''
+  return input.options.join('\n')
+}
+
+function setPickOptions(input: TaskInput, text: string) {
+  if (input.type !== 'pick') return
+  input.options = text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function accountIdMode(t: TaskDefinition): 'active' | 'first' | 'specific' {
+  if (t.accountId === undefined) return 'active'
+  if (t.accountId === null) return 'first'
+  return 'specific'
+}
+
+function setAccountIdMode(
+  t: TaskDefinition,
+  mode: 'active' | 'first' | 'specific',
+) {
+  if (mode === 'active') delete t.accountId
+  else if (mode === 'first') t.accountId = null
+  else if (typeof t.accountId !== 'string') t.accountId = ''
+}
+
+// ── Code tab actions ──
+function applyFromCode() {
+  if (syncVisualFromCode()) {
+    tab.value = 'visual'
+  }
+}
+
+// ── Footer actions ──
 const {
   copied: copiedMessage,
   imported: importedMessage,
@@ -102,9 +303,13 @@ const {
   showImportError,
 } = useClipboardFeedback()
 
-function exportTasks() {
-  navigator.clipboard.writeText(code.value)
-  showCopied()
+async function exportTasks() {
+  try {
+    await navigator.clipboard.writeText(code.value)
+    showCopied()
+  } catch {
+    /* clipboard denied */
+  }
 }
 
 async function importTasks() {
@@ -116,6 +321,7 @@ async function importTasks() {
     }
     parseTasks(text)
     code.value = text
+    syncVisualFromCode()
     showImported()
   } catch {
     showImportError()
@@ -125,9 +331,10 @@ async function importTasks() {
 const { confirming: confirmingReset, trigger: triggerReset } =
   useDoubleConfirm()
 
-async function handleReset() {
+function handleReset() {
   triggerReset(async () => {
     code.value = defaultTasksJson5
+    syncVisualFromCode()
     try {
       if (isTauri) await writeTasks(defaultTasksJson5)
       tasksStore.setFromRaw(defaultTasksJson5)
@@ -139,10 +346,248 @@ async function handleReset() {
 </script>
 
 <template>
-  <div :class="$style.content">
-    <div :class="$style.codePanel">
-      <div :class="$style.codeHint">
+  <div ref="contentRef" :class="$style.editor">
+    <EditorTabs
+      v-model="tab"
+      :tabs="[
+        { value: 'visual', icon: 'list-check', label: 'ビジュアル' },
+        { value: 'code', icon: 'code', label: 'コード' },
+      ]"
+    />
+
+    <!-- Visual tab -->
+    <div v-show="tab === 'visual'" :class="$style.visualPanel">
+      <div :class="$style.visualHint">
         宣言したタスクはコマンドパレットと Task Runner カラムから実行できます。
+      </div>
+
+      <div :class="$style.taskList">
+        <div
+          v-for="(t, i) in visualTasks"
+          :key="t.id + i"
+          :class="[$style.taskCard, { [$style.expanded]: expanded[t.id] }]"
+        >
+          <div :class="$style.taskHeader" @click="toggleExpanded(t.id)">
+            <i class="ti ti-chevron-right" :class="$style.chevron" />
+            <div :class="$style.taskHeaderBody">
+              <span :class="$style.taskLabel">{{ t.label || '(無題)' }}</span>
+              <span :class="$style.taskMeta">
+                <code :class="$style.method">{{ t.action.method }}</code>
+                <span v-if="t.inputs?.length" :class="$style.inputsBadge" title="入力を求める">
+                  <i class="ti ti-keyboard" />{{ t.inputs.length }}
+                </span>
+              </span>
+            </div>
+            <div :class="$style.taskActions" @click.stop>
+              <button
+                class="_button"
+                :class="$style.iconBtn"
+                title="上へ"
+                :disabled="i === 0"
+                @click="moveTask(i, -1)"
+              >
+                <i class="ti ti-chevron-up" />
+              </button>
+              <button
+                class="_button"
+                :class="$style.iconBtn"
+                title="下へ"
+                :disabled="i === visualTasks.length - 1"
+                @click="moveTask(i, 1)"
+              >
+                <i class="ti ti-chevron-down" />
+              </button>
+              <button
+                class="_button"
+                :class="[$style.iconBtn, $style.dangerBtn]"
+                title="削除"
+                @click="removeTask(i)"
+              >
+                <i class="ti ti-trash" />
+              </button>
+            </div>
+          </div>
+
+          <div v-if="expanded[t.id]" :class="$style.taskBody">
+            <label :class="$style.field">
+              <span :class="$style.fieldLabel">ID</span>
+              <input
+                v-model="t.id"
+                type="text"
+                :class="$style.input"
+                pattern="[\w-]+"
+                placeholder="my-task"
+              />
+            </label>
+            <label :class="$style.field">
+              <span :class="$style.fieldLabel">ラベル</span>
+              <input
+                v-model="t.label"
+                type="text"
+                :class="$style.input"
+                placeholder="UI 表示名"
+              />
+            </label>
+            <label :class="$style.field">
+              <span :class="$style.fieldLabel">説明</span>
+              <input
+                :value="t.description ?? ''"
+                type="text"
+                :class="$style.input"
+                placeholder="任意"
+                @input="(e) => {
+                  const v = (e.target as HTMLInputElement).value
+                  if (v) t.description = v
+                  else delete t.description
+                }"
+              />
+            </label>
+
+            <fieldset :class="$style.fieldset">
+              <legend :class="$style.legend">アカウント</legend>
+              <label :class="$style.radioRow">
+                <input
+                  type="radio"
+                  :checked="accountIdMode(t) === 'active'"
+                  @change="setAccountIdMode(t, 'active')"
+                />
+                現在アクティブ
+              </label>
+              <label :class="$style.radioRow">
+                <input
+                  type="radio"
+                  :checked="accountIdMode(t) === 'first'"
+                  @change="setAccountIdMode(t, 'first')"
+                />
+                最初のログイン済み
+              </label>
+              <label :class="$style.radioRow">
+                <input
+                  type="radio"
+                  :checked="accountIdMode(t) === 'specific'"
+                  @change="setAccountIdMode(t, 'specific')"
+                />
+                指定 ID
+                <input
+                  v-if="accountIdMode(t) === 'specific'"
+                  v-model="t.accountId as string"
+                  type="text"
+                  :class="[$style.input, $style.inlineInput]"
+                  placeholder="accountId"
+                />
+              </label>
+            </fieldset>
+
+            <fieldset :class="$style.fieldset">
+              <legend :class="$style.legend">アクション (api)</legend>
+              <label :class="$style.field">
+                <span :class="$style.fieldLabel">method</span>
+                <input
+                  v-model="t.action.method"
+                  type="text"
+                  :class="[$style.input, $style.mono]"
+                  placeholder="notes/create"
+                />
+              </label>
+              <label :class="$style.field">
+                <span :class="$style.fieldLabel">params (JSON5)</span>
+                <textarea
+                  :value="paramsToText(t)"
+                  :class="[$style.input, $style.textarea, $style.mono, { [$style.hasError]: paramsErrorOf(paramsToText(t)) }]"
+                  rows="4"
+                  placeholder="{ visibility: 'home' }"
+                  @input="(e) => setParamsFromText(t, (e.target as HTMLTextAreaElement).value)"
+                />
+              </label>
+            </fieldset>
+
+            <fieldset :class="$style.fieldset">
+              <legend :class="$style.legend">
+                入力フィールド
+                <button
+                  class="_button"
+                  :class="$style.smallBtn"
+                  @click="addInput(t)"
+                >
+                  <i class="ti ti-plus" /> 追加
+                </button>
+              </legend>
+              <div
+                v-for="(input, ii) in t.inputs ?? []"
+                :key="ii"
+                :class="$style.inputItem"
+              >
+                <div :class="$style.inputItemRow">
+                  <select
+                    :value="input.type"
+                    :class="$style.input"
+                    @change="(e) => changeInputType(t, ii, (e.target as HTMLSelectElement).value as 'text' | 'pick')"
+                  >
+                    <option value="text">text</option>
+                    <option value="pick">pick</option>
+                  </select>
+                  <input
+                    v-model="input.id"
+                    type="text"
+                    :class="$style.input"
+                    placeholder="id"
+                  />
+                  <button
+                    class="_button"
+                    :class="[$style.iconBtn, $style.dangerBtn]"
+                    title="削除"
+                    @click="removeInput(t, ii)"
+                  >
+                    <i class="ti ti-x" />
+                  </button>
+                </div>
+                <input
+                  v-model="input.prompt"
+                  type="text"
+                  :class="$style.input"
+                  placeholder="プロンプト"
+                />
+                <textarea
+                  v-if="input.type === 'pick'"
+                  :value="pickOptionsToText(input)"
+                  :class="[$style.input, $style.textarea]"
+                  rows="3"
+                  placeholder="選択肢 (1行に1つ)"
+                  @input="(e) => setPickOptions(input, (e.target as HTMLTextAreaElement).value)"
+                />
+                <input
+                  :value="input.default ?? ''"
+                  type="text"
+                  :class="$style.input"
+                  placeholder="default (任意)"
+                  @input="(e) => {
+                    const v = (e.target as HTMLInputElement).value
+                    if (v) input.default = v
+                    else delete input.default
+                  }"
+                />
+              </div>
+              <div v-if="!t.inputs?.length" :class="$style.inputsEmpty">
+                入力なし — タスクは即座に実行されます
+              </div>
+            </fieldset>
+          </div>
+        </div>
+
+        <div v-if="visualTasks.length === 0" :class="$style.emptyState">
+          タスクがまだありません
+        </div>
+
+        <button class="_button" :class="$style.addBtn" @click="addTask">
+          <i class="ti ti-plus" />
+          タスクを追加
+        </button>
+      </div>
+    </div>
+
+    <!-- Code tab -->
+    <div v-show="tab === 'code'" :class="$style.codePanel">
+      <div :class="$style.codeHint">
         変数: <code>${'$'}{input:&lt;id&gt;}</code>
         <code>${'$'}{account.id}</code>
         <code>${'$'}{account.host}</code>
@@ -160,19 +605,20 @@ async function handleReset() {
       </div>
       <div v-else-if="loaded && code.trim()" :class="$style.codeSuccess">
         <i class="ti ti-check" />
-        {{ taskCount }} タスクを解析済み
+        {{ taskCount }} タスクを解析済み{{ saving ? ' · 保存中…' : '' }}
       </div>
       <button
         class="_button"
         :class="$style.codeApplyBtn"
-        :disabled="!!codeError || saving"
-        @click="save"
+        :disabled="!!codeError"
+        @click="applyFromCode"
       >
-        <i class="ti" :class="saving ? 'ti-loader-2 nd-spin' : 'ti-device-floppy'" />
-        {{ saving ? '保存中' : '保存' }}
+        <i class="ti ti-refresh" />
+        ビジュアルに同期
       </button>
     </div>
 
+    <!-- Actions (footer) -->
     <div :class="$style.actions">
       <div :class="$style.actionGroup">
         <button
@@ -207,13 +653,306 @@ async function handleReset() {
 <style lang="scss" module>
 @use '@/styles/buttons' as *;
 
-.content {
+.editor {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  overflow: hidden;
 }
+
+// ── Visual tab ──
+
+.visualPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.visualHint {
+  padding: 10px 12px 4px;
+  font-size: 0.75em;
+  opacity: 0.55;
+}
+
+.taskList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 12px;
+}
+
+.taskCard {
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-panel);
+  overflow: hidden;
+  transition: border-color var(--nd-duration-base);
+
+  &.expanded {
+    border-color: var(--nd-accent);
+  }
+}
+
+.taskHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+  user-select: none;
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.chevron {
+  flex-shrink: 0;
+  opacity: 0.5;
+  transition: transform var(--nd-duration-base);
+
+  .expanded & {
+    transform: rotate(90deg);
+  }
+}
+
+.taskHeaderBody {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.taskLabel {
+  font-weight: 600;
+  font-size: 0.9em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.taskMeta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75em;
+  opacity: 0.6;
+}
+
+.method {
+  font-family: var(--nd-font-mono, monospace);
+}
+
+.inputsBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: var(--nd-buttonBg);
+}
+
+.taskActions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.iconBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  opacity: 0.55;
+  transition:
+    opacity var(--nd-duration-fast),
+    background var(--nd-duration-fast);
+
+  &:hover:not(:disabled) {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+
+  &:disabled {
+    opacity: 0.2;
+    cursor: not-allowed;
+  }
+}
+
+.dangerBtn:hover:not(:disabled) {
+  color: var(--nd-love, #ec4137);
+}
+
+.taskBody {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid var(--nd-divider);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.fieldLabel {
+  font-size: 0.7em;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.input {
+  width: 100%;
+  padding: 5px 8px;
+  font-size: 0.85em;
+  background: var(--nd-bg);
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  outline: none;
+  transition: border-color var(--nd-duration-base);
+
+  &:focus {
+    border-color: var(--nd-accent);
+  }
+
+  &.hasError {
+    border-color: var(--nd-love, #ec4137);
+  }
+}
+
+.inlineInput {
+  margin-left: 6px;
+  width: auto;
+  flex: 1;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 60px;
+  font-family: inherit;
+}
+
+.mono {
+  font-family: var(--nd-font-mono, monospace);
+}
+
+.fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-bg);
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 4px;
+  font-size: 0.7em;
+  font-weight: bold;
+  opacity: 0.65;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.smallBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 6px;
+  font-size: 0.75em;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  opacity: 0.7;
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.radioRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.inputItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 8px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-panel);
+}
+
+.inputItemRow {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+
+  & > select.input {
+    width: auto;
+    flex-shrink: 0;
+  }
+}
+
+.inputsEmpty {
+  font-size: 0.75em;
+  opacity: 0.5;
+  text-align: center;
+  padding: 6px;
+}
+
+.emptyState {
+  padding: 18px;
+  text-align: center;
+  font-size: 0.8em;
+  opacity: 0.55;
+}
+
+.addBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px;
+  margin-top: 4px;
+  border: 1px dashed var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  font-size: 0.85em;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  transition:
+    border-color var(--nd-duration-base),
+    opacity var(--nd-duration-base);
+
+  &:hover {
+    border-color: var(--nd-accent);
+    color: var(--nd-accent);
+    opacity: 1;
+  }
+}
+
+.expanded { /* modifier */ }
+
+// ── Code tab ──
 
 .codePanel {
   display: flex;
@@ -247,8 +986,6 @@ async function handleReset() {
   }
 }
 
-.hasError { /* modifier */ }
-
 .errorMessage {
   display: flex;
   align-items: center;
@@ -272,6 +1009,8 @@ async function handleReset() {
 
 .codeApplyBtn { @include btn-secondary; }
 
+// ── Actions (footer) ──
+
 .actions { @include action-bar; }
 .actionGroup { @include action-group; }
 
@@ -284,4 +1023,5 @@ async function handleReset() {
 .feedback { /* modifier */ }
 .danger { /* modifier */ }
 .confirming { /* modifier */ }
+.hasError { /* modifier */ }
 </style>

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -19,7 +19,11 @@ import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTasksStore } from '@/stores/tasks'
 import { useToast } from '@/stores/toast'
 import { parseTasks, TasksParseError } from '@/tasks/schema'
-import type { TaskDefinition, TaskInput } from '@/tasks/types'
+import {
+  TASKS_FILE_VERSION,
+  type TaskDefinition,
+  type TaskInput,
+} from '@/tasks/types'
 import { isTauri, readTasks, writeTasks } from '@/utils/settingsFs'
 
 const CodeEditor = defineAsyncComponent(
@@ -72,7 +76,7 @@ const saving = ref(false)
 let suppressSync = false
 
 function tasksToJson(tasks: TaskDefinition[]): string {
-  return JSON5.stringify({ version: 1, tasks }, null, 2)
+  return JSON5.stringify({ version: TASKS_FILE_VERSION, tasks }, null, 2)
 }
 
 function syncVisualFromCode(): boolean {

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -15,6 +15,7 @@ import EditorTabs from '@/components/common/EditorTabs.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { usePointerReorder } from '@/composables/usePointerReorder'
 import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTasksStore } from '@/stores/tasks'
 import { useToast } from '@/stores/toast'
@@ -186,14 +187,17 @@ function removeTask(index: number) {
   delete expanded[t.id]
 }
 
-function moveTask(index: number, delta: number) {
-  const next = index + delta
-  if (next < 0 || next >= visualTasks.value.length) return
-  const arr = [...visualTasks.value]
-  const [moved] = arr.splice(index, 1)
-  if (moved) arr.splice(next, 0, moved)
-  visualTasks.value = arr
-}
+const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
+  dataAttr: 'task-idx',
+  onReorder(fromIdx, toIdx) {
+    const arr = [...visualTasks.value]
+    const [moved] = arr.splice(fromIdx, 1)
+    if (moved) {
+      arr.splice(toIdx, 0, moved)
+      visualTasks.value = arr
+    }
+  },
+})
 
 function toggleExpanded(id: string) {
   expanded[id] = !expanded[id]
@@ -427,9 +431,21 @@ function handleReset() {
         <div
           v-for="(t, i) in visualTasks"
           :key="t.id + i"
-          :class="[$style.taskCard, { [$style.expanded]: expanded[t.id] }]"
+          :data-task-idx="i"
+          :class="[$style.taskCard, {
+            [$style.expanded]: expanded[t.id],
+            [$style.dragging]: dragFromIndex === i,
+            [$style.dragOver]: dragOverIndex === i,
+          }]"
         >
           <div :class="$style.taskHeader" @click="toggleExpanded(t.id)">
+            <i
+              class="ti ti-grip-vertical"
+              :class="$style.grip"
+              title="ドラッグで並び替え"
+              @pointerdown="startDrag(i, $event)"
+              @click.stop
+            />
             <i class="ti ti-chevron-right" :class="$style.chevron" />
             <div :class="$style.taskHeaderBody">
               <span :class="$style.taskLabel">
@@ -446,24 +462,6 @@ function handleReset() {
               </span>
             </div>
             <div :class="$style.taskActions" @click.stop>
-              <button
-                class="_button"
-                :class="$style.iconBtn"
-                title="上へ"
-                :disabled="i === 0"
-                @click="moveTask(i, -1)"
-              >
-                <i class="ti ti-chevron-up" />
-              </button>
-              <button
-                class="_button"
-                :class="$style.iconBtn"
-                title="下へ"
-                :disabled="i === visualTasks.length - 1"
-                @click="moveTask(i, 1)"
-              >
-                <i class="ti ti-chevron-down" />
-              </button>
               <button
                 class="_button"
                 :class="[$style.iconBtn, $style.dangerBtn]"
@@ -831,10 +829,38 @@ function handleReset() {
   border-radius: var(--nd-radius-sm);
   background: var(--nd-panel);
   overflow: hidden;
-  transition: border-color var(--nd-duration-base);
+  transition:
+    border-color var(--nd-duration-base),
+    opacity var(--nd-duration-base);
 
   &.expanded {
     border-color: var(--nd-accent);
+  }
+
+  &.dragging {
+    opacity: 0.3;
+  }
+
+  &.dragOver {
+    outline: 2px solid var(--nd-accent);
+    outline-offset: 1px;
+  }
+}
+
+.grip {
+  flex-shrink: 0;
+  opacity: 0.35;
+  cursor: grab;
+  touch-action: none;
+  padding: 2px;
+  transition: opacity var(--nd-duration-fast);
+
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:active {
+    cursor: grabbing;
   }
 }
 

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -23,6 +23,7 @@ import {
   TASKS_FILE_VERSION,
   type TaskDefinition,
   type TaskInput,
+  type TaskPresentation,
 } from '@/tasks/types'
 import { isTauri, readTasks, writeTasks } from '@/utils/settingsFs'
 
@@ -290,6 +291,59 @@ function setAccountIdMode(
   else if (typeof t.accountId !== 'string') t.accountId = ''
 }
 
+function setOptionalString<K extends 'detail' | 'icon' | 'group'>(
+  t: TaskDefinition,
+  key: K,
+  value: string,
+) {
+  const v = value.trim()
+  if (v) t[key] = v
+  else delete t[key]
+}
+
+function setFlag<K extends 'pinned' | 'isDefault'>(
+  t: TaskDefinition,
+  key: K,
+  value: boolean,
+) {
+  if (value) t[key] = true
+  else delete t[key]
+}
+
+function setIsDefault(t: TaskDefinition, value: boolean) {
+  if (value) {
+    for (const other of visualTasks.value) {
+      if (other !== t) delete other.isDefault
+    }
+    t.isDefault = true
+  } else {
+    delete t.isDefault
+  }
+}
+
+function setPresentation<K extends keyof TaskPresentation>(
+  t: TaskDefinition,
+  key: K,
+  value: TaskPresentation[K] | null,
+) {
+  if (value === null) {
+    if (!t.presentation) return
+    delete t.presentation[key]
+    if (Object.keys(t.presentation).length === 0) delete t.presentation
+    return
+  }
+  if (!t.presentation) t.presentation = {}
+  t.presentation[key] = value
+}
+
+const groupSuggestions = computed<string[]>(() => {
+  const s = new Set<string>()
+  for (const t of visualTasks.value) {
+    if (t.group) s.add(t.group)
+  }
+  return [...s].sort()
+})
+
 // ── Code tab actions ──
 function applyFromCode() {
   if (syncVisualFromCode()) {
@@ -365,6 +419,10 @@ function handleReset() {
         宣言したタスクはコマンドパレットと Task Runner カラムから実行できます。
       </div>
 
+      <datalist id="nd-task-groups">
+        <option v-for="g in groupSuggestions" :key="g" :value="g" />
+      </datalist>
+
       <div :class="$style.taskList">
         <div
           v-for="(t, i) in visualTasks"
@@ -374,9 +432,14 @@ function handleReset() {
           <div :class="$style.taskHeader" @click="toggleExpanded(t.id)">
             <i class="ti ti-chevron-right" :class="$style.chevron" />
             <div :class="$style.taskHeaderBody">
-              <span :class="$style.taskLabel">{{ t.label || '(無題)' }}</span>
+              <span :class="$style.taskLabel">
+                <i v-if="t.pinned" class="ti ti-pin-filled" :class="$style.pinIcon" title="Pinned" />
+                <i v-if="t.isDefault" class="ti ti-player-play-filled" :class="$style.defaultIcon" title="デフォルト実行対象" />
+                {{ t.label || '(無題)' }}
+              </span>
               <span :class="$style.taskMeta">
                 <code :class="$style.method">{{ t.action.method }}</code>
+                <span v-if="t.group" :class="$style.groupBadge">{{ t.group }}</span>
                 <span v-if="t.inputs?.length" :class="$style.inputsBadge" title="入力を求める">
                   <i class="ti ti-keyboard" />{{ t.inputs.length }}
                 </span>
@@ -438,7 +501,7 @@ function handleReset() {
                 :value="t.description ?? ''"
                 type="text"
                 :class="$style.input"
-                placeholder="任意"
+                placeholder="任意 (ツールチップ用の長文)"
                 @input="(e) => {
                   const v = (e.target as HTMLInputElement).value
                   if (v) t.description = v
@@ -446,6 +509,62 @@ function handleReset() {
                 }"
               />
             </label>
+            <label :class="$style.field">
+              <span :class="$style.fieldLabel">detail</span>
+              <input
+                :value="t.detail ?? ''"
+                type="text"
+                :class="$style.input"
+                placeholder="ラベル下の 1 行補足 (任意)"
+                @input="(e) => setOptionalString(t, 'detail', (e.target as HTMLInputElement).value)"
+              />
+            </label>
+
+            <div :class="$style.row">
+              <label :class="[$style.field, $style.grow]">
+                <span :class="$style.fieldLabel">group</span>
+                <input
+                  :value="t.group ?? ''"
+                  type="text"
+                  :class="$style.input"
+                  list="nd-task-groups"
+                  placeholder="自由文字列 (任意)"
+                  @input="(e) => setOptionalString(t, 'group', (e.target as HTMLInputElement).value)"
+                />
+              </label>
+              <label :class="[$style.field, $style.grow]">
+                <span :class="$style.fieldLabel">icon</span>
+                <input
+                  :value="t.icon ?? ''"
+                  type="text"
+                  :class="[$style.input, $style.mono]"
+                  placeholder="player-play"
+                  pattern="[a-z0-9][a-z0-9-]*"
+                  @input="(e) => setOptionalString(t, 'icon', (e.target as HTMLInputElement).value)"
+                />
+              </label>
+            </div>
+
+            <div :class="$style.row">
+              <label :class="$style.checkboxRow">
+                <input
+                  type="checkbox"
+                  :checked="t.pinned === true"
+                  @change="(e) => setFlag(t, 'pinned', (e.target as HTMLInputElement).checked)"
+                />
+                <i class="ti ti-pin-filled" :class="$style.inlineIcon" />
+                Pinned
+              </label>
+              <label :class="$style.checkboxRow">
+                <input
+                  type="checkbox"
+                  :checked="t.isDefault === true"
+                  @change="(e) => setIsDefault(t, (e.target as HTMLInputElement).checked)"
+                />
+                <i class="ti ti-player-play-filled" :class="$style.inlineIcon" />
+                デフォルト実行対象 (1 件のみ)
+              </label>
+            </div>
 
             <fieldset :class="$style.fieldset">
               <legend :class="$style.legend">アカウント</legend>
@@ -502,6 +621,26 @@ function handleReset() {
                   placeholder="{ visibility: 'home' }"
                   @input="(e) => setParamsFromText(t, (e.target as HTMLTextAreaElement).value)"
                 />
+              </label>
+            </fieldset>
+
+            <fieldset :class="$style.fieldset">
+              <legend :class="$style.legend">表示オプション (presentation)</legend>
+              <label :class="$style.checkboxRow">
+                <input
+                  type="checkbox"
+                  :checked="t.presentation?.revealOnRun !== false"
+                  @change="(e) => setPresentation(t, 'revealOnRun', (e.target as HTMLInputElement).checked ? null : false)"
+                />
+                実行時に履歴で自動選択する (revealOnRun)
+              </label>
+              <label :class="$style.checkboxRow">
+                <input
+                  type="checkbox"
+                  :checked="t.presentation?.clearHistoryOnRun === true"
+                  @change="(e) => setPresentation(t, 'clearHistoryOnRun', (e.target as HTMLInputElement).checked ? true : null)"
+                />
+                実行時に過去履歴をクリア (clearHistoryOnRun)
               </label>
             </fieldset>
 
@@ -731,11 +870,24 @@ function handleReset() {
 }
 
 .taskLabel {
+  display: flex;
+  align-items: center;
+  gap: 5px;
   font-weight: 600;
   font-size: 0.9em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.pinIcon {
+  font-size: 0.85em;
+  color: var(--nd-accent);
+}
+
+.defaultIcon {
+  font-size: 0.85em;
+  color: var(--nd-mfmSuccess, #4a8);
 }
 
 .taskMeta {
@@ -744,6 +896,14 @@ function handleReset() {
   gap: 6px;
   font-size: 0.75em;
   opacity: 0.6;
+}
+
+.groupBadge {
+  padding: 0 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
+  color: var(--nd-accent);
+  opacity: 0.9;
 }
 
 .method {
@@ -894,6 +1054,30 @@ function handleReset() {
   gap: 6px;
   font-size: 0.85em;
   cursor: pointer;
+}
+
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.85em;
+  cursor: pointer;
+}
+
+.row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.grow {
+  flex: 1;
+  min-width: 120px;
+}
+
+.inlineIcon {
+  font-size: 0.9em;
+  opacity: 0.7;
 }
 
 .inputItem {

--- a/src/defaults/keybindings.json5
+++ b/src/defaults/keybindings.json5
@@ -81,6 +81,10 @@
     shortcuts: [{ key: "j", ctrl: true, shift: true, scope: "global" }],
   },
   {
+    commandId: "tasks.run-default",
+    shortcuts: [{ key: "b", ctrl: true, alt: true, scope: "global" }],
+  },
+  {
     commandId: "plugins",
     shortcuts: [{ key: "x", ctrl: true, shift: true, scope: "global" }],
   },

--- a/src/defaults/navbar.json5
+++ b/src/defaults/navbar.json5
@@ -2,10 +2,10 @@
 // ナビバー構成
 [
   { type: 'notifications', accountId: null },
-  { type: 'followRequests', accountId: null },
   { type: 'mentions', accountId: null },
   { type: 'specified', accountId: null },
   { type: 'chat', accountId: null },
+  { type: 'followRequests', accountId: null },
   { type: 'search', accountId: null },
   { type: 'lookup', accountId: null },
   { type: 'pluginManager', accountId: null },

--- a/src/defaults/navbar.json5
+++ b/src/defaults/navbar.json5
@@ -8,7 +8,5 @@
   { type: 'chat', accountId: null },
   { type: 'search', accountId: null },
   { type: 'lookup', accountId: null },
-  { type: 'streamInspector', accountId: null },
   { type: 'pluginManager', accountId: null },
-  { type: 'taskRunner', accountId: null },
 ]

--- a/src/defaults/tasks.json5
+++ b/src/defaults/tasks.json5
@@ -32,9 +32,8 @@
 //              (2 件目以降は読み込み時に自動で外れる)
 //
 // ─ presentation (任意) ─
-//   revealOnRun        実行時に履歴パネルへ自動切替 (default: true)
+//   revealOnRun        実行時に履歴パネルで run を自動選択 (default: true)
 //   clearHistoryOnRun  実行時に過去履歴をクリア (default: false)
-//   focusInput         input ダイアログを自動フォーカス (default: true)
 //
 // ─ レシピ設計方針 ─
 //   デフォルトはすべて「押すだけ・入力ダイアログなし・即結果返却」型。

--- a/src/defaults/tasks.json5
+++ b/src/defaults/tasks.json5
@@ -23,6 +23,19 @@
 //   null   → 最初のログイン済みアカウントで実行
 //   "<id>" → 明示指定 (portable ID ではなく内部 accountId)
 //
+// ─ 表示メタ (任意) ─
+//   detail     label の直下に出る 1 行補足 (VSCode tasks の detail 相当)
+//   icon       Tabler icon 名 (kebab-case, 先頭 'ti-' 無し)。例: 'user'
+//   group      自由文字列の分類。同じ group のタスクはセクションにまとまる
+//   pinned     true なら最上段の "Pinned" セクションへ昇格
+//   isDefault  true で「デフォルトタスク」。ファイル全体で 1 件のみ有効
+//              (2 件目以降は読み込み時に自動で外れる)
+//
+// ─ presentation (任意) ─
+//   revealOnRun        実行時に履歴パネルへ自動切替 (default: true)
+//   clearHistoryOnRun  実行時に過去履歴をクリア (default: false)
+//   focusInput         input ダイアログを自動フォーカス (default: true)
+//
 // ─ レシピ設計方針 ─
 //   デフォルトはすべて「押すだけ・入力ダイアログなし・即結果返却」型。
 //   NoteDeck のアプリトークンが要求しているスコープ
@@ -41,6 +54,7 @@
       description: '自分のユーザーオブジェクトをそのまま履歴に残す (debug / 確認用)',
       group: 'Account',
       icon: 'user',
+      isDefault: true, // "デフォルトタスク" の初期サンプル
       action: {
         type: 'api',
         method: 'i',

--- a/src/defaults/tasks.json5
+++ b/src/defaults/tasks.json5
@@ -6,7 +6,7 @@
 //
 // ─ 変数 ─
 //   ${input:<id>}   inputs で収集した値
-//   ${account.id}   実行時の accountId
+//   ${account.id}   実行時の accountId (NoteDeck 内部 ID。Misskey の userId ではない)
 //   ${account.host} 実行時のサーバーホスト
 //
 // ─ action ─
@@ -22,75 +22,65 @@
 //   未指定 → 現在アクティブなアカウントで実行
 //   null   → 最初のログイン済みアカウントで実行
 //   "<id>" → 明示指定 (portable ID ではなく内部 accountId)
+//
+// ─ レシピ設計方針 ─
+//   デフォルトはすべて「押すだけ・入力ダイアログなし・即結果返却」型。
+//   NoteDeck のアプリトークンが要求しているスコープ
+//   (read/write:account, notifications, reactions, favorites, drive,
+//    following, channels, chat, pages, gallery, flash; write:notes/votes)
+//   の範囲内で動く API のみを採用。
+//   既存カラム (Timeline / Notifications / Search / Drive / ServerInfo 等) で
+//   完結する操作は重複を避ける。
 {
   version: 1,
   tasks: [
     {
-      id: 'quick-post',
-      label: 'クイック投稿',
-      description: '本文を入力してホーム投稿',
-      inputs: [
-        { id: 'body', type: 'text', prompt: '本文' },
-        {
-          id: 'visibility',
-          type: 'pick',
-          prompt: '公開範囲',
-          options: ['public', 'home', 'followers'],
-          default: 'home',
-        },
-      ],
-      action: {
-        type: 'api',
-        method: 'notes/create',
-        params: {
-          text: '${input:body}',
-          visibility: '${input:visibility}',
-        },
-      },
-    },
-    {
-      id: 'mark-notifications-read',
-      label: '通知をすべて既読',
-      description: '未読通知を一括で既読にする',
-      action: {
-        type: 'api',
-        method: 'notifications/mark-all-as-read',
-      },
-    },
-    {
-      id: 'server-meta',
-      label: 'サーバー情報を取得',
-      description: 'meta API を叩いて結果を履歴に残す',
-      action: {
-        type: 'api',
-        method: 'meta',
-        params: { detail: true },
-      },
-    },
-    {
-      id: 'lookup-user',
-      label: 'ユーザーを検索',
-      description: 'ユーザー名またはホストつき handle で検索',
-      inputs: [
-        { id: 'query', type: 'text', prompt: 'ユーザー名 (例: alice)' },
-      ],
-      action: {
-        type: 'api',
-        method: 'users/search-by-username-and-host',
-        params: {
-          username: '${input:query}',
-          limit: 10,
-          detail: false,
-        },
-      },
-    },
-    {
-      id: 'my-recent-notes',
-      label: '自分の最新ノートを取得',
-      description: '自分のユーザーIDで直近ノートを取得',
+      id: 'me',
+      label: '自分の詳細を取得',
+      description: '自分のユーザーオブジェクトをそのまま履歴に残す (debug / 確認用)',
       action: {
         type: 'api',
         method: 'i',
+      },
+    },
+    {
+      id: 'drive-usage',
+      label: 'Drive 使用量を確認',
+      description: 'Drive の使用済み / 上限バイト数を取得',
+      action: {
+        type: 'api',
+        method: 'drive',
+      },
+    },
+    {
+      id: 'trending-hashtags',
+      label: 'トレンドタグを取得',
+      description: '今このサーバーで盛り上がっているハッシュタグ一覧',
+      action: {
+        type: 'api',
+        method: 'hashtags/trend',
+      },
+    },
+    {
+      id: 'recent-notifications',
+      label: '最近の通知をスナップショット',
+      description: '通知 5 件を JSON で取得 (markAsRead:false で既読化せず履歴に残す)',
+      action: {
+        type: 'api',
+        method: 'i/notifications',
+        params: {
+          limit: 5,
+          markAsRead: false,
+        },
+      },
+    },
+    {
+      id: 'list-endpoints',
+      label: 'API エンドポイント一覧を取得',
+      description: 'このサーバーで叩ける API 名の一覧 (新タスク作成のリファレンス)',
+      action: {
+        type: 'api',
+        method: 'endpoints',
       },
     },
   ],

--- a/src/defaults/tasks.json5
+++ b/src/defaults/tasks.json5
@@ -32,7 +32,7 @@
 //   既存カラム (Timeline / Notifications / Search / Drive / ServerInfo 等) で
 //   完結する操作は重複を避ける。
 {
-  version: 1,
+  version: 2,
   tasks: [
     {
       id: 'me',

--- a/src/defaults/tasks.json5
+++ b/src/defaults/tasks.json5
@@ -37,7 +37,10 @@
     {
       id: 'me',
       label: '自分の詳細を取得',
+      detail: 'i エンドポイントで自分の User を取得',
       description: '自分のユーザーオブジェクトをそのまま履歴に残す (debug / 確認用)',
+      group: 'Account',
+      icon: 'user',
       action: {
         type: 'api',
         method: 'i',
@@ -46,25 +49,22 @@
     {
       id: 'drive-usage',
       label: 'Drive 使用量を確認',
+      detail: '使用済み / 上限バイト数を取得',
       description: 'Drive の使用済み / 上限バイト数を取得',
+      group: 'Account',
+      icon: 'database',
       action: {
         type: 'api',
         method: 'drive',
       },
     },
     {
-      id: 'trending-hashtags',
-      label: 'トレンドタグを取得',
-      description: '今このサーバーで盛り上がっているハッシュタグ一覧',
-      action: {
-        type: 'api',
-        method: 'hashtags/trend',
-      },
-    },
-    {
       id: 'recent-notifications',
       label: '最近の通知をスナップショット',
+      detail: '5 件取得・既読化しない',
       description: '通知 5 件を JSON で取得 (markAsRead:false で既読化せず履歴に残す)',
+      group: 'Account',
+      icon: 'bell',
       action: {
         type: 'api',
         method: 'i/notifications',
@@ -75,9 +75,24 @@
       },
     },
     {
+      id: 'trending-hashtags',
+      label: 'トレンドタグを取得',
+      detail: 'サーバーで盛り上がっているタグ一覧',
+      description: '今このサーバーで盛り上がっているハッシュタグ一覧',
+      group: 'Discover',
+      icon: 'hash',
+      action: {
+        type: 'api',
+        method: 'hashtags/trend',
+      },
+    },
+    {
       id: 'list-endpoints',
       label: 'API エンドポイント一覧を取得',
+      detail: 'このサーバーで叩ける API 名',
       description: 'このサーバーで叩ける API 名の一覧 (新タスク作成のリファレンス)',
+      group: 'Debug',
+      icon: 'code',
       action: {
         type: 'api',
         method: 'endpoints',

--- a/src/stores/taskRunner.ts
+++ b/src/stores/taskRunner.ts
@@ -1,6 +1,8 @@
 import { defineStore } from 'pinia'
 import { shallowRef } from 'vue'
 import type { JsonValue } from '@/bindings'
+import { useCommandStore } from '@/commands/registry'
+import { TASK_COMMAND_PREFIX } from '@/commands/taskCommandPrefix'
 import { useAccountsStore } from '@/stores/accounts'
 import { usePrompt } from '@/stores/prompt'
 import { useTasksStore } from '@/stores/tasks'
@@ -166,9 +168,30 @@ export const useTaskRunnerStore = defineStore('taskRunner', () => {
     }
   }
 
+  async function runDefault(): Promise<void> {
+    const tasksStore = useTasksStore()
+    const def = tasksStore.definitions.find((d) => d.isDefault)
+    if (def) {
+      await runTask(def.id)
+      return
+    }
+    // VSCode の Run Default Task 相当: 既定が未設定ならタスク一覧を
+    // コマンドパレットで選ばせる
+    const commandStore = useCommandStore()
+    if (tasksStore.definitions.length === 0) {
+      useToast().show(
+        'デフォルトタスクがありません。tasks.json5 で isDefault: true を設定してください。',
+        'info',
+      )
+      return
+    }
+    commandStore.openWithFilter((c) => c.id.startsWith(TASK_COMMAND_PREFIX))
+  }
+
   return {
     runs,
     runTask,
+    runDefault,
     clear,
   }
 })

--- a/src/stores/taskRunner.ts
+++ b/src/stores/taskRunner.ts
@@ -18,6 +18,9 @@ const PRUNE_INTERVAL_MS = 60 * 1000
 
 export const useTaskRunnerStore = defineStore('taskRunner', () => {
   const runs = shallowRef<TaskRun[]>([])
+  // presentation.revealOnRun で run を自動選択させたいときに更新される。
+  // カラム側が watch して selectedId を同期する。
+  const autoSelectedRunId = shallowRef<number | null>(null)
   let nextId = 0
   let pruneTimer: ReturnType<typeof setInterval> | null = null
 
@@ -122,6 +125,10 @@ export const useTaskRunnerStore = defineStore('taskRunner', () => {
       account,
     })
 
+    if (def.presentation?.clearHistoryOnRun === true) {
+      runs.value = []
+    }
+
     const run: TaskRun = {
       id: nextId++,
       taskId: def.id,
@@ -133,6 +140,10 @@ export const useTaskRunnerStore = defineStore('taskRunner', () => {
       params: expandedParams,
     }
     pushRun(run)
+
+    if (def.presentation?.revealOnRun !== false) {
+      autoSelectedRunId.value = run.id
+    }
 
     if (!account.id) {
       updateRun(run.id, {
@@ -190,6 +201,7 @@ export const useTaskRunnerStore = defineStore('taskRunner', () => {
 
   return {
     runs,
+    autoSelectedRunId,
     runTask,
     runDefault,
     clear,

--- a/src/stores/tasks.ts
+++ b/src/stores/tasks.ts
@@ -7,7 +7,7 @@ import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
 import { useToast } from '@/stores/toast'
 import { parseTasks, TasksParseError } from '@/tasks/schema'
-import type { TaskDefinition } from '@/tasks/types'
+import { TASKS_FILE_VERSION, type TaskDefinition } from '@/tasks/types'
 import { isTauri, readTasks, writeTasks } from '@/utils/settingsFs'
 
 export const TASK_COMMAND_PREFIX = 'task.'
@@ -30,7 +30,10 @@ export const useTasksStore = defineStore('tasks', () => {
 
   async function persist(): Promise<void> {
     if (!isTauri) return
-    const payload = { version: 1, tasks: definitions.value }
+    const payload = {
+      version: TASKS_FILE_VERSION,
+      tasks: definitions.value,
+    }
     const content = JSON5.stringify(payload, null, 2)
     await writeTasks(`${content}\n`)
   }
@@ -78,6 +81,19 @@ export const useTasksStore = defineStore('tasks', () => {
     }
   }
 
+  function peekVersion(raw: string): number | null {
+    try {
+      const d = JSON5.parse(raw)
+      if (d && typeof d === 'object' && !Array.isArray(d)) {
+        const v = (d as Record<string, unknown>).version
+        return typeof v === 'number' ? v : null
+      }
+    } catch {
+      return null
+    }
+    return null
+  }
+
   async function init(): Promise<void> {
     if (isTauri) {
       try {
@@ -89,7 +105,17 @@ export const useTasksStore = defineStore('tasks', () => {
           )
           setFromRaw(defaultTasksJson5)
         } else {
+          const sourceVersion = peekVersion(content)
           setFromRaw(content)
+          if (
+            sourceVersion !== null &&
+            sourceVersion !== TASKS_FILE_VERSION &&
+            lastError.value === null
+          ) {
+            await persist().catch((e) =>
+              console.warn('[tasks] migration write failed:', e),
+            )
+          }
         }
       } catch (e) {
         console.warn('[tasks] read failed:', e)

--- a/src/stores/tasks.ts
+++ b/src/stores/tasks.ts
@@ -2,6 +2,7 @@ import JSON5 from 'json5'
 import { defineStore } from 'pinia'
 import { ref, watch } from 'vue'
 import { useCommandStore } from '@/commands/registry'
+import { TASK_COMMAND_PREFIX } from '@/commands/taskCommandPrefix'
 import { PERSIST_DEBOUNCE_MS } from '@/constants/persist'
 import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTaskRunnerStore } from '@/stores/taskRunner'
@@ -10,7 +11,7 @@ import { parseTasks, TasksParseError } from '@/tasks/schema'
 import { TASKS_FILE_VERSION, type TaskDefinition } from '@/tasks/types'
 import { isTauri, readTasks, writeTasks } from '@/utils/settingsFs'
 
-export const TASK_COMMAND_PREFIX = 'task.'
+export { TASK_COMMAND_PREFIX }
 
 export const useTasksStore = defineStore('tasks', () => {
   const definitions = ref<TaskDefinition[]>([])

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -23,6 +23,7 @@ export type WindowType =
   | 'appearanceEditor'
   | 'backup'
   | 'tasksEditor'
+  | 'snippetsEditor'
 
 export interface DeckWindow {
   id: string
@@ -70,6 +71,8 @@ export const WINDOW_SIZES: Record<
   backup: { width: 440, maxHeight: 550 },
   // Tasks editor
   tasksEditor: { width: 500, maxHeight: 700 },
+  // Snippets editor
+  snippetsEditor: { width: 500, maxHeight: 700 },
 }
 
 export const useWindowsStore = defineStore('windows', () => {
@@ -105,6 +108,7 @@ export const useWindowsStore = defineStore('windows', () => {
     'appearanceEditor',
     'backup',
     'tasksEditor',
+    'snippetsEditor',
   ])
 
   function open(type: WindowType, props: Record<string, unknown> = {}): string {

--- a/src/tasks/__tests__/schema.spec.ts
+++ b/src/tasks/__tests__/schema.spec.ts
@@ -1,15 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { parseTasks, TasksParseError } from '../schema'
+import { TASKS_FILE_VERSION } from '../types'
 
 describe('parseTasks', () => {
   it('empty content yields empty task list', () => {
-    expect(parseTasks('')).toEqual({ version: 1, tasks: [] })
-    expect(parseTasks('   \n')).toEqual({ version: 1, tasks: [] })
+    expect(parseTasks('')).toEqual({
+      version: TASKS_FILE_VERSION,
+      tasks: [],
+    })
+    expect(parseTasks('   \n')).toEqual({
+      version: TASKS_FILE_VERSION,
+      tasks: [],
+    })
   })
 
   it('accepts a minimal api task', () => {
     const src = `{
-      version: 1,
+      version: ${TASKS_FILE_VERSION},
       tasks: [{
         id: 'post',
         label: '投稿',
@@ -17,6 +24,7 @@ describe('parseTasks', () => {
       }],
     }`
     const parsed = parseTasks(src)
+    expect(parsed.version).toBe(TASKS_FILE_VERSION)
     expect(parsed.tasks).toHaveLength(1)
     expect(parsed.tasks[0]?.id).toBe('post')
     expect(parsed.tasks[0]?.action).toEqual({
@@ -27,7 +35,7 @@ describe('parseTasks', () => {
 
   it('parses text and pick inputs with defaults', () => {
     const src = `{
-      version: 1,
+      version: ${TASKS_FILE_VERSION},
       tasks: [{
         id: 'p', label: 'p',
         inputs: [
@@ -52,9 +60,15 @@ describe('parseTasks', () => {
     expect(() => parseTasks('{ tasks: [] }')).toThrow(TasksParseError)
   })
 
+  it('rejects unsupported version', () => {
+    expect(() => parseTasks('{ version: 99, tasks: [] }')).toThrow(
+      /version must be one of/,
+    )
+  })
+
   it('rejects non-api action type', () => {
     const src = `{
-      version: 1,
+      version: ${TASKS_FILE_VERSION},
       tasks: [{
         id: 't', label: 't',
         action: { type: 'shell', command: 'ls' },
@@ -65,7 +79,7 @@ describe('parseTasks', () => {
 
   it('rejects duplicate task ids', () => {
     const src = `{
-      version: 1,
+      version: ${TASKS_FILE_VERSION},
       tasks: [
         { id: 'x', label: 'x', action: { type: 'api', method: 'a' } },
         { id: 'x', label: 'y', action: { type: 'api', method: 'b' } },
@@ -76,7 +90,7 @@ describe('parseTasks', () => {
 
   it('rejects invalid id characters', () => {
     const src = `{
-      version: 1,
+      version: ${TASKS_FILE_VERSION},
       tasks: [{ id: 'bad id!', label: 'x', action: { type: 'api', method: 'a' } }],
     }`
     expect(() => parseTasks(src)).toThrow(/tasks\[0\]\.id/)
@@ -84,5 +98,108 @@ describe('parseTasks', () => {
 
   it('reports JSON5 parse errors with context', () => {
     expect(() => parseTasks('{ tasks: ')).toThrow(/JSON5 parse error/)
+  })
+
+  it('auto-upgrades a v1 file to the current version', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(vi.fn())
+    try {
+      const src = `{
+        version: 1,
+        tasks: [
+          { id: 't', label: 't', action: { type: 'api', method: 'i' } },
+        ],
+      }`
+      const parsed = parseTasks(src)
+      expect(parsed.version).toBe(TASKS_FILE_VERSION)
+      expect(parsed.tasks).toHaveLength(1)
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('parses the new v2 optional fields', () => {
+    const src = `{
+      version: ${TASKS_FILE_VERSION},
+      tasks: [{
+        id: 't', label: 't',
+        detail: '詳細 1 行',
+        icon: 'player-play',
+        group: 'Quick Actions',
+        isDefault: true,
+        pinned: true,
+        presentation: { revealOnRun: false, clearHistoryOnRun: true },
+        action: { type: 'api', method: 'i' },
+      }],
+    }`
+    const parsed = parseTasks(src)
+    expect(parsed.tasks[0]).toMatchObject({
+      detail: '詳細 1 行',
+      icon: 'player-play',
+      group: 'Quick Actions',
+      isDefault: true,
+      pinned: true,
+      presentation: { revealOnRun: false, clearHistoryOnRun: true },
+    })
+  })
+
+  it('normalizes empty and whitespace-only group to undefined', () => {
+    const src = `{
+      version: ${TASKS_FILE_VERSION},
+      tasks: [
+        { id: 'a', label: 'a', group: '', action: { type: 'api', method: 'i' } },
+        { id: 'b', label: 'b', group: '   ', action: { type: 'api', method: 'i' } },
+        { id: 'c', label: 'c', group: '  Pinned  ', action: { type: 'api', method: 'i' } },
+      ],
+    }`
+    const parsed = parseTasks(src)
+    expect(parsed.tasks[0]?.group).toBeUndefined()
+    expect(parsed.tasks[1]?.group).toBeUndefined()
+    expect(parsed.tasks[2]?.group).toBe('Pinned')
+  })
+
+  it('demotes extra isDefault tasks so only the first wins', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(vi.fn())
+    try {
+      const src = `{
+        version: ${TASKS_FILE_VERSION},
+        tasks: [
+          { id: 'a', label: 'a', isDefault: true, action: { type: 'api', method: 'i' } },
+          { id: 'b', label: 'b', isDefault: true, action: { type: 'api', method: 'i' } },
+          { id: 'c', label: 'c', isDefault: true, action: { type: 'api', method: 'i' } },
+        ],
+      }`
+      const parsed = parseTasks(src)
+      expect(parsed.tasks[0]?.isDefault).toBe(true)
+      expect(parsed.tasks[1]?.isDefault).toBeUndefined()
+      expect(parsed.tasks[2]?.isDefault).toBeUndefined()
+      expect(warn).toHaveBeenCalled()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('rejects invalid icon format', () => {
+    const src = `{
+      version: ${TASKS_FILE_VERSION},
+      tasks: [{
+        id: 't', label: 't',
+        icon: 'Not A Tabler Name!',
+        action: { type: 'api', method: 'i' },
+      }],
+    }`
+    expect(() => parseTasks(src)).toThrow(/icon/)
+  })
+
+  it('rejects non-boolean presentation fields', () => {
+    const src = `{
+      version: ${TASKS_FILE_VERSION},
+      tasks: [{
+        id: 't', label: 't',
+        presentation: { revealOnRun: 'yes' },
+        action: { type: 'api', method: 'i' },
+      }],
+    }`
+    expect(() => parseTasks(src)).toThrow(/revealOnRun/)
   })
 })

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -80,11 +80,7 @@ function parsePresentation(
   if (raw === undefined) return undefined
   if (!isObj(raw)) throw new TasksParseError(`${path}: must be an object`)
   const out: TaskPresentation = {}
-  for (const key of [
-    'revealOnRun',
-    'clearHistoryOnRun',
-    'focusInput',
-  ] as const) {
+  for (const key of ['revealOnRun', 'clearHistoryOnRun'] as const) {
     const v = raw[key]
     if (v === undefined) continue
     if (typeof v !== 'boolean')

--- a/src/tasks/schema.ts
+++ b/src/tasks/schema.ts
@@ -1,5 +1,12 @@
 import JSON5 from 'json5'
-import type { TaskAction, TaskDefinition, TaskInput, TasksFile } from './types'
+import {
+  TASKS_FILE_VERSION,
+  type TaskAction,
+  type TaskDefinition,
+  type TaskInput,
+  type TaskPresentation,
+  type TasksFile,
+} from './types'
 
 export class TasksParseError extends Error {
   constructor(message: string) {
@@ -7,6 +14,9 @@ export class TasksParseError extends Error {
     this.name = 'TasksParseError'
   }
 }
+
+const SUPPORTED_VERSIONS = [1, 2] as const
+const ICON_NAME_RE = /^[a-z0-9][a-z0-9-]*$/
 
 function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
@@ -63,6 +73,27 @@ function parseAction(raw: unknown, path: string): TaskAction {
   }
 }
 
+function parsePresentation(
+  raw: unknown,
+  path: string,
+): TaskPresentation | undefined {
+  if (raw === undefined) return undefined
+  if (!isObj(raw)) throw new TasksParseError(`${path}: must be an object`)
+  const out: TaskPresentation = {}
+  for (const key of [
+    'revealOnRun',
+    'clearHistoryOnRun',
+    'focusInput',
+  ] as const) {
+    const v = raw[key]
+    if (v === undefined) continue
+    if (typeof v !== 'boolean')
+      throw new TasksParseError(`${path}.${key}: boolean required`)
+    out[key] = v
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
 function parseTask(raw: unknown, path: string): TaskDefinition {
   if (!isObj(raw)) throw new TasksParseError(`${path}: must be an object`)
   const id = raw.id
@@ -73,6 +104,7 @@ function parseTask(raw: unknown, path: string): TaskDefinition {
     )
   if (typeof label !== 'string' || !label)
     throw new TasksParseError(`${path}.label: non-empty string required`)
+
   const inputs = raw.inputs
   const parsedInputs =
     inputs === undefined
@@ -82,25 +114,76 @@ function parseTask(raw: unknown, path: string): TaskDefinition {
         : (() => {
             throw new TasksParseError(`${path}.inputs: must be an array`)
           })()
+
   const action = parseAction(raw.action, `${path}.action`)
   const accountId = raw.accountId
   const description = raw.description
+  const detail = raw.detail
+  const icon = raw.icon
+  const group = raw.group
+  const isDefault = raw.isDefault
+  const pinned = raw.pinned
+  const presentation = parsePresentation(
+    raw.presentation,
+    `${path}.presentation`,
+  )
+
+  if (detail !== undefined && typeof detail !== 'string')
+    throw new TasksParseError(`${path}.detail: string required`)
+  if (icon !== undefined) {
+    if (typeof icon !== 'string' || !ICON_NAME_RE.test(icon))
+      throw new TasksParseError(
+        `${path}.icon: non-empty kebab-case string required (e.g. 'player-play')`,
+      )
+  }
+  if (group !== undefined && typeof group !== 'string')
+    throw new TasksParseError(`${path}.group: string required`)
+  if (isDefault !== undefined && typeof isDefault !== 'boolean')
+    throw new TasksParseError(`${path}.isDefault: boolean required`)
+  if (pinned !== undefined && typeof pinned !== 'boolean')
+    throw new TasksParseError(`${path}.pinned: boolean required`)
+
+  const normalizedGroup =
+    typeof group === 'string' && group.trim() ? group.trim() : undefined
+
   const def: TaskDefinition = {
     id,
     label,
     action,
     ...(typeof description === 'string' ? { description } : {}),
+    ...(typeof detail === 'string' && detail ? { detail } : {}),
+    ...(typeof icon === 'string' ? { icon } : {}),
+    ...(normalizedGroup ? { group: normalizedGroup } : {}),
+    ...(isDefault === true ? { isDefault: true } : {}),
+    ...(pinned === true ? { pinned: true } : {}),
     ...(typeof accountId === 'string' || accountId === null
       ? { accountId }
       : {}),
     ...(parsedInputs ? { inputs: parsedInputs } : {}),
+    ...(presentation ? { presentation } : {}),
   }
   return def
 }
 
+function enforceSingleDefault(tasks: TaskDefinition[]): TaskDefinition[] {
+  let seen = false
+  return tasks.map((t) => {
+    if (!t.isDefault) return t
+    if (seen) {
+      console.warn(
+        `[tasks] multiple isDefault tasks found; "${t.id}" demoted (only the first wins)`,
+      )
+      const { isDefault: _isDefault, ...rest } = t
+      return rest
+    }
+    seen = true
+    return t
+  })
+}
+
 export function parseTasks(raw: string): TasksFile {
   const trimmed = raw.trim()
-  if (!trimmed) return { version: 1, tasks: [] }
+  if (!trimmed) return { version: TASKS_FILE_VERSION, tasks: [] }
   let data: unknown
   try {
     data = JSON5.parse(trimmed)
@@ -111,8 +194,21 @@ export function parseTasks(raw: string): TasksFile {
   }
   if (!isObj(data))
     throw new TasksParseError('tasks.json5: root must be an object')
-  if (data.version !== 1)
-    throw new TasksParseError('tasks.json5: version must be 1')
+
+  const version = data.version
+  if (
+    typeof version !== 'number' ||
+    !SUPPORTED_VERSIONS.includes(version as (typeof SUPPORTED_VERSIONS)[number])
+  )
+    throw new TasksParseError(
+      `tasks.json5: version must be one of ${SUPPORTED_VERSIONS.join(', ')}`,
+    )
+  if (version !== TASKS_FILE_VERSION) {
+    console.warn(
+      `[tasks] upgrading tasks.json5 from v${version} to v${TASKS_FILE_VERSION}`,
+    )
+  }
+
   const tasks = data.tasks
   if (!Array.isArray(tasks))
     throw new TasksParseError('tasks.json5: tasks must be an array')
@@ -123,5 +219,8 @@ export function parseTasks(raw: string): TasksFile {
       throw new TasksParseError(`tasks.json5: duplicate task id "${t.id}"`)
     seen.add(t.id)
   }
-  return { version: 1, tasks: parsed }
+  return {
+    version: TASKS_FILE_VERSION,
+    tasks: enforceSingleDefault(parsed),
+  }
 }

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -23,17 +23,31 @@ export interface TaskApiAction {
 
 export type TaskAction = TaskApiAction
 
+export interface TaskPresentation {
+  revealOnRun?: boolean
+  clearHistoryOnRun?: boolean
+  focusInput?: boolean
+}
+
 export interface TaskDefinition {
   id: string
   label: string
+  detail?: string
   description?: string
+  icon?: string
+  group?: string
+  isDefault?: boolean
+  pinned?: boolean
   accountId?: string | null
   inputs?: TaskInput[]
   action: TaskAction
+  presentation?: TaskPresentation
 }
 
+export const TASKS_FILE_VERSION = 2 as const
+
 export interface TasksFile {
-  version: 1
+  version: typeof TASKS_FILE_VERSION
   tasks: TaskDefinition[]
 }
 

--- a/src/tasks/types.ts
+++ b/src/tasks/types.ts
@@ -26,7 +26,6 @@ export type TaskAction = TaskApiAction
 export interface TaskPresentation {
   revealOnRun?: boolean
   clearHistoryOnRun?: boolean
-  focusInput?: boolean
 }
 
 export interface TaskDefinition {

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -228,6 +228,31 @@ export async function writePerformance(content: string): Promise<void> {
   return writeRootSettingsFile('performance.json5', content)
 }
 
+// --- Snippet helpers ---
+
+const SNIPPETS_DIR = 'snippets'
+const SNIPPET_EXT = /\.(json5?|code-snippets|jsonc)$/i
+
+export async function listSnippetFiles(): Promise<string[]> {
+  const files = await listSettingsFiles(SNIPPETS_DIR)
+  return files.filter((f) => SNIPPET_EXT.test(f))
+}
+
+export async function readSnippetFile(filename: string): Promise<string> {
+  return readSettingsFile(SNIPPETS_DIR, filename)
+}
+
+export async function writeSnippetFile(
+  filename: string,
+  content: string,
+): Promise<void> {
+  return writeSettingsFile(SNIPPETS_DIR, filename, content)
+}
+
+export async function deleteSnippetFile(filename: string): Promise<void> {
+  return deleteSettingsFile(SNIPPETS_DIR, filename)
+}
+
 // --- Plugin helpers ---
 
 const PLUGINS_DIR = 'plugins'


### PR DESCRIPTION
## Summary

v0.10.4 リリース。タスク機能の拡張（group/detail/icon/pinned/isDefault/presentation 編集・D&D 並び替え・status バッジ）と VSCode 互換 AiScript スニペット機能を中心とする機能追加、ナビバーのデフォルト順調整。

## Changes

### Features
- feat(snippets): VSCode 互換の AiScript スニペット機能を追加
- feat(tasks-editor): タスクカードをドラッグ&ドロップで並び替え可能に
- feat(tasks): エディタで group / detail / icon / pinned / isDefault / presentation を編集可能に
- feat(tasks): presentation.revealOnRun / clearHistoryOnRun を実行時に反映
- feat(tasks): isDefault とデフォルト実行ボタン / Ctrl+Alt+B
- feat(tasks): 最終実行 status バッジをタスク行に表示
- feat(tasks): タスクに group / detail / icon / pinned フィールドを追加
- feat(tasks): tasks エディタにビジュアル/コードの 2 タブを追加

### Refactor
- refactor(tasks): schema v2 と新フィールド用の型基盤を整備
- refactor(deck): タスクカラムを他カラムと同等の構造に揃える
- refactor(tasks): デフォルトタスクをゼロ入力かつスコープ内 API に刷新

### Fixes
- fix(deck): カラムタブの見た目を旧TLタブに合わせ直す

### Chore / Docs
- chore(navbar): デフォルト順を Misskey WebUI 準拠に調整
- chore(navbar): 開発者向けカラムをデフォルト navbar から除外
- docs(tasks): defaults/tasks.json5 のコメントヘッダに新フィールドを追記

## Test plan

- [ ] CI（lint / typecheck / test）通過
- [ ] タスクエディタの各フィールド編集・D&D 並び替え動作確認
- [ ] AiScript スニペット補完の動作確認
- [ ] ナビバーのデフォルト表示確認