### PR TITLE
Release v0.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.10.11",
+  "version": "0.10.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.10.11"
+version = "0.10.12"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkDraftsPicker.vue
+++ b/src/components/common/MkDraftsPicker.vue
@@ -7,8 +7,8 @@ import type {
 } from '@/adapters/types'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import MkNote from '@/components/common/MkNote.vue'
+import ColumnTabs, { type ColumnTabDef } from '@/components/deck/ColumnTabs.vue'
 import {
-  deleteAllDrafts,
   deleteDraft,
   draftsVersion,
   loadAllDrafts,
@@ -17,11 +17,19 @@ import {
 } from '@/composables/useDrafts'
 import { type Account, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
+import { useServersStore } from '@/stores/servers'
 import { useThemeStore } from '@/stores/theme'
 import { useToast } from '@/stores/toast'
+import {
+  formatScheduleAbsolute,
+  formatScheduleRelative,
+  isPastSchedule,
+} from '@/utils/scheduleFormat'
 
 const props = defineProps<{
   accountId: string
+  /** Misskey 2025.10+ の `features.scheduledNotes` 判定結果。親から渡す。 */
+  supportsScheduledNotes?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -29,7 +37,11 @@ const emit = defineEmits<{
   close: []
 }>()
 
+const activeTab = ref<string>('drafts')
+const bodyRef = ref<HTMLElement | null>(null)
+
 const accountsStore = useAccountsStore()
+const serversStore = useServersStore()
 const themeStore = useThemeStore()
 const { confirm } = useConfirm()
 const toast = useToast()
@@ -37,6 +49,12 @@ const toast = useToast()
 const account = computed<Account | undefined>(() =>
   accountsStore.accounts.find((a) => a.id === props.accountId),
 )
+
+/** 空状態に出すサーバー側の案内画像（infoImageUrl） */
+const serverInfoImage = computed(() => {
+  const host = account.value?.host
+  return host ? serversStore.servers.get(host)?.infoImageUrl : undefined
+})
 
 /** Per-account custom server theme so the picker matches the post form. */
 const themeVars = computed(() =>
@@ -119,7 +137,7 @@ watch(
   { immediate: true },
 )
 
-const entries = computed<DraftEntry[]>(() => {
+const allEntries = computed<DraftEntry[]>(() => {
   void draftsVersion.value
   if (!loaded.value || !account.value) return []
   const map = loadAllDrafts(props.accountId)
@@ -134,11 +152,82 @@ const entries = computed<DraftEntry[]>(() => {
       note: toPreviewNote(acc, stored),
     })
   }
-  out.sort((a, b) => b.draft.updatedAt.localeCompare(a.draft.updatedAt))
   return out
 })
 
-const draftCount = computed(() => entries.value.length)
+// 予約投稿の判定は scheduledAt 有無のみで行う。isActuallyScheduled は
+// サーバー（特にフォーク）が list のレスポンスに含めないことがあり、
+// そのフィールドを頼るとタブ間でアイテムが消失する。
+const regularEntries = computed<DraftEntry[]>(() =>
+  allEntries.value
+    .filter((e) => e.draft.data.scheduledAt == null)
+    .sort((a, b) => b.draft.updatedAt.localeCompare(a.draft.updatedAt)),
+)
+
+const scheduledEntries = computed<DraftEntry[]>(() =>
+  allEntries.value
+    .filter((e) => e.draft.data.scheduledAt != null)
+    .sort((a, b) =>
+      (a.draft.data.scheduledAt ?? '').localeCompare(
+        b.draft.data.scheduledAt ?? '',
+      ),
+    ),
+)
+
+const entries = computed<DraftEntry[]>(() =>
+  activeTab.value === 'scheduled'
+    ? scheduledEntries.value
+    : regularEntries.value,
+)
+
+const regularCount = computed(() => regularEntries.value.length)
+const scheduledCount = computed(() => scheduledEntries.value.length)
+
+// 予約タブは非対応サーバーでも既存 draft が残っている限り見せる（誤って
+// 作成された予約を取消できるようにするため）。新規作成はフォームの日時
+// ピッカーが出ないので自然に塞がる。
+const showScheduledTab = computed(
+  () => props.supportsScheduledNotes === true || scheduledCount.value > 0,
+)
+
+// supportsScheduledNotes が false になった / 予約が0件になったら drafts に戻す
+watch([showScheduledTab, scheduledCount], () => {
+  if (activeTab.value === 'scheduled' && !showScheduledTab.value) {
+    activeTab.value = 'drafts'
+  }
+})
+
+const tabs = computed<ColumnTabDef[]>(() => {
+  const out: ColumnTabDef[] = [
+    {
+      value: 'drafts',
+      label: regularCount.value ? `下書き ${regularCount.value}` : '下書き',
+      icon: 'notes',
+    },
+  ]
+  if (showScheduledTab.value) {
+    out.push({
+      value: 'scheduled',
+      label: scheduledCount.value ? `予約 ${scheduledCount.value}` : '予約',
+      icon: 'calendar-time',
+    })
+  }
+  return out
+})
+
+// 予約タブを見ている間だけ "あと30分" 等の相対時刻をリアクティブ更新する。
+// onCleanup が前回タイマーを必ず止めるので、アンマウント時も漏れない。
+const nowMs = ref(Date.now())
+watch(
+  activeTab,
+  (t, _, onCleanup) => {
+    if (t !== 'scheduled') return
+    nowMs.value = Date.now()
+    const tm = setInterval(() => (nowMs.value = Date.now()), 30_000)
+    onCleanup(() => clearInterval(tm))
+  },
+  { immediate: true },
+)
 
 function contextLabel(ctx: DraftContext): string {
   switch (ctx.kind) {
@@ -170,16 +259,6 @@ function truncate(s: string, max: number): string {
   const t = s.trim()
   if (t.length <= max) return t
   return `${t.slice(0, max)}…`
-}
-
-function formatScheduledAt(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
 }
 
 function onPick(entry: DraftEntry) {
@@ -215,35 +294,44 @@ function closeMenu() {
 }
 
 async function onDelete(entry: DraftEntry) {
+  const isScheduled = entry.draft.data.scheduledAt != null
   const ok = await confirm({
-    title: '下書きを削除',
-    message: '選択した下書きを削除しますか？',
-    okLabel: '削除',
+    title: isScheduled ? '予約投稿を取消' : '下書きを削除',
+    message: isScheduled
+      ? '選択した予約投稿を取消しますか？'
+      : '選択した下書きを削除しますか？',
+    okLabel: isScheduled ? '取消' : '削除',
     type: 'danger',
   })
   if (!ok) return
   try {
     await deleteDraft(props.accountId, entry.key)
-    toast.show('下書きを削除しました', 'info')
+    toast.show(
+      isScheduled ? '予約投稿を取消しました' : '下書きを削除しました',
+      'info',
+    )
   } catch (e) {
     toast.show(
-      `削除に失敗しました: ${e instanceof Error ? e.message : String(e)}`,
+      `${isScheduled ? '取消' : '削除'}に失敗しました: ${e instanceof Error ? e.message : String(e)}`,
       'error',
     )
   }
 }
 
 async function onDeleteAll() {
-  if (draftCount.value === 0) return
+  if (regularCount.value === 0) return
   const ok = await confirm({
     title: 'すべての下書きを削除',
-    message: `下書き ${draftCount.value} 件をすべて削除しますか？`,
+    message: `下書き ${regularCount.value} 件をすべて削除しますか？（予約投稿は対象外）`,
     okLabel: 'すべて削除',
     type: 'danger',
   })
   if (!ok) return
   try {
-    await deleteAllDrafts(props.accountId)
+    // 予約投稿を誤って巻き込まないよう、下書きタブのエントリだけを個別削除
+    await Promise.allSettled(
+      regularEntries.value.map((e) => deleteDraft(props.accountId, e.key)),
+    )
     toast.show('下書きをすべて削除しました', 'info')
   } catch (e) {
     toast.show(
@@ -256,38 +344,43 @@ async function onDeleteAll() {
 
 <template>
   <div :class="$style.draftsPicker" :style="themeVars" @click.stop>
-    <!-- Header -->
-    <div :class="$style.dpHeader">
-      <span :class="$style.dpTitle">
-        <i class="ti ti-notes" />
-        下書き
-        <span :class="$style.dpCount">{{ draftCount }}</span>
-      </span>
-      <button
-        v-if="draftCount > 0"
-        class="_button"
-        :class="$style.dpHeaderBtn"
-        title="すべて削除"
-        @click="onDeleteAll"
-      >
-        <i class="ti ti-trash" />
-      </button>
-      <button
-        class="_button"
-        :class="$style.dpHeaderBtn"
-        title="閉じる"
-        @click="emit('close')"
-      >
-        <i class="ti ti-x" />
-      </button>
-    </div>
+    <!-- Tabs: 既存カラム/ウィンドウのタブと同一 UX。横スクロール + 横スワイプ対応 -->
+    <ColumnTabs
+      v-model="activeTab"
+      :tabs="tabs"
+      :swipe-target="bodyRef"
+      scrollable
+    >
+      <template #trailing>
+        <div :class="$style.trailingBtns">
+          <button
+            v-if="activeTab === 'drafts' && regularCount > 0"
+            class="_button"
+            :class="$style.dpHeaderBtn"
+            title="下書きをすべて削除"
+            @click="onDeleteAll"
+          >
+            <i class="ti ti-trash" />
+          </button>
+          <button
+            class="_button"
+            :class="$style.dpHeaderBtn"
+            title="閉じる"
+            @click="emit('close')"
+          >
+            <i class="ti ti-x" />
+          </button>
+        </div>
+      </template>
+    </ColumnTabs>
 
     <!-- Body -->
-    <div :class="$style.dpBody">
+    <div ref="bodyRef" :class="$style.dpBody">
       <div v-if="!loaded" :class="$style.dpEmpty">読み込み中...</div>
       <ColumnEmptyState
-        v-else-if="draftCount === 0"
-        message="下書きはありません"
+        v-else-if="entries.length === 0"
+        :message="activeTab === 'scheduled' ? '予約投稿はありません' : '下書きはありません'"
+        :image-url="serverInfoImage"
       />
       <div v-else :class="$style.dpList">
         <div
@@ -297,13 +390,10 @@ async function onDeleteAll() {
           @contextmenu.capture="onContextMenu($event, entry)"
         >
           <div
-            v-if="contextLabel(entry.context) || entry.draft.data.scheduledAt"
+            v-if="contextLabel(entry.context)"
             :class="$style.meta"
           >
-            <span
-              v-if="contextLabel(entry.context)"
-              :class="$style.metaCtx"
-            >
+            <span :class="$style.metaCtx">
               <i :class="contextIcon(entry.context)" />
               {{ contextLabel(entry.context) }}
             </span>
@@ -320,14 +410,6 @@ async function onDeleteAll() {
               <i class="ti ti-device-tv" />
               {{ truncate(entry.context.channelId, 12) }}
             </span>
-            <span
-              v-if="entry.draft.data.scheduledAt"
-              :class="$style.metaScheduled"
-              :title="entry.draft.data.scheduledAt"
-            >
-              <i class="ti ti-clock" />
-              {{ formatScheduledAt(entry.draft.data.scheduledAt) }}
-            </span>
           </div>
           <!-- capture-phase click: MkNote 内部の navigateToDetail (合成IDなので
                404 になる) より先に拾って投稿フォーム復元に振り替える。 -->
@@ -340,6 +422,23 @@ async function onDeleteAll() {
             @keydown.enter="onPick(entry)"
           >
             <MkNote :note="entry.note" embedded />
+            <span
+              v-if="entry.draft.data.scheduledAt"
+              :class="[
+                $style.scheduledBadge,
+                isPastSchedule(entry.draft.data.scheduledAt, nowMs) &&
+                  $style.scheduledBadgePast,
+              ]"
+              :title="formatScheduleAbsolute(entry.draft.data.scheduledAt, nowMs)"
+            >
+              <i class="ti ti-clock" />
+              <span :class="$style.scheduledBadgeRel">
+                {{ formatScheduleRelative(entry.draft.data.scheduledAt, nowMs) }}
+              </span>
+              <span :class="$style.scheduledBadgeAbs">
+                {{ formatScheduleAbsolute(entry.draft.data.scheduledAt, nowMs) }}
+              </span>
+            </span>
           </div>
         </div>
       </div>
@@ -365,8 +464,8 @@ async function onDeleteAll() {
             :class="$style.menuItem"
             @click="onPick(menuState.entry); closeMenu()"
           >
-            <i class="ti ti-arrow-back-up" />
-            復元して投稿フォームに反映
+            <i :class="menuState.entry.draft.data.scheduledAt ? 'ti ti-pencil' : 'ti ti-arrow-back-up'" />
+            {{ menuState.entry.draft.data.scheduledAt ? '内容・時刻を編集' : '復元して投稿フォームに反映' }}
           </button>
           <div :class="$style.menuDivider" />
           <button
@@ -375,7 +474,7 @@ async function onDeleteAll() {
             @click="onDelete(menuState.entry); closeMenu()"
           >
             <i class="ti ti-trash" />
-            削除
+            {{ menuState.entry.draft.data.scheduledAt ? '予約を取消' : '削除' }}
           </button>
         </div>
       </div>
@@ -397,31 +496,12 @@ async function onDeleteAll() {
   box-shadow: 0 8px 32px var(--nd-shadow);
 }
 
-.dpHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--nd-divider);
-}
-
-.dpTitle {
+.trailingBtns {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  font-size: 0.9em;
-  font-weight: 600;
-  flex: 1;
-  min-width: 0;
-}
-
-.dpCount {
-  font-size: 0.75em;
-  padding: 1px 8px;
-  border-radius: 999px;
-  background: var(--nd-accent);
-  color: var(--nd-fgOnAccent);
-  font-weight: 600;
+  gap: 2px;
+  margin-left: auto;
+  padding-right: 8px;
 }
 
 .dpHeaderBtn {
@@ -496,21 +576,50 @@ async function onDeleteAll() {
   background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.06));
 }
 
-.metaScheduled {
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
-  color: var(--nd-accent);
-}
-
 .itemNoteBtn {
+  position: relative;
   display: block;
   width: 100%;
   text-align: left;
   cursor: pointer;
+}
+
+/* 予約時刻バッジ: ノートプレビュー内の右下に重ねる */
+.scheduledBadge {
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
+  color: var(--nd-accent);
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  backdrop-filter: blur(8px);
+}
+
+.scheduledBadgeRel {
+  font-weight: 700;
+}
+
+.scheduledBadgeAbs {
+  opacity: 0.7;
+  font-size: 0.9em;
+
+  &::before {
+    content: '·';
+    margin-right: 4px;
+    opacity: 0.7;
+  }
+}
+
+.scheduledBadgePast {
+  background: color-mix(in srgb, var(--nd-danger, #e64c4c) 18%, transparent);
+  color: var(--nd-danger, #e64c4c);
 }
 
 .dpEmpty {

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -6,6 +6,7 @@ import type { StoredDraft } from '@/composables/useDrafts'
 import type { StoredMemo } from '@/composables/useMemos'
 import { useMentionSearch } from '@/composables/useMentionSearch'
 import { useMfmInsert } from '@/composables/useMfmInsert'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { usePopupControl } from '@/composables/usePopupControl'
 import { usePostFormState } from '@/composables/usePostFormState'
 import {
@@ -21,6 +22,12 @@ import { useWindowsStore } from '@/stores/windows'
 import { buildPreviewNote } from '@/utils/buildPreviewNote'
 import { showLoginPrompt } from '@/utils/loginPrompt'
 import { parseMfm } from '@/utils/mfm'
+import {
+  formatScheduleAbsolute,
+  formatScheduleRelative,
+  toLocalDateInput,
+  toLocalTimeInput,
+} from '@/utils/scheduleFormat'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
 import MkDraftsPicker from './MkDraftsPicker.vue'
 import MkDrivePicker from './MkDrivePicker.vue'
@@ -166,7 +173,6 @@ const autoSaveLabel = computed(() =>
 // --- Popup exclusive control ---
 // ピッカー系 (emoji / drive / memo) はシングルトン: 同時に1つだけ開く
 const popups = usePopupControl()
-const showSchedulePopup = popups.register()
 const showEmojiPopup = popups.register()
 const showMoreMenu = popups.register()
 const showDraftsPicker = popups.register()
@@ -186,35 +192,66 @@ function onDraftPicked(key: string, draft: StoredDraft) {
   showDraftsPicker.value = false
 }
 
-function toggleSchedulePopup() {
-  popups.toggle(showSchedulePopup)
+function setSchedule(v: string | null) {
+  scheduledAt.value = v ? new Date(v).toISOString() : null
 }
 
-function setSchedule(value: string | null) {
-  if (value) {
-    scheduledAt.value = new Date(value).toISOString()
-  } else {
-    scheduledAt.value = null
-  }
-  showSchedulePopup.value = false
-}
+// 予約投稿ダイアログ。既存ダイアログ (AppPrompt/AppConfirm) と同じ構造で、
+// native <dialog> の close 挙動 + date/time を別 input に分けて安定動作させる。
+const showScheduleDialog = ref(false)
+const scheduleDialogRef = ref<HTMLDialogElement | null>(null)
+const pendingScheduleDate = ref('')
+const pendingScheduleTime = ref('')
+const canConfirmSchedule = computed(
+  () => !!pendingScheduleDate.value && !!pendingScheduleTime.value,
+)
+useNativeDialog(scheduleDialogRef, showScheduleDialog, {
+  onCancel: () => (showScheduleDialog.value = false),
+  leaveDuration: 200,
+})
 
-function formatScheduledDate(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
+function openScheduleDialog() {
+  const base = scheduledAt.value
+    ? new Date(scheduledAt.value)
+    : new Date(Date.now() + 60 * 60_000)
+  base.setSeconds(0, 0)
+  pendingScheduleDate.value = toLocalDateInput(base)
+  pendingScheduleTime.value = toLocalTimeInput(base)
+  showScheduleDialog.value = true
 }
-
-/** Minimum datetime for schedule picker (5 minutes from now) */
-function minScheduleDatetime(): string {
-  const d = new Date(Date.now() + 5 * 60 * 1000)
+function confirmSchedule() {
+  if (!canConfirmSchedule.value) return
+  const d = new Date(
+    `${pendingScheduleDate.value}T${pendingScheduleTime.value}`,
+  )
+  // 5 分後を下回る場合は切り上げ
+  const minMs = Date.now() + 5 * 60_000
+  if (d.getTime() < minMs) d.setTime(minMs)
   d.setSeconds(0, 0)
-  return d.toISOString().slice(0, 16)
+  scheduledAt.value = d.toISOString()
+  showScheduleDialog.value = false
 }
+function clearSchedule() {
+  scheduledAt.value = null
+  showScheduleDialog.value = false
+}
+function minScheduleDate(): string {
+  return toLocalDateInput(new Date(Date.now() + 5 * 60_000))
+}
+
+// scheduledAt がセットされている間だけ 30 秒周期で "あと◯分" の now を進める。
+// watch の onCleanup が前回タイマーを自動停止するので onUnmounted は不要。
+const scheduleNow = ref(Date.now())
+watch(
+  scheduledAt,
+  (v, _, onCleanup) => {
+    if (!v) return
+    scheduleNow.value = Date.now()
+    const t = setInterval(() => (scheduleNow.value = Date.now()), 30_000)
+    onCleanup(() => clearInterval(t))
+  },
+  { immediate: true },
+)
 
 // --- Preview ---
 const previewNote = computed<NormalizedNote | null>(() => {
@@ -614,42 +651,28 @@ function onKeydown(e: KeyboardEvent) {
                   <span class="nd-toggle-switch-knob" />
                 </span>
               </div>
-              <!-- Schedule (only if server supports it) -->
+              <!-- Schedule (only if server supports it). ボタンでダイアログを開く。
+                   Misskey 本家と同様 native datetime-local をダイアログ内に表示 -->
               <template v-if="supportsScheduledNotes && !editNote">
                 <div :class="$style.moreMenuDivider" />
                 <button
                   class="_button"
                   :class="[$style.moreMenuItem, { [$style.active]: !!scheduledAt }]"
-                  @click.stop="showSchedulePopup = !showSchedulePopup"
+                  @click.stop="openScheduleDialog(); showMoreMenu = false"
                 >
                   <i class="ti ti-clock" />
                   予約投稿
-                  <span v-if="scheduledAt" :class="$style.moreMenuScheduleBadge">{{ formatScheduledDate(scheduledAt) }}</span>
+                  <span v-if="scheduledAt" :class="$style.moreMenuScheduleBadge">
+                    {{ formatScheduleAbsolute(scheduledAt, scheduleNow) }}
+                  </span>
                 </button>
-                <div v-if="showSchedulePopup" :class="$style.moreMenuSchedulePicker" @click.stop>
-                  <input
-                    type="datetime-local"
-                    :class="$style.scheduleDatetimeInput"
-                    :min="minScheduleDatetime()"
-                    :value="scheduledAt ? scheduledAt.slice(0, 16) : ''"
-                    @change="setSchedule(($event.target as HTMLInputElement).value || null)"
-                  />
-                  <button
-                    v-if="scheduledAt"
-                    class="_button"
-                    :class="$style.scheduleClearBtn"
-                    @click="setSchedule(null)"
-                  >
-                    予約を解除
-                  </button>
-                </div>
               </template>
             </div>
           </div>
 
           <!-- Submit -->
           <button
-            :class="[$style.submitBtn, { [$style.posted]: posted, [$style.scheduled]: !!scheduledAt }]"
+            :class="[$style.submitBtn, { [$style.posted]: posted }]"
             :disabled="!canPost"
             @click="post"
           >
@@ -660,13 +683,6 @@ function onKeydown(e: KeyboardEvent) {
             </template>
             <template v-else-if="isPosting">
               <span :class="$style.postingDots">...</span>
-            </template>
-            <template v-else-if="scheduledAt">
-              <svg viewBox="0 0 24 24" width="16" height="16" :class="$style.submitIcon">
-                <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
-                <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-              </svg>
-              予約投稿
             </template>
             <template v-else>
               <svg viewBox="0 0 24 24" width="16" height="16" :class="$style.submitIcon">
@@ -683,7 +699,7 @@ function onKeydown(e: KeyboardEvent) {
                   <path d="M22 2L11 13M22 2l-7 20-4-9-9-4z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
                 </template>
               </svg>
-              {{ editNote ? '編集' : replyTo ? '返信' : renoteId ? '引用' : 'ノート' }}
+              {{ editNote ? '編集' : replyTo ? '返信' : renoteId ? '引用' : scheduledAt ? '予約' : 'ノート' }}
             </template>
           </button>
         </div>
@@ -712,18 +728,6 @@ function onKeydown(e: KeyboardEvent) {
           <path d="M10 11h6m-3-3v6M3 8V6a2 2 0 012-2h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2v-2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
         </svg>
         引用付き
-      </div>
-
-      <!-- Schedule indicator -->
-      <div v-if="scheduledAt" :class="$style.scheduleIndicator">
-        <svg viewBox="0 0 24 24" width="14" height="14">
-          <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="2" fill="none" />
-          <path d="M12 6v6l4 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
-        </svg>
-        {{ formatScheduledDate(scheduledAt) }}
-        <button class="_button" :class="$style.scheduleClear" @click="scheduledAt = null">
-          <i class="ti ti-x" />
-        </button>
       </div>
 
       <!-- CW input -->
@@ -767,6 +771,27 @@ function onKeydown(e: KeyboardEvent) {
           class="_acrylic"
           :class="[$style.textCount, { [$style.over]: remainingChars < 0 }]"
         >{{ remainingChars }}</span>
+        <span
+          v-if="scheduledAt"
+          :class="$style.scheduleIndicator"
+          :title="formatScheduleAbsolute(scheduledAt, scheduleNow)"
+        >
+          <i class="ti ti-clock" />
+          <span :class="$style.scheduleIndicatorRel">
+            {{ formatScheduleRelative(scheduledAt, scheduleNow) }}
+          </span>
+          <span :class="$style.scheduleIndicatorAbs">
+            {{ formatScheduleAbsolute(scheduledAt, scheduleNow) }}
+          </span>
+          <button
+            class="_button"
+            :class="$style.scheduleClear"
+            :title="'予約を解除'"
+            @click="scheduledAt = null"
+          >
+            <i class="ti ti-x" />
+          </button>
+        </span>
       </div>
 
       <!-- Preview -->
@@ -989,6 +1014,7 @@ function onKeydown(e: KeyboardEvent) {
     <MkDraftsPicker
       v-if="showDraftsPicker"
       :account-id="activeAccountId!"
+      :supports-scheduled-notes="supportsScheduledNotes"
       @pick="onDraftPicked"
       @close="showDraftsPicker = false"
     />
@@ -1028,10 +1054,70 @@ function onKeydown(e: KeyboardEvent) {
       </div>
     </div>
 
+    <!-- Schedule dialog: 既存ダイアログ (AppPrompt/AppConfirm) と同じ構造 -->
+    <dialog
+      v-if="showScheduleDialog"
+      ref="scheduleDialogRef"
+      class="_nativeDialog"
+    >
+      <form
+        class="_dialog nd-popup-content"
+        @submit.prevent="confirmSchedule"
+      >
+        <div :class="$style.scheduleHeader">
+          <div :class="$style.scheduleTitle">予約投稿</div>
+        </div>
+        <div :class="$style.scheduleBody">
+          <div :class="$style.scheduleRow">
+            <input
+              v-model="pendingScheduleDate"
+              type="date"
+              :class="$style.scheduleInput"
+              :min="minScheduleDate()"
+            />
+            <input
+              v-model="pendingScheduleTime"
+              type="time"
+              :class="$style.scheduleInput"
+            />
+          </div>
+        </div>
+        <div :class="$style.scheduleActions">
+          <button
+            v-if="scheduledAt"
+            type="button"
+            class="_button"
+            :class="$style.scheduleBtnClear"
+            @click="clearSchedule"
+          >
+            予約を解除
+          </button>
+          <button
+            type="button"
+            class="_button"
+            :class="$style.scheduleBtnCancel"
+            @click="showScheduleDialog = false"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            class="_button"
+            :class="$style.scheduleBtnOk"
+            :disabled="!canConfirmSchedule"
+          >
+            OK
+          </button>
+        </div>
+      </form>
+    </dialog>
+
   </div>
 </template>
 
 <style lang="scss" module>
+@use '@/styles/buttons' as *;
+
 .postOverlay {
   position: fixed;
   inset: 0;
@@ -1333,10 +1419,6 @@ function onKeydown(e: KeyboardEvent) {
   &.posted {
     background: var(--nd-success);
   }
-
-  &.scheduled {
-    background: var(--nd-accent);
-  }
 }
 
 .postingDots {
@@ -1450,11 +1532,58 @@ function onKeydown(e: KeyboardEvent) {
   opacity: 0.7;
 }
 
-.moreMenuSchedulePicker {
-  padding: 8px 12px;
+/* 予約投稿ダイアログ (AppPrompt/AppConfirm と同パターン) */
+.scheduleHeader {
+  padding: 16px 20px 4px;
+  text-align: center;
+}
+
+.scheduleTitle {
+  font-size: 1em;
+  font-weight: bold;
+  color: var(--nd-fg);
+}
+
+.scheduleBody {
+  padding: 4px 20px 12px;
+}
+
+.scheduleRow {
   display: flex;
-  flex-direction: column;
   gap: 8px;
+}
+
+.scheduleInput {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 12px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-bg);
+  color: var(--nd-fg);
+  font-size: 0.95em;
+  font-family: inherit;
+  outline: none;
+  box-sizing: border-box;
+
+  &:focus {
+    border-color: var(--nd-accent);
+  }
+}
+
+.scheduleActions {
+  display: flex;
+  gap: 6px;
+  padding: 0 16px 16px;
+  justify-content: center;
+}
+
+.scheduleBtnOk { @include btn-primary; }
+.scheduleBtnCancel { @include btn-secondary; }
+.scheduleBtnClear {
+  @include btn-secondary;
+  margin-right: auto;
+  color: var(--nd-danger, #e64c4c);
 }
 
 /* ── Note mode button ── */
@@ -1921,14 +2050,35 @@ function onKeydown(e: KeyboardEvent) {
   opacity: 0.6;
 }
 
-/* ── Schedule indicator ── */
+/* ── Schedule indicator (textarea 右下にフローティング) ── */
 .scheduleIndicator {
-  display: flex;
+  position: absolute;
+  right: 12px;
+  bottom: 10px;
+  display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 6px 24px;
-  font-size: 0.82em;
+  padding: 3px 6px 3px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
   color: var(--nd-accent);
+  font-size: 0.82em;
+  font-variant-numeric: tabular-nums;
+  backdrop-filter: blur(8px);
+}
+
+.scheduleIndicatorRel {
+  font-weight: 700;
+}
+
+.scheduleIndicatorAbs {
+  opacity: 0.7;
+
+  &::before {
+    content: '·';
+    margin-right: 4px;
+    opacity: 0.7;
+  }
 }
 
 .scheduleClear {
@@ -1949,42 +2099,6 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
-/* ── Schedule popup ── */
-.schedulePopup {
-  width: 240px;
-  padding: 12px;
-}
-
-.schedulePopupContent {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.scheduleDatetimeInput {
-  width: 100%;
-  padding: 8px;
-  font-size: 0.85em;
-  font-family: inherit;
-  color: var(--nd-fg);
-  background: var(--nd-buttonBg);
-  border: none;
-  border-radius: var(--nd-radius-sm);
-  outline: none;
-  box-sizing: border-box;
-}
-
-.scheduleClearBtn {
-  padding: 6px;
-  font-size: 0.8em;
-  color: var(--nd-error);
-  border-radius: var(--nd-radius-sm);
-  text-align: center;
-
-  &:hover {
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
 
 /* ── Responsive ── */
 @container (max-width: 500px) {

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -6,9 +6,9 @@ import type { StoredDraft } from '@/composables/useDrafts'
 import type { StoredMemo } from '@/composables/useMemos'
 import { useMentionSearch } from '@/composables/useMentionSearch'
 import { useMfmInsert } from '@/composables/useMfmInsert'
-import { useNativeDialog } from '@/composables/useNativeDialog'
 import { usePopupControl } from '@/composables/usePopupControl'
 import { usePostFormState } from '@/composables/usePostFormState'
+import { useScheduleDialog } from '@/composables/useScheduleDialog'
 import {
   getAccountAvatarUrl,
   getAccountLabel,
@@ -25,8 +25,6 @@ import { parseMfm } from '@/utils/mfm'
 import {
   formatScheduleAbsolute,
   formatScheduleRelative,
-  toLocalDateInput,
-  toLocalTimeInput,
 } from '@/utils/scheduleFormat'
 import MkAutocompletePopup from './MkAutocompletePopup.vue'
 import MkDraftsPicker from './MkDraftsPicker.vue'
@@ -192,66 +190,18 @@ function onDraftPicked(key: string, draft: StoredDraft) {
   showDraftsPicker.value = false
 }
 
-function setSchedule(v: string | null) {
-  scheduledAt.value = v ? new Date(v).toISOString() : null
-}
-
-// 予約投稿ダイアログ。既存ダイアログ (AppPrompt/AppConfirm) と同じ構造で、
-// native <dialog> の close 挙動 + date/time を別 input に分けて安定動作させる。
-const showScheduleDialog = ref(false)
-const scheduleDialogRef = ref<HTMLDialogElement | null>(null)
-const pendingScheduleDate = ref('')
-const pendingScheduleTime = ref('')
-const canConfirmSchedule = computed(
-  () => !!pendingScheduleDate.value && !!pendingScheduleTime.value,
-)
-useNativeDialog(scheduleDialogRef, showScheduleDialog, {
-  onCancel: () => (showScheduleDialog.value = false),
-  leaveDuration: 200,
-})
-
-function openScheduleDialog() {
-  const base = scheduledAt.value
-    ? new Date(scheduledAt.value)
-    : new Date(Date.now() + 60 * 60_000)
-  base.setSeconds(0, 0)
-  pendingScheduleDate.value = toLocalDateInput(base)
-  pendingScheduleTime.value = toLocalTimeInput(base)
-  showScheduleDialog.value = true
-}
-function confirmSchedule() {
-  if (!canConfirmSchedule.value) return
-  const d = new Date(
-    `${pendingScheduleDate.value}T${pendingScheduleTime.value}`,
-  )
-  // 5 分後を下回る場合は切り上げ
-  const minMs = Date.now() + 5 * 60_000
-  if (d.getTime() < minMs) d.setTime(minMs)
-  d.setSeconds(0, 0)
-  scheduledAt.value = d.toISOString()
-  showScheduleDialog.value = false
-}
-function clearSchedule() {
-  scheduledAt.value = null
-  showScheduleDialog.value = false
-}
-function minScheduleDate(): string {
-  return toLocalDateInput(new Date(Date.now() + 5 * 60_000))
-}
-
-// scheduledAt がセットされている間だけ 30 秒周期で "あと◯分" の now を進める。
-// watch の onCleanup が前回タイマーを自動停止するので onUnmounted は不要。
-const scheduleNow = ref(Date.now())
-watch(
-  scheduledAt,
-  (v, _, onCleanup) => {
-    if (!v) return
-    scheduleNow.value = Date.now()
-    const t = setInterval(() => (scheduleNow.value = Date.now()), 30_000)
-    onCleanup(() => clearInterval(t))
-  },
-  { immediate: true },
-)
+const {
+  showScheduleDialog,
+  scheduleDialogRef,
+  pendingScheduleDate,
+  pendingScheduleTime,
+  canConfirmSchedule,
+  scheduleNow,
+  openScheduleDialog,
+  confirmSchedule,
+  clearSchedule,
+  minScheduleDate,
+} = useScheduleDialog(scheduledAt)
 
 // --- Preview ---
 const previewNote = computed<NormalizedNote | null>(() => {

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -243,7 +243,10 @@ async function onPromoteToDraft(entry: MemoEntry) {
   const acc = account.value
   if (!acc) return
   try {
-    await saveDraft(acc.id, null, entry.memo.data)
+    await saveDraft(acc.id, null, {
+      ...entry.memo.data,
+      isActuallyScheduled: false,
+    })
   } catch (e) {
     toast.show(
       `下書き化に失敗しました: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -21,6 +21,7 @@ import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { buildPreviewNote } from '@/utils/buildPreviewNote'
+import { formatScheduleAbsolute } from '@/utils/scheduleFormat'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
 
@@ -183,16 +184,6 @@ function truncate(s: string, max: number): string {
   return `${t.slice(0, max)}…`
 }
 
-function formatScheduledAt(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
-
 /**
  * Embedded MkPostForm state. Default = blank new memo (Obsidian's "Create
  * Unique New Note" flow). Edit ボタンで既存メモの内容を initialSlot に流し
@@ -243,10 +234,7 @@ async function onPromoteToDraft(entry: MemoEntry) {
   const acc = account.value
   if (!acc) return
   try {
-    await saveDraft(acc.id, null, {
-      ...entry.memo.data,
-      isActuallyScheduled: false,
-    })
+    await saveDraft(acc.id, null, { ...entry.memo.data })
   } catch (e) {
     toast.show(
       `下書き化に失敗しました: ${e instanceof Error ? e.message : String(e)}`,
@@ -369,7 +357,7 @@ function closeMenu() {
             :title="entry.memo.data.scheduledAt"
           >
             <i class="ti ti-clock" />
-            {{ formatScheduledAt(entry.memo.data.scheduledAt) }}
+            {{ formatScheduleAbsolute(entry.memo.data.scheduledAt) }}
           </span>
         </div>
 

--- a/src/components/window/LoginContent.vue
+++ b/src/components/window/LoginContent.vue
@@ -9,6 +9,7 @@ import { useVaporTransitionSwitch } from '@/composables/useVaporTransition'
 import { detectServer } from '@/core/server'
 import type { Account } from '@/stores/accounts'
 import { useAccountsStore } from '@/stores/accounts'
+import { useServersStore } from '@/stores/servers'
 import { useIsCompactLayout } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -23,6 +24,7 @@ const emit = defineEmits<{
 }>()
 
 const accountsStore = useAccountsStore()
+const serversStore = useServersStore()
 const isCompact = useIsCompactLayout()
 const auth = new MisskeyAuth()
 
@@ -76,6 +78,10 @@ async function completeLogin() {
 
   try {
     const serverInfo = await detectServer(currentSession.host)
+    // 古い DB キャッシュ (判定ロジック変更前の features など) を、最新検出
+    // 結果で即上書きする。これをしないと以降の getServerInfo が stale な
+    // features.scheduledNotes = false 等を返し続ける。
+    await serversStore.refreshServer(serverInfo)
     const account = unwrap(
       await commands.authCompleteAndSave(currentSession, serverInfo.software),
     ) as unknown as Account
@@ -95,6 +101,7 @@ async function startGuest() {
   try {
     step.value = 'guestLoading'
     const serverInfo = await detectServer(trimmedHost)
+    await serversStore.refreshServer(serverInfo)
     const account = unwrap(
       await commands.createGuestAccount(trimmedHost, serverInfo.software),
     ) as unknown as Account

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -182,10 +182,7 @@ async function onPromoteToDraft() {
   const m = memo.value
   if (!m) return
   try {
-    await saveDraft(props.accountId, null, {
-      ...m.data,
-      isActuallyScheduled: false,
-    })
+    await saveDraft(props.accountId, null, { ...m.data })
   } catch (e) {
     toast.show(`下書き化に失敗しました: ${AppError.from(e).message}`, 'error')
     return

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -182,7 +182,10 @@ async function onPromoteToDraft() {
   const m = memo.value
   if (!m) return
   try {
-    await saveDraft(props.accountId, null, m.data)
+    await saveDraft(props.accountId, null, {
+      ...m.data,
+      isActuallyScheduled: false,
+    })
   } catch (e) {
     toast.show(`下書き化に失敗しました: ${AppError.from(e).message}`, 'error')
     return

--- a/src/composables/useDrafts.ts
+++ b/src/composables/useDrafts.ts
@@ -22,8 +22,9 @@ export interface DraftData {
   /**
    * Misskey 2025.10+ の予約投稿フラグ。`true` かつ `scheduledAt` 設定時に
    * サーバーが時刻到来で自動投稿する（下書き扱いではなくなる）。
+   * 省略時は `false`（純粋な下書き）として扱う。
    */
-  isActuallyScheduled: boolean
+  isActuallyScheduled?: boolean
 }
 
 export interface DraftContext {
@@ -118,7 +119,7 @@ function buildParams(data: DraftData, ctx: DraftContext): JsonValue {
         ? { choices: validChoices, multiple: data.pollMultiple }
         : null,
     scheduledAt: data.scheduledAt ? new Date(data.scheduledAt).getTime() : null,
-    isActuallyScheduled: data.isActuallyScheduled,
+    isActuallyScheduled: data.isActuallyScheduled ?? false,
   }
 }
 

--- a/src/composables/useDrafts.ts
+++ b/src/composables/useDrafts.ts
@@ -19,6 +19,11 @@ export interface DraftData {
   pollMultiple: boolean
   showPoll: boolean
   scheduledAt: string | null
+  /**
+   * Misskey 2025.10+ の予約投稿フラグ。`true` かつ `scheduledAt` 設定時に
+   * サーバーが時刻到来で自動投稿する（下書き扱いではなくなる）。
+   */
+  isActuallyScheduled: boolean
 }
 
 export interface DraftContext {
@@ -58,6 +63,7 @@ interface NoteDraftRaw {
     expiresAt?: number | null
   } | null
   scheduledAt?: number | null
+  isActuallyScheduled?: boolean
 }
 
 // accountId → draftId → StoredDraft
@@ -84,6 +90,7 @@ function toStored(raw: NoteDraftRaw): StoredDraft {
         raw.scheduledAt != null
           ? new Date(raw.scheduledAt).toISOString()
           : null,
+      isActuallyScheduled: raw.isActuallyScheduled ?? false,
     },
     replyId: raw.replyId ?? null,
     renoteId: raw.renoteId ?? null,
@@ -111,6 +118,7 @@ function buildParams(data: DraftData, ctx: DraftContext): JsonValue {
         ? { choices: validChoices, multiple: data.pollMultiple }
         : null,
     scheduledAt: data.scheduledAt ? new Date(data.scheduledAt).getTime() : null,
+    isActuallyScheduled: data.isActuallyScheduled,
   }
 }
 

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -267,6 +267,32 @@ export function usePostFormState(
       return
     }
 
+    // Scheduled post (Misskey 2025.10+): persist as an actually-scheduled
+    // draft via notes/drafts/*. The server fires the note at `scheduledAt`.
+    // On fork servers without the feature flag, fall through to `notes/create`
+    // which may still accept `scheduledAt` (e.g. CherryPick).
+    if (scheduledAt.value != null && supportsScheduledNotes.value) {
+      try {
+        await saveDraft(
+          activeAccountId.value,
+          sessionSlotKey.value,
+          buildSlotData(true),
+          {
+            replyId: props.replyTo?.id ?? null,
+            renoteId: props.renoteId ?? null,
+            channelId: props.channelId ?? null,
+          },
+        )
+        posted.value = true
+        callbacks.onPosted()
+      } catch (e) {
+        error.value = AppError.from(e).message
+      } finally {
+        isPosting.value = false
+      }
+      return
+    }
+
     // New note: optimistic UI — close form immediately, post in background
     const fileIds =
       attachedFiles.value.length > 0
@@ -332,6 +358,7 @@ export function usePostFormState(
             pollMultiple: noteParams.poll?.multiple ?? false,
             showPoll: !!noteParams.poll,
             scheduledAt: noteParams.scheduledAt ?? null,
+            isActuallyScheduled: false,
           },
           retryCtx,
         )
@@ -400,7 +427,7 @@ export function usePostFormState(
     posted.value = false
   }
 
-  function buildSlotData() {
+  function buildSlotData(isActuallyScheduled = false) {
     return {
       text: text.value,
       cw: cw.value,
@@ -412,6 +439,7 @@ export function usePostFormState(
       pollMultiple: pollMultiple.value,
       showPoll: showPoll.value,
       scheduledAt: scheduledAt.value,
+      isActuallyScheduled,
     }
   }
 

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -358,7 +358,6 @@ export function usePostFormState(
             pollMultiple: noteParams.poll?.multiple ?? false,
             showPoll: !!noteParams.poll,
             scheduledAt: noteParams.scheduledAt ?? null,
-            isActuallyScheduled: false,
           },
           retryCtx,
         )

--- a/src/composables/useScheduleDialog.ts
+++ b/src/composables/useScheduleDialog.ts
@@ -1,0 +1,84 @@
+import { computed, type Ref, ref, watch } from 'vue'
+import { useNativeDialog } from '@/composables/useNativeDialog'
+import { toLocalDateInput, toLocalTimeInput } from '@/utils/scheduleFormat'
+
+/**
+ * 予約投稿ダイアログの state と操作を集約する composable。
+ * native `<dialog>` と date/time 分離入力（WebKitGTK 回避）で構成される。
+ *
+ * `scheduledAt` の ISO 文字列 ref を受け取り、OK で更新 / 解除で null 化する。
+ * `scheduleNow` は「あと ◯ 分」表示向けの 30 秒周期タイマーで、`scheduledAt`
+ * が null の間は停止する（watch の onCleanup で漏れない）。
+ */
+export function useScheduleDialog(scheduledAt: Ref<string | null>) {
+  const showScheduleDialog = ref(false)
+  const scheduleDialogRef = ref<HTMLDialogElement | null>(null)
+  const pendingScheduleDate = ref('')
+  const pendingScheduleTime = ref('')
+  const scheduleNow = ref(Date.now())
+
+  const canConfirmSchedule = computed(
+    () => !!pendingScheduleDate.value && !!pendingScheduleTime.value,
+  )
+
+  useNativeDialog(scheduleDialogRef, showScheduleDialog, {
+    onCancel: () => (showScheduleDialog.value = false),
+    leaveDuration: 200,
+  })
+
+  watch(
+    scheduledAt,
+    (v, _, onCleanup) => {
+      if (!v) return
+      scheduleNow.value = Date.now()
+      const t = setInterval(() => (scheduleNow.value = Date.now()), 30_000)
+      onCleanup(() => clearInterval(t))
+    },
+    { immediate: true },
+  )
+
+  function openScheduleDialog() {
+    const base = scheduledAt.value
+      ? new Date(scheduledAt.value)
+      : new Date(Date.now() + 60 * 60_000)
+    base.setSeconds(0, 0)
+    pendingScheduleDate.value = toLocalDateInput(base)
+    pendingScheduleTime.value = toLocalTimeInput(base)
+    showScheduleDialog.value = true
+  }
+
+  function confirmSchedule() {
+    if (!canConfirmSchedule.value) return
+    const d = new Date(
+      `${pendingScheduleDate.value}T${pendingScheduleTime.value}`,
+    )
+    // 5 分後を下回る場合は切り上げ
+    const minMs = Date.now() + 5 * 60_000
+    if (d.getTime() < minMs) d.setTime(minMs)
+    d.setSeconds(0, 0)
+    scheduledAt.value = d.toISOString()
+    showScheduleDialog.value = false
+  }
+
+  function clearSchedule() {
+    scheduledAt.value = null
+    showScheduleDialog.value = false
+  }
+
+  function minScheduleDate(): string {
+    return toLocalDateInput(new Date(Date.now() + 5 * 60_000))
+  }
+
+  return {
+    showScheduleDialog,
+    scheduleDialogRef,
+    pendingScheduleDate,
+    pendingScheduleTime,
+    canConfirmSchedule,
+    scheduleNow,
+    openScheduleDialog,
+    confirmSchedule,
+    clearSchedule,
+    minScheduleDate,
+  }
+}

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -32,7 +32,7 @@ export async function detectServer(host: string): Promise<ServerInfo> {
     host,
     software,
     version: nodeinfo.software.version,
-    features: detectFeatures(software, nodeinfo.software.version),
+    features: detectFeatures(software),
     iconUrl: serverMeta.iconUrl,
     themeColor: serverMeta.themeColor,
     infoImageUrl: serverMeta.infoImageUrl,
@@ -89,53 +89,23 @@ function detectSoftware(name: string, repositoryUrl?: string): ServerSoftware {
 }
 
 /**
- * Parse a Misskey-style version string (e.g. "2025.10.0") into comparable parts.
- * Returns null for unparseable versions.
+ * NoteDeck の前提は「最新版 Misskey または最新版を追従しているフォーク」。
+ * 古いバージョンを名乗るサーバーはサポート対象外のため、版数ガードを設けず
+ * Misskey 互換と判定したすべてで capability を有効化する。未対応サーバーでは
+ * 実際の API 呼び出しがエラーで返るので fail-fast する。
+ *
+ * フォーク固有の capability はここに追加。カスタム TL や modeFlags は
+ * customTimelines.ts のポリシー検出で動的に対応済み。静的に宣言が必要な
+ * capability のみここで設定する。手順: DEVELOPMENT.md の "Fork support" を参照。
  */
-const MISSKEY_VERSION_RE = /^(\d{4})\.(\d+)\.(\d+)/
-
-function parseMisskeyVersion(
-  version: string,
-): { major: number; minor: number; patch: number } | null {
-  const match = version.match(MISSKEY_VERSION_RE)
-  if (!match) return null
-  return {
-    major: Number(match[1]),
-    minor: Number(match[2]),
-    patch: Number(match[3]),
-  }
-}
-
-function isVersionAtLeast(
-  version: string,
-  minMajor: number,
-  minMinor: number,
-  minPatch: number,
-): boolean {
-  const v = parseMisskeyVersion(version)
-  if (!v) return false
-  if (v.major !== minMajor) return v.major > minMajor
-  if (v.minor !== minMinor) return v.minor > minMinor
-  return v.patch >= minPatch
-}
-
-function detectFeatures(
-  software: ServerSoftware,
-  version: string,
-): ServerFeatures {
+function detectFeatures(software: ServerSoftware): ServerFeatures {
   const features = defaultFeatures()
 
-  // Misskey 本家: バージョンベースの capability 検出
-  if (software === 'misskey-dev/misskey') {
-    features.scheduledNotes = isVersionAtLeast(version, 2025, 10, 0)
-    features.groupedNotifications = isVersionAtLeast(version, 2024, 2, 0)
-    features.notesShowPartialBulk = isVersionAtLeast(version, 2025, 5, 1)
+  if (software !== 'unknown') {
+    features.scheduledNotes = true
+    features.groupedNotifications = true
+    features.notesShowPartialBulk = true
   }
-
-  // フォーク固有の capability はここに追加。
-  // カスタム TL や modeFlags は customTimelines.ts のポリシー検出で動的に対応済み。
-  // 静的に宣言が必要な capability のみここで設定する。
-  // 手順: DEVELOPMENT.md の "Fork support" を参照。
 
   return features
 }

--- a/src/stores/servers.ts
+++ b/src/stores/servers.ts
@@ -145,10 +145,21 @@ export const useServersStore = defineStore('servers', () => {
     return servers.value.get(host)
   }
 
+  /**
+   * 外部で取得した最新 ServerInfo をインメモリ + DB キャッシュの双方に
+   * 即時反映する。ログイン完了直後など、古いキャッシュ (features の判定
+   * ロジックが古い版のもの) を確実に上書きしたい場面で使う。
+   */
+  async function refreshServer(info: ServerInfo): Promise<void> {
+    setServer(info.host, info)
+    await persistServer(info)
+  }
+
   return {
     servers,
     loadCachedServers,
     getServerInfo,
     getServer,
+    refreshServer,
   }
 })

--- a/src/utils/scheduleFormat.ts
+++ b/src/utils/scheduleFormat.ts
@@ -1,0 +1,76 @@
+/**
+ * 予約投稿の日時表示ユーティリティ。日本語固定。
+ */
+
+const DOW = '日月火水木金土'
+const z2 = (n: number) => String(n).padStart(2, '0')
+const startOfDay = (ms: number) => new Date(ms).setHours(0, 0, 0, 0)
+
+/** "今日 14:30" / "明日 09:00" / "12/5(金) 14:30" / "2027/2/3(水) 10:00" */
+export function formatScheduleAbsolute(iso: string, now = Date.now()): string {
+  const d = new Date(iso)
+  const hm = `${z2(d.getHours())}:${z2(d.getMinutes())}`
+  const diff = Math.round(
+    (startOfDay(d.getTime()) - startOfDay(now)) / 86400000,
+  )
+  if (diff === 0) return `今日 ${hm}`
+  if (diff === 1) return `明日 ${hm}`
+  if (diff === -1) return `昨日 ${hm}`
+  const y =
+    d.getFullYear() === new Date(now).getFullYear() ? '' : `${d.getFullYear()}/`
+  return `${y}${d.getMonth() + 1}/${d.getDate()}(${DOW[d.getDay()]}) ${hm}`
+}
+
+/** "あと30分" / "あと2時間15分" / "期限切れ" / 7日以上先は絶対表示 */
+export function formatScheduleRelative(iso: string, now = Date.now()): string {
+  const diff = new Date(iso).getTime() - now
+  const past = diff < 0
+  const prefix = past ? '' : 'あと'
+  const suffix = past ? '前' : ''
+  const min = Math.floor(Math.abs(diff) / 60000)
+  if (min < 1) return past ? '期限切れ' : 'まもなく'
+  if (min < 60) return `${prefix}${min}分${suffix}`
+  const h = Math.floor(min / 60)
+  if (h < 24) {
+    const m = min % 60
+    return `${prefix}${h}時間${m ? `${m}分` : ''}${suffix}`
+  }
+  const day = Math.floor(h / 24)
+  if (day < 7) return `${prefix}${day}日${suffix}`
+  return formatScheduleAbsolute(iso, now)
+}
+
+export const isPastSchedule = (iso: string, now = Date.now()) =>
+  new Date(iso).getTime() < now
+
+/** 日時ピッカーのプリセット。`at(now)` で実時刻を算出する。 */
+export const SCHEDULE_PRESETS: readonly {
+  label: string
+  at: (now: Date) => Date
+}[] = [
+  { label: '30分後', at: (n) => new Date(n.getTime() + 30 * 60_000) },
+  { label: '1時間後', at: (n) => new Date(n.getTime() + 60 * 60_000) },
+  { label: '3時間後', at: (n) => new Date(n.getTime() + 180 * 60_000) },
+  {
+    label: '明日9:00',
+    at: (n) => {
+      const d = new Date(n)
+      d.setDate(d.getDate() + 1)
+      d.setHours(9, 0, 0, 0)
+      return d
+    },
+  },
+  { label: '1週間後', at: (n) => new Date(n.getTime() + 7 * 24 * 60 * 60_000) },
+] as const
+
+/** input[type=date] 用 "YYYY-MM-DD"（ローカル時刻） */
+export const toLocalDateInput = (d: Date) =>
+  `${d.getFullYear()}-${z2(d.getMonth() + 1)}-${z2(d.getDate())}`
+
+/** input[type=time] 用 "HH:MM"（ローカル時刻） */
+export const toLocalTimeInput = (d: Date) =>
+  `${z2(d.getHours())}:${z2(d.getMinutes())}`
+
+/** datetime-local input 用の "YYYY-MM-DDTHH:MM"（ローカル時刻） */
+export const toLocalDatetimeInput = (d: Date) =>
+  `${toLocalDateInput(d)}T${toLocalTimeInput(d)}`


### PR DESCRIPTION
## Summary

- 予約投稿をアカウントごとに対応（#341）
- サイトヒーローの「Note Deck」表示崩れを修正
- 予約投稿ダイアログを useScheduleDialog に切り出し（内部リファクタ）

## Changes since v0.10.11

- refactor(post-form): 予約投稿ダイアログを useScheduleDialog に切り出し
- feat: アカウントごとの予約投稿に対応 (#341)
- fix(site): ヒーローの「Note Deck」の隙間を解消
- chore: bump version to 0.10.12

## Test plan

- [ ] CI (lint, typecheck, test) がグリーン
- [ ] アカウントごとの予約投稿が機能する