### PR TITLE
fix(note): 投票ノートのリアルタイム反映を修正 (#351)

### DIFF
--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -30,6 +30,7 @@ const MkPostForm = defineAsyncComponent(
 
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
+import { useNoteCapture } from '@/composables/useNoteCapture'
 import { usePortal } from '@/composables/usePortal'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
@@ -58,6 +59,35 @@ const renotes = ref<NormalizedNote[]>([])
 const reactions = ref<NoteReaction[]>([])
 const isLoading = ref(true)
 const error = ref<AppError | null>(null)
+const myUserId = ref<string | undefined>()
+
+// Note Capture: 投票・リアクション等の pollVoted/reacted イベントを受けて
+// 表示中のノートをリアルタイム更新する。カラムと違い詳細ウィンドウは
+// channel auto-capture の対象外のため明示的に購読する。
+const { sync: syncCapture } = useNoteCapture(
+  () => adapter?.stream,
+  (event) => {
+    noteStore.applyUpdate(event, myUserId.value)
+    const latest = noteStore.get(event.noteId)
+    if (note.value?.id === event.noteId) {
+      note.value = latest ?? null
+    }
+    ancestors.value = ancestors.value.map((n) =>
+      n.id === event.noteId && latest
+        ? latest
+        : n.renoteId === event.noteId && latest
+          ? { ...n, renote: latest }
+          : n,
+    )
+    children.value = children.value.map((n) =>
+      n.id === event.noteId && latest
+        ? latest
+        : n.renoteId === event.noteId && latest
+          ? { ...n, renote: latest }
+          : n,
+    )
+  },
+)
 
 type DetailTab = 'replies' | 'renotes' | 'reactions'
 const activeTab = ref<DetailTab>('replies')
@@ -80,6 +110,7 @@ onMounted(async () => {
     isLoading.value = false
     return
   }
+  myUserId.value = account.userId
 
   // Logged-out / offline: show cached note in read-only mode
   if (!account.hasToken) {
@@ -130,6 +161,20 @@ onMounted(async () => {
     isLoading.value = false
   }
 })
+
+// 表示中ノートが変わったらストア登録と購読を同期
+watch(
+  [note, ancestors, children],
+  () => {
+    const notes: NormalizedNote[] = []
+    if (note.value) notes.push(note.value)
+    notes.push(...ancestors.value, ...children.value)
+    if (notes.length === 0) return
+    noteStore.put(notes)
+    syncCapture(notes)
+  },
+  { immediate: true },
+)
 
 const loadedTabs = ref<Set<DetailTab>>(new Set(['replies']))
 

--- a/src/stores/notes.ts
+++ b/src/stores/notes.ts
@@ -216,8 +216,11 @@ export const useNoteStore = defineStore('notes', () => {
       case 'pollVoted': {
         const choice = event.body.choice
         if (choice == null || !note.poll) return
+        const isMine = !!myUserId && event.body.userId === myUserId
         const newChoices = note.poll.choices.map((c, i) =>
-          i === choice ? { ...c, votes: c.votes + 1 } : c,
+          i === choice
+            ? { ...c, votes: c.votes + 1, ...(isMine ? { isVoted: true } : {}) }
+            : c,
         )
         noteMap.value.set(event.noteId, {
           ...note,


### PR DESCRIPTION
## Summary

Fixes #351

投票ノートへの投票がリアルタイム反映されなかった問題を修正。

- **原因1**: `NoteDetailContent.vue` が Note Capture (`subNote`) を購読していなかったため、詳細ウィンドウで開いているノートに対する `pollVoted` / `reacted` 等のストリーミングイベントが届かない。カラムは `useNoteColumn` 経由で購読しているが、詳細ウィンドウはその外。
- **原因2**: `noteStore.applyUpdate` の `pollVoted` ケースが `body.userId` を無視して votes を +1 するだけだった。他クライアントから同アカウントが投票した際に `isVoted` が反映されず、UI が「未投票」表示のままになる。

## Fix

- [NoteDetailContent.vue](../../blob/fix/351-poll-realtime-update/src/components/window/NoteDetailContent.vue): `useNoteCapture` を導入し、focal/ancestors/children をまとめて購読。イベント受信時に `noteStore.applyUpdate` でストアを更新し、ローカル refs (`note`, `ancestors`, `children`) もミラー更新する。
- [notes.ts](../../blob/fix/351-poll-realtime-update/src/stores/notes.ts): `applyUpdate` の `pollVoted` で `body.userId === myUserId` なら `isVoted: true` もセット（Misskey 本家 `use-note-capture.ts` に準拠）。

## Test plan

- [ ] 詳細ウィンドウで投票ノートを開き、候補バーをクリックして即座に votes と候補バーが更新されることを確認
- [ ] 詳細ウィンドウ表示中に他ユーザーが同じ投票ノートに投票し、リアルタイムで votes が +1 されることを確認
- [ ] 詳細ウィンドウ表示中に同アカウントが他クライアント (公式 Web 等) から投票し、`isVoted` が反映されて「投票済み」状態になることを確認
- [ ] ancestors / children に含まれる投票ノートに対しても同様に動作することを確認
- [ ] 既存のカラム（Timeline/Mentions 等）での投票・リアクション反映に regress がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)