### PR TITLE
Release v0.10.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.10.7",
+  "version": "0.10.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.10.7"
+version = "0.10.8"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
     "core:webview:allow-create-webview-window",
     "core:webview:allow-set-webview-zoom",
     "opener:default",
+    "opener:allow-open-path",
     "notification:default",
     "os:default",
     "haptics:default",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,7 +27,6 @@
     "core:webview:allow-create-webview-window",
     "core:webview:allow-set-webview-zoom",
     "opener:default",
-    "opener:allow-open-path",
     "notification:default",
     "os:default",
     "haptics:default",

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -215,6 +215,73 @@ pub fn get_settings_dir(app: tauri::AppHandle) -> Result<String> {
     Ok(settings_base_dir(&app)?.to_string_lossy().to_string())
 }
 
+/// Open a settings file in the OS default editor. WSL2 では xdg-open が GUI
+/// エディタへルーティングできないため、wslpath で Windows パスへ変換し
+/// cmd.exe start 経由で Windows 側の既定アプリに委譲する。
+#[tauri::command]
+#[specta::specta]
+pub fn open_settings_file_in_editor(
+    app: tauri::AppHandle,
+    subdir: Option<String>,
+    name: String,
+) -> Result<()> {
+    let path = match subdir.as_deref() {
+        Some(s) => resolve_path(&app, s, &name)?,
+        None => resolve_root_path(&app, &name)?,
+    };
+    if !path.exists() {
+        return Err(NoteDeckError::InvalidInput(format!(
+            "File does not exist: {}",
+            path.display()
+        )));
+    }
+
+    #[cfg(target_os = "linux")]
+    if is_wsl() {
+        return open_in_windows_host(&path);
+    }
+
+    tauri_plugin_opener::open_path(&path, None::<&str>)
+        .map_err(|e| NoteDeckError::InvalidInput(format!("Failed to open {}: {e}", path.display())))
+}
+
+#[cfg(target_os = "linux")]
+fn is_wsl() -> bool {
+    if std::env::var_os("WSL_DISTRO_NAME").is_some() {
+        return true;
+    }
+    fs::read_to_string("/proc/version")
+        .map(|v| {
+            let lower = v.to_lowercase();
+            lower.contains("microsoft") || lower.contains("wsl")
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(target_os = "linux")]
+fn open_in_windows_host(path: &std::path::Path) -> Result<()> {
+    use std::process::Command;
+    let output = Command::new("wslpath")
+        .arg("-w")
+        .arg(path)
+        .output()
+        .map_err(|e| NoteDeckError::InvalidInput(format!("wslpath exec failed: {e}")))?;
+    if !output.status.success() {
+        return Err(NoteDeckError::InvalidInput(format!(
+            "wslpath failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    let winpath = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // `start` は最初の引用符付き引数をウィンドウタイトルとして扱うので、
+    // 空文字列のタイトルを先に渡してからパスを渡す。
+    Command::new("cmd.exe")
+        .args(["/c", "start", "", &winpath])
+        .spawn()
+        .map_err(|e| NoteDeckError::InvalidInput(format!("cmd.exe exec failed: {e}")))?;
+    Ok(())
+}
+
 /// Read `settings.json5` (VSCode `settings.json` equivalent — single source of truth
 /// for scalar preferences). Returns empty string if the file does not exist (first run).
 ///

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -10,7 +10,7 @@ use super::Result;
 const SETTINGS_DIR: &str = "notedeck";
 
 /// Allowed subdirectory names for settings files.
-const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets"];
+const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "drafts"];
 
 /// Validate a subdirectory name against the whitelist.
 fn validate_subdir(subdir: &str) -> Result<()> {
@@ -251,7 +251,7 @@ pub fn write_notedeck_json(app: tauri::AppHandle, content: &str) -> Result<()> {
 }
 
 /// Directories and root files to include in settings backup.
-const BACKUP_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets"];
+const BACKUP_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "drafts"];
 
 /// Export all settings files to a JSON bundle via save dialog.
 #[tauri::command]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -9,7 +9,7 @@ use super::Result;
 /// Settings subdirectory name under app_data_dir.
 const SETTINGS_DIR: &str = "notedeck";
 
-/// Allowed subdirectory names for settings files.
+/// Allowed subdirectory names for settings files. Also the set included in settings backup.
 const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "drafts"];
 
 /// Validate a subdirectory name against the whitelist.
@@ -318,9 +318,6 @@ pub fn write_notedeck_json(app: tauri::AppHandle, content: &str) -> Result<()> {
     })
 }
 
-/// Directories and root files to include in settings backup.
-const BACKUP_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "drafts"];
-
 /// Export all settings files to a JSON bundle via save dialog.
 #[tauri::command]
 #[specta::specta]
@@ -348,7 +345,7 @@ pub async fn export_settings_json(app: tauri::AppHandle) -> Result<bool> {
     let mut bundle: BTreeMap<String, String> = BTreeMap::new();
 
     // Add subdirectory files (profiles/, themes/, plugins/)
-    for subdir in BACKUP_SUBDIRS {
+    for subdir in ALLOWED_SUBDIRS {
         let dir = base_dir.join(subdir);
         if !dir.exists() {
             continue;
@@ -423,7 +420,7 @@ pub async fn import_settings_json(app: tauri::AppHandle) -> Result<bool> {
         }
 
         // Validate: must be in allowed subdirs or allowed root files
-        let allowed = BACKUP_SUBDIRS
+        let allowed = ALLOWED_SUBDIRS
             .iter()
             .any(|d| key.starts_with(&format!("{d}/")))
             || ALLOWED_ROOT_FILES.contains(&key.as_str());
@@ -543,7 +540,7 @@ mod tests {
         let json_path = base.join("backup.json");
         {
             let mut bundle: BTreeMap<String, String> = BTreeMap::new();
-            for subdir in BACKUP_SUBDIRS {
+            for subdir in ALLOWED_SUBDIRS {
                 let d = base.join(subdir);
                 if !d.exists() {
                     continue;
@@ -584,7 +581,7 @@ mod tests {
                 if key.contains("..") || key.starts_with('/') || key.starts_with('\\') {
                     continue;
                 }
-                let allowed = BACKUP_SUBDIRS
+                let allowed = ALLOWED_SUBDIRS
                     .iter()
                     .any(|d| key.starts_with(&format!("{d}/")))
                     || ALLOWED_ROOT_FILES.contains(&key.as_str());
@@ -642,7 +639,7 @@ mod tests {
             if key.contains("..") || key.starts_with('/') || key.starts_with('\\') {
                 continue;
             }
-            let allowed = BACKUP_SUBDIRS
+            let allowed = ALLOWED_SUBDIRS
                 .iter()
                 .any(|d| key.starts_with(&format!("{d}/")))
                 || ALLOWED_ROOT_FILES.contains(&key.as_str());
@@ -683,7 +680,7 @@ mod tests {
             if key.contains("..") || key.starts_with('/') || key.starts_with('\\') {
                 continue;
             }
-            let allowed = BACKUP_SUBDIRS
+            let allowed = ALLOWED_SUBDIRS
                 .iter()
                 .any(|d| key.starts_with(&format!("{d}/")))
                 || ALLOWED_ROOT_FILES.contains(&key.as_str());

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -169,6 +169,7 @@ const ALLOWED_ROOT_FILES: &[&str] = &[
     "performance.json5",
     "accounts.json5",
     "navbar.json5",
+    "postform.json5",
     "settings.json5",
     "tasks.json5",
 ];

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -226,6 +226,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::delete_settings_file,
             commands::rename_settings_file,
             commands::get_settings_dir,
+            commands::open_settings_file_in_editor,
             commands::read_root_settings_file,
             commands::write_root_settings_file,
             commands::read_notedeck_json,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1255,6 +1255,19 @@ async getSettingsDir() : Promise<Result<string, { code: string; message: string 
 }
 },
 /**
+ * Open a settings file in the OS default editor. WSL2 では xdg-open が GUI
+ * エディタへルーティングできないため、wslpath で Windows パスへ変換し
+ * cmd.exe start 経由で Windows 側の既定アプリに委譲する。
+ */
+async openSettingsFileInEditor(subdir: string | null, name: string) : Promise<Result<null, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_settings_file_in_editor", { subdir, name }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Read a root-level settings file as a UTF-8 string.
  */
 async readRootSettingsFile(name: string) : Promise<Result<string, { code: string; message: string }>> {

--- a/src/components/common/MkDraftsPicker.vue
+++ b/src/components/common/MkDraftsPicker.vue
@@ -1,0 +1,610 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import type {
+  NormalizedNote,
+  NormalizedUser,
+  NoteVisibility,
+} from '@/adapters/types'
+import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
+import MkNote from '@/components/common/MkNote.vue'
+import {
+  deleteAllDrafts,
+  deleteDraft,
+  draftsVersion,
+  ensureDraftsLoaded,
+  loadAllDrafts,
+  type StoredDraft,
+} from '@/composables/useDrafts'
+import { type Account, useAccountsStore } from '@/stores/accounts'
+import { useConfirm } from '@/stores/confirm'
+import { useServersStore } from '@/stores/servers'
+import { useThemeStore } from '@/stores/theme'
+import { useToast } from '@/stores/toast'
+
+const props = defineProps<{
+  accountId: string
+}>()
+
+const emit = defineEmits<{
+  pick: [draft: StoredDraft]
+  close: []
+}>()
+
+const accountsStore = useAccountsStore()
+const serversStore = useServersStore()
+const themeStore = useThemeStore()
+const { confirm } = useConfirm()
+const toast = useToast()
+
+const account = computed<Account | undefined>(() =>
+  accountsStore.accounts.find((a) => a.id === props.accountId),
+)
+
+/** Per-account custom server theme — same vars the post form uses. */
+const themeVars = computed(() =>
+  themeStore.getStyleVarsForAccount(props.accountId),
+)
+
+/** Misskey server's empty state image (infoImageUrl) for the current account. */
+const serverInfoImageUrl = computed(() => {
+  const acc = account.value
+  if (!acc) return undefined
+  return serversStore.getServer(acc.host)?.infoImageUrl
+})
+
+interface DraftContext {
+  kind: 'reply' | 'renote' | 'note' | 'channel-note' | 'legacy'
+  channelId: string | null
+  refId: string | null
+}
+
+interface DraftEntry {
+  key: string
+  draft: StoredDraft
+  context: DraftContext
+  note: NormalizedNote
+}
+
+function parseDraftKey(key: string): DraftContext {
+  if (key.startsWith('legacy:')) {
+    return { kind: 'legacy', channelId: null, refId: key.slice(7) }
+  }
+  let rest = key
+  let channelId: string | null = null
+  if (rest.startsWith('channel:')) {
+    const m = rest.slice(8).match(/^(.*?)(?=(?:renote|reply|note):)/)
+    if (m) {
+      channelId = m[1] ?? null
+      rest = rest.slice(8 + (m[1]?.length ?? 0))
+    }
+  }
+  const idx = rest.indexOf(':')
+  if (idx < 0) return { kind: 'note', channelId, refId: null }
+  const prefix = rest.slice(0, idx)
+  const refId = rest.slice(idx + 1) || null
+  if (prefix === 'renote') return { kind: 'renote', channelId, refId }
+  if (prefix === 'reply') return { kind: 'reply', channelId, refId }
+  if (prefix === 'note') {
+    return {
+      kind: channelId ? 'channel-note' : 'note',
+      channelId,
+      refId,
+    }
+  }
+  return { kind: 'note', channelId, refId: null }
+}
+
+function userFromAccount(acc: Account): NormalizedUser {
+  return {
+    id: acc.userId,
+    username: acc.username,
+    host: null,
+    name: acc.displayName ?? null,
+    avatarUrl: acc.avatarUrl ?? null,
+  }
+}
+
+function toPreviewNote(
+  acc: Account,
+  key: string,
+  stored: StoredDraft,
+  ctx: DraftContext,
+): NormalizedNote {
+  const d = stored.data
+  return {
+    id: `draft:${acc.id}:${key}`,
+    _accountId: acc.id,
+    _serverHost: acc.host,
+    createdAt: stored.updatedAt,
+    text: d.text || null,
+    cw: d.showCw && d.cw ? d.cw : null,
+    user: userFromAccount(acc),
+    visibility: d.visibility as NoteVisibility,
+    emojis: {},
+    reactionEmojis: {},
+    reactions: {},
+    renoteCount: 0,
+    repliesCount: 0,
+    files: [],
+    localOnly: d.localOnly,
+    replyId: ctx.kind === 'reply' ? ctx.refId : null,
+    renoteId: ctx.kind === 'renote' ? ctx.refId : null,
+    channelId: ctx.channelId,
+  }
+}
+
+const loaded = ref(false)
+
+watch(
+  () => props.accountId,
+  async (id) => {
+    loaded.value = false
+    await ensureDraftsLoaded(id)
+    loaded.value = true
+  },
+  { immediate: true },
+)
+
+const entries = computed<DraftEntry[]>(() => {
+  // Track reactive version so save/delete from anywhere re-renders us.
+  void draftsVersion.value
+  if (!loaded.value || !account.value) return []
+  const map = loadAllDrafts(props.accountId)
+  const acc = account.value
+  const out: DraftEntry[] = []
+  for (const [key, draft] of Object.entries(map)) {
+    const ctx = parseDraftKey(key)
+    out.push({
+      key,
+      draft,
+      context: ctx,
+      note: toPreviewNote(acc, key, draft, ctx),
+    })
+  }
+  out.sort((a, b) => b.draft.updatedAt.localeCompare(a.draft.updatedAt))
+  return out
+})
+
+const draftCount = computed(() => entries.value.length)
+
+function contextLabel(ctx: DraftContext): string {
+  switch (ctx.kind) {
+    case 'reply':
+      return '返信'
+    case 'renote':
+      return '引用'
+    case 'channel-note':
+      return 'チャンネル投稿'
+    case 'legacy':
+      return '旧下書き'
+    default:
+      return '新規ノート'
+  }
+}
+
+function contextIcon(ctx: DraftContext): string {
+  switch (ctx.kind) {
+    case 'reply':
+      return 'ti ti-arrow-back-up'
+    case 'renote':
+      return 'ti ti-quote'
+    case 'channel-note':
+      return 'ti ti-device-tv'
+    case 'legacy':
+      return 'ti ti-archive'
+    default:
+      return 'ti ti-pencil'
+  }
+}
+
+function truncate(s: string, max: number): string {
+  const t = s.trim()
+  if (t.length <= max) return t
+  return `${t.slice(0, max)}…`
+}
+
+function formatScheduledAt(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function onPick(entry: DraftEntry) {
+  emit('pick', entry.draft)
+}
+
+// --- Custom context menu (overrides MkNote's default NoteMoreMenu) ---
+const menuState = ref<{
+  x: number
+  y: number
+  entry: DraftEntry
+} | null>(null)
+const menuRef = ref<HTMLElement | null>(null)
+
+function onContextMenu(e: MouseEvent, entry: DraftEntry) {
+  e.preventDefault()
+  e.stopPropagation()
+  menuState.value = { x: e.clientX, y: e.clientY, entry }
+  void nextTick(() => {
+    const el = menuRef.value
+    if (!el || !menuState.value) return
+    const rect = el.getBoundingClientRect()
+    const vw = window.innerWidth
+    const vh = window.innerHeight
+    const nx = Math.min(menuState.value.x, vw - rect.width - 4)
+    const ny = Math.min(menuState.value.y, vh - rect.height - 4)
+    menuState.value = { x: nx, y: ny, entry: menuState.value.entry }
+  })
+}
+
+function closeMenu() {
+  menuState.value = null
+}
+
+async function onDelete(entry: DraftEntry) {
+  const ok = await confirm({
+    title: '下書きを削除',
+    message: '選択した下書きを削除しますか？',
+    okLabel: '削除',
+    type: 'danger',
+  })
+  if (!ok) return
+  deleteDraft(props.accountId, entry.key)
+  toast.show('下書きを削除しました', 'info')
+}
+
+async function onDeleteAll() {
+  if (draftCount.value === 0) return
+  const ok = await confirm({
+    title: 'すべての下書きを削除',
+    message: `下書き ${draftCount.value} 件をすべて削除しますか？`,
+    okLabel: 'すべて削除',
+    type: 'danger',
+  })
+  if (!ok) return
+  deleteAllDrafts(props.accountId)
+  toast.show('下書きをすべて削除しました', 'info')
+}
+</script>
+
+<template>
+  <div :class="$style.draftsPicker" :style="themeVars" @click.stop>
+    <!-- Header -->
+    <div :class="$style.dpHeader">
+      <span :class="$style.dpTitle">
+        <i class="ti ti-notes" />
+        下書き
+        <span :class="$style.dpCount">{{ draftCount }}</span>
+      </span>
+      <button
+        v-if="draftCount > 0"
+        class="_button"
+        :class="$style.dpHeaderBtn"
+        title="すべて削除"
+        @click="onDeleteAll"
+      >
+        <i class="ti ti-trash" />
+      </button>
+      <button class="_button" :class="$style.dpHeaderBtn" title="閉じる" @click="emit('close')">
+        <i class="ti ti-x" />
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div :class="$style.dpBody">
+      <div v-if="!loaded" :class="$style.dpEmpty">読み込み中...</div>
+      <ColumnEmptyState
+        v-else-if="draftCount === 0"
+        message="下書きはありません"
+        :image-url="serverInfoImageUrl"
+      />
+      <div v-else :class="$style.dpList">
+        <div
+          v-for="entry in entries"
+          :key="entry.key"
+          :class="$style.item"
+          @contextmenu.capture="onContextMenu($event, entry)"
+        >
+          <div :class="$style.meta">
+            <span
+              v-if="entry.context.kind !== 'note'"
+              :class="$style.metaCtx"
+            >
+              <i :class="contextIcon(entry.context)" />
+              {{ contextLabel(entry.context) }}
+            </span>
+            <span
+              v-if="entry.context.refId && (entry.context.kind === 'reply' || entry.context.kind === 'renote')"
+              :class="$style.metaRef"
+              :title="entry.context.refId"
+            >{{ truncate(entry.context.refId, 14) }}</span>
+            <span
+              v-if="entry.context.channelId"
+              :class="$style.metaChannel"
+              :title="entry.context.channelId"
+            >
+              <i class="ti ti-device-tv" />
+              {{ truncate(entry.context.channelId, 12) }}
+            </span>
+            <span
+              v-if="entry.draft.data.scheduledAt"
+              :class="$style.metaScheduled"
+              :title="entry.draft.data.scheduledAt"
+            >
+              <i class="ti ti-clock" />
+              {{ formatScheduledAt(entry.draft.data.scheduledAt) }}
+            </span>
+            <span
+              v-if="entry.draft.data.showPoll && entry.draft.data.pollChoices.length"
+              :class="$style.metaBadge"
+            >
+              <i class="ti ti-chart-bar" />
+              投票
+              {{ entry.draft.data.pollChoices.filter((c) => c.trim()).length }}択
+            </span>
+            <span v-if="entry.draft.data.fileIds.length" :class="$style.metaBadge">
+              <i class="ti ti-paperclip" />
+              添付 {{ entry.draft.data.fileIds.length }}
+            </span>
+          </div>
+          <button
+            class="_button"
+            :class="$style.itemNoteBtn"
+            title="この下書きを復元"
+            @click="onPick(entry)"
+          >
+            <MkNote :note="entry.note" embedded />
+          </button>
+          <div :class="$style.itemActions">
+            <button
+              class="_button"
+              :class="$style.itemEditBtn"
+              title="編集（投稿フォームに反映）"
+              @click.stop="onPick(entry)"
+            >
+              <i class="ti ti-pencil" />
+            </button>
+            <button
+              class="_button"
+              :class="$style.itemRemoveBtn"
+              title="削除"
+              @click.stop="onDelete(entry)"
+            >
+              <i class="ti ti-x" />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Custom right-click menu (overrides MkNote's default NoteMoreMenu) -->
+    <Teleport to="body">
+      <div
+        v-if="menuState"
+        :class="$style.menuBackdrop"
+        @click="closeMenu"
+        @contextmenu.prevent="closeMenu"
+      >
+        <div
+          ref="menuRef"
+          class="_popup"
+          :class="$style.menu"
+          :style="{ top: `${menuState.y}px`, left: `${menuState.x}px` }"
+          @click.stop
+          @contextmenu.stop.prevent
+        >
+          <button
+            class="_button"
+            :class="$style.menuItem"
+            @click="onPick(menuState.entry); closeMenu()"
+          >
+            <i class="ti ti-arrow-back-up" />
+            復元して投稿フォームに反映
+          </button>
+          <div :class="$style.menuDivider" />
+          <button
+            class="_button"
+            :class="[$style.menuItem, $style.menuItemDanger]"
+            @click="onDelete(menuState.entry); closeMenu()"
+          >
+            <i class="ti ti-trash" />
+            削除
+          </button>
+        </div>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style lang="scss" module>
+.draftsPicker {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 520px;
+  max-height: min(75vh, 640px);
+  margin: 0 16px 16px;
+  background: var(--nd-panelBg, var(--nd-popup));
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px var(--nd-shadow);
+}
+
+.dpHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.dpTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.9em;
+  font-weight: 600;
+  flex: 1;
+  min-width: 0;
+}
+
+.dpCount {
+  font-size: 0.75em;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--nd-accent);
+  color: var(--nd-fgOnAccent);
+  font-weight: 600;
+}
+
+.dpHeaderBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  opacity: 0.6;
+  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
+
+  &:hover {
+    opacity: 1;
+    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
+  }
+}
+
+.dpBody {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.dpList {
+  display: flex;
+  flex-direction: column;
+}
+
+.item {
+  position: relative;
+  border-bottom: 1px solid var(--nd-divider);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background: light-dark(rgba(0, 0, 0, 0.015), rgba(255, 255, 255, 0.015));
+  }
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 10px;
+  padding: 8px 14px 0;
+  font-size: 0.75em;
+  opacity: 0.8;
+}
+
+.metaCtx {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+}
+
+.metaRef {
+  font-family: var(--nd-font-mono, monospace);
+  opacity: 0.7;
+}
+
+.metaChannel {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.06));
+}
+
+.metaScheduled {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
+  color: var(--nd-accent);
+}
+
+.metaBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  opacity: 0.7;
+}
+
+.itemNoteBtn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+/* Hover-revealed action buttons (matches AppearanceEditor theme grid pattern) */
+.itemActions {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  display: flex;
+  gap: 4px;
+  z-index: 1;
+  opacity: 0;
+  transition: opacity var(--nd-duration-fast);
+
+  .item:hover & {
+    opacity: 1;
+  }
+}
+
+.itemEditBtn,
+.itemRemoveBtn {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: filter var(--nd-duration-base);
+
+  &:hover {
+    filter: brightness(0.85);
+  }
+}
+
+.itemEditBtn {
+  background: var(--nd-accent, #86b300);
+}
+
+.itemRemoveBtn {
+  background: var(--nd-error, #ec4137);
+}
+
+.dpEmpty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 40px 16px;
+  text-align: center;
+}
+</style>

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -19,7 +19,6 @@ import {
 import { usePostFormStore } from '@/stores/postForm'
 import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
-import { useWindowsStore } from '@/stores/windows'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
@@ -27,6 +26,7 @@ import MkDraftsPicker from './MkDraftsPicker.vue'
 import MkDrivePicker from './MkDrivePicker.vue'
 import MkMfm from './MkMfm.vue'
 import MkNote from './MkNote.vue'
+import MkPostFormButtonsPicker from './MkPostFormButtonsPicker.vue'
 import MkReactionPicker from './MkReactionPicker.vue'
 
 const props = defineProps<{
@@ -51,11 +51,6 @@ const emit = defineEmits<{
 const isCompact = useIsCompactLayout()
 const settingsStore = useSettingsStore()
 const postFormStore = usePostFormStore()
-const windowsStore = useWindowsStore()
-
-function openPostFormEditor() {
-  windowsStore.open('postFormEditor')
-}
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
 const showPreview = computed<boolean>({
@@ -159,6 +154,11 @@ const showAttachMenu = popups.register()
 const showMoreMenu = popups.register()
 const showDraftsPicker = popups.register()
 const showDrivePicker = popups.register()
+const showPostFormButtonsPicker = popups.register()
+
+function togglePostFormButtonsPicker() {
+  popups.toggle(showPostFormButtonsPicker)
+}
 
 // --- Drafts picker (inline, opens below the form) ---
 function toggleDraftsPicker() {
@@ -970,9 +970,9 @@ function onKeydown(e: KeyboardEvent) {
           <!-- Post form editor -->
           <button
             class="_button"
-            :class="$style.footerBtn"
+            :class="[$style.footerBtn, { [$style.active]: showPostFormButtonsPicker }]"
             title="ボタン並び替え"
-            @click="openPostFormEditor"
+            @click.stop="togglePostFormButtonsPicker"
           >
             <i class="ti ti-settings" />
           </button>
@@ -995,6 +995,12 @@ function onKeydown(e: KeyboardEvent) {
       :account-id="activeAccountId!"
       @pick="onDriveFilesPicked"
       @close="showDrivePicker = false"
+    />
+
+    <!-- Post form buttons picker (below post form) -->
+    <MkPostFormButtonsPicker
+      v-if="showPostFormButtonsPicker"
+      @close="showPostFormButtonsPicker = false"
     />
 
   </div>

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -134,16 +134,6 @@ const removePollChoiceKeyed = (index: number) => {
   pollChoiceKeys.value.splice(index, 1)
 }
 
-// --- Drafts picker (inline, opens below the form) ---
-const showDraftsPicker = ref(false)
-function toggleDraftsPicker() {
-  showDraftsPicker.value = !showDraftsPicker.value
-}
-function onDraftPicked(draft: StoredDraft) {
-  restoreDraft(draft)
-  showDraftsPicker.value = false
-}
-
 // --- Auto-save draft toggle (persisted in settings, like preview) ---
 const autoSaveDraft = computed<boolean>({
   get: () => settingsStore.get('postForm.autoSaveDraft') ?? false,
@@ -153,12 +143,23 @@ const autoSaveDraft = computed<boolean>({
 })
 
 // --- Popup exclusive control ---
+// ピッカー系 (emoji / drive / drafts) はシングルトン: 同時に1つだけ開く
 const popups = usePopupControl()
 const showSchedulePopup = popups.register()
 const showEmojiPopup = popups.register()
 const showAttachMenu = popups.register()
-
 const showMoreMenu = popups.register()
+const showDraftsPicker = popups.register()
+const showDrivePicker = popups.register()
+
+// --- Drafts picker (inline, opens below the form) ---
+function toggleDraftsPicker() {
+  popups.toggle(showDraftsPicker)
+}
+function onDraftPicked(draft: StoredDraft) {
+  restoreDraft(draft)
+  showDraftsPicker.value = false
+}
 
 function toggleSchedulePopup() {
   popups.toggle(showSchedulePopup)
@@ -288,8 +289,6 @@ const {
 } = useAutocomplete(text, textareaRef, activeAccountId, serverHost)
 
 // --- File attach menu ---
-const showDrivePicker = ref(false)
-
 function toggleAttachMenu() {
   popups.toggle(showAttachMenu)
 }
@@ -300,7 +299,7 @@ function attachFromLocal() {
 }
 
 function attachFromDrive() {
-  showAttachMenu.value = false
+  popups.closeOthers(showDrivePicker)
   showDrivePicker.value = true
 }
 
@@ -918,7 +917,7 @@ function onKeydown(e: KeyboardEvent) {
             class="_button"
             :class="[$style.footerBtn, { [$style.active]: showDraftsPicker }]"
             title="下書き一覧"
-            @click="toggleDraftsPicker"
+            @click.stop="toggleDraftsPicker"
           >
             <i class="ti ti-notes" />
           </button>

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -966,7 +966,7 @@ function onKeydown(e: KeyboardEvent) {
             </button>
           </template>
         </div>
-        <div :class="$style.footerRight">
+        <div v-if="!props.inline" :class="$style.footerRight">
           <!-- Post form editor -->
           <button
             class="_button"

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -6,6 +6,7 @@ import type {
   NormalizedUser,
 } from '@/adapters/types'
 import { useAutocomplete } from '@/composables/useAutocomplete'
+import type { StoredDraft } from '@/composables/useDrafts'
 import { useMentionSearch } from '@/composables/useMentionSearch'
 import { useMfmInsert } from '@/composables/useMfmInsert'
 import { usePopupControl } from '@/composables/usePopupControl'
@@ -20,6 +21,7 @@ import { useIsCompactLayout } from '@/stores/ui'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
+import MkDraftsPicker from './MkDraftsPicker.vue'
 import MkDrivePicker from './MkDrivePicker.vue'
 import MkMfm from './MkMfm.vue'
 import MkNote from './MkNote.vue'
@@ -85,8 +87,6 @@ const {
   pollExpiresAt,
   scheduledAt,
   supportsScheduledNotes,
-  drafts,
-  showDraftMenu,
   initAdapter,
   switchAccount,
   post,
@@ -102,9 +102,7 @@ const {
   addPollChoice,
   removePollChoice,
   resetForm,
-  saveCurrentDraft,
   restoreDraft,
-  removeDraft,
 } = usePostFormState(
   props,
   {
@@ -136,9 +134,26 @@ const removePollChoiceKeyed = (index: number) => {
   pollChoiceKeys.value.splice(index, 1)
 }
 
+// --- Drafts picker (inline, opens below the form) ---
+const showDraftsPicker = ref(false)
+function toggleDraftsPicker() {
+  showDraftsPicker.value = !showDraftsPicker.value
+}
+function onDraftPicked(draft: StoredDraft) {
+  restoreDraft(draft)
+  showDraftsPicker.value = false
+}
+
+// --- Auto-save draft toggle (persisted in settings, like preview) ---
+const autoSaveDraft = computed<boolean>({
+  get: () => settingsStore.get('postForm.autoSaveDraft') ?? false,
+  set: (v) => {
+    settingsStore.set('postForm.autoSaveDraft', v)
+  },
+})
+
 // --- Popup exclusive control ---
 const popups = usePopupControl()
-popups.track(showDraftMenu)
 const showSchedulePopup = popups.register()
 const showEmojiPopup = popups.register()
 const showAttachMenu = popups.register()
@@ -166,11 +181,6 @@ function formatScheduledDate(iso: string): string {
     hour: '2-digit',
     minute: '2-digit',
   })
-}
-
-// --- Draft menu ---
-function toggleDraftMenu() {
-  popups.toggle(showDraftMenu)
 }
 
 /** Minimum datetime for schedule picker (5 minutes from now) */
@@ -556,46 +566,23 @@ function onKeydown(e: KeyboardEvent) {
                   <span class="nd-toggle-switch-knob" />
                 </span>
               </div>
-              <!-- Draft save -->
-              <button
-                class="_button"
+              <!-- Auto-save draft toggle (persisted, mirrors preview pattern) -->
+              <div
                 :class="$style.moreMenuItem"
-                @click="saveCurrentDraft(); showMoreMenu = false"
+                role="switch"
+                :aria-checked="autoSaveDraft"
+                @click="autoSaveDraft = !autoSaveDraft"
               >
                 <i class="ti ti-device-floppy" />
                 下書きを保存
-              </button>
-              <!-- Draft list -->
-              <button
-                class="_button"
-                :class="[$style.moreMenuItem, { [$style.active]: showDraftMenu }]"
-                @click.stop="showDraftMenu = !showDraftMenu"
-              >
-                <i class="ti ti-notes" />
-                下書き
-                <span v-if="drafts.length > 0" :class="$style.moreMenuBadge">{{ drafts.length }}</span>
-              </button>
-              <!-- Draft list popup (nested) -->
-              <div v-if="showDraftMenu" :class="$style.moreMenuDraftList">
-                <div
-                  v-for="d in drafts"
-                  :key="d.id"
-                  :class="$style.draftItem"
+                <span
+                  class="nd-toggle-switch"
+                  :class="{ on: autoSaveDraft }"
+                  :style="{ marginLeft: 'auto' }"
+                  aria-hidden="true"
                 >
-                  <button class="_button" :class="$style.draftItemMain" @click="restoreDraft(d); showMoreMenu = false">
-                    <span :class="$style.draftItemText">{{ d.text || '(空)' }}</span>
-                    <span :class="$style.draftItemDate">{{ new Date(d.savedAt).toLocaleDateString() }}</span>
-                  </button>
-                  <button
-                    class="_button"
-                    :class="$style.draftItemDelete"
-                    title="下書きを削除"
-                    @click.stop="removeDraft(d.id)"
-                  >
-                    <i class="ti ti-x" />
-                  </button>
-                </div>
-                <div v-if="drafts.length === 0" :class="$style.draftEmpty">下書きはありません</div>
+                  <span class="nd-toggle-switch-knob" />
+                </span>
               </div>
               <!-- Schedule (only if server supports it) -->
               <template v-if="supportsScheduledNotes && !editNote">
@@ -926,6 +913,16 @@ function onKeydown(e: KeyboardEvent) {
             </div>
           </div>
 
+          <!-- Drafts picker toggle -->
+          <button
+            class="_button"
+            :class="[$style.footerBtn, { [$style.active]: showDraftsPicker }]"
+            title="下書き一覧"
+            @click="toggleDraftsPicker"
+          >
+            <i class="ti ti-notes" />
+          </button>
+
           <!-- Clear -->
           <button
             class="_button"
@@ -955,6 +952,14 @@ function onKeydown(e: KeyboardEvent) {
       </footer>
 
     </div>
+
+    <!-- Drafts picker (below post form) -->
+    <MkDraftsPicker
+      v-if="showDraftsPicker"
+      :account-id="activeAccountId!"
+      @pick="onDraftPicked"
+      @close="showDraftsPicker = false"
+    />
 
     <!-- Drive picker (below post form) -->
     <MkDrivePicker
@@ -1374,15 +1379,6 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
-.moreMenuBadge {
-  margin-left: auto;
-  font-size: 0.75em;
-  padding: 1px 6px;
-  border-radius: 10px;
-  background: var(--nd-accent);
-  color: var(--nd-fgOnAccent);
-}
-
 .moreMenuDivider {
   height: 1px;
   margin: 2px 8px;
@@ -1393,13 +1389,6 @@ function onKeydown(e: KeyboardEvent) {
   margin-left: auto;
   font-size: 0.75em;
   opacity: 0.7;
-}
-
-.moreMenuDraftList {
-  max-height: 200px;
-  overflow-y: auto;
-  padding: 0 4px 4px;
-  scrollbar-width: none;
 }
 
 .moreMenuSchedulePicker {
@@ -1908,107 +1897,6 @@ function onKeydown(e: KeyboardEvent) {
     opacity: 1;
     background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
   }
-}
-
-/* ── Draft menu ── */
-.draftMenu {
-  width: 280px;
-  max-height: 360px;
-  overflow: hidden;
-  display: flex;
-  flex-direction: column;
-}
-
-.draftMenuItem {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 10px 12px;
-  font-size: 0.85em;
-  color: var(--nd-fg);
-  border-radius: var(--nd-radius-sm);
-  transition: background var(--nd-duration-base);
-
-  &:hover {
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
-
-.draftSave {
-  color: var(--nd-accent);
-  font-weight: bold;
-}
-
-.draftDivider {
-  height: 1px;
-  margin: 2px 8px;
-  background: var(--nd-divider);
-}
-
-.draftList {
-  flex: 1;
-  overflow-y: auto;
-  padding: 4px;
-  scrollbar-width: none;
-}
-
-.draftItem {
-  display: flex;
-  align-items: center;
-  border-radius: var(--nd-radius-sm);
-  transition: background var(--nd-duration-base);
-
-  &:hover {
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
-
-.draftItemMain {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  padding: 8px;
-  min-width: 0;
-  text-align: left;
-  color: var(--nd-fg);
-}
-
-.draftItemText {
-  font-size: 0.82em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.draftItemDate {
-  font-size: 0.72em;
-  opacity: 0.5;
-}
-
-.draftItemDelete {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  flex-shrink: 0;
-  border-radius: var(--nd-radius-sm);
-  color: var(--nd-fg);
-  opacity: 0.4;
-
-  &:hover {
-    opacity: 1;
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
-
-.draftEmpty {
-  padding: 16px;
-  text-align: center;
-  font-size: 0.8em;
-  opacity: 0.5;
 }
 
 /* ── Schedule popup ── */

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -821,18 +821,15 @@ function onKeydown(e: KeyboardEvent) {
         <div :class="$style.footerLeft">
           <template v-for="btnId in postFormStore.buttons" :key="btnId">
             <!-- Emoji -->
-            <div v-if="btnId === 'emoji'" :class="$style.footerPopupWrapper">
-              <button class="_button" :class="$style.footerBtn" title="絵文字" @click.stop="toggleEmojiPopup">
-                <i class="ti ti-mood-happy" />
-              </button>
-              <div v-if="showEmojiPopup && account" :class="[$style.footerPopup, $style.emojiPopup]" @click.stop>
-                <MkReactionPicker
-                  :server-host="account.host"
-                  :account-id="activeAccountId"
-                  @pick="pickEmoji"
-                />
-              </div>
-            </div>
+            <button
+              v-if="btnId === 'emoji'"
+              class="_button"
+              :class="[$style.footerBtn, { [$style.active]: showEmojiPopup }]"
+              title="絵文字"
+              @click.stop="toggleEmojiPopup"
+            >
+              <i class="ti ti-mood-happy" />
+            </button>
 
             <!-- Attach file -->
             <div v-else-if="btnId === 'attach'" :class="$style.footerPopupWrapper">
@@ -1002,6 +999,27 @@ function onKeydown(e: KeyboardEvent) {
       v-if="showPostFormButtonsPicker"
       @close="showPostFormButtonsPicker = false"
     />
+
+    <!-- Emoji picker (below post form) -->
+    <div v-if="showEmojiPopup && account" :class="$style.emojiPickerPanel" :style="formThemeVars" @click.stop>
+      <div :class="$style.emojiPickerHeader">
+        <span :class="$style.emojiPickerTitle">
+          <i class="ti ti-mood-happy" />
+          絵文字
+        </span>
+        <button class="_button" :class="$style.emojiPickerCloseBtn" title="閉じる" @click="showEmojiPopup = false">
+          <i class="ti ti-x" />
+        </button>
+      </div>
+      <div :class="$style.emojiPickerBody">
+        <MkReactionPicker
+          :server-host="account.host"
+          :account-id="activeAccountId"
+          full-width
+          @pick="pickEmoji"
+        />
+      </div>
+    </div>
 
   </div>
 </template>
@@ -1669,6 +1687,7 @@ function onKeydown(e: KeyboardEvent) {
 
 /* ── Footer ── */
 .footer {
+  position: relative;
   display: flex;
   padding: 0 4px 4px;
   font-size: 1em;
@@ -1693,7 +1712,7 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 .footerPopupWrapper {
-  position: relative;
+  /* no positioning — popups anchor to .footer so they stay within form bounds */
 }
 
 .footerBtn {
@@ -1810,16 +1829,6 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 /* ── Emoji popup ── */
-.emojiPopup {
-  width: 320px;
-  max-height: 360px;
-  overflow: hidden;
-  /* Override default centering: anchor to right edge since it's in footer-right */
-  left: auto;
-  right: 0;
-  transform: none;
-  direction: ltr;
-}
 
 /* ── MFM menu ── */
 .mfmMenu {
@@ -2020,8 +2029,60 @@ function onKeydown(e: KeyboardEvent) {
 .attachMenu {
   min-width: 200px;
   padding: 4px;
-  left: 0;
-  transform: none;
+}
+
+/* ── Emoji picker (below post form, matches form width) ── */
+.emojiPickerPanel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 520px;
+  max-height: min(60vh, 520px);
+  margin: 0 16px 16px;
+  background: var(--nd-panelBg, var(--nd-popup));
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px var(--nd-shadow);
+}
+
+.emojiPickerHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.emojiPickerTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: bold;
+  font-size: 0.9em;
+  flex: 1;
+}
+
+.emojiPickerCloseBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: var(--nd-fg);
+  opacity: 0.7;
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+    opacity: 1;
+  }
+}
+
+.emojiPickerBody {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
 }
 
 .attachMenuItem {

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -16,8 +16,10 @@ import {
   getAccountLabel,
   isGuestAccount,
 } from '@/stores/accounts'
+import { usePostFormStore } from '@/stores/postForm'
 import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
+import { useWindowsStore } from '@/stores/windows'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
@@ -48,6 +50,12 @@ const emit = defineEmits<{
 
 const isCompact = useIsCompactLayout()
 const settingsStore = useSettingsStore()
+const postFormStore = usePostFormStore()
+const windowsStore = useWindowsStore()
+
+function openPostFormEditor() {
+  windowsStore.open('postFormEditor')
+}
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const fileInput = ref<HTMLInputElement | null>(null)
 const showPreview = computed<boolean>({
@@ -811,142 +819,163 @@ function onKeydown(e: KeyboardEvent) {
       <!-- Footer -->
       <footer :class="$style.footer">
         <div :class="$style.footerLeft">
-          <!-- Attach file -->
-          <div :class="$style.footerPopupWrapper">
+          <template v-for="btnId in postFormStore.buttons" :key="btnId">
+            <!-- Emoji -->
+            <div v-if="btnId === 'emoji'" :class="$style.footerPopupWrapper">
+              <button class="_button" :class="$style.footerBtn" title="絵文字" @click.stop="toggleEmojiPopup">
+                <i class="ti ti-mood-happy" />
+              </button>
+              <div v-if="showEmojiPopup && account" :class="[$style.footerPopup, $style.emojiPopup]" @click.stop>
+                <MkReactionPicker
+                  :server-host="account.host"
+                  :account-id="activeAccountId"
+                  @pick="pickEmoji"
+                />
+              </div>
+            </div>
+
+            <!-- Attach file -->
+            <div v-else-if="btnId === 'attach'" :class="$style.footerPopupWrapper">
+              <button
+                class="_button"
+                :class="$style.footerBtn"
+                title="ファイルを添付"
+                :disabled="isUploading"
+                @click.stop="toggleAttachMenu"
+              >
+                <i class="ti ti-photo-plus" />
+              </button>
+              <div v-if="showAttachMenu" :class="[$style.footerPopup, $style.attachMenu]" @click.stop>
+                <button class="_button" :class="$style.attachMenuItem" @click="attachFromLocal">
+                  <i class="ti ti-upload" />
+                  <span>アップロード</span>
+                </button>
+                <button class="_button" :class="$style.attachMenuItem" @click="attachFromDrive">
+                  <i class="ti ti-cloud" />
+                  <span>ドライブから</span>
+                </button>
+              </div>
+            </div>
+
+            <!-- Poll -->
             <button
+              v-else-if="btnId === 'poll'"
+              class="_button"
+              :class="[$style.footerBtn, { [$style.active]: showPoll }]"
+              title="投票"
+              @click="showPoll = !showPoll"
+            >
+              <i class="ti ti-chart-arrows" />
+            </button>
+
+            <!-- CW -->
+            <button
+              v-else-if="btnId === 'cw'"
+              class="_button"
+              :class="[$style.footerBtn, { [$style.active]: showCw }]"
+              title="閲覧注意"
+              @click="showCw = !showCw"
+            >
+              <i class="ti ti-eye-off" />
+            </button>
+
+            <!-- Hashtag -->
+            <button
+              v-else-if="btnId === 'hashtag'"
               class="_button"
               :class="$style.footerBtn"
-              title="ファイルを添付"
-              :disabled="isUploading"
-              @click.stop="toggleAttachMenu"
+              title="ハッシュタグ"
+              @click="insertHashtag"
             >
-              <i class="ti ti-photo-plus" />
+              <i class="ti ti-hash" />
             </button>
-            <div v-if="showAttachMenu" :class="[$style.footerPopup, $style.attachMenu]" @click.stop>
-              <button class="_button" :class="$style.attachMenuItem" @click="attachFromLocal">
-                <i class="ti ti-upload" />
-                <span>アップロード</span>
+
+            <!-- Mention -->
+            <div v-else-if="btnId === 'mention'" :class="$style.footerPopupWrapper">
+              <button class="_button" :class="$style.footerBtn" title="メンション" @click.stop="toggleMentionPopup">
+                <i class="ti ti-at" />
               </button>
-              <button class="_button" :class="$style.attachMenuItem" @click="attachFromDrive">
-                <i class="ti ti-cloud" />
-                <span>ドライブから</span>
-              </button>
-            </div>
-          </div>
-
-          <!-- Poll -->
-          <button
-            class="_button"
-            :class="[$style.footerBtn, { [$style.active]: showPoll }]"
-            title="投票"
-            @click="showPoll = !showPoll"
-          >
-            <i class="ti ti-chart-arrows" />
-          </button>
-
-          <!-- CW -->
-          <button
-            class="_button"
-            :class="[$style.footerBtn, { [$style.active]: showCw }]"
-            title="閲覧注意"
-            @click="showCw = !showCw"
-          >
-            <i class="ti ti-eye-off" />
-          </button>
-
-          <!-- Hashtag -->
-          <button class="_button" :class="$style.footerBtn" title="ハッシュタグ" @click="insertHashtag">
-            <i class="ti ti-hash" />
-          </button>
-
-          <!-- Mention -->
-          <div :class="$style.footerPopupWrapper">
-            <button class="_button" :class="$style.footerBtn" title="メンション" @click.stop="toggleMentionPopup">
-              <i class="ti ti-at" />
-            </button>
-            <div v-if="showMentionPopup" :class="[$style.footerPopup, $style.mentionPopup]" @click.stop>
-              <input
-                v-model="mentionQuery"
-                :class="$style.mentionSearchInput"
-                type="text"
-                placeholder="ユーザーを検索..."
-                @input="onMentionInput"
-              />
-              <div :class="$style.mentionResults">
-                <button
-                  v-for="user in mentionResults"
-                  :key="user.id"
-                  class="_button"
-                  :class="$style.mentionResultItem"
-                  @click="pickMention(user)"
-                >
-                  <img v-if="user.avatarUrl" :src="user.avatarUrl" :class="$style.mentionAvatar" />
-                  <div :class="$style.mentionInfo">
-                    <span :class="$style.mentionName">{{ user.username }}</span>
-                    <span v-if="user.host" :class="$style.mentionHost">@{{ user.host }}</span>
+              <div v-if="showMentionPopup" :class="[$style.footerPopup, $style.mentionPopup]" @click.stop>
+                <input
+                  v-model="mentionQuery"
+                  :class="$style.mentionSearchInput"
+                  type="text"
+                  placeholder="ユーザーを検索..."
+                  @input="onMentionInput"
+                />
+                <div :class="$style.mentionResults">
+                  <button
+                    v-for="user in mentionResults"
+                    :key="user.id"
+                    class="_button"
+                    :class="$style.mentionResultItem"
+                    @click="pickMention(user)"
+                  >
+                    <img v-if="user.avatarUrl" :src="user.avatarUrl" :class="$style.mentionAvatar" />
+                    <div :class="$style.mentionInfo">
+                      <span :class="$style.mentionName">{{ user.username }}</span>
+                      <span v-if="user.host" :class="$style.mentionHost">@{{ user.host }}</span>
+                    </div>
+                  </button>
+                  <div v-if="mentionSearching" :class="$style.mentionStatus">検索中...</div>
+                  <div v-else-if="mentionQuery && mentionResults.length === 0" :class="$style.mentionStatus">
+                    ユーザーが見つかりません
                   </div>
-                </button>
-                <div v-if="mentionSearching" :class="$style.mentionStatus">検索中...</div>
-                <div v-else-if="mentionQuery && mentionResults.length === 0" :class="$style.mentionStatus">
-                  ユーザーが見つかりません
                 </div>
               </div>
             </div>
-          </div>
 
-          <!-- MFM -->
-          <div :class="$style.footerPopupWrapper">
-            <button class="_button" :class="$style.footerBtn" title="MFM" @click.stop="toggleMfmMenu">
-              <i class="ti ti-palette" />
-            </button>
-            <div v-if="showMfmMenu" :class="[$style.footerPopup, $style.mfmMenu]" @click.stop>
-              <button
-                v-for="fn in mfmFunctions"
-                :key="fn.label"
-                class="_button"
-                :class="$style.mfmMenuItem"
-                @click="pickMfm(fn)"
-              >
-                {{ fn.label }}
+            <!-- MFM -->
+            <div v-else-if="btnId === 'mfm'" :class="$style.footerPopupWrapper">
+              <button class="_button" :class="$style.footerBtn" title="MFM" @click.stop="toggleMfmMenu">
+                <i class="ti ti-palette" />
               </button>
+              <div v-if="showMfmMenu" :class="[$style.footerPopup, $style.mfmMenu]" @click.stop>
+                <button
+                  v-for="fn in mfmFunctions"
+                  :key="fn.label"
+                  class="_button"
+                  :class="$style.mfmMenuItem"
+                  @click="pickMfm(fn)"
+                >
+                  {{ fn.label }}
+                </button>
+              </div>
             </div>
-          </div>
 
-          <!-- Drafts picker toggle -->
-          <button
-            class="_button"
-            :class="[$style.footerBtn, { [$style.active]: showDraftsPicker }]"
-            title="下書き一覧"
-            @click.stop="toggleDraftsPicker"
-          >
-            <i class="ti ti-notes" />
-          </button>
+            <!-- Drafts picker toggle -->
+            <button
+              v-else-if="btnId === 'draft'"
+              class="_button"
+              :class="[$style.footerBtn, { [$style.active]: showDraftsPicker }]"
+              title="下書き一覧"
+              @click.stop="toggleDraftsPicker"
+            >
+              <i class="ti ti-notes" />
+            </button>
 
-          <!-- Clear -->
+            <!-- Clear -->
+            <button
+              v-else-if="btnId === 'clear'"
+              class="_button"
+              :class="$style.footerBtn"
+              title="クリア"
+              @click="resetForm"
+            >
+              <i class="ti ti-trash" />
+            </button>
+          </template>
+        </div>
+        <div :class="$style.footerRight">
+          <!-- Post form editor -->
           <button
             class="_button"
             :class="$style.footerBtn"
-            title="クリア"
-            @click="resetForm"
+            title="ボタン並び替え"
+            @click="openPostFormEditor"
           >
-            <i class="ti ti-trash" />
+            <i class="ti ti-settings" />
           </button>
-
-        </div>
-        <div :class="$style.footerRight">
-          <!-- Emoji -->
-          <div :class="$style.footerPopupWrapper">
-            <button class="_button" :class="$style.footerBtn" title="絵文字" @click.stop="toggleEmojiPopup">
-              <i class="ti ti-mood-happy" />
-            </button>
-            <div v-if="showEmojiPopup && account" :class="[$style.footerPopup, $style.emojiPopup]" @click.stop>
-              <MkReactionPicker
-                :server-host="account.host"
-                :account-id="activeAccountId"
-                @pick="pickEmoji"
-              />
-            </div>
-          </div>
         </div>
       </footer>
 

--- a/src/components/common/MkPostFormButtonsPicker.vue
+++ b/src/components/common/MkPostFormButtonsPicker.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
+
+const PostFormEditorContent = defineAsyncComponent(
+  () => import('@/components/window/PostFormEditorContent.vue'),
+)
+
+const emit = defineEmits<{
+  close: []
+}>()
+</script>
+
+<template>
+  <div :class="$style.picker" @click.stop>
+    <div :class="$style.header">
+      <span :class="$style.title">
+        <i class="ti ti-forms" />
+        投稿フォームボタン
+      </span>
+      <button class="_button" :class="$style.closeBtn" title="閉じる" @click="emit('close')">
+        <i class="ti ti-x" />
+      </button>
+    </div>
+    <div :class="$style.body">
+      <PostFormEditorContent />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" module>
+.picker {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 520px;
+  max-height: min(75vh, 640px);
+  margin: 0 16px 16px;
+  background: var(--nd-panelBg, var(--nd-popup));
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 32px var(--nd-shadow);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: bold;
+  font-size: 0.9em;
+  flex: 1;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: var(--nd-fg);
+  opacity: 0.7;
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+    opacity: 1;
+  }
+}
+
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+</style>

--- a/src/components/common/MkReactionPicker.vue
+++ b/src/components/common/MkReactionPicker.vue
@@ -14,6 +14,7 @@ import MkReactionPickerSection from './MkReactionPickerSection.vue'
 const props = defineProps<{
   serverHost: string
   accountId: string
+  fullWidth?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -189,7 +190,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <div :class="[$style.reactionPickerPanel, { [$style.mobile]: isCompact }]" @click.stop>
+  <div :class="[$style.reactionPickerPanel, { [$style.mobile]: isCompact, [$style.fullWidth]: props.fullWidth }]" @click.stop>
     <!-- Search (top when has query, bottom otherwise via CSS order) -->
     <div :class="[$style.pickerSearch, searchQuery.length > 0 && $style.hasQuery]">
       <input
@@ -354,6 +355,13 @@ onMounted(() => {
   max-width: calc(100vw - 32px);
   max-height: 360px;
   overflow: hidden;
+
+  &.fullWidth {
+    width: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    flex: 1;
+  }
 }
 
 .pickerSearch {

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { provideWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useIsCompactLayout } from '@/stores/ui'
 import {
   type DeckWindow,
   useWindowsStore,
   WINDOW_SIZES,
 } from '@/stores/windows'
+import { isTauri, openSettingsFileInEditor } from '@/utils/settingsFs'
 
 const props = defineProps<{
   window: DeckWindow
@@ -17,6 +19,18 @@ const emit = defineEmits<{ close: [] }>()
 const windowsStore = useWindowsStore()
 const isCompact = useIsCompactLayout()
 const size = computed(() => WINDOW_SIZES[props.window.type])
+
+// ヘッダー右側「外部エディタで開く」ボタン — 中身のコンポーネントが登録する
+const externalFile = provideWindowExternalFile()
+async function openExternalFile() {
+  const t = externalFile.value
+  if (!t || t.disabled) return
+  try {
+    await openSettingsFileInEditor(t.name, t.subdir)
+  } catch (e) {
+    console.warn('[DeckWindow] openExternalFile failed:', e)
+  }
+}
 
 const BASE_TITLES: Record<string, string> = {
   'note-detail': 'ノート',
@@ -154,6 +168,16 @@ onBeforeUnmount(() => {
     <div :class="$style.windowHeader" @pointerdown="onHeaderPointerDown">
       <i :class="[icons[window.type], $style.windowIcon]" />
       <span :class="$style.windowTitle">{{ windowTitle }}</span>
+      <button
+        v-if="isTauri && externalFile"
+        class="_button"
+        :class="$style.windowBtn"
+        :disabled="externalFile.disabled"
+        :title="`OS の既定エディタで ${externalFile.name} を開く`"
+        @click="openExternalFile"
+      >
+        <i class="ti ti-external-link" />
+      </button>
       <button class="_button" :class="$style.windowBtn" title="最小化" @click="windowsStore.toggleMinimize(window.id)">
         <i class="ti ti-minus" />
       </button>
@@ -262,9 +286,14 @@ onBeforeUnmount(() => {
     background var(--nd-duration-fast),
     opacity var(--nd-duration-fast);
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: var(--nd-buttonHoverBg);
     opacity: 1;
+  }
+
+  &:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
   }
 }
 

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -43,6 +43,7 @@ const BASE_TITLES: Record<string, string> = {
   backup: 'バックアップ',
   tasksEditor: 'タスク設定',
   snippetsEditor: 'スニペット',
+  postFormEditor: '投稿フォームボタン',
 }
 
 const windowTitle = computed(() => {
@@ -78,6 +79,7 @@ const icons: Record<string, string> = {
   backup: 'ti ti-package-export',
   tasksEditor: 'ti ti-player-play',
   snippetsEditor: 'ti ti-code-plus',
+  postFormEditor: 'ti ti-forms',
 }
 
 const isMinimized = computed(() => props.window.minimized)

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from 'vue'
 import { provideWindowExternalFile } from '@/composables/useWindowExternalFile'
+import { provideWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useIsCompactLayout } from '@/stores/ui'
 import {
   type DeckWindow,
@@ -29,6 +30,19 @@ async function openExternalFile() {
     await openSettingsFileInEditor(t.name, t.subdir)
   } catch (e) {
     console.warn('[DeckWindow] openExternalFile failed:', e)
+  }
+}
+
+// ヘッダー右側「外部ブラウザで開く」ボタン
+const externalLink = provideWindowExternalLink()
+async function openExternalLink() {
+  const t = externalLink.value
+  if (!t || t.disabled) return
+  try {
+    const { openUrl } = await import('@tauri-apps/plugin-opener')
+    await openUrl(t.url)
+  } catch (e) {
+    console.warn('[DeckWindow] openExternalLink failed:', e)
   }
 }
 
@@ -168,6 +182,16 @@ onBeforeUnmount(() => {
     <div :class="$style.windowHeader" @pointerdown="onHeaderPointerDown">
       <i :class="[icons[window.type], $style.windowIcon]" />
       <span :class="$style.windowTitle">{{ windowTitle }}</span>
+      <button
+        v-if="isTauri && externalLink"
+        class="_button"
+        :class="$style.windowBtn"
+        :disabled="externalLink.disabled"
+        :title="externalLink.title ?? 'Web で開く'"
+        @click="openExternalLink"
+      >
+        <i :class="`ti ti-${externalLink.icon ?? 'world'}`" />
+      </button>
       <button
         v-if="isTauri && externalFile"
         class="_button"

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -43,7 +43,6 @@ const BASE_TITLES: Record<string, string> = {
   backup: 'バックアップ',
   tasksEditor: 'タスク設定',
   snippetsEditor: 'スニペット',
-  postFormEditor: '投稿フォームボタン',
 }
 
 const windowTitle = computed(() => {
@@ -79,7 +78,6 @@ const icons: Record<string, string> = {
   backup: 'ti ti-package-export',
   tasksEditor: 'ti ti-player-play',
   snippetsEditor: 'ti ti-code-plus',
-  postFormEditor: 'ti ti-forms',
 }
 
 const isMinimized = computed(() => props.window.minimized)

--- a/src/components/deck/DeckWindowLayer.vue
+++ b/src/components/deck/DeckWindowLayer.vue
@@ -68,6 +68,9 @@ const TasksEditorContent = defineAsyncComponent(
 const SnippetsEditorContent = defineAsyncComponent(
   () => import('@/components/window/SnippetsEditorContent.vue'),
 )
+const PostFormEditorContent = defineAsyncComponent(
+  () => import('@/components/window/PostFormEditorContent.vue'),
+)
 
 const windowsStore = useWindowsStore()
 const themeStore = useThemeStore()
@@ -217,6 +220,10 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
       />
       <SnippetsEditorContent
         v-if="win.type === 'snippetsEditor'"
+      />
+      <PostFormEditorContent
+        v-if="win.type === 'postFormEditor'"
+        :initial-tab="(win.props.initialTab as string | undefined)"
       />
     </DeckWindow>
   </div>

--- a/src/components/deck/DeckWindowLayer.vue
+++ b/src/components/deck/DeckWindowLayer.vue
@@ -68,9 +68,6 @@ const TasksEditorContent = defineAsyncComponent(
 const SnippetsEditorContent = defineAsyncComponent(
   () => import('@/components/window/SnippetsEditorContent.vue'),
 )
-const PostFormEditorContent = defineAsyncComponent(
-  () => import('@/components/window/PostFormEditorContent.vue'),
-)
 
 const windowsStore = useWindowsStore()
 const themeStore = useThemeStore()
@@ -220,10 +217,6 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
       />
       <SnippetsEditorContent
         v-if="win.type === 'snippetsEditor'"
-      />
-      <PostFormEditorContent
-        v-if="win.type === 'postFormEditor'"
-        :initial-tab="(win.props.initialTab as string | undefined)"
       />
     </DeckWindow>
   </div>

--- a/src/components/window/AccountManagerContent.vue
+++ b/src/components/window/AccountManagerContent.vue
@@ -7,6 +7,7 @@ import type { ReorderableItem } from '@/components/common/ReorderableList.vue'
 import ReorderableList from '@/components/common/ReorderableList.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import {
   type Account,
   getAccountAvatarUrl,
@@ -41,6 +42,10 @@ function getServerIconUrl(host: string): string | undefined {
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'accounts.json5' } : null,
 )
 
 // ── ReorderableList items ──

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -16,6 +16,7 @@ import { useClickOutside } from '@/composables/useClickOutside'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const mdLang = markdown({ codeLanguages: languages })
@@ -28,6 +29,12 @@ const { tab, containerRef: editorRef } = useEditorTabs(
   ['api', 'prompt'] as const,
   (props.initialTab as 'api' | 'prompt') ?? 'api',
 )
+
+useWindowExternalFile(() => {
+  if (tab.value === 'prompt') return { name: 'AI.md' }
+  if (tab.value === 'api') return { name: 'ai.json5' }
+  return null
+})
 
 // --- Provider schema (data-driven UI) ---
 

--- a/src/components/window/AppearanceEditorContent.vue
+++ b/src/components/window/AppearanceEditorContent.vue
@@ -6,6 +6,7 @@ import DayNightToggle from '@/components/deck/DayNightToggle.vue'
 import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import ThemePreview from '@/components/ThemePreview.vue'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { CURRENT_SCHEMA_VERSION, parseSettings } from '@/settings/schema'
 import { useConfirm } from '@/stores/confirm'
 import { useDeckStore } from '@/stores/deck'
@@ -30,6 +31,10 @@ const { confirm } = useConfirm()
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'settings.json5' } : null,
 )
 
 // ── Visual tab: theme settings ──

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -8,6 +8,7 @@ import { useClickOutside } from '@/composables/useClickOutside'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useThemeStore } from '@/stores/theme'
 
 const cssLang = css()
@@ -51,6 +52,10 @@ const themeStore = useThemeStore()
 const { tab, containerRef: editorRef } = useEditorTabs(
   ['presets', 'code'] as const,
   (props.initialTab as 'presets' | 'code') ?? 'presets',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'custom.css' } : null,
 )
 
 // Local CSS mirror (synced from store on mount)

--- a/src/components/window/KeybindsContent.vue
+++ b/src/components/window/KeybindsContent.vue
@@ -8,6 +8,7 @@ import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useKeybindsStore } from '@/stores/keybinds'
 import { STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 
@@ -45,6 +46,10 @@ const props = defineProps<{
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'keybinds.json5' } : null,
 )
 
 // ── Visual tab: category-based GUI ──

--- a/src/components/window/NavEditorContent.vue
+++ b/src/components/window/NavEditorContent.vue
@@ -18,6 +18,7 @@ import { COLUMN_ICONS, COLUMN_LABELS } from '@/composables/useColumnTabs'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePointerReorder } from '@/composables/usePointerReorder'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import {
@@ -64,6 +65,10 @@ const props = defineProps<{
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'navbar.json5' } : null,
 )
 
 function getItemIcon(item: NavColumnItem): string {

--- a/src/components/window/PerformanceEditorContent.vue
+++ b/src/components/window/PerformanceEditorContent.vue
@@ -6,6 +6,7 @@ import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import {
   CATEGORY_LABELS,
   FIELD_META,
@@ -24,6 +25,10 @@ const perfStore = usePerformanceStore()
 const { tab, containerRef: editorRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'performance.json5' } : null,
 )
 
 // --- Visual tab state ---

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -11,7 +11,9 @@ import AiScriptEditor from '@/components/deck/widgets/AiScriptEditor.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
+import { pluginSrcFilename } from '@/utils/settingsFs'
 
 const props = defineProps<{
   initialPluginId?: string
@@ -63,6 +65,16 @@ const { tab, containerRef: editorRef } = useEditorTabs(
   ['config', 'code', 'logs'] as const,
   (defaultTab.value as 'config' | 'code' | 'logs') ?? 'code',
 )
+
+useWindowExternalFile(() => {
+  if (tab.value !== 'code' || isNewInstall.value) return null
+  const p = plugin.value
+  if (!p) return null
+  return {
+    name: pluginSrcFilename(p.name || p.installId),
+    subdir: 'plugins',
+  }
+})
 
 const tabDefs = computed(() => {
   const defs: { value: string; icon: string; label: string }[] = []

--- a/src/components/window/PostFormEditorContent.vue
+++ b/src/components/window/PostFormEditorContent.vue
@@ -16,6 +16,7 @@ import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePointerReorder } from '@/composables/usePointerReorder'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import {
   ALL_POST_FORM_BUTTONS,
   DEFAULT_POST_FORM_BUTTONS,
@@ -40,6 +41,10 @@ const props = defineProps<{
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'postform.json5' } : null,
 )
 
 const items = ref<PostFormButtonId[]>([

--- a/src/components/window/PostFormEditorContent.vue
+++ b/src/components/window/PostFormEditorContent.vue
@@ -1,0 +1,529 @@
+<script setup lang="ts">
+import { json } from '@codemirror/lang-json'
+import JSON5 from 'json5'
+import {
+  computed,
+  defineAsyncComponent,
+  nextTick,
+  ref,
+  toRaw,
+  watch,
+} from 'vue'
+import EditorTabs from '@/components/common/EditorTabs.vue'
+import type { ReorderableItem } from '@/components/common/ReorderableList.vue'
+import ReorderableList from '@/components/common/ReorderableList.vue'
+import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
+import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
+import { useEditorTabs } from '@/composables/useEditorTabs'
+import { usePointerReorder } from '@/composables/usePointerReorder'
+import {
+  ALL_POST_FORM_BUTTONS,
+  DEFAULT_POST_FORM_BUTTONS,
+  POST_FORM_BUTTON_META,
+  type PostFormButtonId,
+  usePostFormStore,
+} from '@/stores/postForm'
+import { useIsCompactLayout } from '@/stores/ui'
+
+const CodeEditor = defineAsyncComponent(
+  () => import('@/components/deck/widgets/CodeEditor.vue'),
+)
+
+const postFormStore = usePostFormStore()
+const isCompact = useIsCompactLayout()
+const jsonLang = json()
+
+const props = defineProps<{
+  initialTab?: string
+}>()
+
+const { tab, containerRef: contentRef } = useEditorTabs(
+  ['visual', 'code'] as const,
+  (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+const items = ref<PostFormButtonId[]>([
+  ...structuredClone(toRaw(postFormStore.buttons)),
+])
+
+let skipSave = false
+
+watch(
+  items,
+  (v) => {
+    if (skipSave) return
+    postFormStore.setButtons([...v])
+  },
+  { deep: true },
+)
+
+const availableButtons = computed(() =>
+  ALL_POST_FORM_BUTTONS.filter((id) => !items.value.includes(id)),
+)
+
+function removeItem(index: number) {
+  items.value.splice(index, 1)
+}
+
+function addItem(id: PostFormButtonId) {
+  if (items.value.includes(id)) return
+  items.value.push(id)
+}
+
+function onReorder(fromIdx: number, toIdx: number) {
+  const arr = [...items.value]
+  const [moved] = arr.splice(fromIdx, 1)
+  if (moved !== undefined) {
+    arr.splice(toIdx, 0, moved)
+    items.value = arr
+  }
+}
+
+const reorderableItems = computed<ReorderableItem[]>(() =>
+  items.value.map((id) => ({
+    icon: POST_FORM_BUTTON_META[id].icon,
+    label: POST_FORM_BUTTON_META[id].label,
+  })),
+)
+
+const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
+  dataAttr: 'pf-idx',
+  onReorder,
+})
+
+// ── Code tab ──
+function itemsToJson(): string {
+  if (!postFormStore.isCustomized) return 'null'
+  return JSON5.stringify(items.value, null, 2)
+}
+
+const jsonCode = ref(itemsToJson())
+const codeError = ref<string | null>(null)
+
+watch(tab, (t) => {
+  if (t === 'code') {
+    jsonCode.value = itemsToJson()
+    codeError.value = null
+  }
+})
+
+watch(items, () => {
+  if (tab.value === 'code') {
+    const current = itemsToJson()
+    if (current !== jsonCode.value) jsonCode.value = current
+  }
+})
+
+function applyFromCode() {
+  try {
+    const parsed = JSON5.parse(jsonCode.value)
+    if (parsed === null) {
+      skipSave = true
+      items.value = [...DEFAULT_POST_FORM_BUTTONS]
+      postFormStore.setButtons(undefined)
+      nextTick(() => {
+        skipSave = false
+      })
+      codeError.value = null
+      return
+    }
+    if (!Array.isArray(parsed)) {
+      codeError.value = '配列または null が必要です'
+      return
+    }
+    const filtered = parsed.filter(
+      (x): x is PostFormButtonId =>
+        typeof x === 'string' &&
+        (ALL_POST_FORM_BUTTONS as string[]).includes(x),
+    )
+    items.value = [...new Set(filtered)]
+    codeError.value = null
+  } catch (e) {
+    codeError.value = e instanceof Error ? e.message : '無効な JSON5'
+  }
+}
+
+// ── Actions ──
+const { copied: copiedMessage, showCopied } = useClipboardFeedback()
+const { confirming: confirmingReset, trigger: triggerReset } =
+  useDoubleConfirm()
+
+function handleReset() {
+  triggerReset(() => {
+    skipSave = true
+    items.value = [...DEFAULT_POST_FORM_BUTTONS]
+    postFormStore.setButtons(undefined)
+    nextTick(() => {
+      skipSave = false
+    })
+  })
+}
+
+async function exportList() {
+  try {
+    await navigator.clipboard.writeText(itemsToJson())
+    showCopied()
+  } catch {
+    /* clipboard access denied */
+  }
+}
+
+async function importList() {
+  try {
+    const text = await navigator.clipboard.readText()
+    const parsed = JSON5.parse(text)
+    if (!Array.isArray(parsed)) return
+    const filtered = parsed.filter(
+      (x): x is PostFormButtonId =>
+        typeof x === 'string' &&
+        (ALL_POST_FORM_BUTTONS as string[]).includes(x),
+    )
+    items.value = [...new Set(filtered)]
+  } catch {
+    /* clipboard access denied or invalid */
+  }
+}
+</script>
+
+<template>
+  <div ref="contentRef" :class="$style.editor">
+    <EditorTabs
+      v-model="tab"
+      :tabs="[
+        { value: 'visual', icon: 'adjustments', label: 'ビジュアル' },
+        { value: 'code', icon: 'code', label: 'コード' },
+      ]"
+    />
+
+    <!-- Visual tab -->
+    <div v-show="tab === 'visual'" :class="$style.visualPanel">
+      <div :class="$style.sectionHeader">
+        <i class="ti ti-list" />
+        現在の並び
+        <span :class="$style.sectionBadge">{{ items.length }}</span>
+      </div>
+
+      <!-- Mobile: row list -->
+      <ReorderableList
+        v-if="isCompact"
+        :items="reorderableItems"
+        data-attr="pf-idx"
+        empty-text="ボタンなし"
+        @reorder="onReorder"
+        @remove="removeItem"
+      />
+
+      <!-- Desktop: horizontal preview with drag -->
+      <div v-else :class="$style.rowPreview">
+        <div
+          v-for="(id, i) in items"
+          :key="id"
+          :data-pf-idx="i"
+          :class="[
+            $style.btn,
+            {
+              [$style.dragging]: dragFromIndex === i,
+              [$style.dragOver]: dragOverIndex === i,
+            },
+          ]"
+          :title="POST_FORM_BUTTON_META[id].label"
+          @pointerdown="startDrag(i, $event)"
+        >
+          <i :class="['ti', `ti-${POST_FORM_BUTTON_META[id].icon}`]" />
+          <button class="_button" :class="$style.removeBtn" @click.stop="removeItem(i)">
+            <i class="ti ti-x" />
+          </button>
+        </div>
+        <div v-if="items.length === 0" :class="$style.empty">ボタンなし</div>
+      </div>
+
+      <div :class="$style.sectionHeader">
+        <i class="ti ti-plus" />
+        追加できるボタン
+      </div>
+
+      <div :class="$style.addGrid">
+        <button
+          v-for="id in availableButtons"
+          :key="id"
+          class="_button"
+          :class="$style.addBtn"
+          @click="addItem(id)"
+        >
+          <i :class="['ti', `ti-${POST_FORM_BUTTON_META[id].icon}`]" />
+          <span>{{ POST_FORM_BUTTON_META[id].label }}</span>
+        </button>
+        <div v-if="availableButtons.length === 0" :class="$style.empty">
+          すべてのボタンが追加済み
+        </div>
+      </div>
+    </div>
+
+    <!-- Code tab -->
+    <div v-show="tab === 'code'" :class="$style.codePanel">
+      <div :class="$style.codeHint">
+        デフォルト値からの差分 — null はデフォルト設定を使用
+      </div>
+      <CodeEditor
+        v-model="jsonCode"
+        :language="jsonLang"
+        :class="[$style.codeEditorWrap, { [$style.hasError]: codeError }]"
+        auto-height
+      />
+      <div v-if="codeError" :class="$style.errorMessage">
+        <i class="ti ti-alert-triangle" />
+        {{ codeError }}
+      </div>
+      <div
+        v-if="!codeError && jsonCode.trim() && jsonCode.trim() !== '[]' && jsonCode.trim() !== 'null'"
+        :class="$style.codeSuccess"
+      >
+        <i class="ti ti-check" />
+        適用中
+      </div>
+      <button class="_button" :class="$style.codeApplyBtn" @click="applyFromCode">
+        <i class="ti ti-refresh" />
+        ビジュアルに同期
+      </button>
+    </div>
+
+    <!-- Actions -->
+    <div :class="$style.actions">
+      <div :class="$style.actionGroup">
+        <button
+          class="_button"
+          :class="[$style.actionBtn, $style.secondary]"
+          @click="importList"
+        >
+          <i class="ti ti-clipboard-text" />
+          インポート
+        </button>
+        <button
+          class="_button"
+          :class="[$style.actionBtn, $style.secondary, { [$style.feedback]: copiedMessage }]"
+          @click="exportList"
+        >
+          <i class="ti ti-clipboard-copy" />
+          {{ copiedMessage ? 'コピー済み' : 'エクスポート' }}
+        </button>
+      </div>
+      <button
+        class="_button"
+        :class="[$style.actionBtn, $style.danger, { [$style.confirming]: confirmingReset }]"
+        @click="handleReset"
+      >
+        <i class="ti ti-trash" />
+        {{ confirmingReset ? '本当にリセット？' : 'デフォルトに戻す' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" module>
+@use '@/styles/buttons' as *;
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.visualPanel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px 6px;
+  font-size: 0.75em;
+  font-weight: bold;
+  color: var(--nd-fg);
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.sectionBadge {
+  margin-left: auto;
+  font-weight: normal;
+  opacity: 0.8;
+}
+
+.rowPreview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 12px 12px;
+}
+
+.btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-panel);
+  color: var(--nd-fg);
+  cursor: grab;
+  user-select: none;
+  transition: background var(--nd-duration-base);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+
+  &.dragging {
+    opacity: 0.3;
+    cursor: grabbing;
+  }
+
+  &.dragOver {
+    outline: 2px solid var(--nd-accent);
+    outline-offset: 1px;
+  }
+}
+
+.removeBtn {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--nd-panel);
+  font-size: 9px;
+  color: var(--nd-fg);
+  opacity: 0;
+  transition: opacity var(--nd-duration-fast);
+
+  .btn:hover & {
+    opacity: 1;
+  }
+
+  &:hover {
+    color: var(--nd-love, #ec4137);
+  }
+}
+
+.addGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 12px 12px;
+}
+
+.addBtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--nd-panel);
+  border-radius: var(--nd-radius-sm);
+  font-size: 0.85em;
+  color: var(--nd-fg);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.empty {
+  padding: 8px 12px;
+  text-align: center;
+  color: var(--nd-fg);
+  opacity: 0.4;
+  font-size: 0.75em;
+}
+
+.codePanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.codeHint {
+  font-size: 0.75em;
+  opacity: 0.5;
+}
+
+.codeEditorWrap {
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+
+  &.hasError {
+    border-color: var(--nd-love, #ec4137);
+  }
+}
+
+.errorMessage {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75em;
+  color: var(--nd-love, #ec4137);
+}
+
+.codeSuccess {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75em;
+  color: var(--nd-accent);
+  opacity: 0.7;
+}
+
+.codeApplyBtn {
+  @include btn-secondary;
+}
+
+.actions {
+  @include action-bar;
+}
+
+.actionGroup {
+  @include action-group;
+}
+
+.actionBtn {
+  &.secondary {
+    @include btn-action;
+  }
+
+  &.danger {
+    @include btn-danger-ghost;
+  }
+}
+
+.secondary {
+  /* modifier */
+}
+
+.feedback {
+  /* modifier */
+}
+
+.danger {
+  /* modifier */
+}
+
+.confirming {
+  /* modifier */
+}
+</style>

--- a/src/components/window/ProfileEditorContent.vue
+++ b/src/components/window/ProfileEditorContent.vue
@@ -14,6 +14,7 @@ import {
 } from '@/composables/useColumnTabs'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePointerReorder } from '@/composables/usePointerReorder'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
@@ -21,6 +22,7 @@ import { useDeckProfileStore } from '@/stores/deckProfile'
 import { useServersStore } from '@/stores/servers'
 import { useIsCompactLayout } from '@/stores/ui'
 import { createJson5Linter } from '@/utils/json5Linter'
+import { profileFilename } from '@/utils/settingsFs'
 
 const AddColumnDialog = defineAsyncComponent(
   () => import('@/components/deck/AddColumnDialog.vue'),
@@ -93,6 +95,16 @@ const codeError = ref<string | null>(null)
 const { tab, containerRef: editorRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code'
+    ? {
+        name: profileFilename(editingName.value),
+        subdir: 'profiles',
+        disabled: !editingName.value,
+      }
+    : null,
 )
 
 // When profileId prop changes, refresh code tab content

--- a/src/components/window/SnippetsEditorContent.vue
+++ b/src/components/window/SnippetsEditorContent.vue
@@ -7,6 +7,7 @@ import { reloadSnippets } from '@/aiscript/snippets/cache'
 import { DEFAULT_AISCRIPT_SNIPPETS } from '@/aiscript/snippets/defaultSnippets'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useToast } from '@/stores/toast'
 import {
   isTauri,
@@ -51,6 +52,10 @@ const dirty = ref(false)
 const saved = ref(false)
 const error = ref<string | null>(null)
 const loaded = ref(false)
+
+useWindowExternalFile(() =>
+  currentFile.value ? { name: currentFile.value, subdir: 'snippets' } : null,
+)
 
 const statusText = computed(() => {
   if (error.value) return error.value

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -16,6 +16,7 @@ import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePointerReorder } from '@/composables/usePointerReorder'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import defaultTasksJson5 from '@/defaults/tasks.json5?raw'
 import { useTasksStore } from '@/stores/tasks'
 import { useToast } from '@/stores/toast'
@@ -66,6 +67,10 @@ const tasksStore = useTasksStore()
 const { tab, containerRef: contentRef } = useEditorTabs(
   ['visual', 'code'] as const,
   (props.initialTab as 'visual' | 'code') ?? 'visual',
+)
+
+useWindowExternalFile(() =>
+  tab.value === 'code' ? { name: 'tasks.json5' } : null,
 )
 
 // ── State ──

--- a/src/components/window/ThemeEditorContent.vue
+++ b/src/components/window/ThemeEditorContent.vue
@@ -15,12 +15,14 @@ import EditorTabs from '@/components/common/EditorTabs.vue'
 import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useEditorTabs } from '@/composables/useEditorTabs'
+import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useThemeStore } from '@/stores/theme'
 import { DARK_BASE, LIGHT_BASE } from '@/theme/builtinThemes'
 import { parseColor } from '@/theme/colorUtils'
 import { compileMisskeyTheme } from '@/theme/compiler'
 import type { MisskeyTheme } from '@/theme/types'
 import { createJson5Linter } from '@/utils/json5Linter'
+import { themeFilename } from '@/utils/settingsFs'
 
 const jsonLang = json()
 const jsonLinter = createJson5Linter()
@@ -41,6 +43,17 @@ const themeName = ref('My Theme')
 const baseMode = ref<'dark' | 'light'>('dark')
 // Track the ID of the theme being edited (null = new theme)
 const editingThemeId = ref<string | null>(null)
+
+// 外部エディタ起動用: 既存テーマのみ対象（未保存は disabled）
+useWindowExternalFile(() =>
+  tab.value === 'code'
+    ? {
+        name: themeFilename(themeName.value),
+        subdir: 'themes',
+        disabled: !editingThemeId.value,
+      }
+    : null,
+)
 
 // Primary color props that users typically want to edit directly
 const PRIMARY_PROPS: { key: string; label: string }[] = [

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -37,6 +37,7 @@ import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
 import { usePortal } from '@/composables/usePortal'
 import { useSensitiveMask } from '@/composables/useSensitiveMask'
+import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
@@ -54,11 +55,6 @@ import { commands, unwrap } from '@/utils/tauriInvoke'
 import { toggleFollow } from '@/utils/toggleFollow'
 import { toggleReaction } from '@/utils/toggleReaction'
 import { openSafeUrl, safeCssUrl } from '@/utils/url'
-
-const openUrl = async (url: string) => {
-  const { openUrl: open } = await import('@tauri-apps/plugin-opener')
-  return open(url)
-}
 
 const props = defineProps<{
   accountId: string
@@ -134,6 +130,27 @@ const { tab: topTab, containerRef: profileRef } = useEditorTabs<TopTab>(
 )
 
 const user = ref<NormalizedUserDetail | null>(null)
+
+// ヘッダー「Web UIで開く」ボタンの登録 — 自プロフィールは編集画面、他は公開ページ
+useWindowExternalLink(() => {
+  const u = user.value
+  const host = account.value?.host
+  if (!u || !host) return null
+  if (isOwnProfile.value) {
+    return {
+      url: `https://${host}/settings/profile`,
+      title: 'プロフィールを編集',
+      icon: 'pencil',
+    }
+  }
+  const suffix = u.host ? `@${u.host}` : ''
+  return {
+    url: `https://${host}/@${u.username}${suffix}`,
+    title: 'Web UIで開く',
+    icon: 'world',
+  }
+})
+
 const canSeeFollowing = computed(() => {
   if (isOwnProfile.value) return true
   const v = user.value?.followingVisibility ?? 'public'
@@ -972,9 +989,6 @@ async function handlePosted(editedNoteId?: string) {
             <button class="_button" :class="$style.bannerActionBtn" title="QRコード" @click="openQrCode">
               <i class="ti ti-qrcode" />
             </button>
-            <button class="_button" :class="$style.bannerActionBtn" :title="isOwnProfile ? 'プロフィールを編集' : 'Web UIで開く'" @click="openUrl(`https://${account?.host}/${isOwnProfile ? 'settings/profile' : `@${user.username}${user.host ? `@${user.host}` : ''}`}`)">
-              <i :class="isOwnProfile ? 'ti ti-pencil' : 'ti ti-external-link'" />
-            </button>
             <button
               v-if="!isOwnProfile"
               class="_button"
@@ -1049,9 +1063,7 @@ async function handlePosted(editedNoteId?: string) {
           </div>
           <div v-if="user.url" :class="$style.profileInfoItem">
             <i class="ti ti-link" />
-            <button class="_button" :class="$style.profileInfoLink" @click="openUrl(user.url!)">
-              {{ displayUrl(user.url!) }}
-            </button>
+            <span>{{ displayUrl(user.url!) }}</span>
           </div>
           <div v-if="user.createdAt" :class="$style.profileInfoItem">
             <i class="ti ti-calendar" />
@@ -1826,15 +1838,6 @@ async function handlePosted(editedNoteId?: string) {
 
   i {
     font-size: 1em;
-  }
-}
-
-.profileInfoLink {
-  color: var(--nd-accent);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
   }
 }
 

--- a/src/composables/useDeckInit.ts
+++ b/src/composables/useDeckInit.ts
@@ -16,6 +16,7 @@ import { destroyApiBridge, initApiBridge } from '@/core/apiBridge'
 import { useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { usePluginsStore } from '@/stores/plugins'
+import { usePostFormStore } from '@/stores/postForm'
 import { useRealtimeModeStore } from '@/stores/realtimeMode'
 import { useTasksStore } from '@/stores/tasks'
 import { useUiStore } from '@/stores/ui'
@@ -75,6 +76,7 @@ export function useDeckInit(options: {
 
     // Load navbar from file (async, non-blocking)
     deckStore.initNavbar()
+    void usePostFormStore().init()
 
     // Register commands synchronously (needed for keyboard shortcuts)
     registerDefaultCommands({

--- a/src/composables/useDrafts.ts
+++ b/src/composables/useDrafts.ts
@@ -1,7 +1,57 @@
+import { ref } from 'vue'
 import type { NoteVisibility } from '@/adapters/types'
-import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
+import { isTauri, readDraftFile, writeDraftFile } from '@/utils/settingsFs'
+import {
+  getStorageJson,
+  removeStorage,
+  STORAGE_KEYS,
+  setStorageJson,
+} from '@/utils/storage'
 
-export interface Draft {
+export interface DraftData {
+  text: string
+  cw: string
+  showCw: boolean
+  visibility: NoteVisibility
+  localOnly: boolean
+  fileIds: string[]
+  pollChoices: string[]
+  pollMultiple: boolean
+  showPoll: boolean
+  scheduledAt: string | null
+}
+
+export interface StoredDraft {
+  updatedAt: string
+  data: DraftData
+}
+
+export type StoredDrafts = Record<string, StoredDraft>
+
+/**
+ * Misskey 本家 MkPostForm.vue の `draftKey` と同じ算出式。
+ * 同じコンテキスト（reply/renote/channel/new）の編集中は常に1件だけが保存され、
+ * 次回同じコンテキストを開いたとき自動で復元できるようにする。
+ */
+export function computeDraftKey(ctx: {
+  userId: string
+  channelId?: string | null
+  renoteId?: string | null
+  replyId?: string | null
+}): string {
+  let key = ctx.channelId ? `channel:${ctx.channelId}` : ''
+  if (ctx.renoteId) {
+    key += `renote:${ctx.renoteId}`
+  } else if (ctx.replyId) {
+    key += `reply:${ctx.replyId}`
+  } else {
+    key += `note:${ctx.userId}`
+  }
+  return key
+}
+
+// --- Legacy v1 (array with id/savedAt) → v2 (draftKey map) ---
+interface LegacyDraftV1 {
   id: string
   text: string
   cw: string
@@ -16,34 +66,152 @@ export interface Draft {
   savedAt: number
 }
 
-const MAX_DRAFTS = 10
-
-function generateId(): string {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+function migrate(raw: unknown): { drafts: StoredDrafts; migrated: boolean } {
+  if (Array.isArray(raw)) {
+    const drafts: StoredDrafts = {}
+    for (const d of raw as LegacyDraftV1[]) {
+      if (!d || typeof d !== 'object' || !d.id) continue
+      drafts[`legacy:${d.id}`] = {
+        updatedAt: new Date(d.savedAt || Date.now()).toISOString(),
+        data: {
+          text: d.text ?? '',
+          cw: d.cw ?? '',
+          showCw: !!d.showCw,
+          visibility: d.visibility,
+          localOnly: !!d.localOnly,
+          fileIds: d.fileIds ?? [],
+          pollChoices: d.pollChoices ?? [],
+          pollMultiple: !!d.pollMultiple,
+          showPoll: !!d.showPoll,
+          scheduledAt: d.scheduledAt ?? null,
+        },
+      }
+    }
+    return { drafts, migrated: true }
+  }
+  if (raw && typeof raw === 'object') {
+    return { drafts: raw as StoredDrafts, migrated: false }
+  }
+  return { drafts: {}, migrated: false }
 }
 
-export function loadDrafts(accountId: string): Draft[] {
-  return getStorageJson<Draft[]>(STORAGE_KEYS.drafts(accountId), [])
+// --- File-backed cache (Tauri) with localStorage fallback (browser dev) ---
+
+const cache = new Map<string, StoredDrafts>()
+const loaded = new Set<string>()
+
+/**
+ * Reactive version counter — bumped on every save/delete so that components
+ * can watch it to re-render when drafts mutate from elsewhere (e.g. auto-save
+ * triggered by usePostFormState while the picker is open).
+ */
+export const draftsVersion = ref(0)
+
+function readFromLocalStorage(accountId: string): StoredDrafts {
+  const raw = getStorageJson<unknown>(STORAGE_KEYS.drafts(accountId), {})
+  return migrate(raw).drafts
+}
+
+function writeToLocalStorage(accountId: string, drafts: StoredDrafts): void {
+  setStorageJson(STORAGE_KEYS.drafts(accountId), drafts)
+}
+
+/**
+ * Load drafts from disk (Tauri) or localStorage (browser) into the in-memory
+ * cache. Must be awaited before sync read/write APIs are used for that account.
+ * One-time migration: if no file exists yet but localStorage has entries, the
+ * data is copied to disk and the localStorage entry is removed.
+ */
+export async function ensureDraftsLoaded(accountId: string): Promise<void> {
+  if (loaded.has(accountId)) return
+  let drafts: StoredDrafts = {}
+  if (isTauri) {
+    let fileContent = ''
+    try {
+      fileContent = await readDraftFile(accountId)
+    } catch {
+      fileContent = ''
+    }
+    if (fileContent) {
+      try {
+        drafts = migrate(JSON.parse(fileContent)).drafts
+      } catch {
+        drafts = {}
+      }
+    } else {
+      // Migrate localStorage → file (one-time)
+      const legacy = readFromLocalStorage(accountId)
+      if (Object.keys(legacy).length > 0) {
+        drafts = legacy
+        try {
+          await writeDraftFile(accountId, JSON.stringify(drafts, null, 2))
+          removeStorage(STORAGE_KEYS.drafts(accountId))
+        } catch {
+          // Keep localStorage as fallback if write fails
+        }
+      }
+    }
+  } else {
+    drafts = readFromLocalStorage(accountId)
+  }
+  cache.set(accountId, drafts)
+  loaded.add(accountId)
+}
+
+const writeTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+function persist(accountId: string) {
+  const drafts = cache.get(accountId) ?? {}
+  if (isTauri) {
+    const existing = writeTimers.get(accountId)
+    if (existing) clearTimeout(existing)
+    writeTimers.set(
+      accountId,
+      setTimeout(() => {
+        void writeDraftFile(accountId, JSON.stringify(drafts, null, 2))
+        writeTimers.delete(accountId)
+      }, 300),
+    )
+  } else {
+    writeToLocalStorage(accountId, drafts)
+  }
+}
+
+export function loadAllDrafts(accountId: string): StoredDrafts {
+  return cache.get(accountId) ?? {}
+}
+
+export function loadDraft(
+  accountId: string,
+  draftKey: string,
+): StoredDraft | null {
+  return loadAllDrafts(accountId)[draftKey] ?? null
 }
 
 export function saveDraft(
   accountId: string,
-  draft: Omit<Draft, 'id' | 'savedAt'>,
-): Draft {
-  const drafts = loadDrafts(accountId)
-  const newDraft: Draft = {
-    ...draft,
-    id: generateId(),
-    savedAt: Date.now(),
-  }
-  drafts.unshift(newDraft)
-  // Keep only the latest entries
-  const trimmed = drafts.slice(0, MAX_DRAFTS)
-  setStorageJson(STORAGE_KEYS.drafts(accountId), trimmed)
-  return newDraft
+  draftKey: string,
+  data: DraftData,
+): StoredDraft {
+  const next = { ...loadAllDrafts(accountId) }
+  const stored: StoredDraft = { updatedAt: new Date().toISOString(), data }
+  next[draftKey] = stored
+  cache.set(accountId, next)
+  persist(accountId)
+  draftsVersion.value++
+  return stored
 }
 
-export function deleteDraft(accountId: string, draftId: string): void {
-  const drafts = loadDrafts(accountId).filter((d) => d.id !== draftId)
-  setStorageJson(STORAGE_KEYS.drafts(accountId), drafts)
+export function deleteDraft(accountId: string, draftKey: string): void {
+  const next = { ...loadAllDrafts(accountId) }
+  delete next[draftKey]
+  cache.set(accountId, next)
+  persist(accountId)
+  draftsVersion.value++
+}
+
+export function deleteAllDrafts(accountId: string): void {
+  cache.set(accountId, {})
+  persist(accountId)
+  draftsVersion.value++
 }

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -1,4 +1,4 @@
-import { computed, nextTick, type Ref, ref, shallowRef } from 'vue'
+import { computed, nextTick, type Ref, ref, shallowRef, watch } from 'vue'
 import { initAdapterFor } from '@/adapters/initAdapter'
 import type {
   NormalizedNote,
@@ -14,13 +14,16 @@ import {
   visibilityOptions,
 } from '@/composables/postFormConstants'
 import {
-  type Draft,
+  computeDraftKey,
   deleteDraft,
-  loadDrafts,
+  ensureDraftsLoaded,
+  loadDraft,
+  type StoredDraft,
   saveDraft,
 } from '@/composables/useDrafts'
 import { useFileAttachment } from '@/composables/useFileAttachment'
 import { useAccountsStore } from '@/stores/accounts'
+import { useSettingsStore } from '@/stores/settings'
 import { useThemeStore } from '@/stores/theme'
 import { useToast } from '@/stores/toast'
 import {
@@ -44,6 +47,7 @@ export function usePostFormState(
   fileInput: Ref<HTMLInputElement | null>,
 ) {
   const accountsStore = useAccountsStore()
+  const settingsStore = useSettingsStore()
   const themeStore = useThemeStore()
 
   const text = ref('')
@@ -74,13 +78,21 @@ export function usePostFormState(
   const pollExpiresAt = ref<number | null>(null)
   const scheduledAt = ref<string | null>(null)
   const supportsScheduledNotes = ref(false)
-  const drafts = ref<Draft[]>([])
-  const showDraftMenu = ref(false)
+  const currentDraft = ref<StoredDraft | null>(null)
 
   const activeAccountId = ref(props.accountId)
   const accounts = computed(() => accountsStore.accounts)
   const account = computed(() =>
     accountsStore.accounts.find((a) => a.id === activeAccountId.value),
+  )
+
+  const draftKey = computed(() =>
+    computeDraftKey({
+      userId: account.value?.userId ?? activeAccountId.value,
+      channelId: props.channelId,
+      renoteId: props.renoteId,
+      replyId: props.replyTo?.id,
+    }),
   )
 
   const formThemeVars = computed(() =>
@@ -118,8 +130,9 @@ export function usePostFormState(
       error.value = AppError.from(e).message
       supportsScheduledNotes.value = false
     }
-    // Load drafts for this account
-    drafts.value = loadDrafts(acc.id)
+    // Load the draft for the current context (if any)
+    await ensureDraftsLoaded(acc.id)
+    currentDraft.value = loadDraft(acc.id, draftKey.value)
 
     // Fetch modes, policies, and user settings in parallel (all independent after adapter init)
     const [availabilityResult, policiesResult, userInfoResult] =
@@ -267,11 +280,12 @@ export function usePostFormState(
     // Fire API call in background — on failure, save draft and notify
     const currentAdapter = adapter
     const currentAccountId = activeAccountId.value
+    const currentDraftKey = draftKey.value
     currentAdapter.api.createNote(noteParams).catch((e) => {
       const { show } = useToast()
       show(AppError.from(e).message, 'error')
       // Auto-save as draft so user can retry
-      saveDraft(currentAccountId, {
+      saveDraft(currentAccountId, currentDraftKey, {
         text: noteParams.text ?? '',
         cw: noteParams.cw ?? '',
         showCw: !!noteParams.cw,
@@ -345,7 +359,7 @@ export function usePostFormState(
   function saveCurrentDraft() {
     const acc = account.value
     if (!acc) return
-    const draft = saveDraft(acc.id, {
+    currentDraft.value = saveDraft(acc.id, draftKey.value, {
       text: text.value,
       cw: cw.value,
       showCw: showCw.value,
@@ -357,33 +371,64 @@ export function usePostFormState(
       showPoll: showPoll.value,
       scheduledAt: scheduledAt.value,
     })
-    drafts.value = [
-      draft,
-      ...drafts.value.filter((d) => d.id !== draft.id),
-    ].slice(0, 10)
-    showDraftMenu.value = false
   }
 
-  function restoreDraft(draft: Draft) {
-    text.value = draft.text
-    cw.value = draft.cw
-    showCw.value = draft.showCw
-    visibility.value = draft.visibility
-    localOnly.value = draft.localOnly
-    pollChoices.value =
-      draft.pollChoices.length >= 2 ? draft.pollChoices : ['', '']
-    pollMultiple.value = draft.pollMultiple
-    showPoll.value = draft.showPoll
-    scheduledAt.value = draft.scheduledAt
+  /**
+   * Auto-save: when `postForm.autoSaveDraft` is on, persist on every change
+   * (debounced). Skip empty forms so we never save a no-op draft.
+   */
+  let autoSaveTimer: ReturnType<typeof setTimeout> | null = null
+  function hasAnyContent(): boolean {
+    if (text.value.trim().length > 0) return true
+    if (attachedFiles.value.length > 0) return true
+    if (showPoll.value && pollChoices.value.some((c) => c.trim())) return true
+    return false
+  }
+  watch(
+    [
+      text,
+      cw,
+      showCw,
+      visibility,
+      localOnly,
+      attachedFiles,
+      pollChoices,
+      pollMultiple,
+      showPoll,
+      scheduledAt,
+    ],
+    () => {
+      if (!settingsStore.get('postForm.autoSaveDraft')) return
+      if (!account.value) return
+      if (!hasAnyContent()) return
+      if (autoSaveTimer) clearTimeout(autoSaveTimer)
+      autoSaveTimer = setTimeout(() => {
+        saveCurrentDraft()
+        autoSaveTimer = null
+      }, 800)
+    },
+    { deep: true },
+  )
+
+  function restoreDraft(stored: StoredDraft) {
+    const d = stored.data
+    text.value = d.text
+    cw.value = d.cw
+    showCw.value = d.showCw
+    visibility.value = d.visibility
+    localOnly.value = d.localOnly
+    pollChoices.value = d.pollChoices.length >= 2 ? d.pollChoices : ['', '']
+    pollMultiple.value = d.pollMultiple
+    showPoll.value = d.showPoll
+    scheduledAt.value = d.scheduledAt
     // Note: file attachments are not restored (IDs may be expired)
-    showDraftMenu.value = false
   }
 
-  function removeDraft(draftId: string) {
+  function removeCurrentDraft() {
     const acc = account.value
     if (!acc) return
-    deleteDraft(acc.id, draftId)
-    drafts.value = drafts.value.filter((d) => d.id !== draftId)
+    deleteDraft(acc.id, draftKey.value)
+    currentDraft.value = null
   }
 
   return {
@@ -409,8 +454,8 @@ export function usePostFormState(
     pollExpiresAt,
     scheduledAt,
     supportsScheduledNotes,
-    drafts,
-    showDraftMenu,
+    currentDraft,
+    draftKey,
     // Computed
     accounts,
     account,
@@ -439,6 +484,6 @@ export function usePostFormState(
     resetForm,
     saveCurrentDraft,
     restoreDraft,
-    removeDraft,
+    removeCurrentDraft,
   }
 }

--- a/src/composables/useWindowExternalFile.ts
+++ b/src/composables/useWindowExternalFile.ts
@@ -1,0 +1,48 @@
+import {
+  type InjectionKey,
+  inject,
+  onScopeDispose,
+  provide,
+  type Ref,
+  ref,
+  watchEffect,
+} from 'vue'
+
+export interface WindowExternalFile {
+  name: string
+  subdir?: string
+  disabled?: boolean
+}
+
+export const WINDOW_EXTERNAL_FILE_KEY: InjectionKey<
+  Ref<WindowExternalFile | null>
+> = Symbol('windowExternalFile')
+
+/**
+ * DeckWindow 側で provide する。戻り値の ref を読んでヘッダーのボタン表示を判定する。
+ */
+export function provideWindowExternalFile() {
+  const target = ref<WindowExternalFile | null>(null)
+  provide(WINDOW_EXTERNAL_FILE_KEY, target)
+  return target
+}
+
+/**
+ * 編集ウィンドウの中身 (Content コンポーネント) から、ヘッダーに置く
+ * 「外部エディタで開く」ボタンの対象ファイルを登録する。
+ *
+ * `source` はリアクティブ (ref/computed) でもプレーンオブジェクトでも OK。
+ * コンポーネント破棄時に自動で登録解除される。
+ */
+export function useWindowExternalFile(
+  source: (() => WindowExternalFile | null) | Ref<WindowExternalFile | null>,
+) {
+  const target = inject(WINDOW_EXTERNAL_FILE_KEY, null)
+  if (!target) return
+  watchEffect(() => {
+    target.value = typeof source === 'function' ? source() : source.value
+  })
+  onScopeDispose(() => {
+    target.value = null
+  })
+}

--- a/src/composables/useWindowExternalLink.ts
+++ b/src/composables/useWindowExternalLink.ts
@@ -1,0 +1,47 @@
+import {
+  type InjectionKey,
+  inject,
+  onScopeDispose,
+  provide,
+  type Ref,
+  ref,
+  watchEffect,
+} from 'vue'
+
+export interface WindowExternalLink {
+  url: string
+  /** title 属性。省略時は 'Web で開く' */
+  title?: string
+  /** tabler アイコン名 (ti- 接頭辞なし)。省略時は 'world' */
+  icon?: string
+  disabled?: boolean
+}
+
+export const WINDOW_EXTERNAL_LINK_KEY: InjectionKey<
+  Ref<WindowExternalLink | null>
+> = Symbol('windowExternalLink')
+
+/** DeckWindow 側で provide する。戻り値を読んでヘッダーボタンを描画する。 */
+export function provideWindowExternalLink() {
+  const target = ref<WindowExternalLink | null>(null)
+  provide(WINDOW_EXTERNAL_LINK_KEY, target)
+  return target
+}
+
+/**
+ * Content コンポーネントから「外部ブラウザで開く」ターゲット URL を登録する。
+ * `source` は ref/computed またはプレーン関数。未登録状態に戻すときは null を返す。
+ * スコープ破棄時に自動で登録解除される。
+ */
+export function useWindowExternalLink(
+  source: (() => WindowExternalLink | null) | Ref<WindowExternalLink | null>,
+) {
+  const target = inject(WINDOW_EXTERNAL_LINK_KEY, null)
+  if (!target) return
+  watchEffect(() => {
+    target.value = typeof source === 'function' ? source() : source.value
+  })
+  onScopeDispose(() => {
+    target.value = null
+  })
+}

--- a/src/defaults/postform.json5
+++ b/src/defaults/postform.json5
@@ -1,0 +1,12 @@
+// NoteDeck postform.json5 デフォルト
+// 投稿フォーム下部ボタンの並び
+[
+  'emoji',
+  'attach',
+  'poll',
+  'cw',
+  'mention',
+  'mfm',
+  'draft',
+  'clear',
+]

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -28,6 +28,7 @@ export interface NotedeckSettings {
 
   // --- Post form ---
   'postForm.preview'?: boolean
+  'postForm.autoSaveDraft'?: boolean
 
   // keybinds は keybinds.json5 に分離済み（独立ファイル）
   // AI は ai.json5 + AI.md に分離済み（独立ファイル）

--- a/src/stores/postForm.ts
+++ b/src/stores/postForm.ts
@@ -1,0 +1,122 @@
+import JSON5 from 'json5'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { PERSIST_DEBOUNCE_MS } from '@/constants/persist'
+import defaultPostFormJson5 from '@/defaults/postform.json5?raw'
+import { isTauri, readPostForm, writePostForm } from '@/utils/settingsFs'
+
+export type PostFormButtonId =
+  | 'attach'
+  | 'poll'
+  | 'cw'
+  | 'hashtag'
+  | 'mention'
+  | 'mfm'
+  | 'draft'
+  | 'clear'
+  | 'emoji'
+
+export const POST_FORM_BUTTON_META: Record<
+  PostFormButtonId,
+  { icon: string; label: string }
+> = {
+  emoji: { icon: 'mood-happy', label: '絵文字' },
+  attach: { icon: 'photo-plus', label: '添付' },
+  poll: { icon: 'chart-arrows', label: '投票' },
+  cw: { icon: 'eye-off', label: '閲覧注意' },
+  hashtag: { icon: 'hash', label: 'ハッシュタグ' },
+  mention: { icon: 'at', label: 'メンション' },
+  mfm: { icon: 'palette', label: 'MFM' },
+  draft: { icon: 'notes', label: '下書き' },
+  clear: { icon: 'trash', label: 'クリア' },
+}
+
+export const ALL_POST_FORM_BUTTONS = Object.keys(
+  POST_FORM_BUTTON_META,
+) as PostFormButtonId[]
+
+export const DEFAULT_POST_FORM_BUTTONS: PostFormButtonId[] =
+  JSON5.parse(defaultPostFormJson5)
+
+function sanitize(items: unknown): PostFormButtonId[] {
+  if (!Array.isArray(items)) return [...DEFAULT_POST_FORM_BUTTONS]
+  const seen = new Set<PostFormButtonId>()
+  const out: PostFormButtonId[] = []
+  for (const raw of items) {
+    if (typeof raw !== 'string') continue
+    if (!ALL_POST_FORM_BUTTONS.includes(raw as PostFormButtonId)) continue
+    const id = raw as PostFormButtonId
+    if (seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}
+
+export const usePostFormStore = defineStore('postForm', () => {
+  const buttons = ref<PostFormButtonId[]>([...DEFAULT_POST_FORM_BUTTONS])
+  const isCustomized = ref(false)
+
+  let persistTimer: ReturnType<typeof setTimeout> | null = null
+
+  function schedulePersist() {
+    if (persistTimer) clearTimeout(persistTimer)
+    persistTimer = setTimeout(() => {
+      persistTimer = null
+      flushPersist()
+    }, PERSIST_DEBOUNCE_MS)
+  }
+
+  function flushPersist() {
+    if (persistTimer) {
+      clearTimeout(persistTimer)
+      persistTimer = null
+    }
+    if (!isTauri) return
+    const content = JSON5.stringify(buttons.value, null, 2)
+    writePostForm(content).catch((e) =>
+      console.warn('[postForm] failed to persist:', e),
+    )
+  }
+
+  function setButtons(items: PostFormButtonId[] | undefined) {
+    if (items == null) {
+      buttons.value = [...DEFAULT_POST_FORM_BUTTONS]
+      isCustomized.value = false
+      if (isTauri) {
+        writePostForm('').catch((e) =>
+          console.warn('[postForm] failed to clear:', e),
+        )
+      }
+    } else {
+      buttons.value = sanitize(items)
+      isCustomized.value = true
+      schedulePersist()
+    }
+  }
+
+  async function init() {
+    if (!isTauri) return
+    try {
+      const content = await readPostForm()
+      if (content?.trim()) {
+        const parsed = JSON5.parse(content)
+        const clean = sanitize(parsed)
+        if (clean.length > 0) {
+          buttons.value = clean
+          isCustomized.value = true
+        }
+      }
+    } catch (e) {
+      console.warn('[postForm] failed to init:', e)
+    }
+  }
+
+  return {
+    buttons,
+    isCustomized,
+    setButtons,
+    flushPersist,
+    init,
+  }
+})

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -24,7 +24,6 @@ export type WindowType =
   | 'backup'
   | 'tasksEditor'
   | 'snippetsEditor'
-  | 'postFormEditor'
 
 export interface DeckWindow {
   id: string
@@ -74,8 +73,6 @@ export const WINDOW_SIZES: Record<
   tasksEditor: { width: 500, maxHeight: 700 },
   // Snippets editor
   snippetsEditor: { width: 500, maxHeight: 700 },
-  // Post form editor
-  postFormEditor: { width: 400, maxHeight: 650 },
 }
 
 export const useWindowsStore = defineStore('windows', () => {
@@ -112,7 +109,6 @@ export const useWindowsStore = defineStore('windows', () => {
     'backup',
     'tasksEditor',
     'snippetsEditor',
-    'postFormEditor',
   ])
 
   function open(type: WindowType, props: Record<string, unknown> = {}): string {

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -24,6 +24,7 @@ export type WindowType =
   | 'backup'
   | 'tasksEditor'
   | 'snippetsEditor'
+  | 'postFormEditor'
 
 export interface DeckWindow {
   id: string
@@ -73,6 +74,8 @@ export const WINDOW_SIZES: Record<
   tasksEditor: { width: 500, maxHeight: 700 },
   // Snippets editor
   snippetsEditor: { width: 500, maxHeight: 700 },
+  // Post form editor
+  postFormEditor: { width: 400, maxHeight: 650 },
 }
 
 export const useWindowsStore = defineStore('windows', () => {
@@ -109,6 +112,7 @@ export const useWindowsStore = defineStore('windows', () => {
     'backup',
     'tasksEditor',
     'snippetsEditor',
+    'postFormEditor',
   ])
 
   function open(type: WindowType, props: Record<string, unknown> = {}): string {

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -253,6 +253,34 @@ export async function deleteSnippetFile(filename: string): Promise<void> {
   return deleteSettingsFile(SNIPPETS_DIR, filename)
 }
 
+// --- Draft helpers (per-account JSON files in drafts/) ---
+
+const DRAFTS_DIR = 'drafts'
+
+export function draftFilename(accountId: string): string {
+  return `${sanitizeFilename(accountId)}.json`
+}
+
+export async function listDraftFiles(): Promise<string[]> {
+  const files = await listSettingsFiles(DRAFTS_DIR)
+  return files.filter((f) => f.endsWith('.json'))
+}
+
+export async function readDraftFile(accountId: string): Promise<string> {
+  return readSettingsFile(DRAFTS_DIR, draftFilename(accountId))
+}
+
+export async function writeDraftFile(
+  accountId: string,
+  content: string,
+): Promise<void> {
+  return writeSettingsFile(DRAFTS_DIR, draftFilename(accountId), content)
+}
+
+export async function deleteDraftFile(accountId: string): Promise<void> {
+  return deleteSettingsFile(DRAFTS_DIR, draftFilename(accountId))
+}
+
 // --- Plugin helpers ---
 
 const PLUGINS_DIR = 'plugins'

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -63,6 +63,24 @@ export async function getSettingsDir(): Promise<string> {
   return unwrap(await commands.getSettingsDir())
 }
 
+/**
+ * OS 既定アプリ (通常はユーザーが登録したテキストエディタ) で設定ファイルを開く。
+ * `getSettingsDir()` で得た絶対パスに subdir と name を結合して `openPath()` に渡す。
+ */
+export async function openSettingsFileInEditor(
+  name: string,
+  subdir?: string,
+): Promise<void> {
+  if (!isTauri) return
+  const dir = await getSettingsDir()
+  if (!dir) return
+  const sep = dir.includes('\\') && !dir.includes('/') ? '\\' : '/'
+  const parts = subdir ? [dir, subdir, name] : [dir, name]
+  const fullPath = parts.join(sep)
+  const { openPath } = await import('@tauri-apps/plugin-opener')
+  await openPath(fullPath)
+}
+
 // --- Profile-specific helpers ---
 
 const PROFILES_DIR = 'profiles'

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -65,20 +65,15 @@ export async function getSettingsDir(): Promise<string> {
 
 /**
  * OS 既定アプリ (通常はユーザーが登録したテキストエディタ) で設定ファイルを開く。
- * `getSettingsDir()` で得た絶対パスに subdir と name を結合して `openPath()` に渡す。
+ * WSL2 環境では xdg-open が GUI エディタへ届かないため、Rust 側で
+ * wslpath + cmd.exe start に委譲する。
  */
 export async function openSettingsFileInEditor(
   name: string,
   subdir?: string,
 ): Promise<void> {
   if (!isTauri) return
-  const dir = await getSettingsDir()
-  if (!dir) return
-  const sep = dir.includes('\\') && !dir.includes('/') ? '\\' : '/'
-  const parts = subdir ? [dir, subdir, name] : [dir, name]
-  const fullPath = parts.join(sep)
-  const { openPath } = await import('@tauri-apps/plugin-opener')
-  await openPath(fullPath)
+  unwrap(await commands.openSettingsFileInEditor(subdir ?? null, name))
 }
 
 // --- Profile-specific helpers ---

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -208,6 +208,16 @@ export async function writeNavbar(content: string): Promise<void> {
   return writeRootSettingsFile('navbar.json5', content)
 }
 
+// --- Post form button order helpers ---
+
+export async function readPostForm(): Promise<string> {
+  return readRootSettingsFile('postform.json5')
+}
+
+export async function writePostForm(content: string): Promise<void> {
+  return writeRootSettingsFile('postform.json5', content)
+}
+
 // --- Account order helpers ---
 
 export async function readAccountOrder(): Promise<string> {


### PR DESCRIPTION
## Summary

v0.10.8 リリース。投稿フォームのピッカー刷新（シングルトン化・インライン下書き・ボタン並び替えエディタ）、設定ファイル/ユーザー Web UI を OS 既定で開く導線、WSL2 での外部エディタ起動修正。

## Changes

### Features
- feat(post-form): 下書きを drafts.json 化＋インラインピッカー＋自動保存トグル
- feat(post-form): ボタン並び替えエディタを追加
- feat(window): 設定ファイルを OS 既定エディタで開くヘッダーボタンを追加
- feat(user-profile): Web UIで開く導線をウィンドウヘッダーに昇格

### Refactor
- refactor(post-form): 絵文字/ドライブ/下書きピッカーをシングルトン化
- refactor(post-form): ボタン編集をウィンドウからピッカーに変更
- refactor(post-form): ピッカーを位置非依存にし絵文字をフォーム幅に拡大

### Fixes
- fix(post-form): 埋め込みフォームでは並び替えボタンを非表示
- fix(settings): WSL2 で外部エディタが Windows 既定アプリで開くよう修正

## Test plan

- [ ] CI（lint / typecheck / test）通過
- [ ] 投稿フォームのピッカー（絵文字/ドライブ/下書き）シングルトン動作確認
- [ ] 下書き自動保存・復元の動作確認
- [ ] ボタン並び替えエディタの動作確認
- [ ] 設定ファイル/ユーザー Web UI の OS 既定オープン動作確認（WSL2 含む）