### PR TITLE
fix(site): ヒーローの「Note Deck」の隙間を解消

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -68,7 +68,7 @@
   <section class="hero">
     <h1>
       <img src="https://raw.githubusercontent.com/hitalin/notedeck/main/src-tauri/icons/128x128%402x.png" alt="" class="hero-logo" />
-      Note<span>Deck</span>
+      <span class="hero-wordmark">Note<span>Deck</span></span>
     </h1>
     <p class="tagline">Misskey Integrated Deck Environment</p>
   </section>

--- a/site/style.css
+++ b/site/style.css
@@ -138,7 +138,7 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 @media(prefers-reduced-motion:reduce){.blob{animation:none}}
 .hero h1{display:flex;align-items:center;justify-content:center;gap:.6rem;font-size:clamp(2.5rem,6vw,4rem);font-weight:800;letter-spacing:-0.02em}
 .hero h1 .hero-logo{width:1em;height:1em;border-radius:22%}
-.hero h1 span{background:linear-gradient(135deg,var(--accent),var(--accent-dark));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
+.hero h1 .hero-wordmark span{background:linear-gradient(135deg,var(--accent),var(--accent-dark));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
 .hero .tagline{font-size:clamp(1.05rem,2.5vw,1.3rem);color:var(--text-muted);max-width:540px}
 
 /* ===== Buttons ===== */


### PR DESCRIPTION
## Summary
- `.hero h1` の flex `gap:.6rem` が "Note" と `<span>Deck</span>` の間にも適用され不自然な空きになっていた
- テキスト全体を `.hero-wordmark` でラップして flex アイテムをロゴ + 文字列の 2 つに減らし、隙間を解消
- グラデーション CSS は内側 span に限定するようセレクタを調整

## Test plan
- [ ] Cloudflare Pages のデプロイ完了後、サイトのヒーロー表記「NoteDeck」が隙間なく表示されること
- [ ] 「Deck」部分のアクセントグラデーションが維持されていること
- [ ] ロゴとワードマークの間には従来通り `.6rem` のギャップが残ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)