### PR TITLE
Release v0.10.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.10.6",
+  "version": "0.10.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.10.6"
+version = "0.10.7"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkDrivePicker.vue
+++ b/src/components/common/MkDrivePicker.vue
@@ -127,7 +127,7 @@ fetchDrive()
 .drivePicker {
   width: 100%;
   max-width: 520px;
-  max-height: 50vh;
+  max-height: min(75vh, 640px);
   margin: 0 16px 16px;
   display: flex;
   flex-direction: column;

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -1011,7 +1011,7 @@ function onKeydown(e: KeyboardEvent) {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 12vh;
+  padding-top: calc(var(--nd-app-inset-top, 0px) + 12px);
   background: var(--nd-modalBg);
   overflow-y: auto;
 }
@@ -2186,7 +2186,7 @@ function onKeydown(e: KeyboardEvent) {
 /* Mobile: デスクトップと同じ枠付きモーダル（背景は透過して背後のカラムが透ける） */
 .mobile {
   &.postOverlay {
-    padding-top: calc(8vh + var(--nd-safe-area-top, env(safe-area-inset-top)));
+    padding-top: var(--nd-safe-area-top, env(safe-area-inset-top));
     padding-bottom: var(--nd-safe-area-bottom, env(safe-area-inset-bottom));
   }
 

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -2183,22 +2183,11 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
-/* Mobile fullscreen */
+/* Mobile: デスクトップと同じ枠付きモーダル（背景は透過して背後のカラムが透ける） */
 .mobile {
   &.postOverlay {
-    background: var(--nd-bg);
-    padding-top: var(--nd-safe-area-top, env(safe-area-inset-top));
+    padding-top: calc(8vh + var(--nd-safe-area-top, env(safe-area-inset-top)));
     padding-bottom: var(--nd-safe-area-bottom, env(safe-area-inset-bottom));
-    align-items: stretch;
-  }
-
-  .postForm:not(.postFormInline) {
-    max-width: none;
-    margin: 0;
-    border-radius: 0;
-    height: 100%;
-    max-height: none;
-    box-shadow: none;
   }
 
   .emojiPopup {

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -1,24 +1,14 @@
 <script setup lang="ts">
-import {
-  computed,
-  defineAsyncComponent,
-  nextTick,
-  onMounted,
-  ref,
-  useTemplateRef,
-  watch,
-} from 'vue'
+import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import type {
   NormalizedDriveFile,
   NormalizedNote,
   NormalizedUser,
 } from '@/adapters/types'
 import { useAutocomplete } from '@/composables/useAutocomplete'
-import { useHoverPopup } from '@/composables/useHoverPopup'
 import { useMentionSearch } from '@/composables/useMentionSearch'
 import { useMfmInsert } from '@/composables/useMfmInsert'
 import { usePopupControl } from '@/composables/usePopupControl'
-import { usePortal } from '@/composables/usePortal'
 import { usePostFormState } from '@/composables/usePostFormState'
 import {
   getAccountAvatarUrl,
@@ -29,15 +19,11 @@ import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
-import { commands, unwrap } from '@/utils/tauriInvoke'
-import { extractColumnThemeVars } from '@/utils/themeVars'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
 import MkDrivePicker from './MkDrivePicker.vue'
-import MkMediaGrid from './MkMediaGrid.vue'
 import MkMfm from './MkMfm.vue'
+import MkNote from './MkNote.vue'
 import MkReactionPicker from './MkReactionPicker.vue'
-
-const MkUserPopup = defineAsyncComponent(() => import('./MkUserPopup.vue'))
 
 const props = defineProps<{
   accountId: string
@@ -194,6 +180,39 @@ function minScheduleDatetime(): string {
   return d.toISOString().slice(0, 16)
 }
 
+// --- Preview ---
+const previewNote = computed<NormalizedNote | null>(() => {
+  if (!showPreview.value) return null
+  const acc = account.value
+  if (!acc) return null
+  return {
+    id: `preview-${acc.id}`,
+    _accountId: acc.id,
+    _serverHost: acc.host,
+    createdAt: new Date().toISOString(),
+    text: text.value || null,
+    cw: showCw.value && cw.value ? cw.value : null,
+    user: {
+      id: acc.userId,
+      username: acc.username,
+      host: null,
+      name: acc.displayName,
+      avatarUrl: acc.avatarUrl,
+    },
+    visibility: visibility.value,
+    emojis: {},
+    reactionEmojis: {},
+    reactions: {},
+    renoteCount: 0,
+    repliesCount: 0,
+    files: attachedFiles.value,
+    localOnly: localOnly.value,
+    replyId: props.replyTo?.id ?? null,
+    renoteId: props.renoteId ?? null,
+    channelId: props.channelId ?? null,
+  }
+})
+
 // --- Mention popup ---
 const {
   showMentionPopup,
@@ -289,47 +308,6 @@ function closePopups() {
   popups.closeAll()
   acDismiss()
 }
-
-// --- Mention hover popup in preview ---
-const previewMentionPopup = useHoverPopup()
-const previewMentionUserId = ref('')
-const previewMentionTheme = ref<Record<string, string>>()
-let previewMentionHovering = false
-
-async function onPreviewMentionHover(
-  e: MouseEvent,
-  username: string,
-  host: string | null,
-) {
-  previewMentionHovering = true
-  const el = e.currentTarget as HTMLElement
-  const rect = el.getBoundingClientRect()
-  previewMentionTheme.value = extractColumnThemeVars(el)
-  try {
-    const user = unwrap(
-      await commands.apiLookupUser(
-        activeAccountId.value,
-        username,
-        host ?? null,
-      ),
-    )
-    if (!previewMentionHovering) return
-    previewMentionUserId.value = user.id
-    previewMentionPopup.show({ x: rect.right + 8, y: rect.top })
-  } catch {
-    // lookup failed
-  }
-}
-
-function onPreviewMentionLeave() {
-  previewMentionHovering = false
-  previewMentionPopup.hide()
-}
-
-const previewMentionPortalRef = useTemplateRef<HTMLElement>(
-  'previewMentionPortalRef',
-)
-usePortal(previewMentionPortalRef)
 
 onMounted(async () => {
   await initAdapter()
@@ -776,27 +754,8 @@ function onKeydown(e: KeyboardEvent) {
 
       <!-- Preview -->
       <div v-if="showPreview" :class="$style.previewSection">
-        <div :class="$style.previewHeader">
-          <i class="ti ti-eye" />
-          プレビュー
-        </div>
-        <div :class="$style.previewArea">
-          <div v-if="text" :class="$style.previewContent">
-            <MkMfm
-              :text="text"
-              :emojis="{}"
-              :server-host="account?.host"
-              :my-username="account?.username"
-              :my-host="account?.host"
-              @mention-hover="onPreviewMentionHover"
-              @mention-leave="onPreviewMentionLeave"
-            />
-          </div>
-          <div v-else :class="$style.previewEmpty">テキストを入力するとプレビューが表示されます</div>
-        </div>
-        <div v-if="attachedFiles.length > 0" :class="$style.previewFiles">
-          <MkMediaGrid :files="attachedFiles" />
-        </div>
+        <MkNote v-if="previewNote" :note="previewNote" embedded />
+        <div v-else :class="$style.previewEmpty">アカウントが選択されていません</div>
       </div>
 
       <!-- Poll editor -->
@@ -1005,17 +964,6 @@ function onKeydown(e: KeyboardEvent) {
       @close="showDrivePicker = false"
     />
 
-    <!-- Mention hover popup in preview -->
-    <div v-if="previewMentionPopup.isVisible.value && previewMentionUserId" ref="previewMentionPortalRef">
-      <MkUserPopup
-        :user-id="previewMentionUserId"
-        :account-id="activeAccountId!"
-        :x="previewMentionPopup.position.value.x"
-        :y="previewMentionPopup.position.value.y"
-        :theme-vars="previewMentionTheme"
-        @close="previewMentionPopup.forceClose()"
-      />
-    </div>
   </div>
 </template>
 
@@ -1580,30 +1528,9 @@ function onKeydown(e: KeyboardEvent) {
 /* ── Preview ── */
 .previewSection {
   border-top: 1px solid color-mix(in srgb, var(--nd-fg) 12%, transparent);
-}
-
-.previewHeader {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 24px;
-  font-size: 0.8em;
-  color: var(--nd-fg);
-  opacity: 0.5;
-}
-
-.previewArea {
-  padding: 0 24px;
-  max-height: 300px;
+  max-height: 360px;
   overflow-y: auto;
-  line-height: 1.5;
-  font-size: 110%;
   scrollbar-width: thin;
-}
-
-.previewContent {
-  word-break: break-word;
-  overflow-wrap: break-word;
 }
 
 .previewEmpty {
@@ -1612,10 +1539,6 @@ function onKeydown(e: KeyboardEvent) {
   color: var(--nd-fg);
   opacity: 0.35;
   font-size: 0.9em;
-}
-
-.previewFiles {
-  padding: 8px 24px;
 }
 
 /* ── Error ── */

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -25,6 +25,7 @@ import {
   getAccountLabel,
   isGuestAccount,
 } from '@/stores/accounts'
+import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
@@ -58,9 +59,15 @@ const emit = defineEmits<{
 }>()
 
 const isCompact = useIsCompactLayout()
+const settingsStore = useSettingsStore()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
-const showPreview = ref(false)
+const showPreview = computed<boolean>({
+  get: () => settingsStore.get('postForm.preview') ?? false,
+  set: (v) => {
+    settingsStore.set('postForm.preview', v)
+  },
+})
 
 const {
   text,
@@ -553,15 +560,24 @@ function onKeydown(e: KeyboardEvent) {
               <i class="ti ti-dots" />
             </button>
             <div v-if="showMoreMenu" :class="$style.moreMenu" @click.stop>
-              <!-- Preview -->
-              <button
-                class="_button"
-                :class="[$style.moreMenuItem, { [$style.active]: showPreview }]"
-                @click="showPreview = !showPreview; showMoreMenu = false"
+              <!-- Preview toggle -->
+              <div
+                :class="$style.moreMenuItem"
+                role="switch"
+                :aria-checked="showPreview"
+                @click="showPreview = !showPreview"
               >
                 <i class="ti ti-eye" />
                 プレビュー
-              </button>
+                <span
+                  class="nd-toggle-switch"
+                  :class="{ on: showPreview }"
+                  :style="{ marginLeft: 'auto' }"
+                  aria-hidden="true"
+                >
+                  <span class="nd-toggle-switch-knob" />
+                </span>
+              </div>
               <!-- Draft save -->
               <button
                 class="_button"
@@ -1397,6 +1413,8 @@ function onKeydown(e: KeyboardEvent) {
   font-size: 0.85em;
   border-radius: var(--nd-radius-sm);
   color: var(--nd-fg);
+  cursor: pointer;
+  user-select: none;
   transition: background var(--nd-duration-base);
 
   &:hover {

--- a/src/components/deck/ColumnTabs.vue
+++ b/src/components/deck/ColumnTabs.vue
@@ -148,6 +148,9 @@ watch(
   border-bottom: 1px solid var(--nd-divider);
   background: var(--nd-bg);
   flex-shrink: 0;
+  /* button 間の物理的な間隔。padding (button 内部) と責務を分離し、
+     Chromium 系で glyph advance width が膨らんでも隣接タブへ干渉しない。 */
+  gap: 4px;
 }
 
 .tabs.scrollable {

--- a/src/components/deck/DeckColumnsArea.vue
+++ b/src/components/deck/DeckColumnsArea.vue
@@ -162,8 +162,6 @@ function getShellPreview(colId: string): string[] {
   })
 }
 
-const eagerMountRadius = computed(() => (isCompact.value ? 0 : 1))
-
 const activeGroupIndex = computed(() => {
   const activeId = deckStore.activeColumnId
   if (!activeId) return 0
@@ -173,18 +171,24 @@ const activeGroupIndex = computed(() => {
   return idx >= 0 ? idx : 0
 })
 
-function isPriorityGroup(groupIndex: number): boolean {
-  return Math.abs(groupIndex - activeGroupIndex.value) <= eagerMountRadius.value
-}
-
-function shouldMountColumn(colId: string, groupIndex: number): boolean {
-  return isPriorityGroup(groupIndex) || colVisibility.isColumnMounted(colId)
+// 可視範囲ベースのマウント判定:
+// - モバイル: アクティブカラムは常にマウント、それ以外は IntersectionObserver に委ねる
+// - デスクトップ: 全カラムを IntersectionObserver 判定に委ねる
+//   (observe 時に initialMounted:true で開始し、非可視判定されたら columnUnloadDelay 後に自然に外れる)
+function shouldMountColumn(colId: string): boolean {
+  if (isCompact.value) {
+    return (
+      colId === deckStore.activeColumnId || colVisibility.isColumnMounted(colId)
+    )
+  }
+  return colVisibility.isColumnMounted(colId)
 }
 
 function preloadVisiblePriorityGroups() {
   if (!import.meta.env.PROD) return
+  const activeIdx = activeGroupIndex.value
   for (const [groupIndex, group] of deckStore.windowLayout.entries()) {
-    if (!isPriorityGroup(groupIndex)) continue
+    if (Math.abs(groupIndex - activeIdx) > 1) continue
     for (const colId of group) {
       const col = columnMap.value.get(colId)
       if (col) COLUMN_PRELOADERS[col.type]?.()
@@ -205,15 +209,24 @@ onUnmounted(() => {
   colVisibility.disconnect()
 })
 
-// Re-observe column cells when layout changes
+// Re-observe column cells when layout changes, and cleanup removed columns
+let prevColumnIds = new Set<string>()
 watch(
   () => deckStore.windowLayout,
-  () => {
+  (layout) => {
     if (!columnsRef.value) return
+    const currentIds = new Set<string>(layout.flat())
+    for (const id of prevColumnIds) {
+      if (!currentIds.has(id)) colVisibility.cleanup(id)
+    }
+    prevColumnIds = currentIds
+    // デスクトップは初回表示を滑らかにするため initialMounted:true で開始
+    // モバイルは従来通り false 開始（アクティブのみ shouldMountColumn で true 判定）
+    const initialMounted = !isCompact.value
     for (const cell of columnsRef.value.querySelectorAll<HTMLElement>(
       '.stack-cell[data-column-id]',
     )) {
-      colVisibility.observe(cell)
+      colVisibility.observe(cell, { initialMounted })
     }
   },
   { flush: 'post', deep: true, immediate: true },
@@ -345,7 +358,7 @@ defineExpose({
         >
           <component
             v-if="
-              shouldMountColumn(colId, groupIndex) &&
+              shouldMountColumn(colId) &&
               columnMap.get(colId) &&
               COLUMN_COMPONENTS[columnMap.get(colId)!.type]
             "

--- a/src/components/deck/DeckSettingsMenu.vue
+++ b/src/components/deck/DeckSettingsMenu.vue
@@ -604,6 +604,10 @@ usePortal(settingsMenuPortalRef)
   opacity: 0.5;
 }
 
+.activeDot + .chevronNav {
+  margin-left: 0;
+}
+
 .themeSelectBody {
   margin-top: 8px;
   max-height: 200px;

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -60,6 +60,7 @@ const cssCode = ref(themeStore.customCss)
 const presets = ref({
   customFont: '',
   fontSize: 0,
+  customCursor: '',
 })
 
 // Parse existing CSS to restore preset states
@@ -68,6 +69,8 @@ function parsePresetsFromCss(cssStr: string) {
   presets.value.customFont = fontMatch?.[1] ?? ''
   const sizeMatch = cssStr.match(/\/\* nd-fontsize: (.+?) \*\//)
   presets.value.fontSize = sizeMatch ? Number(sizeMatch[1]) : 0
+  const cursorMatch = cssStr.match(/\/\* nd-cursor: (.+?) \*\//)
+  presets.value.customCursor = cursorMatch?.[1] ?? ''
 }
 parsePresetsFromCss(cssCode.value)
 
@@ -128,6 +131,24 @@ const FONT_SIZE_BASE = 15
 const FONT_SIZE_MIN = -3
 const FONT_SIZE_MAX = 5
 
+interface CursorOption {
+  key: string
+  label: string
+  css: string
+}
+
+const ROCKET_CURSOR_SVG =
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20'><text y='16' font-size='16'>%F0%9F%9A%80</text></svg>"
+
+const CURSOR_OPTIONS: CursorOption[] = [
+  { key: '', label: 'デフォルト', css: '' },
+  {
+    key: 'rocket',
+    label: 'ロケット',
+    css: `url("${ROCKET_CURSOR_SVG}") 2 18, auto`,
+  },
+]
+
 const fontSizeLabel = computed(() => {
   if (presets.value.fontSize === 0) return 'デフォルト (15px)'
   return `${FONT_SIZE_BASE + presets.value.fontSize}px`
@@ -175,6 +196,14 @@ function buildPresetCss(): string {
     parts.push(`html { font-size: ${px}px; }`)
   }
 
+  if (presets.value.customCursor) {
+    const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
+    if (opt?.css) {
+      parts.push(`/* nd-cursor: ${opt.key} */`)
+      parts.push(`*, *::before, *::after { cursor: ${opt.css}; }`)
+    }
+  }
+
   return parts.join('\n')
 }
 
@@ -186,10 +215,12 @@ function extractUserCss(fullCss: string): string {
       if (!t) return false
       if (t.startsWith('/* nd-font:')) return false
       if (t.startsWith('/* nd-fontsize:')) return false
+      if (t.startsWith('/* nd-cursor:')) return false
       if (t.startsWith('@import url(')) return false
       if (t.startsWith('@font-face')) return false
       if (t.match(/^html\s*\{\s*font-family:/)) return false
       if (t.match(/^html\s*\{\s*font-size:/)) return false
+      if (t.match(/^\*,\s*\*::before,\s*\*::after\s*\{\s*cursor:/)) return false
       return true
     })
     .join('\n')
@@ -224,7 +255,11 @@ watch(fullCss, (cssStr) => {
 })
 
 watch(
-  () => [presets.value.customFont, presets.value.fontSize],
+  () => [
+    presets.value.customFont,
+    presets.value.fontSize,
+    presets.value.customCursor,
+  ],
   () => {
     const cssStr = fullCss.value
     cssCode.value = cssStr
@@ -299,7 +334,7 @@ const { confirming: confirmingClear, trigger: triggerClear } =
 
 function handleClear() {
   triggerClear(() => {
-    presets.value = { customFont: '', fontSize: 0 }
+    presets.value = { customFont: '', fontSize: 0, customCursor: '' }
     userFreeformCss.value = ''
     cssCode.value = ''
     cssError.value = null
@@ -324,6 +359,29 @@ function selectFont(value: string) {
 
 useClickOutside(dropdownRef, () => {
   showFontDropdown.value = false
+})
+
+// Cursor dropdown
+const showCursorDropdown = ref(false)
+const cursorDropdownRef = ref<HTMLElement | null>(null)
+
+const selectedCursorLabel = computed(() => {
+  const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
+  return opt?.label ?? 'デフォルト'
+})
+
+const cursorPreviewStyle = computed(() => {
+  const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
+  return opt?.css ? { cursor: opt.css } : {}
+})
+
+function selectCursor(key: string) {
+  presets.value.customCursor = key
+  showCursorDropdown.value = false
+}
+
+useClickOutside(cursorDropdownRef, () => {
+  showCursorDropdown.value = false
 })
 
 watch(tab, (t) => {
@@ -424,6 +482,44 @@ watch(tab, (t) => {
           >
             リセット
           </button>
+        </template>
+      </div>
+
+      <!-- Cursor -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('cursor')">
+          <i class="ti ti-pointer" />
+          カーソル
+          <span :class="$style.sectionValue">{{ selectedCursorLabel }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.cursor }]" />
+        </button>
+        <template v-if="expandedSections.cursor">
+          <div ref="cursorDropdownRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showCursorDropdown = !showCursorDropdown"
+            >
+              <span>{{ selectedCursorLabel }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showCursorDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in CURSOR_OPTIONS"
+                :key="opt.key"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: presets.customCursor === opt.key }]"
+                :style="opt.css ? { cursor: opt.css } : {}"
+                @click="selectCursor(opt.key)"
+              >
+                <span>{{ opt.label }}</span>
+                <i v-if="presets.customCursor === opt.key" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+          <div :class="$style.preview" :style="cursorPreviewStyle">
+            ここにマウスを重ねてプレビュー
+          </div>
         </template>
       </div>
 

--- a/src/composables/useColumnVisibility.ts
+++ b/src/composables/useColumnVisibility.ts
@@ -40,6 +40,8 @@ export function provideColumnVisibility() {
 
   // Track pending unload timers per column
   const unloadTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  // Track observed elements per column so we can unobserve on cleanup
+  const observedElements = new Map<string, Element>()
 
   let observer: IntersectionObserver | null = null
 
@@ -77,22 +79,41 @@ export function provideColumnVisibility() {
           }
         }
       },
-      { root: container.value, threshold: 0 },
+      // rootMargin で横方向に 10% 余裕を持たせ、端ピクセルの判定不安定を吸収
+      { root: container.value, threshold: 0, rootMargin: '0px 10%' },
     )
   }
 
-  function observe(el: Element) {
+  function observe(el: Element, options?: { initialMounted?: boolean }) {
     observer?.observe(el)
-    // New columns start unmounted unless the consumer opts into eager mount.
     const colId = (el as HTMLElement).dataset.columnId
-    if (colId && !mounted.has(colId)) {
-      mounted.set(colId, false)
+    if (!colId) return
+    observedElements.set(colId, el)
+    if (!mounted.has(colId)) {
+      mounted.set(colId, options?.initialMounted ?? false)
     }
+  }
+
+  function cleanup(colId: string) {
+    const el = observedElements.get(colId)
+    if (el) {
+      observer?.unobserve(el)
+      observedElements.delete(colId)
+    }
+    const timer = unloadTimers.get(colId)
+    if (timer != null) {
+      clearTimeout(timer)
+      unloadTimers.delete(colId)
+    }
+    map.delete(colId)
+    mounted.delete(colId)
+    live.delete(colId)
   }
 
   function disconnect() {
     observer?.disconnect()
     observer = null
+    observedElements.clear()
     // Clear all pending timers
     for (const timer of unloadTimers.values()) {
       clearTimeout(timer)
@@ -145,7 +166,14 @@ export function provideColumnVisibility() {
     }
   }
 
-  return { setup, observe, disconnect, isColumnMounted, updateLiveBudget }
+  return {
+    setup,
+    observe,
+    cleanup,
+    disconnect,
+    isColumnMounted,
+    updateLiveBudget,
+  }
 }
 
 /** Inject column visibility state. Returns true when column is visible or unknown. */

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -26,6 +26,9 @@ export interface NotedeckSettings {
   'modes.realtime'?: boolean
   'modes.offline'?: boolean
 
+  // --- Post form ---
+  'postForm.preview'?: boolean
+
   // keybinds は keybinds.json5 に分離済み（独立ファイル）
   // AI は ai.json5 + AI.md に分離済み（独立ファイル）
 }


### PR DESCRIPTION
## Summary

v0.10.7 リリース。投稿フォームのレイアウト改善・プレビューの MkNote カード化、ドライブピッカー表示改善、カスタム CSS のカーソルプリセット追加、カラム可視性クリーンアップの刷新。

## Changes

### Features
- feat(css-editor): カスタムCSSにカーソルプリセットを追加
- feat(post-form): プレビュー表示トグルを永続化しスイッチUIに変更

### Refactor
- refactor(post-form): プレビューをMkNoteカード表示に置き換え

### Fixes
- fix(drive-picker): メディアグリッドの3段目まで見切れず表示できる高さを確保
- fix(post-form): 投稿フォームの上端をタイトルバー/ステータスバー直下まで引き上げる
- fix(post-form): モバイルでも枠付きモーダル表示にして背後カラムを透過
- fix(settings): モバイル設定メニューのインディケーターを右揃えに
- fix(deck): タブ間に明示的な gap を設けて Chromium 系の詰まりを解消
- fix(deck): カラム可視性の距離判定を廃止し cleanup を実装

## Test plan

- [ ] CI（lint / typecheck / test）通過
- [ ] 投稿フォームのプレビュー(MkNoteカード)・トグル永続化の動作確認
- [ ] モバイルでの投稿フォーム・ドライブピッカー表示確認
- [ ] カスタムCSSエディタのカーソルプリセット適用確認