### PR TITLE
feat(note): OGP URL プレビューをノート末尾に集約 (#357)

### DIFF
--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { computed, defineAsyncComponent, useCssModule } from 'vue'
+import { computed, useCssModule } from 'vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyUrl } from '@/utils/imageProxy'
@@ -8,15 +8,12 @@ import { type MfmToken, parseMfm } from '@/utils/mfm'
 import { isSafeUrl } from '@/utils/url'
 import MkEmoji from './MkEmoji.vue'
 
-const MkUrlPreview = defineAsyncComponent(() => import('./MkUrlPreview.vue'))
-
 const props = defineProps<{
   text?: string
   tokens?: MfmToken[]
   emojis?: Record<string, string>
   reactionEmojis?: Record<string, string>
   serverHost?: string
-  compact?: boolean
   plain?: boolean
   myUsername?: string
   myHost?: string
@@ -408,7 +405,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
 
 <template>
   <span class="mfm" :class="$style.mfm"><template v-for="(token, i) in resolvedTokens" :key="i"><!--
-    --><!-- URL --><span v-if="token.type === 'url'" :class="$style.mfmUrlBlock"><a :href="isSafeUrl(token.value) ? token.value : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.value)">{{ token.value }}</a><MkUrlPreview v-if="!compact" :url="token.value" /></span><!--
+    --><!-- URL --><a v-if="token.type === 'url'" :href="isSafeUrl(token.value) ? token.value : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.value)">{{ token.value }}</a><!--
     --><!-- Link --><a v-else-if="token.type === 'link'" :href="isSafeUrl(token.url) ? token.url : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.url)"><MkMfm :tokens="token.label" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></a><!--
     --><!-- Mention --><span v-else-if="token.type === 'mention'" :class="isMentionMe(token.username, token.host) ? $style.mfmMentionMe : $style.mfmMention" @click.stop="emit('mentionClick', token.username, token.host)" @mouseenter="emit('mentionHover', $event, token.username, token.host)" @mouseleave="emit('mentionLeave')">{{ token.acct }}</span><!--
     --><!-- Hashtag --><span v-else-if="token.type === 'hashtag'" :class="$style.mfmHashtag" @click.stop>#{{ token.value }}</span><!--
@@ -440,10 +437,6 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.5;
-}
-
-.mfmUrlBlock {
-  display: inline;
 }
 
 .mfmUrl {

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -21,9 +21,11 @@ import {
 } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
 import { CUSTOM_TL_ICONS } from '@/utils/customTimelines'
+import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
 import { formatTime } from '@/utils/formatTime'
 import { proxyThumbUrl, proxyUrl } from '@/utils/imageProxy'
 import { showLoginPrompt } from '@/utils/loginPrompt'
+import { parseMfm } from '@/utils/mfm'
 import { spawnReactionEffect } from '@/utils/reactionEffect'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { extractColumnThemeVars } from '@/utils/themeVars'
@@ -37,6 +39,7 @@ import NoteReactionPickerPopup from './NoteReactionPickerPopup.vue'
 import NoteReactionUsersPopup from './NoteReactionUsersPopup.vue'
 
 const MkUserPopup = defineAsyncComponent(() => import('./MkUserPopup.vue'))
+const MkUrlPreview = defineAsyncComponent(() => import('./MkUrlPreview.vue'))
 const NoteReactionUsersModal = defineAsyncComponent(
   () => import('./NoteReactionUsersModal.vue'),
 )
@@ -68,6 +71,17 @@ const allEmojis = computed(() => ({
 const isPureRenote = computed(
   () => props.note.renote && props.note.text === null,
 )
+
+/** 本文から抽出した URL（renote の url/uri と一致するものは除外） */
+const extractedUrls = computed<string[]>(() => {
+  const text = effectiveNote.value.text
+  if (!text) return []
+  const tokens = parseMfm(text)
+  const renote = effectiveNote.value.renote
+  return extractUrlFromMfm(tokens).filter(
+    (u) => u !== renote?.url && u !== renote?.uri,
+  )
+})
 
 provideNoteAccountId(props.note._accountId)
 
@@ -544,7 +558,6 @@ function handlePickerReaction(reaction: string) {
           :text="effectiveNote.reply!.cw ?? effectiveNote.reply!.text?.slice(0, 100) ?? ''"
           :emojis="{ ...effectiveNote.reply!.emojis, ...effectiveNote.reply!.reactionEmojis }"
           :server-host="effectiveNote._serverHost"
-          compact
         />
       </span>
     </div>
@@ -690,6 +703,11 @@ function handlePickerReaction(reaction: string) {
             :poll="effectiveNote.poll"
             @vote="(choice) => emit('vote', choice, effectiveNote)"
           />
+
+          <!-- OGP URL previews aggregated at note bottom (Misskey parity) -->
+          <div v-if="extractedUrls.length > 0" :class="$style.urlPreviewsContainer">
+            <MkUrlPreview v-for="url in extractedUrls" :key="url" :url="url" />
+          </div>
 
           <!-- Quote renote (when note has text + renote) -->
           <div v-if="note.renote && note.text !== null" :class="$style.quote" @click.stop>
@@ -1246,6 +1264,14 @@ function handlePickerReaction(reaction: string) {
 
 .text {
   margin: 0;
+}
+
+/* OGP URL previews aggregated at note bottom */
+.urlPreviewsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 /* Quote renote */

--- a/src/components/common/MkUrlPreview.vue
+++ b/src/components/common/MkUrlPreview.vue
@@ -261,7 +261,6 @@ function hostname(url: string): string {
   box-shadow: 0 0 0 1px var(--nd-divider);
   border-radius: var(--nd-radius-md);
   overflow: clip;
-  margin-top: 8px;
   cursor: pointer;
   background: var(--nd-panelHighlight);
   max-width: 100%;

--- a/src/utils/extractUrlFromMfm.test.ts
+++ b/src/utils/extractUrlFromMfm.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { extractUrlFromMfm } from './extractUrlFromMfm'
+import { parseTokens } from './mfmParser'
+
+describe('extractUrlFromMfm', () => {
+  describe('基本', () => {
+    it('空配列を渡すと空配列を返す', () => {
+      expect(extractUrlFromMfm([])).toEqual([])
+    })
+
+    it('プレーンテキストだけのトークンでは URL を抽出しない', () => {
+      expect(
+        extractUrlFromMfm(parseTokens('これはただのテキストです')),
+      ).toEqual([])
+    })
+
+    it('ハッシュタグやメンションは抽出対象に含めない', () => {
+      const tokens = parseTokens('#タグ @user@example.com これはテキスト')
+      expect(extractUrlFromMfm(tokens)).toEqual([])
+    })
+  })
+
+  describe('url トークン', () => {
+    it('bare URL を 1 件抽出できる', () => {
+      const tokens = parseTokens('見てね https://example.com ね')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('複数の bare URL を順序を保って抽出できる', () => {
+      const tokens = parseTokens(
+        'まず https://a.example と次に https://b.example',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual([
+        'https://a.example',
+        'https://b.example',
+      ])
+    })
+  })
+
+  describe('link トークン', () => {
+    it('MFM link 記法の URL を抽出できる', () => {
+      const tokens = parseTokens('[公式サイト](https://example.com)')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('silent link (?[...]()) は既定で除外される', () => {
+      const tokens = parseTokens('?[内緒](https://secret.example)')
+      expect(extractUrlFromMfm(tokens)).toEqual([])
+    })
+
+    it('respectSilentFlag=false では silent link も抽出する', () => {
+      const tokens = parseTokens('?[内緒](https://secret.example)')
+      expect(extractUrlFromMfm(tokens, false)).toEqual([
+        'https://secret.example',
+      ])
+    })
+
+    it('link の label 内に含まれる url トークンも再帰的に抽出する', () => {
+      const tokens = parseTokens(
+        '[https://inner.example を見る](https://outer.example)',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual([
+        'https://outer.example',
+        'https://inner.example',
+      ])
+    })
+  })
+
+  describe('重複排除', () => {
+    it('完全一致の重複は 1 件にまとめる', () => {
+      const tokens = parseTokens(
+        'https://example.com もう一度 https://example.com',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('ハッシュ (#...) だけ異なる URL は先頭のみ残す', () => {
+      const tokens = parseTokens(
+        'https://example.com/page#a と https://example.com/page#b',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com/page#a'])
+    })
+
+    it('ハッシュの有無が混在しても先頭のものだけ残す', () => {
+      const tokens = parseTokens(
+        'https://example.com/page と https://example.com/page#section',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com/page'])
+    })
+  })
+
+  describe('ネストされた構造', () => {
+    it('bold の中の URL を抽出できる', () => {
+      const tokens = parseTokens('**https://bold.example**')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://bold.example'])
+    })
+
+    it('quote の中の URL を抽出できる', () => {
+      const tokens = parseTokens('> 引用内 https://quote.example\n')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://quote.example'])
+    })
+
+    it('fn (MFM 関数) の中の URL を抽出できる', () => {
+      const tokens = parseTokens('$[x2 https://fn.example]')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://fn.example'])
+    })
+
+    it('small / center タグ内の URL を抽出できる', () => {
+      const tokens = parseTokens('<small>https://small.example</small>')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://small.example'])
+    })
+  })
+})

--- a/src/utils/extractUrlFromMfm.ts
+++ b/src/utils/extractUrlFromMfm.ts
@@ -1,0 +1,62 @@
+/**
+ * MFM トークン列から URL を再帰抽出するユーティリティ。
+ * Misskey 本家 `packages/frontend/src/utility/extract-url-from-mfm.ts` 準拠。
+ *
+ * - `url` トークンと `link` トークンの URL を収集
+ * - `link` の `silent === true` は既定で除外（`respectSilentFlag=false` で含む）
+ * - `link.label` の中に含まれる `url` / `link` も再帰的に拾う
+ * - 完全一致の重複排除 → ハッシュ (#...) 除去キーでの重複排除を 2 段で適用
+ */
+import type { MfmToken } from './mfmParser'
+
+const removeHash = (url: string): string => url.replace(/#[^#]*$/, '')
+
+export function extractUrlFromMfm(
+  tokens: MfmToken[],
+  respectSilentFlag = true,
+): string[] {
+  const collected: string[] = []
+  walk(tokens, collected, respectSilentFlag)
+
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const url of collected) {
+    if (!seen.has(url)) {
+      seen.add(url)
+      unique.push(url)
+    }
+  }
+
+  return unique.reduce<string[]>((acc, url) => {
+    const key = removeHash(url)
+    if (!acc.some((x) => removeHash(x) === key)) acc.push(url)
+    return acc
+  }, [])
+}
+
+function walk(
+  tokens: MfmToken[],
+  out: string[],
+  respectSilentFlag: boolean,
+): void {
+  for (const t of tokens) {
+    switch (t.type) {
+      case 'url':
+        out.push(t.value)
+        break
+      case 'link':
+        if (!respectSilentFlag || !t.silent) out.push(t.url)
+        walk(t.label, out, respectSilentFlag)
+        break
+      case 'bold':
+      case 'italic':
+      case 'strike':
+      case 'small':
+      case 'center':
+      case 'quote':
+      case 'fn':
+        walk(t.children, out, respectSilentFlag)
+        break
+    }
+  }
+}

--- a/src/utils/mfmParser.ts
+++ b/src/utils/mfmParser.ts
@@ -10,7 +10,7 @@ import { char2twemojiUrl } from './twemoji'
 export type MfmToken =
   | { type: 'text'; value: string }
   | { type: 'url'; value: string }
-  | { type: 'link'; label: MfmToken[]; url: string }
+  | { type: 'link'; label: MfmToken[]; url: string; silent?: boolean }
   | { type: 'mention'; username: string; host: string | null; acct: string }
   | { type: 'hashtag'; value: string }
   | { type: 'bold'; children: MfmToken[] }
@@ -51,11 +51,12 @@ const inlinePatterns: PatternDef[] = [
     parse: (m) => ({ type: 'inlineCode', value: g(m, 1) }),
   },
   {
-    regex: /\??\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    regex: /(\??)\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
     parse: (m) => ({
       type: 'link',
-      label: parseTokens(g(m, 1)),
-      url: g(m, 2),
+      label: parseTokens(g(m, 2)),
+      url: g(m, 3),
+      silent: g(m, 1) === '?',
     }),
   },
   {

--- a/tests/utils/mfm.test.ts
+++ b/tests/utils/mfm.test.ts
@@ -285,6 +285,7 @@ describe('parseMfm', () => {
       type: 'link',
       label: [{ type: 'text', value: 'here' }],
       url: 'https://example.com',
+      silent: false,
     })
   })
 
@@ -295,6 +296,7 @@ describe('parseMfm', () => {
       type: 'link',
       label: [{ type: 'text', value: 'silent' }],
       url: 'https://example.com',
+      silent: true,
     })
   })
 
@@ -310,6 +312,7 @@ describe('parseMfm', () => {
         { type: 'text', value: ' (misskey.day)' },
       ],
       url: 'https://misskey.day',
+      silent: true,
     })
   })
 


### PR DESCRIPTION
## Summary

本文中の URL 直後にインライン表示していた OGP プレビューカードを、Misskey 本家 WebUI と同じく**本文末尾にまとめて表示**するよう変更。

本家 `packages/frontend/src/components/MkNote.vue` と `packages/frontend/src/utility/extract-url-from-mfm.ts` の挙動を踏襲。

Closes #357

## 変更点

- `src/utils/extractUrlFromMfm.ts` を新設（本家 `extract-url-from-mfm.ts` 準拠）
  - `url` トークンと非 silent な `link` トークンを再帰抽出
  - 完全一致の重複排除 + ハッシュ (#...) 除去キーでの重複排除を 2 段で適用
- `MfmToken.link` に `silent?: boolean` を追加し、`?[...](url)` を抽出対象外に
- `MkMfm.vue` から URL トークンのインライン `MkUrlPreview` を削除（URL は `<a>` のみ）
- `MkMfm.vue` の `compact` prop を廃止（用途が URL プレビュー抑制のみだったため）
- `MkNote.vue` に `extractedUrls` computed と集約表示ブロックを追加
  - `effectiveNote.renote?.url` / `uri` と一致する URL は除外（引用と二重にならないよう）
  - 配置位置は `MkPoll` の後、引用リノートの前（本家 UI と同じ）
- `MkUrlPreview.vue` から `.urlPreview` の `margin-top: 8px` を削除し、集約ラッパー側の `gap`/`margin-top` で間隔を管理

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過（269 tests passed、新規 16 tests 追加）
- [ ] `pnpm tauri:dev` で手動確認
  - [ ] 単一 URL のノート → 本文末尾にカード 1 枚
  - [ ] 複数 URL（ハッシュ違い含む）→ 集約＆重複排除
  - [ ] `[label](https://...)` link → リンクはインライン、プレビューは末尾
  - [ ] `?[label](https://...)` silent link → プレビュー出ない
  - [ ] 引用リノート → `renote.url` 一致で集約から除外
  - [ ] MkPoll あり → Poll の直後、引用の前に集約表示
  - [ ] note URL (`/notes/xxx`) → MkNoteEmbed への既存分岐維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)