### PR TITLE
Release v0.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.11.2",
+  "version": "0.11.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.11.2"
+version = "0.11.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -5,12 +5,14 @@ import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useTabSlide } from '@/composables/useTabSlide'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import {
+  getPluginDetailUrl,
   PLUGIN_CATEGORY_LABELS,
   type StorePluginEntry,
   useMisStoreStore,
 } from '@/stores/misstore'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
 import { useWindowsStore } from '@/stores/windows'
+import { openSafeUrl } from '@/utils/url'
 import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
@@ -130,6 +132,10 @@ async function handleStoreInstall(entry: StorePluginEntry) {
   } catch (e) {
     installError.value = e instanceof Error ? e.message : 'インストール失敗'
   }
+}
+
+function handleOpenStoreDetail(entry: StorePluginEntry) {
+  openSafeUrl(getPluginDetailUrl(entry.id))
 }
 
 // --- Installed tab actions ---
@@ -313,6 +319,7 @@ function handleUninstall(plugin: PluginMeta) {
             :installing="misStore.installing === entry.id"
             :already-installed="misStore.installedNames.has(entry.name)"
             @install="handleStoreInstall(entry)"
+            @open-detail="handleOpenStoreDetail(entry)"
           />
 
           <div v-if="filteredStorePlugins.length === 0 && !misStore.loading" :class="$style.empty">

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -23,6 +23,7 @@ const emit = defineEmits<{
   (e: 'uninstall'): void
   (e: 'install'): void
   (e: 'settings'): void
+  (e: 'open-detail'): void
 }>()
 
 const disabled = computed(
@@ -85,6 +86,14 @@ const disabled = computed(
 
           <!-- Store mode -->
           <template v-else>
+            <button
+              class="_button"
+              :class="$style.iconBtn"
+              title="MisStore で詳細を開く"
+              @click.stop="emit('open-detail')"
+            >
+              <i class="ti ti-external-link" />
+            </button>
             <button
               v-if="alreadyInstalled"
               class="_button"

--- a/src/composables/useNavigation.ts
+++ b/src/composables/useNavigation.ts
@@ -10,7 +10,10 @@ export function useNavigation() {
   const deckStore = useDeckStore()
 
   function isDeckActive(): boolean {
-    return router.currentRoute.value.name === 'deck'
+    const name = router.currentRoute.value.name
+    // PiP ウィンドウ内もデッキ扱いにして windowsStore.open() に流す。
+    // store 側で PiP コンテキストを検知して新規 PiP ウィンドウにリダイレクトする。
+    return name === 'deck' || name === 'pip'
   }
 
   function navigateToNote(accountId: string, noteId: string) {

--- a/src/composables/usePipWindow.ts
+++ b/src/composables/usePipWindow.ts
@@ -1,11 +1,13 @@
 import { listen } from '@tauri-apps/api/event'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import type { DeckColumn } from '@/stores/deck'
+import { WINDOW_SIZES, type WindowType } from '@/stores/windows'
 
 const PIP_WIDTH = 360
 const PIP_HEIGHT = 640
 const PIP_MIN_WIDTH = 280
 const PIP_MIN_HEIGHT = 400
+const PIP_WINDOW_MAX_HEIGHT = 900
 
 const pipWindows = new Map<string, WebviewWindow>()
 const creatingSet = new Set<string>()
@@ -13,6 +15,10 @@ let pipCounter = 0
 
 function genPipLabel(): string {
   return `pip-${Date.now()}-${++pipCounter}`
+}
+
+function encodePayload(value: unknown): string {
+  return btoa(encodeURIComponent(JSON.stringify(value)))
 }
 
 /**
@@ -23,25 +29,58 @@ function genPipLabel(): string {
 export async function openPipWindow(
   columnConfig?: Omit<DeckColumn, 'id'>,
 ): Promise<void> {
+  const url = columnConfig ? `/pip?col=${encodePayload(columnConfig)}` : '/pip'
+  await createPipWebview(url, {
+    width: PIP_WIDTH,
+    height: PIP_HEIGHT,
+    minWidth: PIP_MIN_WIDTH,
+    minHeight: PIP_MIN_HEIGHT,
+  })
+}
+
+/**
+ * Open a new PiP window that renders a single window-type component
+ * (e.g. note-detail, user-profile, keybinds). Lets PiP users navigate
+ * from inside a PiP context while staying in OS-level PiP windows.
+ */
+export async function openPipWindowForWindow(
+  type: WindowType,
+  props: Record<string, unknown> = {},
+): Promise<void> {
+  const size = WINDOW_SIZES[type]
+  const width = size?.width ?? PIP_WIDTH
+  const height = Math.min(size?.maxHeight ?? PIP_HEIGHT, PIP_WINDOW_MAX_HEIGHT)
+  const url = `/pip?win=${encodePayload({ type, props })}`
+  await createPipWebview(url, {
+    width,
+    height,
+    minWidth: PIP_MIN_WIDTH,
+    minHeight: Math.min(PIP_MIN_HEIGHT, height),
+  })
+}
+
+async function createPipWebview(
+  url: string,
+  sizes: {
+    width: number
+    height: number
+    minWidth: number
+    minHeight: number
+  },
+): Promise<void> {
   const label = genPipLabel()
 
   if (creatingSet.has(label)) return
   creatingSet.add(label)
 
   try {
-    let url = '/pip'
-    if (columnConfig) {
-      const encoded = btoa(encodeURIComponent(JSON.stringify(columnConfig)))
-      url = `/pip?col=${encoded}`
-    }
-
     const win = new WebviewWindow(label, {
       url,
       title: 'NoteDeck PiP',
-      width: PIP_WIDTH,
-      height: PIP_HEIGHT,
-      minWidth: PIP_MIN_WIDTH,
-      minHeight: PIP_MIN_HEIGHT,
+      width: sizes.width,
+      height: sizes.height,
+      minWidth: sizes.minWidth,
+      minHeight: sizes.minHeight,
       decorations: false,
       alwaysOnTop: true,
       resizable: true,

--- a/src/stores/misstore.ts
+++ b/src/stores/misstore.ts
@@ -7,6 +7,10 @@ import { useThemeStore } from '@/stores/theme'
 const STORE_BASE_URL = 'https://misstore.hital.in'
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
+export function getPluginDetailUrl(id: string): string {
+  return `${STORE_BASE_URL}/plugins/${encodeURIComponent(id)}`
+}
+
 // --- MisStore types (mirrors misstore registry schema) ---
 
 export type PluginCategory =

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -141,7 +141,25 @@ export const useWindowsStore = defineStore('windows', () => {
     'snippetsEditor',
   ])
 
+  // PiP WebView (別 OS ウィンドウ) 内では DeckWindow オーバーレイが存在しないため、
+  // open() 呼び出しを新規 PiP ウィンドウの起動にリダイレクトする。
+  function isInPipContext(): boolean {
+    return (
+      typeof window !== 'undefined' &&
+      window.location.pathname.startsWith('/pip')
+    )
+  }
+
   function open(type: WindowType, props: Record<string, unknown> = {}): string {
+    if (isInPipContext()) {
+      import('@/composables/usePipWindow').then(
+        ({ openPipWindowForWindow }) => {
+          openPipWindowForWindow(type, props)
+        },
+      )
+      return ''
+    }
+
     const duplicate = windows.value.find((w) => {
       if (w.type !== type) return false
       const keys = PROPS_DEDUP_KEYS[type]

--- a/src/views/PipPage.vue
+++ b/src/views/PipPage.vue
@@ -1,27 +1,160 @@
 <script setup lang="ts">
-import { computed, onMounted, provide, ref } from 'vue'
+import { computed, defineAsyncComponent, onMounted, provide, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { COLUMN_COMPONENTS } from '@/columns/registry'
 import AddColumnDialog from '@/components/deck/AddColumnDialog.vue'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import { useThemeStore } from '@/stores/theme'
+import type { WindowType } from '@/stores/windows'
+
+type WindowPayload = { type: WindowType; props: Record<string, unknown> }
+
+const WINDOW_TITLES: Partial<Record<WindowType, string>> = {
+  'note-detail': 'ノート',
+  'note-inspector': 'ノート Inspector',
+  'notification-inspector': '通知 Inspector',
+  'user-profile': 'プロフィール',
+  'federation-instance': 'サーバー',
+  'follow-list': 'フォロー / フォロワー',
+  login: 'ログイン',
+  plugins: 'プラグイン',
+  keybinds: 'キーバインド',
+  cssEditor: 'カスタム CSS',
+  themeEditor: 'テーマ',
+  profileEditor: 'プロファイル',
+  aiSettings: 'AI 設定',
+  about: 'NoteDeck について',
+  navEditor: 'ナビバー',
+  performanceEditor: 'パフォーマンス',
+  'account-manager': 'アカウント',
+  appearanceEditor: '外観',
+  backup: 'バックアップ',
+  tasksEditor: 'タスク',
+  snippetsEditor: 'スニペット',
+  memoEditor: 'メモ',
+  'page-detail': 'ページ',
+  'play-detail': 'Play',
+  'gallery-detail': 'ギャラリー',
+  'list-detail': 'リスト',
+  'clip-detail': 'クリップ',
+  'page-edit': 'ページ編集',
+  'play-edit': 'Play 編集',
+}
+
+// Lazy-loaded window content components (same set as DeckWindowLayer uses).
+const NoteDetailContent = defineAsyncComponent(
+  () => import('@/components/window/NoteDetailContent.vue'),
+)
+const NoteInspectorContent = defineAsyncComponent(
+  () => import('@/components/window/NoteInspectorContent.vue'),
+)
+const NotificationInspectorContent = defineAsyncComponent(
+  () => import('@/components/window/NotificationInspectorContent.vue'),
+)
+const UserProfileContent = defineAsyncComponent(
+  () => import('@/components/window/UserProfileContent.vue'),
+)
+const InstanceProfileContent = defineAsyncComponent(
+  () => import('@/components/window/InstanceProfileContent.vue'),
+)
+const FollowListContent = defineAsyncComponent(
+  () => import('@/components/window/FollowListContent.vue'),
+)
+const LoginContent = defineAsyncComponent(
+  () => import('@/components/window/LoginContent.vue'),
+)
+const PluginsContent = defineAsyncComponent(
+  () => import('@/components/window/PluginsContent.vue'),
+)
+const KeybindsContent = defineAsyncComponent(
+  () => import('@/components/window/KeybindsContent.vue'),
+)
+const CssEditorContent = defineAsyncComponent(
+  () => import('@/components/window/CssEditorContent.vue'),
+)
+const ThemeEditorContent = defineAsyncComponent(
+  () => import('@/components/window/ThemeEditorContent.vue'),
+)
+const ProfileEditorContent = defineAsyncComponent(
+  () => import('@/components/window/ProfileEditorContent.vue'),
+)
+const AiSettingsContent = defineAsyncComponent(
+  () => import('@/components/window/AiSettingsContent.vue'),
+)
+const AboutContent = defineAsyncComponent(
+  () => import('@/components/window/AboutContent.vue'),
+)
+const NavEditorContent = defineAsyncComponent(
+  () => import('@/components/window/NavEditorContent.vue'),
+)
+const PerformanceEditorContent = defineAsyncComponent(
+  () => import('@/components/window/PerformanceEditorContent.vue'),
+)
+const AccountManagerContent = defineAsyncComponent(
+  () => import('@/components/window/AccountManagerContent.vue'),
+)
+const AppearanceEditorContent = defineAsyncComponent(
+  () => import('@/components/window/AppearanceEditorContent.vue'),
+)
+const BackupContent = defineAsyncComponent(
+  () => import('@/components/window/BackupContent.vue'),
+)
+const TasksEditorContent = defineAsyncComponent(
+  () => import('@/components/window/TasksEditorContent.vue'),
+)
+const SnippetsEditorContent = defineAsyncComponent(
+  () => import('@/components/window/SnippetsEditorContent.vue'),
+)
+const MemoEditorContent = defineAsyncComponent(
+  () => import('@/components/window/MemoEditorContent.vue'),
+)
+const PageDetailContent = defineAsyncComponent(
+  () => import('@/components/window/PageDetailContent.vue'),
+)
+const PlayDetailContent = defineAsyncComponent(
+  () => import('@/components/window/PlayDetailContent.vue'),
+)
+const GalleryDetailContent = defineAsyncComponent(
+  () => import('@/components/window/GalleryDetailContent.vue'),
+)
+const ListDetailContent = defineAsyncComponent(
+  () => import('@/components/window/ListDetailContent.vue'),
+)
+const ClipDetailContent = defineAsyncComponent(
+  () => import('@/components/window/ClipDetailContent.vue'),
+)
+const PageEditContent = defineAsyncComponent(
+  () => import('@/components/window/PageEditContent.vue'),
+)
+const PlayEditContent = defineAsyncComponent(
+  () => import('@/components/window/PlayEditContent.vue'),
+)
 
 const route = useRoute()
+const accountsStore = useAccountsStore()
+const themeStore = useThemeStore()
 
 let pipColumnCounter = 0
 function genPipColumnId(): string {
   return `pip-${Date.now()}-${++pipColumnCounter}`
 }
 
-const accountsStore = useAccountsStore()
-const themeStore = useThemeStore()
-
 const selectedColumn = ref<DeckColumn | null>(null)
+const windowPayload = ref<WindowPayload | null>(null)
+
 const themeVars = computed(() => {
-  const accountId = selectedColumn.value?.accountId
+  const accountId =
+    selectedColumn.value?.accountId ??
+    (windowPayload.value?.props.accountId as string | undefined)
   if (!accountId) return undefined
   return themeStore.getStyleVarsForAccount(accountId)
+})
+
+const windowTitle = computed(() => {
+  const t = windowPayload.value?.type
+  if (!t) return ''
+  return WINDOW_TITLES[t] ?? t
 })
 
 function onColumnSelected(config: Omit<DeckColumn, 'id'>) {
@@ -48,12 +181,28 @@ function parseColumnFromUrl(): Omit<DeckColumn, 'id'> | null {
   }
 }
 
+/** Parse window payload from URL query param (base64-encoded JSON) */
+function parseWindowFromUrl(): WindowPayload | null {
+  const encoded = route.query.win as string | undefined
+  if (!encoded) return null
+  try {
+    return JSON.parse(decodeURIComponent(atob(encoded)))
+  } catch {
+    return null
+  }
+}
+
 onMounted(async () => {
   if (!accountsStore.isLoaded) {
     await accountsStore.loadAccounts()
   }
 
-  // If column config is provided via URL, render it immediately
+  const winPayload = parseWindowFromUrl()
+  if (winPayload) {
+    windowPayload.value = winPayload
+    return
+  }
+
   const urlConfig = parseColumnFromUrl()
   if (urlConfig) {
     onColumnSelected(urlConfig)
@@ -63,8 +212,155 @@ onMounted(async () => {
 
 <template>
   <div :class="$style.pipRoot" :style="themeVars">
+    <!-- Window mode: single window-type component -->
+    <template v-if="windowPayload">
+      <div :class="$style.pipDragBar" data-tauri-drag-region>
+        <span :class="$style.pipDragTitle" data-tauri-drag-region>{{ windowTitle }}</span>
+        <button :class="$style.pipDragClose" @click="closeWindow">
+          <i class="ti ti-x" />
+        </button>
+      </div>
+      <div :class="$style.pipWindowBody">
+        <NoteDetailContent
+          v-if="windowPayload.type === 'note-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :note-id="(windowPayload.props.noteId as string)"
+          @close="closeWindow"
+        />
+        <NoteInspectorContent
+          v-else-if="windowPayload.type === 'note-inspector'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :note-id="(windowPayload.props.noteId as string)"
+          :note-uri="(windowPayload.props.noteUri as string | undefined)"
+          :server-host="(windowPayload.props.serverHost as string | undefined)"
+        />
+        <NotificationInspectorContent
+          v-else-if="windowPayload.type === 'notification-inspector'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :notification="(windowPayload.props.notification as any)"
+        />
+        <UserProfileContent
+          v-else-if="windowPayload.type === 'user-profile'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :user-id="(windowPayload.props.userId as string)"
+        />
+        <InstanceProfileContent
+          v-else-if="windowPayload.type === 'federation-instance'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :host="(windowPayload.props.host as string)"
+          :initial-instance="(windowPayload.props.initialInstance as any)"
+        />
+        <FollowListContent
+          v-else-if="windowPayload.type === 'follow-list'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :user-id="(windowPayload.props.userId as string)"
+          :initial-tab="(windowPayload.props.initialTab as 'following' | 'followers' | undefined)"
+        />
+        <LoginContent
+          v-else-if="windowPayload.type === 'login'"
+          :initial-host="(windowPayload.props.initialHost as string | undefined)"
+          @close="closeWindow"
+          @success="closeWindow"
+        />
+        <PluginsContent
+          v-else-if="windowPayload.type === 'plugins'"
+          :initial-plugin-id="(windowPayload.props.initialPluginId as string | undefined)"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <KeybindsContent
+          v-else-if="windowPayload.type === 'keybinds'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <CssEditorContent
+          v-else-if="windowPayload.type === 'cssEditor'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <ThemeEditorContent
+          v-else-if="windowPayload.type === 'themeEditor'"
+          :initial-theme-id="(windowPayload.props.initialThemeId as string | undefined)"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <ProfileEditorContent
+          v-else-if="windowPayload.type === 'profileEditor'"
+          :profile-id="(windowPayload.props.profileId as string)"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <AiSettingsContent
+          v-else-if="windowPayload.type === 'aiSettings'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <AboutContent v-else-if="windowPayload.type === 'about'" />
+        <NavEditorContent
+          v-else-if="windowPayload.type === 'navEditor'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <PerformanceEditorContent
+          v-else-if="windowPayload.type === 'performanceEditor'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <AccountManagerContent
+          v-else-if="windowPayload.type === 'account-manager'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+          @close="closeWindow"
+        />
+        <AppearanceEditorContent
+          v-else-if="windowPayload.type === 'appearanceEditor'"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <BackupContent
+          v-else-if="windowPayload.type === 'backup'"
+          :initial-tab="(windowPayload.props.initialTab as 'notedeck' | 'db' | undefined)"
+        />
+        <TasksEditorContent v-else-if="windowPayload.type === 'tasksEditor'" />
+        <SnippetsEditorContent v-else-if="windowPayload.type === 'snippetsEditor'" />
+        <MemoEditorContent
+          v-else-if="windowPayload.type === 'memoEditor'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :memo-key="(windowPayload.props.memoKey as string)"
+          :initial-tab="(windowPayload.props.initialTab as string | undefined)"
+        />
+        <PageDetailContent
+          v-else-if="windowPayload.type === 'page-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :page-id="(windowPayload.props.pageId as string)"
+        />
+        <PlayDetailContent
+          v-else-if="windowPayload.type === 'play-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :flash-id="(windowPayload.props.flashId as string)"
+        />
+        <GalleryDetailContent
+          v-else-if="windowPayload.type === 'gallery-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :post-id="(windowPayload.props.postId as string)"
+          :post="(windowPayload.props.post as any)"
+        />
+        <ListDetailContent
+          v-else-if="windowPayload.type === 'list-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :list-id="(windowPayload.props.listId as string)"
+          :owner-user-id="(windowPayload.props.ownerUserId as string | undefined)"
+        />
+        <ClipDetailContent
+          v-else-if="windowPayload.type === 'clip-detail'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :clip-id="(windowPayload.props.clipId as string)"
+        />
+        <PageEditContent
+          v-else-if="windowPayload.type === 'page-edit'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :page-id="(windowPayload.props.pageId as string)"
+        />
+        <PlayEditContent
+          v-else-if="windowPayload.type === 'play-edit'"
+          :account-id="(windowPayload.props.accountId as string)"
+          :flash-id="(windowPayload.props.flashId as string)"
+        />
+      </div>
+    </template>
+
     <!-- Column selector -->
-    <template v-if="!selectedColumn">
+    <template v-else-if="!selectedColumn">
       <!-- Drag bar for selector state -->
       <div :class="$style.pipDragBar" data-tauri-drag-region>
         <span :class="$style.pipDragTitle" data-tauri-drag-region>カラムを追加</span>
@@ -148,5 +444,14 @@ onMounted(async () => {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.pipWindowBody {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  background: var(--nd-panel);
 }
 </style>


### PR DESCRIPTION
## Summary

v0.11.3 リリース。PiP ウィンドウ内のナビゲーション対応、プラグインストアから MisStore への導線追加。

## Changelog (v0.11.2 → v0.11.3)

### Features

- feat(pip): PipPage に ?win= モードを追加
- feat(pip): openPipWindowForWindow を追加
- feat(pip): PiP 内のナビゲーションを新規 PiP ウィンドウにリダイレクト
- feat(plugin-column): ストアタブのプラグインから MisStore 詳細ページへの導線を追加

## Closes

- #374 PiP ウィンドウ内のナビゲーション対応（派生ウィンドウも PiP として開く）

## Test plan

- [x] `pnpm typecheck` 通過 (pre-commit hook)
- [x] `cargo check` 通過
- [ ] CI (lint / typecheck / test) 通過を待つ
- [ ] マージ後にタグ `v0.11.3` を push してリリースワークフローをトリガー

🤖 Generated with [Claude Code](https://claude.com/claude-code)