### PR TITLE
Release v0.11.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.11.6",
+  "version": "0.11.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.11.6"
+version = "0.11.7"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -10,7 +10,7 @@ use super::Result;
 const SETTINGS_DIR: &str = "notedeck";
 
 /// Allowed subdirectory names for settings files. Also the set included in settings backup.
-const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "memos"];
+const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "memos", "widgets"];
 
 /// Validate a subdirectory name against the whitelist.
 fn validate_subdir(subdir: &str) -> Result<()> {
@@ -344,7 +344,7 @@ pub async fn export_settings_json(app: tauri::AppHandle) -> Result<bool> {
 
     let mut bundle: BTreeMap<String, String> = BTreeMap::new();
 
-    // Add subdirectory files (profiles/, themes/, plugins/, snippets/, memos/)
+    // Add subdirectory files (profiles/, themes/, plugins/, snippets/, memos/, widgets/)
     for subdir in ALLOWED_SUBDIRS {
         let dir = base_dir.join(subdir);
         if !dir.exists() {
@@ -455,6 +455,7 @@ mod tests {
         assert!(validate_subdir("themes").is_ok());
         assert!(validate_subdir("plugins").is_ok());
         assert!(validate_subdir("snippets").is_ok());
+        assert!(validate_subdir("widgets").is_ok());
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -444,7 +444,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
   // ============================================================
   widget: {
     label: 'ウィジェット',
-    icon: 'app-window',
+    icon: 'layout-dashboard',
     group: 'tool',
     guestAllowed: true,
     accountOptional: true,

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -5,6 +5,7 @@ import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { useWidgetsStore } from '@/stores/widgets'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
 
@@ -17,13 +18,29 @@ const props = defineProps<{
 }>()
 
 const deckStore = useDeckStore()
+const widgetsStore = useWidgetsStore()
+widgetsStore.ensureLoaded()
 
 const { account, columnThemeVars } = useColumnTheme(() => props.column)
 const { serverIconUrl, serverInfoImageUrl } = useServerImages(
   () => props.column,
 )
 
-const widgets = computed(() => props.column.widgets ?? [])
+/**
+ * sidebar widget カラム (ナビバートグルで開閉) は sidebarWidgetIds[] を参照し、
+ * non-sidebar widget カラムはカラム自身の widgetIds[] を参照する。
+ * 追加・削除の責務は deckStore 側に集約 (sidebar 判定は内部で実施)。
+ */
+const isSidebar = computed(() => props.column.sidebar === true)
+
+const widgets = computed(() => {
+  const ids = isSidebar.value
+    ? widgetsStore.sidebarWidgetIds
+    : (props.column.widgetIds ?? [])
+  return ids
+    .map((id) => widgetsStore.getWidget(id))
+    .filter((w): w is NonNullable<typeof w> => w !== undefined)
+})
 
 const showEmptyState = computed(
   () => widgets.value.length === 0 && props.column.accountId !== null,
@@ -39,8 +56,8 @@ function scrollToTop() {
   widgetBodyRef.value?.scrollTo({ top: 0, behavior: 'smooth' })
 }
 
-function removeWidget(widgetId: string) {
-  deckStore.removeWidget(props.column.id, widgetId)
+function handleRemove(installId: string) {
+  deckStore.removeWidget(props.column.id, installId)
 }
 </script>
 
@@ -61,13 +78,17 @@ function removeWidget(widgetId: string) {
         :image-url="serverInfoImageUrl"
       />
 
-      <div v-for="widget in widgets" :key="widget.id" :class="$style.widgetItem">
+      <div v-for="widget in widgets" :key="widget.installId" :class="$style.widgetItem">
         <div :class="$style.widgetHeader">
           <span :class="$style.widgetLabel">
             <i class="ti ti-apps" />
             AiScript
           </span>
-          <button :class="$style.widgetRemove" @click="removeWidget(widget.id)">
+          <button
+            :class="$style.widgetRemove"
+            :title="isSidebar ? 'widget を削除 (コードも消えます)' : 'このカラムから外す (widget 本体は保持)'"
+            @click="handleRemove(widget.installId)"
+          >
             <i class="ti ti-x" />
           </button>
         </div>

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -64,7 +64,7 @@ function handleRemove(installId: string) {
 <template>
   <DeckColumn :column-id="column.id" :title="column.name ?? 'ウィジェット'" :theme-vars="columnThemeVars" data-column-type="widget" @header-click="scrollToTop">
     <template #header-icon>
-      <i class="ti ti-app-window" />
+      <i class="ti ti-layout-dashboard" />
     </template>
 
     <template #header-meta>

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -79,26 +79,13 @@ function handleRemove(installId: string) {
       />
 
       <div v-for="widget in widgets" :key="widget.installId" :class="$style.widgetItem">
-        <div :class="$style.widgetHeader">
-          <span :class="$style.widgetLabel">
-            <i class="ti ti-apps" />
-            AiScript
-          </span>
-          <button
-            :class="$style.widgetRemove"
-            :title="isSidebar ? 'widget を削除 (コードも消えます)' : 'このカラムから外す (widget 本体は保持)'"
-            @click="handleRemove(widget.installId)"
-          >
-            <i class="ti ti-x" />
-          </button>
-        </div>
-        <div :class="$style.widgetContent">
-          <WidgetAiScript
-            :widget="widget"
-            :column-id="column.id"
-            :account-id="column.accountId"
-          />
-        </div>
+        <WidgetAiScript
+          :widget="widget"
+          :column-id="column.id"
+          :account-id="column.accountId"
+          :is-sidebar="isSidebar"
+          @remove="handleRemove(widget.installId)"
+        />
       </div>
 
       <div :class="$style.addWidgetArea">
@@ -128,50 +115,6 @@ function handleRemove(installId: string) {
   overflow: hidden;
   contain: layout style paint;
   content-visibility: auto;
-}
-
-.widgetHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--nd-divider);
-  font-size: 0.85em;
-  background: var(--nd-panelHeaderBg);
-  color: var(--nd-panelHeaderFg);
-}
-
-.widgetLabel {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 500;
-  opacity: 0.8;
-}
-
-.widgetRemove {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border: none;
-  background: none;
-  color: var(--nd-fg);
-  cursor: pointer;
-  border-radius: var(--nd-radius-sm);
-  opacity: 0.35;
-  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
-
-  &:hover {
-    opacity: 1;
-    color: var(--nd-love);
-    background: var(--nd-love-subtle);
-  }
-}
-
-.widgetContent {
-  padding: 10px;
 }
 
 .addWidgetArea {

--- a/src/components/deck/widgets/AiScriptUiRenderer.vue
+++ b/src/components/deck/widgets/AiScriptUiRenderer.vue
@@ -46,6 +46,19 @@ async function callHandler(
   }
 }
 
+function containerAlignItems(align: string | undefined): string | undefined {
+  switch (align) {
+    case 'center':
+      return 'center'
+    case 'right':
+      return 'flex-end'
+    case 'left':
+      return 'flex-start'
+    default:
+      return undefined
+  }
+}
+
 function handlePostFormButton(comp: UiComponent) {
   const form = comp.props.form as Record<string, unknown> | undefined
   emit('post', {
@@ -146,6 +159,7 @@ function handlePostFormButton(comp: UiComponent) {
         :class="$style.aisContainer"
         :style="({
           textAlign: (comp.props.align as string) ?? undefined,
+          alignItems: containerAlignItems(comp.props.align as string | undefined),
           backgroundColor: (comp.props.bgColor as string) ?? undefined,
           color: (comp.props.fgColor as string) ?? undefined,
           padding: (comp.props.padding as string) ? `${comp.props.padding}px` : undefined,

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -281,7 +281,7 @@ onMounted(() => {
   <div :class="$style.widgetApp">
     <div :class="$style.widgetHeader">
       <span :class="$style.widgetLabel" :title="displayName">
-        <i class="ti ti-apps" />
+        <i class="ti ti-layout-dashboard" />
         <span :class="$style.widgetLabelText">{{ displayName }}</span>
       </span>
       <div v-if="!showTemplatePicker" :class="$style.headerActions">

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -3,6 +3,7 @@ import { type Ast, Interpreter, Parser } from '@syuilo/aiscript'
 import {
   computed,
   defineAsyncComponent,
+  onBeforeUnmount,
   onMounted,
   ref,
   useTemplateRef,
@@ -29,9 +30,9 @@ const MkPostForm = defineAsyncComponent(
 )
 
 import { useAccountsStore } from '@/stores/accounts'
-import type { WidgetConfig } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { getWidgetDetailUrl } from '@/stores/misstore'
+import { useWidgetsStore, type WidgetMeta } from '@/stores/widgets'
 import { openSafeUrl } from '@/utils/url'
 import AiScriptEditor from './AiScriptEditor.vue'
 import type { PostFormRequest } from './AiScriptUiRenderer.vue'
@@ -40,12 +41,13 @@ import { checkWidgetCapabilities } from './capabilities'
 import { fetchWidgetCode, useWidgetTemplates } from './templates'
 
 const props = defineProps<{
-  widget: WidgetConfig
+  widget: WidgetMeta
   columnId: string
   accountId: string | null
 }>()
 
 const deckStore = useDeckStore()
+const widgetsStore = useWidgetsStore()
 const commandStore = useCommandStore()
 const accountsStore = useAccountsStore()
 const serverUrl = computed(() => {
@@ -53,7 +55,7 @@ const serverUrl = computed(() => {
   const account = accountsStore.accounts.find((a) => a.id === props.accountId)
   return account ? `https://${account.host}` : ''
 })
-const code = ref(props.widget.data.code ?? '')
+const code = ref(props.widget.src ?? '')
 const uiComponents = ref<UiComponent[]>([])
 const output = ref<{ text: string; isError: boolean }[]>([])
 const error = ref<string | null>(null)
@@ -106,9 +108,11 @@ async function applyTemplate(templateId: string) {
   applyingTemplateId.value = templateId
   try {
     code.value = await fetchWidgetCode(tmpl)
-    deckStore.updateWidgetData(props.columnId, props.widget.id, {
-      storeId: tmpl.id,
-    })
+    widgetsStore.setStoreId(props.widget.installId, tmpl.id)
+    widgetsStore.setAutoRun(props.widget.installId, tmpl.autoRun)
+    // debounce を介さず即座にソースを保存 (適用直後にカラム閉じても消えないように)
+    flushPendingSave()
+    widgetsStore.updateSrc(props.widget.installId, code.value)
     showTemplatePicker.value = false
     showEditor.value = false
     if (tmpl.autoRun) run()
@@ -146,14 +150,24 @@ function closePostForm() {
   postFormData.value = {}
 }
 
-// Persist code on change
+// Persist code on change (debounce + アンマウント時 flush で取りこぼし防止)
 let saveTimer: ReturnType<typeof setTimeout> | null = null
+function flushPendingSave() {
+  if (saveTimer) {
+    clearTimeout(saveTimer)
+    saveTimer = null
+    widgetsStore.updateSrc(props.widget.installId, code.value)
+  }
+}
 watch(code, (val) => {
   if (saveTimer) clearTimeout(saveTimer)
   saveTimer = setTimeout(() => {
-    deckStore.updateWidgetData(props.columnId, props.widget.id, { code: val })
+    saveTimer = null
+    widgetsStore.updateSrc(props.widget.installId, val)
   }, 500)
 })
+
+onBeforeUnmount(flushPendingSave)
 
 async function run() {
   if (running.value) return
@@ -184,7 +198,7 @@ async function run() {
   const env = createAiScriptEnv(
     {
       api: apiOption,
-      storagePrefix: `app-${props.widget.id}`,
+      storagePrefix: `app-${props.widget.installId}`,
       onDialog: (title, text, type) =>
         dialogRef.value?.showDialog(title, text, type) ?? Promise.resolve(),
       onConfirm: (title, text) =>
@@ -192,7 +206,7 @@ async function run() {
       onToast: (text, type) => showToast(text, type),
     },
     {
-      THIS_ID: props.widget.id,
+      THIS_ID: props.widget.installId,
       THIS_URL: '',
       USER_ID:
         accountsStore.accounts.find((a) => a.id === props.accountId)?.userId ??
@@ -242,11 +256,10 @@ async function run() {
   running.value = false
 }
 
+// autoRun=true な widget は mount のたびに自動実行する。
+// (フラグを下げない: カラム再表示・ナビバートグル・他カラム参照のたびに UI を出すため)
 onMounted(() => {
-  if (props.widget.data.autoRun && code.value) {
-    deckStore.updateWidgetData(props.columnId, props.widget.id, {
-      autoRun: false,
-    })
+  if (props.widget.autoRun && code.value) {
     run()
   }
 })

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -44,10 +44,21 @@ const props = defineProps<{
   widget: WidgetMeta
   columnId: string
   accountId: string | null
+  isSidebar?: boolean
+}>()
+
+const emit = defineEmits<{
+  remove: []
 }>()
 
 const deckStore = useDeckStore()
 const widgetsStore = useWidgetsStore()
+
+const displayName = computed(() => {
+  const name = props.widget.name?.trim()
+  if (!name || /^Widget [0-9a-z]{4,}$/i.test(name)) return 'AiScript'
+  return name
+})
 const commandStore = useCommandStore()
 const accountsStore = useAccountsStore()
 const serverUrl = computed(() => {
@@ -110,6 +121,7 @@ async function applyTemplate(templateId: string) {
     code.value = await fetchWidgetCode(tmpl)
     widgetsStore.setStoreId(props.widget.installId, tmpl.id)
     widgetsStore.setAutoRun(props.widget.installId, tmpl.autoRun)
+    widgetsStore.renameWidget(props.widget.installId, tmpl.label)
     // debounce を介さず即座にソースを保存 (適用直後にカラム閉じても消えないように)
     flushPendingSave()
     widgetsStore.updateSrc(props.widget.installId, code.value)
@@ -267,9 +279,44 @@ onMounted(() => {
 
 <template>
   <div :class="$style.widgetApp">
-    <AiScriptDialog ref="dialogRef" />
+    <div :class="$style.widgetHeader">
+      <span :class="$style.widgetLabel" :title="displayName">
+        <i class="ti ti-apps" />
+        <span :class="$style.widgetLabelText">{{ displayName }}</span>
+      </span>
+      <div v-if="!showTemplatePicker" :class="$style.headerActions">
+        <button
+          :class="$style.toolBtn"
+          :title="showEditor ? 'エディタを閉じる' : 'コードを編集'"
+          @click="showEditor = !showEditor"
+        >
+          <i :class="showEditor ? 'ti ti-chevron-up' : 'ti ti-code'" />
+        </button>
+        <button
+          :class="[$style.toolBtn, $style.run]"
+          :disabled="running"
+          title="実行"
+          @click="run"
+        >
+          <i class="ti ti-player-play" />
+        </button>
+      </div>
+      <button
+        :class="$style.widgetRemove"
+        :title="isSidebar ? 'widget を削除 (コードも消えます)' : 'このカラムから外す (widget 本体は保持)'"
+        @click="emit('remove')"
+      >
+        <i class="ti ti-x" />
+      </button>
+    </div>
 
-    <div v-if="showTemplatePicker" :class="$style.templatePicker">
+    <div :class="$style.widgetBody">
+      <AiScriptDialog ref="dialogRef" />
+
+      <div v-if="showTemplatePicker" :class="$style.templatePicker">
+      <button :class="$style.templateSkip" @click="skipTemplate">
+        空のエディタで始める
+      </button>
       <div :class="$style.searchWrap">
         <input
           v-model="templateQuery"
@@ -314,7 +361,7 @@ onMounted(() => {
           <div :class="$style.accentBar" />
           <div :class="$style.icon">
             <i v-if="applyingTemplateId === tmpl.id" class="ti ti-loader nd-spin" />
-            <span v-else>📟</span>
+            <i v-else class="ti ti-layout-dashboard" />
           </div>
           <div :class="$style.body">
             <div :class="$style.row1">
@@ -354,48 +401,39 @@ onMounted(() => {
           </div>
         </button>
       </template>
-      <button :class="$style.templateSkip" @click="skipTemplate">
-        空のエディタで始める
-      </button>
     </div>
 
-    <template v-else>
-      <div :class="$style.appToolbar">
-        <button :class="$style.toolBtn" @click="showEditor = !showEditor">
-          <i :class="showEditor ? 'ti ti-chevron-up' : 'ti ti-code'" />
-        </button>
-        <button :class="[$style.toolBtn, $style.run]" :disabled="running" @click="run">
-          <i class="ti ti-player-play" />
-        </button>
-      </div>
+      <template v-else>
+        <AiScriptEditor
+          v-if="showEditor"
+          v-model="code"
+          placeholder="AiScript App code..."
+        />
 
-      <AiScriptEditor
-        v-if="showEditor"
-        v-model="code"
-        placeholder="AiScript App code..."
-      />
+        <template v-else>
+          <div v-if="error" :class="$style.appError">{{ error }}</div>
 
-      <div v-if="error" :class="$style.appError">{{ error }}</div>
+          <AiScriptUiRenderer
+            v-if="uiComponents.length"
+            :components="uiComponents"
+            :interpreter="(interpreter as Interpreter | null)"
+            :server-url="serverUrl"
+            @post="handlePost"
+          />
 
-      <AiScriptUiRenderer
-        v-if="uiComponents.length"
-        :components="uiComponents"
-        :interpreter="(interpreter as Interpreter | null)"
-        :server-url="serverUrl"
-        @post="handlePost"
-      />
-
-      <details v-if="output.length" :class="$style.outputPanel">
-        <summary>出力 ({{ output.length }})</summary>
-        <div
-          v-for="(line, i) in output"
-          :key="i"
-          :class="[$style.outputLine, { [$style.error]: line.isError }]"
-        >
-          {{ line.text }}
-        </div>
-      </details>
-    </template>
+          <details v-if="output.length" :class="$style.outputPanel">
+            <summary>出力 ({{ output.length }})</summary>
+            <div
+              v-for="(line, i) in output"
+              :key="i"
+              :class="[$style.outputLine, { [$style.error]: line.isError }]"
+            >
+              {{ line.text }}
+            </div>
+          </details>
+        </template>
+      </template>
+    </div>
   </div>
 
   <div v-if="showPostForm && props.accountId" ref="postFormPortalRef">
@@ -415,21 +453,76 @@ onMounted(() => {
 .widgetApp {
   display: flex;
   flex-direction: column;
-  gap: 6px;
 }
 
-.appToolbar {
+.widgetHeader {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
   gap: 4px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--nd-divider);
+  font-size: 0.85em;
+  background: var(--nd-panelHeaderBg);
+  color: var(--nd-panelHeaderFg);
+}
+
+.widgetLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-right: auto;
+  min-width: 0;
+  font-weight: 500;
+  opacity: 0.8;
+}
+
+.widgetLabelText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.widgetRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: none;
+  color: var(--nd-fg);
+  cursor: pointer;
+  border-radius: var(--nd-radius-sm);
+  opacity: 0.35;
+  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
+
+  &:hover {
+    opacity: 1;
+    color: var(--nd-love);
+    background: var(--nd-love-subtle);
+  }
+}
+
+.widgetBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px;
 }
 
 .toolBtn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   border: none;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-buttonBg);
@@ -567,7 +660,7 @@ onMounted(() => {
   height: 48px;
   flex-shrink: 0;
   color: var(--nd-accent);
-  font-size: 28px;
+  font-size: 32px;
   line-height: 1;
 }
 
@@ -709,7 +802,6 @@ onMounted(() => {
   cursor: pointer;
   font-size: 0.85em;
   opacity: 0.5;
-  margin-top: 4px;
   transition: background var(--nd-duration-base);
 
   &:hover {

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -8,6 +8,7 @@ import defaultNavbarJson5 from '@/defaults/navbar.json5?raw'
 import { useAccountsStore } from '@/stores/accounts'
 import { useDeckProfileStore } from '@/stores/deckProfile'
 import { useDeckWallpaperStore } from '@/stores/deckWallpaper'
+import { generateWidgetId, useWidgetsStore } from '@/stores/widgets'
 import { buildColumnUri } from '@/utils/columnUri'
 import * as deckLayout from '@/utils/deckLayout'
 import { hapticMedium } from '@/utils/haptics'
@@ -53,6 +54,9 @@ export type ColumnType =
   | 'charts'
   | 'federation'
 
+/**
+ * @deprecated useWidgetsStore に移行済み。マイグレーション用にのみ残置 (1〜2 リリース後に削除)
+ */
 export interface WidgetData {
   code?: string
   autoRun?: boolean
@@ -60,6 +64,9 @@ export interface WidgetData {
   storeId?: string
 }
 
+/**
+ * @deprecated useWidgetsStore.WidgetMeta に移行済み。マイグレーション用にのみ残置
+ */
 export interface WidgetConfig {
   id: string
   data: WidgetData
@@ -100,6 +107,9 @@ export interface DeckColumn {
   channelId?: string
   roleId?: string
   userId?: string
+  /** widget カラムが参照する WidgetMeta の installId 列。本体は useWidgetsStore に存在 */
+  widgetIds?: string[]
+  /** @deprecated widgetIds + useWidgetsStore に移行済み。マイグレーション読取専用 */
   widgets?: WidgetConfig[]
   aiscriptCode?: string
   flashId?: string
@@ -434,36 +444,60 @@ export const useDeckStore = defineStore('deck', () => {
     }
   }
 
-  // Widget helpers
-  let widgetCounter = 0
-  function genWidgetId(): string {
-    return `wgt-${Date.now()}-${++widgetCounter}`
-  }
+  // Widget helpers (widget 本体は useWidgetsStore、カラムは installId の参照のみ)
+  const widgetsStore = useWidgetsStore()
 
-  function addWidget(columnId: string, initialData?: WidgetData) {
-    const col = getColumn(columnId)
-    if (!col || col.type !== 'widget') return
-    if (!col.widgets) col.widgets = []
-    col.widgets.push({ id: genWidgetId(), data: initialData ?? {} })
-    save()
-  }
-
-  function removeWidget(columnId: string, widgetId: string) {
-    const col = getColumn(columnId)
-    if (!col?.widgets) return
-    col.widgets = col.widgets.filter((w) => w.id !== widgetId)
-    save()
-  }
-
-  function updateWidgetData(
+  /**
+   * widget カラムに新規 widget を追加する。
+   * sidebar widget カラム (ナビバートグルで開閉) なら sidebar 並びに登録、
+   * non-sidebar widget カラムならカラム自身の widgetIds[] に push する。
+   */
+  function addWidget(
     columnId: string,
-    widgetId: string,
-    data: Partial<WidgetData>,
+    initial?: { src?: string; autoRun?: boolean; storeId?: string },
   ) {
     const col = getColumn(columnId)
-    const widget = col?.widgets?.find((w) => w.id === widgetId)
-    if (!widget) return
-    widget.data = { ...widget.data, ...data }
+    if (!col || col.type !== 'widget') return
+    const installId = generateWidgetId()
+    const now = Date.now()
+    widgetsStore.addWidget({
+      installId,
+      name: `Widget ${installId.slice(4, 12)}`,
+      src: initial?.src ?? '',
+      autoRun: initial?.autoRun ?? false,
+      storeId: initial?.storeId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    if (col.sidebar === true) {
+      widgetsStore.addToSidebar(installId)
+    } else {
+      if (!col.widgetIds) col.widgetIds = []
+      col.widgetIds.push(installId)
+      save()
+    }
+  }
+
+  /**
+   * widget カラムから widget を取り除く。
+   * sidebar widget カラムなら本体削除 (コードも消える)、
+   * non-sidebar widget カラムならカラムからの参照剥がしのみ (本体ストアに残る)。
+   */
+  function removeWidget(columnId: string, installId: string) {
+    const col = getColumn(columnId)
+    if (!col || col.type !== 'widget') return
+    if (col.sidebar === true) {
+      widgetsStore.removeWidget(installId)
+    } else if (col.widgetIds) {
+      col.widgetIds = col.widgetIds.filter((id) => id !== installId)
+      save()
+    }
+  }
+
+  function reorderWidgetIds(columnId: string, ids: string[]) {
+    const col = getColumn(columnId)
+    if (!col || col.type !== 'widget') return
+    col.widgetIds = ids
     save()
   }
 
@@ -585,7 +619,7 @@ export const useDeckStore = defineStore('deck', () => {
     clear,
     addWidget,
     removeWidget,
-    updateWidgetData,
+    reorderWidgetIds,
     // Wallpaper (facade)
     wallpaper: computed(() => wallpaperStore.wallpaper),
     setWallpaper: wallpaperStore.setWallpaper,

--- a/src/stores/deckProfile.ts
+++ b/src/stores/deckProfile.ts
@@ -4,6 +4,7 @@ import { computed, ref, shallowRef } from 'vue'
 
 import { PERSIST_DEBOUNCE_MS } from '@/constants/persist'
 import type { DeckColumn, DeckProfile, DeckWindowLayout } from '@/stores/deck'
+import { useWidgetsStore, type WidgetMeta } from '@/stores/widgets'
 import * as settingsFs from '@/utils/settingsFs'
 import {
   getStorageJson,
@@ -27,31 +28,60 @@ function toFileFormat(profile: DeckProfile): Record<string, unknown> {
 }
 
 /**
- * Widget 単層化 (commit 8eb4bfe 以降) の読込時マイグレーション。
- * - `type: 'aiscriptConsole'` の widget 行は削除 (コードは失われる)。
- * - それ以外 (旧 `aiscriptApp` 等) は `type` フィールドを剥がして保持。
- * 削除件数は startup 時の toast 通知用に返す。
+ * Widget マイグレーション。
+ * - 旧 `type: 'aiscriptConsole'` の widget 行は削除 (コードは失われる)。
+ * - 旧 `widgets[]` は本体を抽出してストアに移送、カラムには `widgetIds[]` のみ残す。
+ * - 既に `widgetIds[]` 化済みのカラムは触らない (idempotent)。
+ * 削除件数と抽出した widget は呼び出し側でストアに登録するため返す。
  */
 function migrateWidgetColumns(columns: DeckColumn[]): {
   columns: DeckColumn[]
   droppedConsoleCount: number
+  extractedWidgets: WidgetMeta[]
+  sidebarSeed: string[]
 } {
   let droppedConsoleCount = 0
+  const extractedWidgets: WidgetMeta[] = []
+  const sidebarSeed: string[] = []
+  const now = Date.now()
   const migrated = columns.map((col) => {
-    if (col.type !== 'widget' || !col.widgets) return col
-    const cleaned = col.widgets.flatMap((w) => {
+    if (col.type !== 'widget') return col
+    if (!col.widgets) return col
+
+    const newIds: string[] = []
+    for (const w of col.widgets) {
       const legacyType = (w as { type?: string }).type
       if (legacyType === 'aiscriptConsole') {
         droppedConsoleCount++
-        return []
+        continue
       }
-      if (legacyType === undefined) return [w]
-      const { type: _t, ...rest } = w as typeof w & { type?: string }
-      return [rest]
-    })
-    return { ...col, widgets: cleaned }
+      // 既存 widget.id をそのまま installId に再利用
+      // (AiScript の `Mk:save` localStorage キー prefix `nd-aiscript-app-${id}:` を保全する最重要不変条件)
+      const installId = w.id
+      newIds.push(installId)
+      extractedWidgets.push({
+        installId,
+        name: `Widget ${installId.slice(4, 12)}`,
+        src: w.data?.code ?? '',
+        autoRun: w.data?.autoRun ?? false,
+        storeId: w.data?.storeId,
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // sidebar widget カラムの並びはストア外 sidebarWidgetIds に引き継ぐ
+    if (col.sidebar) sidebarSeed.push(...newIds)
+
+    const { widgets: _w, ...rest } = col
+    return { ...rest, widgetIds: newIds } as DeckColumn
   })
-  return { columns: migrated, droppedConsoleCount }
+  return {
+    columns: migrated,
+    droppedConsoleCount,
+    extractedWidgets,
+    sidebarSeed,
+  }
 }
 
 /** 起動時に累積する Console widget 削除件数。toast 表示後に 0 に戻す。 */
@@ -59,14 +89,34 @@ let pendingConsoleMigrationCount = 0
 /** マイグレーション適用後にディスク上のプロファイルファイルを書き直す必要があるか。 */
 let pendingConsoleMigrationFilesDirty = false
 
+/** マイグレーションで widgets[] → widgetIds[] への変換が起きたか。プロファイル再書込判定用 */
+let pendingWidgetExtractionDirty = false
+
+/** 抽出した widget を widgetsStore に流し込む (重複 installId は skip)。 */
+function pushExtractedWidgets(extracted: WidgetMeta[], sidebarSeed: string[]) {
+  if (extracted.length === 0 && sidebarSeed.length === 0) return
+  pendingWidgetExtractionDirty = true
+  const store = useWidgetsStore()
+  store.ensureLoaded()
+  for (const w of extracted) {
+    if (store.getWidget(w.installId)) continue
+    store.addWidget(w)
+  }
+  for (const id of sidebarSeed) {
+    store.addToSidebar(id)
+  }
+}
+
 /** Parse a profile file and assign an ID based on filename. */
 function fromFileFormat(
   filename: string,
   data: Record<string, unknown>,
 ): DeckProfile {
   const rawColumns = (data.columns as DeckColumn[]) || []
-  const { columns, droppedConsoleCount } = migrateWidgetColumns(rawColumns)
+  const { columns, droppedConsoleCount, extractedWidgets, sidebarSeed } =
+    migrateWidgetColumns(rawColumns)
   pendingConsoleMigrationCount += droppedConsoleCount
+  pushExtractedWidgets(extractedWidgets, sidebarSeed)
   return {
     id: filename,
     name: (data.name as string) || filename,
@@ -252,10 +302,10 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
   function loadProfilesFromStorage(): DeckProfile[] {
     const raw = getStorageJson<DeckProfile[]>(STORAGE_KEYS.deckProfiles, [])
     return raw.map((p) => {
-      const { columns, droppedConsoleCount } = migrateWidgetColumns(
-        p.columns ?? [],
-      )
+      const { columns, droppedConsoleCount, extractedWidgets, sidebarSeed } =
+        migrateWidgetColumns(p.columns ?? [])
       pendingConsoleMigrationCount += droppedConsoleCount
+      pushExtractedWidgets(extractedWidgets, sidebarSeed)
       return { ...p, columns }
     })
   }
@@ -598,8 +648,9 @@ export const useDeckProfileStore = defineStore('deckProfile', () => {
     flushConsoleMigrationNotice()
 
     // Rewrite files with migrated content so the next load is clean
-    if (pendingConsoleMigrationFilesDirty) {
+    if (pendingConsoleMigrationFilesDirty || pendingWidgetExtractionDirty) {
       pendingConsoleMigrationFilesDirty = false
+      pendingWidgetExtractionDirty = false
       persistProfilesToFiles(profilesData.value).catch((e) =>
         console.warn('[deckProfile] migration rewrite failed:', e),
       )

--- a/src/stores/widgets.ts
+++ b/src/stores/widgets.ts
@@ -1,0 +1,316 @@
+import JSON5 from 'json5'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+import * as settingsFs from '@/utils/settingsFs'
+import {
+  getStorageJson,
+  removeStorageByPrefix,
+  STORAGE_KEYS,
+  setStorageJson,
+} from '@/utils/storage'
+
+export interface WidgetMeta {
+  installId: string
+  name: string
+  src: string
+  autoRun: boolean
+  storeId?: string
+  createdAt: number
+  updatedAt: number
+}
+
+/** Metadata fields stored in *.meta.json5 (everything except src). */
+interface WidgetFileMeta {
+  installId: string
+  name: string
+  autoRun: boolean
+  storeId?: string
+  createdAt: number
+  updatedAt: number
+}
+
+function loadWidgetsFromStorage(): WidgetMeta[] {
+  return getStorageJson<WidgetMeta[]>(STORAGE_KEYS.widgets, [])
+}
+
+function saveWidgetsToStorage(widgets: WidgetMeta[]) {
+  setStorageJson(STORAGE_KEYS.widgets, widgets)
+}
+
+function loadSidebarOrderFromStorage(): string[] {
+  return getStorageJson<string[]>(STORAGE_KEYS.widgetsSidebarOrder, [])
+}
+
+function saveSidebarOrderToStorage(ids: string[]) {
+  setStorageJson(STORAGE_KEYS.widgetsSidebarOrder, ids)
+}
+
+export function generateWidgetId(): string {
+  return `wgt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export const useWidgetsStore = defineStore('widgets', () => {
+  const widgets = ref<WidgetMeta[]>([])
+  /**
+   * sidebar widget カラム (ナビバートグルで開閉される 1 個固定) に並べる widget の順序。
+   * カラムのライフサイクル外で永続化されるので、カラムを閉じても並びが消えない。
+   * non-sidebar widget カラムで作られた widget はここに自動追加されない。
+   */
+  const sidebarWidgetIds = ref<string[]>([])
+  let loaded = false
+  const initialized = ref(false)
+
+  function ensureLoaded() {
+    if (loaded) return
+    loaded = true
+    widgets.value = loadWidgetsFromStorage()
+    sidebarWidgetIds.value = loadSidebarOrderFromStorage()
+
+    if (settingsFs.isTauri) {
+      initFileStorage().catch((e) =>
+        console.warn('[widgets] file storage init failed:', e),
+      )
+    } else {
+      initialized.value = true
+    }
+  }
+
+  /** sidebar 並び順から不在 widget を排除 (起動時のクリーンアップ) */
+  function pruneSidebarOrder() {
+    const present = new Set(widgets.value.map((w) => w.installId))
+    const filtered = sidebarWidgetIds.value.filter((id) => present.has(id))
+    if (filtered.length !== sidebarWidgetIds.value.length) {
+      sidebarWidgetIds.value = filtered
+      saveSidebarOrderToStorage(filtered)
+    }
+  }
+
+  function persist(widget?: WidgetMeta) {
+    saveWidgetsToStorage(widgets.value)
+    if (initialized.value) {
+      const task = widget ? persistSingleWidget(widget) : persistAllToFiles()
+      task.catch((e) =>
+        console.warn('[widgets] failed to persist to files:', e),
+      )
+    }
+  }
+
+  async function persistSingleWidget(widget: WidgetMeta): Promise<void> {
+    const baseName = widget.name || widget.installId
+    const srcFilename = settingsFs.widgetSrcFilename(baseName)
+    const metaFilename = settingsFs.widgetMetaFilename(baseName)
+
+    const meta: WidgetFileMeta = {
+      installId: widget.installId,
+      name: widget.name,
+      autoRun: widget.autoRun,
+      ...(widget.storeId ? { storeId: widget.storeId } : {}),
+      createdAt: widget.createdAt,
+      updatedAt: widget.updatedAt,
+    }
+    await Promise.all([
+      settingsFs.writeWidgetFile(srcFilename, widget.src),
+      settingsFs.writeWidgetFile(metaFilename, JSON5.stringify(meta, null, 2)),
+    ])
+  }
+
+  async function persistAllToFiles(): Promise<void> {
+    await Promise.all(widgets.value.map((w) => persistSingleWidget(w)))
+  }
+
+  async function deleteWidgetFiles(widget: WidgetMeta): Promise<void> {
+    const baseName = widget.name || widget.installId
+    await Promise.all([
+      settingsFs.deleteWidgetFile(settingsFs.widgetSrcFilename(baseName)),
+      settingsFs.deleteWidgetFile(settingsFs.widgetMetaFilename(baseName)),
+    ])
+  }
+
+  /** Load widgets from files. Files are source of truth. */
+  async function initFileStorage(): Promise<void> {
+    const allFiles = await settingsFs.listWidgetFiles()
+    const metaFiles = allFiles.filter((f) => f.endsWith('.meta.json5'))
+
+    if (metaFiles.length > 0) {
+      const results = await Promise.all(
+        metaFiles.map(async (metaFile) => {
+          try {
+            const srcFile = metaFile.replace(/\.meta\.json5$/, '.is')
+            const [metaContent, src] = await Promise.all([
+              settingsFs.readWidgetFile(metaFile),
+              allFiles.includes(srcFile)
+                ? settingsFs.readWidgetFile(srcFile)
+                : Promise.resolve(''),
+            ])
+            const meta = JSON5.parse(metaContent) as WidgetFileMeta
+            return {
+              installId: meta.installId || metaFile,
+              name: meta.name || metaFile,
+              src,
+              autoRun: meta.autoRun ?? false,
+              storeId: meta.storeId,
+              createdAt: meta.createdAt ?? Date.now(),
+              updatedAt: meta.updatedAt ?? Date.now(),
+            } as WidgetMeta
+          } catch (e) {
+            console.warn(`[widgets] failed to parse ${metaFile}:`, e)
+            return null
+          }
+        }),
+      )
+      const fileWidgets = results.filter((w): w is WidgetMeta => w !== null)
+
+      if (fileWidgets.length > 0) {
+        // 並び順を確定するため createdAt 昇順でソート (ファイル列挙順は OS 依存)
+        fileWidgets.sort((a, b) => a.createdAt - b.createdAt)
+        // 初期化 (この async 関数が走る間) にメモリ追加された widget は
+        // ファイルにはまだ無いのでマージしないと消える。installId で dedup。
+        const fileIds = new Set(fileWidgets.map((w) => w.installId))
+        const memoryOnly = widgets.value.filter(
+          (w) => !fileIds.has(w.installId),
+        )
+        widgets.value = [...fileWidgets, ...memoryOnly]
+        saveWidgetsToStorage(widgets.value)
+        // 在メモリだけだった widget をファイル化 (次回起動時に消えないように)
+        if (memoryOnly.length > 0) {
+          Promise.all(memoryOnly.map((w) => persistSingleWidget(w))).catch(
+            (e) =>
+              console.warn(
+                '[widgets] failed to persist memory-only widgets:',
+                e,
+              ),
+          )
+        }
+      }
+    }
+
+    initialized.value = true
+    pruneSidebarOrder()
+
+    // localStorage 由来のデータがあるが files が無い場合の片方向移行
+    if (metaFiles.length === 0 && widgets.value.length > 0) {
+      persistAllToFiles().catch((e) =>
+        console.warn('[widgets] migration to files failed:', e),
+      )
+    }
+  }
+
+  function addWidget(widget: WidgetMeta) {
+    ensureLoaded()
+    widgets.value.push(widget)
+    persist(widget)
+  }
+
+  function removeWidget(installId: string) {
+    ensureLoaded()
+    const removed = widgets.value.find((w) => w.installId === installId)
+    // AiScript の Mk:save 領域を一掃 (storagePrefix='app-${installId}')
+    removeStorageByPrefix(STORAGE_KEYS.aiscriptStorage(`app-${installId}`))
+    widgets.value = widgets.value.filter((w) => w.installId !== installId)
+    saveWidgetsToStorage(widgets.value)
+    // sidebar 並びからも自動的に剥がす
+    if (sidebarWidgetIds.value.includes(installId)) {
+      sidebarWidgetIds.value = sidebarWidgetIds.value.filter(
+        (id) => id !== installId,
+      )
+      saveSidebarOrderToStorage(sidebarWidgetIds.value)
+    }
+    if (initialized.value && removed) {
+      deleteWidgetFiles(removed).catch((e) =>
+        console.warn('[widgets] failed to delete widget files:', e),
+      )
+    }
+  }
+
+  function addToSidebar(installId: string) {
+    ensureLoaded()
+    if (sidebarWidgetIds.value.includes(installId)) return
+    sidebarWidgetIds.value = [...sidebarWidgetIds.value, installId]
+    saveSidebarOrderToStorage(sidebarWidgetIds.value)
+  }
+
+  function removeFromSidebar(installId: string) {
+    ensureLoaded()
+    if (!sidebarWidgetIds.value.includes(installId)) return
+    sidebarWidgetIds.value = sidebarWidgetIds.value.filter(
+      (id) => id !== installId,
+    )
+    saveSidebarOrderToStorage(sidebarWidgetIds.value)
+  }
+
+  function reorderSidebar(ids: string[]) {
+    ensureLoaded()
+    sidebarWidgetIds.value = ids
+    saveSidebarOrderToStorage(ids)
+  }
+
+  function updateSrc(installId: string, src: string) {
+    ensureLoaded()
+    const widget = widgets.value.find((w) => w.installId === installId)
+    if (widget) {
+      widget.src = src
+      widget.updatedAt = Date.now()
+      persist(widget)
+    }
+  }
+
+  function setAutoRun(installId: string, autoRun: boolean) {
+    ensureLoaded()
+    const widget = widgets.value.find((w) => w.installId === installId)
+    if (widget) {
+      widget.autoRun = autoRun
+      widget.updatedAt = Date.now()
+      persist(widget)
+    }
+  }
+
+  function setStoreId(installId: string, storeId: string | undefined) {
+    ensureLoaded()
+    const widget = widgets.value.find((w) => w.installId === installId)
+    if (widget) {
+      widget.storeId = storeId
+      widget.updatedAt = Date.now()
+      persist(widget)
+    }
+  }
+
+  function renameWidget(installId: string, newName: string) {
+    ensureLoaded()
+    const widget = widgets.value.find((w) => w.installId === installId)
+    if (!widget) return
+
+    const oldBaseName = widget.name || widget.installId
+    widget.name = newName
+    widget.updatedAt = Date.now()
+    persist(widget)
+
+    if (initialized.value && oldBaseName !== newName) {
+      deleteWidgetFiles({ ...widget, name: oldBaseName } as WidgetMeta).catch(
+        (e) => console.warn('[widgets] failed to delete old widget files:', e),
+      )
+    }
+  }
+
+  function getWidget(installId: string): WidgetMeta | undefined {
+    ensureLoaded()
+    return widgets.value.find((w) => w.installId === installId)
+  }
+
+  return {
+    widgets,
+    sidebarWidgetIds,
+    initialized,
+    ensureLoaded,
+    addWidget,
+    removeWidget,
+    updateSrc,
+    setAutoRun,
+    setStoreId,
+    renameWidget,
+    getWidget,
+    addToSidebar,
+    removeFromSidebar,
+    reorderSidebar,
+  }
+})

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -344,3 +344,43 @@ export async function renamePluginFile(
 ): Promise<void> {
   return renameSettingsFile(PLUGINS_DIR, oldFilename, newFilename)
 }
+
+// --- Widget helpers ---
+
+const WIDGETS_DIR = 'widgets'
+const WIDGET_SRC_EXT = '.is'
+const WIDGET_META_EXT = '.meta.json5'
+
+export function widgetSrcFilename(name: string): string {
+  return sanitizeFilename(name) + WIDGET_SRC_EXT
+}
+
+export function widgetMetaFilename(name: string): string {
+  return sanitizeFilename(name) + WIDGET_META_EXT
+}
+
+export async function listWidgetFiles(): Promise<string[]> {
+  return listSettingsFiles(WIDGETS_DIR)
+}
+
+export async function readWidgetFile(filename: string): Promise<string> {
+  return readSettingsFile(WIDGETS_DIR, filename)
+}
+
+export async function writeWidgetFile(
+  filename: string,
+  content: string,
+): Promise<void> {
+  return writeSettingsFile(WIDGETS_DIR, filename, content)
+}
+
+export async function deleteWidgetFile(filename: string): Promise<void> {
+  return deleteSettingsFile(WIDGETS_DIR, filename)
+}
+
+export async function renameWidgetFile(
+  oldFilename: string,
+  newFilename: string,
+): Promise<void> {
+  return renameSettingsFile(WIDGETS_DIR, oldFilename, newFilename)
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -77,6 +77,8 @@ export const STORAGE_KEYS = {
   // Per-feature
   keybinds: 'nd-keybinds',
   plugins: 'nd-plugins',
+  widgets: 'nd-widgets',
+  widgetsSidebarOrder: 'nd-widgets-sidebar-order',
   recentEmojis: 'nd-recent-emojis',
   emojisCache: 'emojis_cache',
   performance: 'nd-performance',


### PR DESCRIPTION
## Summary

v0.11.7 リリース。widget カラムのリファクタと UI/UX 整理。widget 本体をカラム外ストアに切り出し、UI/UX を整理、アイコンを `layout-dashboard` に統一。

## Changelog (v0.11.6 → v0.11.7)

### Refactor

- refactor(widgets): widget 本体をカラム外ストアに切り出し
- refactor(widgets): widget アイコンを layout-dashboard に統一

### Features

- feat(widgets): widget カラムの UI/UX を整理

## Test plan

- [x] `pnpm typecheck` 通過 (pre-commit hook)
- [x] `cargo check` 通過
- [ ] CI (lint / typecheck / test) 通過を待つ
- [ ] マージ後にタグ `v0.11.7` を push してリリースワークフローをトリガー

🤖 Generated with [Claude Code](https://claude.com/claude-code)