### PR TITLE
feat(note): チャンネル投稿ノートにバッジと縦線を表示 (#300)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli.git?rev=f00b3da#f00b3da0a864987d5606b7f0c37b5c88798acc0e"
+source = "git+https://github.com/hitalin/notecli.git?rev=536c7df#536c7df638c914cc0339379c9c5eb94a8498fc20"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli.git", rev = "f00b3da", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli.git", rev = "536c7df", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -133,6 +133,7 @@ export interface CreateAntennaParams {
 export interface Channel {
   id: string
   name: string
+  color?: string | null
 }
 
 export interface ServerAd {
@@ -211,6 +212,7 @@ export interface NormalizedNote {
   replyId?: string | null
   renoteId?: string | null
   channelId?: string | null
+  channel?: Channel | null
   reactionAcceptance?: string | null
   uri?: string
   url?: string

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1415,7 +1415,7 @@ export type Antenna = { id: string; name: string }
 export type AuthSession = { sessionId: string; url: string; host: string }
 export type AvatarDecoration = { id: string; url: string; angle?: number | null; flipH?: boolean | null; offsetX?: number | null; offsetY?: number | null }
 export type CacheStats = { note_count: number; db_size_bytes: number }
-export type Channel = { id: string; name: string }
+export type Channel = { id: string; name: string; color?: string | null }
 export type ChatMessage = { id: string; createdAt: string; fromUserId: string; fromUser: ChatUser | null; toUserId: string | null; toUser: ChatUser | null; toRoomId: string | null; toRoom: ChatRoom | null; text: string | null; fileId: string | null; file: NormalizedDriveFile | null; isRead: boolean | null; reactions?: ChatMessageReaction[] }
 export type ChatMessageReaction = { user: ChatReactionUser | null; reaction: string }
 export type ChatReactionUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null }
@@ -1435,7 +1435,7 @@ export type CreateNotePoll = { choices: string[]; multiple: boolean | null; expi
 export type HealthCheckResult = { ok: boolean; status: number; message: string }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type NormalizedDriveFile = { id: string; name: string; type: string; url: string; thumbnailUrl: string | null; size?: number; isSensitive?: boolean }
-export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
+export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; channel?: Channel | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
 /**
  * Fork-specific mode flags (e.g., isNoteInYamiMode)
  */

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -49,6 +49,8 @@ const props = defineProps<{
   embedded?: boolean
   /** Hint from virtual scroller: this note is near the viewport, use eager image loading */
   nearViewport?: boolean
+  /** チャンネルカラム内など、チャンネル情報を重複表示したくない時に true */
+  hideChannelBadge?: boolean
 }>()
 
 /** Pure renote → show inner note, otherwise show note itself */
@@ -115,7 +117,40 @@ const emit = defineEmits<{
   vote: [choice: number, note: NormalizedNote]
 }>()
 
-const { navigateToNote: navToNote, navigateToUser: navToUser } = useNavigation()
+const {
+  navigateToNote: navToNote,
+  navigateToUser: navToUser,
+  navigateToChannel: navToChannel,
+} = useNavigation()
+
+function hashChannelColor(id: string): string {
+  let h = 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0
+  const hue = ((h % 360) + 360) % 360
+  return `hsl(${hue}, 65%, 55%)`
+}
+
+const channelInfo = computed(() => {
+  const ch = effectiveNote.value.channel
+  const id = ch?.id ?? effectiveNote.value.channelId
+  if (!id) return null
+  return {
+    id,
+    name: ch?.name ?? null,
+    color: ch?.color || hashChannelColor(id),
+  }
+})
+
+const showChannelInfo = computed(
+  () => !!channelInfo.value && !props.hideChannelBadge && !props.embedded,
+)
+
+function openChannelColumn(e: MouseEvent) {
+  e.stopPropagation()
+  const info = channelInfo.value
+  if (!info) return
+  navToChannel(props.note._accountId, info.id, info.name ?? undefined)
+}
 const accountsStore = useAccountsStore()
 const myAccount = computed(() =>
   accountsStore.accountMap.get(props.note._accountId),
@@ -436,7 +471,15 @@ function handlePickerReaction(reaction: string) {
 <template>
   <div
     class="note-root"
-    :class="[$style.noteRoot, { [$style.detailed]: detailed, [$style.focused]: focused }]"
+    :class="[
+      $style.noteRoot,
+      {
+        [$style.detailed]: detailed,
+        [$style.focused]: focused,
+        [$style.hasChannel]: showChannelInfo,
+      },
+    ]"
+    :style="channelInfo && showChannelInfo ? { '--nd-channel-color': channelInfo.color } : undefined"
     tabindex="0"
     @contextmenu.prevent.stop="moreMenuRef?.open($event)"
   >
@@ -695,6 +738,20 @@ function handlePickerReaction(reaction: string) {
           </div>
         </div>
 
+        <!-- Channel badge -->
+        <button
+          v-if="showChannelInfo && channelInfo"
+          :class="$style.channelBadge"
+          type="button"
+          :title="channelInfo.name ?? channelInfo.id"
+          @click.stop="openChannelColumn"
+        >
+          <i class="ti ti-device-tv" :class="$style.channelBadgeIcon" />
+          <span :class="$style.channelBadgeName">
+            {{ channelInfo.name ?? 'チャンネル' }}
+          </span>
+        </button>
+
         <!-- Footer -->
         <footer v-if="!embedded" :class="$style.footer">
           <button :class="[$style.footerButton, $style.replyButton, { [$style.footerDisabled]: isGuest }]" :disabled="isGuest" @click.stop="canInteract ? emit('reply', effectiveNote) : showLoginPrompt()">
@@ -842,6 +899,53 @@ function handlePickerReaction(reaction: string) {
       background: var(--nd-panelHighlight);
     }
   }
+
+  &.hasChannel {
+    box-shadow: inset 4px 0 0 var(--nd-channel-color);
+  }
+
+  &.hasChannel.focused {
+    box-shadow:
+      inset 4px 0 0 var(--nd-channel-color),
+      inset 7px 0 0 var(--nd-accent);
+  }
+}
+
+.channelBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  margin-top: 6px;
+  padding: 2px 10px 2px 8px;
+  background: transparent;
+  border: 1px solid var(--nd-divider);
+  border-radius: 999px;
+  color: var(--nd-fg);
+  opacity: 0.75;
+  font: inherit;
+  font-size: 0.78em;
+  line-height: 1.4;
+  cursor: pointer;
+  transition:
+    background var(--nd-duration-base) ease,
+    opacity var(--nd-duration-base) ease;
+
+  &:hover {
+    background: var(--nd-panelHighlight);
+    opacity: 1;
+  }
+}
+
+.channelBadgeIcon {
+  flex-shrink: 0;
+  font-size: 0.95em;
+}
+
+.channelBadgeName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Pinned indicator */

--- a/src/components/deck/DeckChannelColumn.vue
+++ b/src/components/deck/DeckChannelColumn.vue
@@ -49,6 +49,7 @@ const noteColumnConfig: NoteColumnConfig = {
     icon="ti-device-tv"
     :web-ui-path="column.channelId ? `/channels/${column.channelId}` : undefined"
     sound-enabled
+    hide-channel-badge
     :note-column-config="noteColumnConfig"
   >
     <template #before-notes="{ handlePosted }">

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -36,6 +36,8 @@ const props = withDefaults(
     emptyMessage?: string
     /** 空状態に「ノートを書く」CTA を表示するか */
     showEmptyCta?: boolean
+    /** チャンネルカラム等、自明な文脈ではノートのチャンネルバッジを非表示にする */
+    hideChannelBadge?: boolean
   }>(),
   {
     emptyMessage: 'まだノートがありません',
@@ -207,6 +209,7 @@ defineExpose({
                 :note="item"
                 :focused="item.id === focusedNoteId"
                 :near-viewport="nearViewport"
+                :hide-channel-badge="hideChannelBadge"
                 @react="handlers.reaction"
                 @reply="handlers.reply"
                 @renote="handlers.renote"

--- a/src/composables/useNavigation.ts
+++ b/src/composables/useNavigation.ts
@@ -32,6 +32,30 @@ export function useNavigation() {
     }
   }
 
+  function navigateToChannel(
+    accountId: string,
+    channelId: string,
+    name?: string,
+  ) {
+    if (!isDeckActive()) {
+      router.push('/deck')
+    }
+    const existing = deckStore.columns.find(
+      (c) => c.type === 'channel' && c.channelId === channelId,
+    )
+    if (existing) {
+      deckStore.setActiveColumn(existing.id)
+      return
+    }
+    deckStore.addColumn({
+      type: 'channel',
+      accountId,
+      channelId,
+      name: name ?? null,
+      width: 360,
+    })
+  }
+
   function navigateToLogin(host?: string) {
     if (accountsStore.accounts.length === 0) {
       router.push(host ? { path: '/login', query: { host } } : '/login')
@@ -72,6 +96,7 @@ export function useNavigation() {
   return {
     navigateToNote,
     navigateToUser,
+    navigateToChannel,
     navigateToLogin,
     navigateToSearch,
     navigateToNotifications,


### PR DESCRIPTION
## Summary

- ホームTL等、チャンネル外のタイムラインでもチャンネル投稿ノートを視覚的に区別できるようにした (#300)
- 左端 4px のチャンネル色ストライプ + フッター直上のピル型バッジ（チャンネル名）。バッジクリックで該当チャンネルカラムを開く（既にあればフォーカス）
- notecli (rev `536c7df`) 側で `channel` オブジェクトを `NormalizedNote` に埋め込み、追加 API 呼び出しなしで即描画

## 主な変更

- `notecli`: `Channel.color` / `RawNote.channel` / `NormalizedNote.channel` を追加、`From<RawNote>` で伝播
- `MkNote.vue`: `showChannelInfo` / `channelInfo` computed、縦線用クラス `.hasChannel`、チャンネル名ピル（グレー基調・hover で強調）。`hideChannelBadge` prop を追加
- `DeckNoteColumn.vue`: `hideChannelBadge` pass-through
- `DeckChannelColumn.vue`: `hide-channel-badge` を有効化（カラム文脈では冗長なので非表示）
- `useNavigation.ts`: `navigateToChannel(accountId, channelId, name?)` を追加。既存カラムがあれば focus、なければ追加

## Fallback 挙動

- `channel.color` が空のサーバー（古い Misskey / フォーク）: `channelId` のハッシュから HSL を生成してストライプ色にフォールバック
- `channel` オブジェクトが無いが `channelId` だけある場合: バッジ名は「チャンネル」表示で、色はハッシュから

## Test plan

- [ ] ホーム / ローカル TL にチャンネル投稿ノートを流し、左縦線とピルバッジが表示される
- [ ] バッジクリックで該当チャンネルカラムが開く
- [ ] 同チャンネルカラムが既にある場合は focus のみで二重作成されない
- [ ] チャンネルカラム内のノートではバッジが**出ない**（縦線は出てよい）
- [ ] focus 状態とチャンネル縦線が共存しても両方見える
- [ ] 古いサーバー（color なし）でも縦線色がハッシュフォールバックで描画される

🤖 Generated with [Claude Code](https://claude.com/claude-code)