### PR TITLE
Release v0.11.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.11.3",
+  "version": "0.11.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli.git?rev=f00b3da#f00b3da0a864987d5606b7f0c37b5c88798acc0e"
+source = "git+https://github.com/hitalin/notecli.git?rev=536c7df#536c7df638c914cc0339379c9c5eb94a8498fc20"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.11.3"
+version = "0.11.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli.git", rev = "f00b3da", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli.git", rev = "536c7df", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -133,6 +133,7 @@ export interface CreateAntennaParams {
 export interface Channel {
   id: string
   name: string
+  color?: string | null
 }
 
 export interface ServerAd {
@@ -211,6 +212,7 @@ export interface NormalizedNote {
   replyId?: string | null
   renoteId?: string | null
   channelId?: string | null
+  channel?: Channel | null
   reactionAcceptance?: string | null
   uri?: string
   url?: string

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1415,7 +1415,7 @@ export type Antenna = { id: string; name: string }
 export type AuthSession = { sessionId: string; url: string; host: string }
 export type AvatarDecoration = { id: string; url: string; angle?: number | null; flipH?: boolean | null; offsetX?: number | null; offsetY?: number | null }
 export type CacheStats = { note_count: number; db_size_bytes: number }
-export type Channel = { id: string; name: string }
+export type Channel = { id: string; name: string; color?: string | null }
 export type ChatMessage = { id: string; createdAt: string; fromUserId: string; fromUser: ChatUser | null; toUserId: string | null; toUser: ChatUser | null; toRoomId: string | null; toRoom: ChatRoom | null; text: string | null; fileId: string | null; file: NormalizedDriveFile | null; isRead: boolean | null; reactions?: ChatMessageReaction[] }
 export type ChatMessageReaction = { user: ChatReactionUser | null; reaction: string }
 export type ChatReactionUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null }
@@ -1435,7 +1435,7 @@ export type CreateNotePoll = { choices: string[]; multiple: boolean | null; expi
 export type HealthCheckResult = { ok: boolean; status: number; message: string }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
 export type NormalizedDriveFile = { id: string; name: string; type: string; url: string; thumbnailUrl: string | null; size?: number; isSensitive?: boolean }
-export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
+export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; channel?: Channel | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
 /**
  * Fork-specific mode flags (e.g., isNoteInYamiMode)
  */

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { computed, defineAsyncComponent, useCssModule } from 'vue'
+import { computed, useCssModule } from 'vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyUrl } from '@/utils/imageProxy'
@@ -8,15 +8,12 @@ import { type MfmToken, parseMfm } from '@/utils/mfm'
 import { isSafeUrl } from '@/utils/url'
 import MkEmoji from './MkEmoji.vue'
 
-const MkUrlPreview = defineAsyncComponent(() => import('./MkUrlPreview.vue'))
-
 const props = defineProps<{
   text?: string
   tokens?: MfmToken[]
   emojis?: Record<string, string>
   reactionEmojis?: Record<string, string>
   serverHost?: string
-  compact?: boolean
   plain?: boolean
   myUsername?: string
   myHost?: string
@@ -408,7 +405,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
 
 <template>
   <span class="mfm" :class="$style.mfm"><template v-for="(token, i) in resolvedTokens" :key="i"><!--
-    --><!-- URL --><span v-if="token.type === 'url'" :class="$style.mfmUrlBlock"><a :href="isSafeUrl(token.value) ? token.value : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.value)">{{ token.value }}</a><MkUrlPreview v-if="!compact" :url="token.value" /></span><!--
+    --><!-- URL --><a v-if="token.type === 'url'" :href="isSafeUrl(token.value) ? token.value : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.value)">{{ token.value }}</a><!--
     --><!-- Link --><a v-else-if="token.type === 'link'" :href="isSafeUrl(token.url) ? token.url : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.url)"><MkMfm :tokens="token.label" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></a><!--
     --><!-- Mention --><span v-else-if="token.type === 'mention'" :class="isMentionMe(token.username, token.host) ? $style.mfmMentionMe : $style.mfmMention" @click.stop="emit('mentionClick', token.username, token.host)" @mouseenter="emit('mentionHover', $event, token.username, token.host)" @mouseleave="emit('mentionLeave')">{{ token.acct }}</span><!--
     --><!-- Hashtag --><span v-else-if="token.type === 'hashtag'" :class="$style.mfmHashtag" @click.stop>#{{ token.value }}</span><!--
@@ -440,10 +437,6 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
   white-space: pre-wrap;
   word-break: break-word;
   line-height: 1.5;
-}
-
-.mfmUrlBlock {
-  display: inline;
 }
 
 .mfmUrl {

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -49,6 +49,8 @@ const props = defineProps<{
   embedded?: boolean
   /** Hint from virtual scroller: this note is near the viewport, use eager image loading */
   nearViewport?: boolean
+  /** チャンネルカラム内など、チャンネル情報を重複表示したくない時に true */
+  hideChannelBadge?: boolean
 }>()
 
 /** Pure renote → show inner note, otherwise show note itself */
@@ -115,7 +117,40 @@ const emit = defineEmits<{
   vote: [choice: number, note: NormalizedNote]
 }>()
 
-const { navigateToNote: navToNote, navigateToUser: navToUser } = useNavigation()
+const {
+  navigateToNote: navToNote,
+  navigateToUser: navToUser,
+  navigateToChannel: navToChannel,
+} = useNavigation()
+
+function hashChannelColor(id: string): string {
+  let h = 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0
+  const hue = ((h % 360) + 360) % 360
+  return `hsl(${hue}, 65%, 55%)`
+}
+
+const channelInfo = computed(() => {
+  const ch = effectiveNote.value.channel
+  const id = ch?.id ?? effectiveNote.value.channelId
+  if (!id) return null
+  return {
+    id,
+    name: ch?.name ?? null,
+    color: ch?.color || hashChannelColor(id),
+  }
+})
+
+const showChannelInfo = computed(
+  () => !!channelInfo.value && !props.hideChannelBadge && !props.embedded,
+)
+
+function openChannelColumn(e: MouseEvent) {
+  e.stopPropagation()
+  const info = channelInfo.value
+  if (!info) return
+  navToChannel(props.note._accountId, info.id, info.name ?? undefined)
+}
 const accountsStore = useAccountsStore()
 const myAccount = computed(() =>
   accountsStore.accountMap.get(props.note._accountId),
@@ -436,7 +471,15 @@ function handlePickerReaction(reaction: string) {
 <template>
   <div
     class="note-root"
-    :class="[$style.noteRoot, { [$style.detailed]: detailed, [$style.focused]: focused }]"
+    :class="[
+      $style.noteRoot,
+      {
+        [$style.detailed]: detailed,
+        [$style.focused]: focused,
+        [$style.hasChannel]: showChannelInfo,
+      },
+    ]"
+    :style="channelInfo && showChannelInfo ? { '--nd-channel-color': channelInfo.color } : undefined"
     tabindex="0"
     @contextmenu.prevent.stop="moreMenuRef?.open($event)"
   >
@@ -695,6 +738,20 @@ function handlePickerReaction(reaction: string) {
           </div>
         </div>
 
+        <!-- Channel badge -->
+        <button
+          v-if="showChannelInfo && channelInfo"
+          :class="$style.channelBadge"
+          type="button"
+          :title="channelInfo.name ?? channelInfo.id"
+          @click.stop="openChannelColumn"
+        >
+          <i class="ti ti-device-tv" :class="$style.channelBadgeIcon" />
+          <span :class="$style.channelBadgeName">
+            {{ channelInfo.name ?? 'チャンネル' }}
+          </span>
+        </button>
+
         <!-- Footer -->
         <footer v-if="!embedded" :class="$style.footer">
           <button :class="[$style.footerButton, $style.replyButton, { [$style.footerDisabled]: isGuest }]" :disabled="isGuest" @click.stop="canInteract ? emit('reply', effectiveNote) : showLoginPrompt()">
@@ -842,6 +899,53 @@ function handlePickerReaction(reaction: string) {
       background: var(--nd-panelHighlight);
     }
   }
+
+  &.hasChannel {
+    box-shadow: inset 4px 0 0 var(--nd-channel-color);
+  }
+
+  &.hasChannel.focused {
+    box-shadow:
+      inset 4px 0 0 var(--nd-channel-color),
+      inset 7px 0 0 var(--nd-accent);
+  }
+}
+
+.channelBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  margin-top: 6px;
+  padding: 2px 10px 2px 8px;
+  background: transparent;
+  border: 1px solid var(--nd-divider);
+  border-radius: 999px;
+  color: var(--nd-fg);
+  opacity: 0.75;
+  font: inherit;
+  font-size: 0.78em;
+  line-height: 1.4;
+  cursor: pointer;
+  transition:
+    background var(--nd-duration-base) ease,
+    opacity var(--nd-duration-base) ease;
+
+  &:hover {
+    background: var(--nd-panelHighlight);
+    opacity: 1;
+  }
+}
+
+.channelBadgeIcon {
+  flex-shrink: 0;
+  font-size: 0.95em;
+}
+
+.channelBadgeName {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Pinned indicator */

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -21,9 +21,11 @@ import {
 } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
 import { CUSTOM_TL_ICONS } from '@/utils/customTimelines'
+import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
 import { formatTime } from '@/utils/formatTime'
 import { proxyThumbUrl, proxyUrl } from '@/utils/imageProxy'
 import { showLoginPrompt } from '@/utils/loginPrompt'
+import { parseMfm } from '@/utils/mfm'
 import { spawnReactionEffect } from '@/utils/reactionEffect'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { extractColumnThemeVars } from '@/utils/themeVars'
@@ -37,6 +39,7 @@ import NoteReactionPickerPopup from './NoteReactionPickerPopup.vue'
 import NoteReactionUsersPopup from './NoteReactionUsersPopup.vue'
 
 const MkUserPopup = defineAsyncComponent(() => import('./MkUserPopup.vue'))
+const MkUrlPreview = defineAsyncComponent(() => import('./MkUrlPreview.vue'))
 const NoteReactionUsersModal = defineAsyncComponent(
   () => import('./NoteReactionUsersModal.vue'),
 )
@@ -68,6 +71,17 @@ const allEmojis = computed(() => ({
 const isPureRenote = computed(
   () => props.note.renote && props.note.text === null,
 )
+
+/** 本文から抽出した URL（renote の url/uri と一致するものは除外） */
+const extractedUrls = computed<string[]>(() => {
+  const text = effectiveNote.value.text
+  if (!text) return []
+  const tokens = parseMfm(text)
+  const renote = effectiveNote.value.renote
+  return extractUrlFromMfm(tokens).filter(
+    (u) => u !== renote?.url && u !== renote?.uri,
+  )
+})
 
 provideNoteAccountId(props.note._accountId)
 
@@ -544,7 +558,6 @@ function handlePickerReaction(reaction: string) {
           :text="effectiveNote.reply!.cw ?? effectiveNote.reply!.text?.slice(0, 100) ?? ''"
           :emojis="{ ...effectiveNote.reply!.emojis, ...effectiveNote.reply!.reactionEmojis }"
           :server-host="effectiveNote._serverHost"
-          compact
         />
       </span>
     </div>
@@ -690,6 +703,11 @@ function handlePickerReaction(reaction: string) {
             :poll="effectiveNote.poll"
             @vote="(choice) => emit('vote', choice, effectiveNote)"
           />
+
+          <!-- OGP URL previews aggregated at note bottom (Misskey parity) -->
+          <div v-if="extractedUrls.length > 0" :class="$style.urlPreviewsContainer">
+            <MkUrlPreview v-for="url in extractedUrls" :key="url" :url="url" />
+          </div>
 
           <!-- Quote renote (when note has text + renote) -->
           <div v-if="note.renote && note.text !== null" :class="$style.quote" @click.stop>
@@ -1246,6 +1264,14 @@ function handlePickerReaction(reaction: string) {
 
 .text {
   margin: 0;
+}
+
+/* OGP URL previews aggregated at note bottom */
+.urlPreviewsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 /* Quote renote */

--- a/src/components/common/MkUrlPreview.vue
+++ b/src/components/common/MkUrlPreview.vue
@@ -261,7 +261,6 @@ function hostname(url: string): string {
   box-shadow: 0 0 0 1px var(--nd-divider);
   border-radius: var(--nd-radius-md);
   overflow: clip;
-  margin-top: 8px;
   cursor: pointer;
   background: var(--nd-panelHighlight);
   max-width: 100%;

--- a/src/components/deck/DeckChannelColumn.vue
+++ b/src/components/deck/DeckChannelColumn.vue
@@ -49,6 +49,7 @@ const noteColumnConfig: NoteColumnConfig = {
     icon="ti-device-tv"
     :web-ui-path="column.channelId ? `/channels/${column.channelId}` : undefined"
     sound-enabled
+    hide-channel-badge
     :note-column-config="noteColumnConfig"
   >
     <template #before-notes="{ handlePosted }">

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -36,6 +36,8 @@ const props = withDefaults(
     emptyMessage?: string
     /** 空状態に「ノートを書く」CTA を表示するか */
     showEmptyCta?: boolean
+    /** チャンネルカラム等、自明な文脈ではノートのチャンネルバッジを非表示にする */
+    hideChannelBadge?: boolean
   }>(),
   {
     emptyMessage: 'まだノートがありません',
@@ -207,6 +209,7 @@ defineExpose({
                 :note="item"
                 :focused="item.id === focusedNoteId"
                 :near-viewport="nearViewport"
+                :hide-channel-badge="hideChannelBadge"
                 @react="handlers.reaction"
                 @reply="handlers.reply"
                 @renote="handlers.renote"

--- a/src/composables/useNavigation.ts
+++ b/src/composables/useNavigation.ts
@@ -32,6 +32,30 @@ export function useNavigation() {
     }
   }
 
+  function navigateToChannel(
+    accountId: string,
+    channelId: string,
+    name?: string,
+  ) {
+    if (!isDeckActive()) {
+      router.push('/deck')
+    }
+    const existing = deckStore.columns.find(
+      (c) => c.type === 'channel' && c.channelId === channelId,
+    )
+    if (existing) {
+      deckStore.setActiveColumn(existing.id)
+      return
+    }
+    deckStore.addColumn({
+      type: 'channel',
+      accountId,
+      channelId,
+      name: name ?? null,
+      width: 360,
+    })
+  }
+
   function navigateToLogin(host?: string) {
     if (accountsStore.accounts.length === 0) {
       router.push(host ? { path: '/login', query: { host } } : '/login')
@@ -72,6 +96,7 @@ export function useNavigation() {
   return {
     navigateToNote,
     navigateToUser,
+    navigateToChannel,
     navigateToLogin,
     navigateToSearch,
     navigateToNotifications,

--- a/src/utils/extractUrlFromMfm.test.ts
+++ b/src/utils/extractUrlFromMfm.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { extractUrlFromMfm } from './extractUrlFromMfm'
+import { parseTokens } from './mfmParser'
+
+describe('extractUrlFromMfm', () => {
+  describe('基本', () => {
+    it('空配列を渡すと空配列を返す', () => {
+      expect(extractUrlFromMfm([])).toEqual([])
+    })
+
+    it('プレーンテキストだけのトークンでは URL を抽出しない', () => {
+      expect(
+        extractUrlFromMfm(parseTokens('これはただのテキストです')),
+      ).toEqual([])
+    })
+
+    it('ハッシュタグやメンションは抽出対象に含めない', () => {
+      const tokens = parseTokens('#タグ @user@example.com これはテキスト')
+      expect(extractUrlFromMfm(tokens)).toEqual([])
+    })
+  })
+
+  describe('url トークン', () => {
+    it('bare URL を 1 件抽出できる', () => {
+      const tokens = parseTokens('見てね https://example.com ね')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('複数の bare URL を順序を保って抽出できる', () => {
+      const tokens = parseTokens(
+        'まず https://a.example と次に https://b.example',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual([
+        'https://a.example',
+        'https://b.example',
+      ])
+    })
+  })
+
+  describe('link トークン', () => {
+    it('MFM link 記法の URL を抽出できる', () => {
+      const tokens = parseTokens('[公式サイト](https://example.com)')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('silent link (?[...]()) は既定で除外される', () => {
+      const tokens = parseTokens('?[内緒](https://secret.example)')
+      expect(extractUrlFromMfm(tokens)).toEqual([])
+    })
+
+    it('respectSilentFlag=false では silent link も抽出する', () => {
+      const tokens = parseTokens('?[内緒](https://secret.example)')
+      expect(extractUrlFromMfm(tokens, false)).toEqual([
+        'https://secret.example',
+      ])
+    })
+
+    it('link の label 内に含まれる url トークンも再帰的に抽出する', () => {
+      const tokens = parseTokens(
+        '[https://inner.example を見る](https://outer.example)',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual([
+        'https://outer.example',
+        'https://inner.example',
+      ])
+    })
+  })
+
+  describe('重複排除', () => {
+    it('完全一致の重複は 1 件にまとめる', () => {
+      const tokens = parseTokens(
+        'https://example.com もう一度 https://example.com',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com'])
+    })
+
+    it('ハッシュ (#...) だけ異なる URL は先頭のみ残す', () => {
+      const tokens = parseTokens(
+        'https://example.com/page#a と https://example.com/page#b',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com/page#a'])
+    })
+
+    it('ハッシュの有無が混在しても先頭のものだけ残す', () => {
+      const tokens = parseTokens(
+        'https://example.com/page と https://example.com/page#section',
+      )
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://example.com/page'])
+    })
+  })
+
+  describe('ネストされた構造', () => {
+    it('bold の中の URL を抽出できる', () => {
+      const tokens = parseTokens('**https://bold.example**')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://bold.example'])
+    })
+
+    it('quote の中の URL を抽出できる', () => {
+      const tokens = parseTokens('> 引用内 https://quote.example\n')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://quote.example'])
+    })
+
+    it('fn (MFM 関数) の中の URL を抽出できる', () => {
+      const tokens = parseTokens('$[x2 https://fn.example]')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://fn.example'])
+    })
+
+    it('small / center タグ内の URL を抽出できる', () => {
+      const tokens = parseTokens('<small>https://small.example</small>')
+      expect(extractUrlFromMfm(tokens)).toEqual(['https://small.example'])
+    })
+  })
+})

--- a/src/utils/extractUrlFromMfm.ts
+++ b/src/utils/extractUrlFromMfm.ts
@@ -1,0 +1,62 @@
+/**
+ * MFM トークン列から URL を再帰抽出するユーティリティ。
+ * Misskey 本家 `packages/frontend/src/utility/extract-url-from-mfm.ts` 準拠。
+ *
+ * - `url` トークンと `link` トークンの URL を収集
+ * - `link` の `silent === true` は既定で除外（`respectSilentFlag=false` で含む）
+ * - `link.label` の中に含まれる `url` / `link` も再帰的に拾う
+ * - 完全一致の重複排除 → ハッシュ (#...) 除去キーでの重複排除を 2 段で適用
+ */
+import type { MfmToken } from './mfmParser'
+
+const removeHash = (url: string): string => url.replace(/#[^#]*$/, '')
+
+export function extractUrlFromMfm(
+  tokens: MfmToken[],
+  respectSilentFlag = true,
+): string[] {
+  const collected: string[] = []
+  walk(tokens, collected, respectSilentFlag)
+
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const url of collected) {
+    if (!seen.has(url)) {
+      seen.add(url)
+      unique.push(url)
+    }
+  }
+
+  return unique.reduce<string[]>((acc, url) => {
+    const key = removeHash(url)
+    if (!acc.some((x) => removeHash(x) === key)) acc.push(url)
+    return acc
+  }, [])
+}
+
+function walk(
+  tokens: MfmToken[],
+  out: string[],
+  respectSilentFlag: boolean,
+): void {
+  for (const t of tokens) {
+    switch (t.type) {
+      case 'url':
+        out.push(t.value)
+        break
+      case 'link':
+        if (!respectSilentFlag || !t.silent) out.push(t.url)
+        walk(t.label, out, respectSilentFlag)
+        break
+      case 'bold':
+      case 'italic':
+      case 'strike':
+      case 'small':
+      case 'center':
+      case 'quote':
+      case 'fn':
+        walk(t.children, out, respectSilentFlag)
+        break
+    }
+  }
+}

--- a/src/utils/mfmParser.ts
+++ b/src/utils/mfmParser.ts
@@ -10,7 +10,7 @@ import { char2twemojiUrl } from './twemoji'
 export type MfmToken =
   | { type: 'text'; value: string }
   | { type: 'url'; value: string }
-  | { type: 'link'; label: MfmToken[]; url: string }
+  | { type: 'link'; label: MfmToken[]; url: string; silent?: boolean }
   | { type: 'mention'; username: string; host: string | null; acct: string }
   | { type: 'hashtag'; value: string }
   | { type: 'bold'; children: MfmToken[] }
@@ -51,11 +51,12 @@ const inlinePatterns: PatternDef[] = [
     parse: (m) => ({ type: 'inlineCode', value: g(m, 1) }),
   },
   {
-    regex: /\??\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    regex: /(\??)\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
     parse: (m) => ({
       type: 'link',
-      label: parseTokens(g(m, 1)),
-      url: g(m, 2),
+      label: parseTokens(g(m, 2)),
+      url: g(m, 3),
+      silent: g(m, 1) === '?',
     }),
   },
   {

--- a/tests/utils/mfm.test.ts
+++ b/tests/utils/mfm.test.ts
@@ -285,6 +285,7 @@ describe('parseMfm', () => {
       type: 'link',
       label: [{ type: 'text', value: 'here' }],
       url: 'https://example.com',
+      silent: false,
     })
   })
 
@@ -295,6 +296,7 @@ describe('parseMfm', () => {
       type: 'link',
       label: [{ type: 'text', value: 'silent' }],
       url: 'https://example.com',
+      silent: true,
     })
   })
 
@@ -310,6 +312,7 @@ describe('parseMfm', () => {
         { type: 'text', value: ' (misskey.day)' },
       ],
       url: 'https://misskey.day',
+      silent: true,
     })
   })
 


### PR DESCRIPTION
## Summary

v0.11.4 リリース。チャンネル投稿ノートのバッジ表示、OGP URL プレビューのノート末尾集約。

## Changelog (v0.11.3 → v0.11.4)

### Features

- feat(note): チャンネル投稿ノートにバッジと縦線を表示 (#300)
- feat(note): OGP URL プレビューをノート末尾に集約 (#357)

## Closes

- Close #300 チャンネルに投稿されたノートを区別できるようにしてほしい
- Close #357 OGP の URL プレビュー位置をノートの下に集約

## Test plan

- [x] `pnpm typecheck` 通過 (pre-commit hook)
- [x] `cargo check` 通過
- [ ] CI (lint / typecheck / test) 通過を待つ
- [ ] マージ後にタグ `v0.11.4` を push してリリースワークフローをトリガー

🤖 Generated with [Claude Code](https://claude.com/claude-code)