### PR TITLE
Release v0.11.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.11.4",
+  "version": "0.11.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.11.4"
+version = "0.11.5"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -67,55 +67,58 @@ impl TauriEmitter {
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        let label = match notif_type {
-            "reaction" => "リアクション",
-            "reply" => "リプライ",
-            "renote" => "リノート",
-            "quote" => "引用",
-            "mention" => "メンション",
-            "follow" => "フォロー",
-            "followRequestAccepted" => "フォローリクエスト承認",
-            "receiveFollowRequest" => "フォローリクエスト",
-            "pollEnded" => "投票終了",
-            "achievementEarned" => "実績獲得",
-            "app" => "通知",
-            "login" => "ログイン検知",
-            "test" => "テスト通知",
+        // アクター系: 送信元ユーザーを title に。user が欠落したら "誰か" で従来挙動を維持。
+        let actor_name = || {
+            notification
+                .get("user")
+                .and_then(|u| {
+                    u.get("name")
+                        .and_then(|v| v.as_str())
+                        .or_else(|| u.get("username").and_then(|v| v.as_str()))
+                })
+                .unwrap_or("誰か")
+                .to_string()
+        };
+
+        // Misskey 本家 (packages/sw/src/scripts/create-notification.ts) に合わせ、
+        // アクター系 (title = user) と自己/システム通知 (title = 固定ラベル) を分ける。
+        let (title, body_opt): (String, Option<String>) = match notif_type {
+            "reaction" => {
+                let body = notification
+                    .get("reaction")
+                    .and_then(|v| v.as_str())
+                    .map(|r| format!("リアクション {r}"))
+                    .unwrap_or_else(|| "リアクション".to_string());
+                (actor_name(), Some(body))
+            }
+            "reply" => (actor_name(), Some("リプライ".to_string())),
+            "renote" => (actor_name(), Some("リノート".to_string())),
+            "quote" => (actor_name(), Some("引用".to_string())),
+            "mention" => (actor_name(), Some("メンション".to_string())),
+            "follow" => (actor_name(), Some("フォロー".to_string())),
+            "followRequestAccepted" => (actor_name(), Some("フォローリクエスト承認".to_string())),
+            "receiveFollowRequest" => (actor_name(), Some("フォローリクエスト".to_string())),
+
+            // user フィールドを持たない自己/システム通知
+            "achievementEarned" => {
+                let body = notification
+                    .get("achievement")
+                    .and_then(|v| v.as_str())
+                    .map(|a| achievement_label(a).to_string());
+                ("実績獲得".to_string(), body)
+            }
+            "login" => ("ログイン検知".to_string(), None),
+            "pollEnded" => ("投票終了".to_string(), None),
+            "app" => ("通知".to_string(), None),
+            "test" => ("テスト通知".to_string(), Some("テスト通知".to_string())),
+
             _ => return,
         };
 
-        let user_name = notification
-            .get("user")
-            .and_then(|u| {
-                u.get("name")
-                    .and_then(|v| v.as_str())
-                    .or_else(|| u.get("username").and_then(|v| v.as_str()))
-            })
-            .unwrap_or("誰か");
-
-        let body = if notif_type == "reaction" {
-            if let Some(reaction) = notification.get("reaction").and_then(|v| v.as_str()) {
-                format!("{label} {reaction}")
-            } else {
-                label.to_string()
-            }
-        } else if notif_type == "achievementEarned" {
-            if let Some(name) = notification.get("achievement").and_then(|v| v.as_str()) {
-                format!("{label}: {}", achievement_label(name))
-            } else {
-                label.to_string()
-            }
-        } else {
-            label.to_string()
-        };
-
-        #[allow(unused_mut)]
-        let mut builder = self
-            .app
-            .notification()
-            .builder()
-            .title(user_name)
-            .body(&body);
+        let mut builder = self.app.notification().builder().title(&title);
+        if let Some(body) = body_opt.as_deref() {
+            builder = builder.body(body);
+        }
         #[cfg(target_os = "android")]
         {
             builder = builder.channel_id(NOTIFICATION_CHANNEL_ID);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -496,7 +496,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
   },
   ai: {
     label: 'AIチャット',
-    icon: 'sparkles',
+    icon: 'brain',
     group: 'tool',
     accountIndependent: true,
     defaultProps: { accountId: null },

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -97,7 +97,7 @@ function onKeydown(e: KeyboardEvent) {
 <template>
   <DeckColumnComponent :column-id="column.id" :title="column.name || 'AIチャット'" @header-click="scrollToTop">
     <template #header-icon>
-      <i class="ti ti-sparkles" />
+      <i class="ti ti-brain" />
     </template>
 
     <template #header-meta>
@@ -112,7 +112,22 @@ function onKeydown(e: KeyboardEvent) {
       <div ref="aiMessagesRef" :class="$style.aiMessages">
         <div v-if="messages.length === 0" :class="$style.aiEmpty">
           <div :class="$style.aiEmptyIcon">
-            <i class="ti ti-sparkles" />
+            <svg :class="$style.aiSignIcon" viewBox="0 0 500 300" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+              <g transform="matrix(1,0,0,1,0,-822.52)">
+                <g transform="matrix(0.678544,0,0,0.678544,75.2996,401.189)">
+                  <path d="M301.271,941.862L308.01,937.525M126.688,1005.21C108.505,987.528 77.382,989.437 73.654,1007.73C68.898,1031.08 106.782,1040.24 128.203,1028.44C151.103,1015.83 224.341,907.088 253.967,916.312C279.544,924.276 236.794,1023.39 236.794,1023.39C236.794,1023.39 168.043,929.904 134.769,960.759C106.99,986.518 194.368,1029.45 236.794,1023.39C273.16,1023.89 296.898,958.738 296.898,958.738C296.898,958.738 278.21,1011.77 317.606,1013.79C357.002,1015.81 438.783,962.575 414.581,947.627C397.408,937.02 363.568,967.83 363.568,967.83C363.568,967.83 372.487,922.311 347.911,938.03C329.301,949.934 335.79,1000.18 365.589,1003.69C382.835,1010.45 409.126,1007.16 428.246,998.581C499.435,966.651 498.47,810.412 419.575,760.939L390.1,694.621L353.257,746.202C309.563,725.858 244.295,720.675 204.409,740.307L183.776,672.514L139.564,746.202C51.735,803.663 56.171,883.374 95.352,930.419" />
+                </g>
+                <g transform="matrix(0.678544,0,0,0.678544,72.5861,413.246)">
+                  <path d="M199.143,802.119L205.882,768.308" />
+                </g>
+                <g transform="matrix(0.678544,0,0,0.678544,147.586,414.717)">
+                  <path d="M202.513,807.32L205.882,768.308" />
+                </g>
+                <g transform="matrix(0.678544,0,0,0.678544,77.5861,398.246)">
+                  <path d="M268.831,846.331L246.725,868.437L231.988,846.331" />
+                </g>
+              </g>
+            </svg>
           </div>
           <span :class="$style.aiEmptyTitle">AI Chat</span>
           <span :class="$style.aiEmptyHint">質問を入力してください</span>
@@ -136,7 +151,7 @@ function onKeydown(e: KeyboardEvent) {
             :class="[$style.aiMessage, $style[msg.role]]"
           >
             <div :class="$style.messageAvatar">
-              <i v-if="msg.role === 'assistant'" class="ti ti-sparkles" />
+              <i v-if="msg.role === 'assistant'" class="ti ti-brain" />
               <i v-else class="ti ti-user" />
             </div>
             <div :class="$style.messageBody">
@@ -146,7 +161,7 @@ function onKeydown(e: KeyboardEvent) {
 
           <div v-if="isGenerating" :class="[$style.aiMessage, $style.assistant]">
             <div :class="$style.messageAvatar">
-              <i class="ti ti-sparkles" />
+              <i class="ti ti-brain" />
             </div>
             <div :class="$style.messageBody">
               <div :class="$style.messageTyping">
@@ -186,6 +201,17 @@ function onKeydown(e: KeyboardEvent) {
 </template>
 
 <style lang="scss" module>
+.aiSignIcon {
+  display: block;
+  width: 3em;
+  height: auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 14px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
 .providerDot {
   width: 6px;
   height: 6px;
@@ -233,7 +259,8 @@ function onKeydown(e: KeyboardEvent) {
 
 .aiEmptyIcon {
   font-size: 2.5em;
-  opacity: 0.15;
+  opacity: 0.35;
+  color: var(--nd-accent);
 }
 
 .aiEmptyTitle {

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -118,7 +118,7 @@ const icons: Record<string, string> = {
   cssEditor: 'ti ti-code',
   themeEditor: 'ti ti-palette',
   profileEditor: 'ti ti-layout-columns',
-  ai: 'ti ti-sparkles',
+  ai: 'ti ti-brain',
   aiSettings: 'ti ti-robot',
   chat: 'ti ti-messages',
   about: 'ti ti-info-circle',

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -30,6 +30,7 @@ const MkPostForm = defineAsyncComponent(
 
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
+import { useNoteCapture } from '@/composables/useNoteCapture'
 import { usePortal } from '@/composables/usePortal'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
@@ -58,6 +59,35 @@ const renotes = ref<NormalizedNote[]>([])
 const reactions = ref<NoteReaction[]>([])
 const isLoading = ref(true)
 const error = ref<AppError | null>(null)
+const myUserId = ref<string | undefined>()
+
+// Note Capture: 投票・リアクション等の pollVoted/reacted イベントを受けて
+// 表示中のノートをリアルタイム更新する。カラムと違い詳細ウィンドウは
+// channel auto-capture の対象外のため明示的に購読する。
+const { sync: syncCapture } = useNoteCapture(
+  () => adapter?.stream,
+  (event) => {
+    noteStore.applyUpdate(event, myUserId.value)
+    const latest = noteStore.get(event.noteId)
+    if (note.value?.id === event.noteId) {
+      note.value = latest ?? null
+    }
+    ancestors.value = ancestors.value.map((n) =>
+      n.id === event.noteId && latest
+        ? latest
+        : n.renoteId === event.noteId && latest
+          ? { ...n, renote: latest }
+          : n,
+    )
+    children.value = children.value.map((n) =>
+      n.id === event.noteId && latest
+        ? latest
+        : n.renoteId === event.noteId && latest
+          ? { ...n, renote: latest }
+          : n,
+    )
+  },
+)
 
 type DetailTab = 'replies' | 'renotes' | 'reactions'
 const activeTab = ref<DetailTab>('replies')
@@ -80,6 +110,7 @@ onMounted(async () => {
     isLoading.value = false
     return
   }
+  myUserId.value = account.userId
 
   // Logged-out / offline: show cached note in read-only mode
   if (!account.hasToken) {
@@ -130,6 +161,20 @@ onMounted(async () => {
     isLoading.value = false
   }
 })
+
+// 表示中ノートが変わったらストア登録と購読を同期
+watch(
+  [note, ancestors, children],
+  () => {
+    const notes: NormalizedNote[] = []
+    if (note.value) notes.push(note.value)
+    notes.push(...ancestors.value, ...children.value)
+    if (notes.length === 0) return
+    noteStore.put(notes)
+    syncCapture(notes)
+  },
+  { immediate: true },
+)
 
 const loadedTabs = ref<Set<DetailTab>>(new Set(['replies']))
 

--- a/src/defaults/navbar.json5
+++ b/src/defaults/navbar.json5
@@ -9,4 +9,5 @@
   { type: 'search', accountId: null },
   { type: 'lookup', accountId: null },
   { type: 'pluginManager', accountId: null },
+  { type: 'ai', accountId: null },
 ]

--- a/src/stores/notes.ts
+++ b/src/stores/notes.ts
@@ -216,8 +216,11 @@ export const useNoteStore = defineStore('notes', () => {
       case 'pollVoted': {
         const choice = event.body.choice
         if (choice == null || !note.poll) return
+        const isMine = !!myUserId && event.body.userId === myUserId
         const newChoices = note.poll.choices.map((c, i) =>
-          i === choice ? { ...c, votes: c.votes + 1 } : c,
+          i === choice
+            ? { ...c, votes: c.votes + 1, ...(isMine ? { isVoted: true } : {}) }
+            : c,
         )
         noteMap.value.set(event.noteId, {
           ...note,


### PR DESCRIPTION
## Summary

v0.11.5 リリース。自己/システム通知の表示修正、投票ノートのリアルタイム反映修正、AI カラムをデフォルトナビバーに追加。

## Changelog (v0.11.4 → v0.11.5)

### Features

- feat(ai-column): アイコンを brain に統一し空状態に藍サインを表示
- chore(navbar): デフォルトに AI カラムを追加

### Fixes

- fix(streaming): 自己/システム通知の title を固定ラベルに変更 (#358)
- fix(note): 投票ノートのリアルタイム反映を修正 (#351)

## Closes

- Close #358 自分のOS通知が「誰か」扱いになる
- Close #351 投票ノートへの投票がリアルタイム反映されない

## Test plan

- [x] `pnpm typecheck` 通過 (pre-commit hook)
- [x] `cargo check` 通過
- [ ] CI (lint / typecheck / test) 通過を待つ
- [ ] マージ後にタグ `v0.11.5` を push してリリースワークフローをトリガー

🤖 Generated with [Claude Code](https://claude.com/claude-code)