### PR TITLE
perf(query): drop note bodies from Rust read model (id-only design)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -351,18 +351,33 @@ canonical key（serde JSON）で同一 query を dedup し、`subscriber_count` 
 - `query_set_runtime_state(queryId, state)` — `live | warm | suspended`。live ↔ suspended 遷移時は対応する subscription も resume / suspend
 - `query_close(queryId)` — refcount-- し 0 になったら stream も unsubscribe
 - `query_get_snapshot(queryId)` — メタデータ
-- `query_get_read_model_snapshot(queryId, limit?)` — 初期 snapshot（items + revision）
+- `query_get_read_model_snapshot(queryId, limit?)` — 初期 snapshot（item_ids + revision）
 
-**Read Model:**
+**Read Model: id-only design**
 
 ```text
 QueryEntry {
-    items: Vec<Value>,    // 上限 200, newest-first, dedup by id
+    recent_ids: VecDeque<String>,  // 上限 200, newest-first
+    id_set: HashSet<String>,       // O(1) dedupe lookup
     revision: u64,
     runtime_state: Live | Warm | Suspended,
     source_subscription_id: Option<String>,
 }
 ```
+
+note 本体は保持せず、id 列だけを順序付きで持つ。理由:
+
+1. **二重化回避**: note 本体は JS 側 noteStore (`src/stores/notes.ts`) が唯一の真実。Rust 側に複製を持たない。
+2. **dedupe 専用**: insert/delete 時の同一 id 検出を `id_set` で O(1) に。
+3. **Suspended で全クリア**: `set_runtime_state(Suspended)` 遷移時に `recent_ids` / `id_set` / `pending` を破棄。`apply()` も Suspended 中は gate される。Live 復帰時は JS 側 noteStore + 各カラムの orderedIds で表示維持、新規 delta のみ流入する。
+
+**delta は note 本体を含む**: pending.inserts / QueryDelta.inserts は依然として `Vec<Value>` で note 本体を JS に流す（16ms debounce window でしか保持されない短期バッファ）。JS 側はこれを noteStore に put する。
+
+**将来の拡張余地（別 PR）:**
+
+- **disk 永続化**: アプリ再起動時の cold-start 高速化のため `recent_ids` を sqlite に永続化。snapshot 取得時に id list を返し、JS 側で notecli の note cache から hydrate する。
+- **同 query 並列共有**: 同じ query (例: Home Timeline) を複数カラムで並列表示するときに id list を共有して二重 fetch を回避。
+- **新着件数バッジ**: `revision` 差分や `recent_ids` の長さから新着数を計算し UI に表示。
 
 `StreamChange::from_event` が以下の stream-* を `Insert(item)` / `Delete(id)` に正規化し `apply()` で entry に反映:
 
@@ -379,9 +394,9 @@ QueryEntry {
 **WebView 側（`useQuerySubscription`）:**
 
 - `open()` で query を開いて queryId を取得
-- `query_get_read_model_snapshot` で初期 items / revision を読む
-- `events.queryDelta.listen()` で `queryId` 一致 + 新しい revision のみ items を増分更新
-- `isLive` 引数で `query_set_runtime_state` を呼び、Rust 側 subscription の suspend/resume を駆動
+- `query_get_read_model_snapshot` で初期 itemIds / revision を読む
+- `events.queryDelta.listen()` で `queryId` 一致 + 新しい revision のみ itemIds を増分更新（delta.inserts は note 本体を含むので消費側が noteStore に put）
+- `isLive` 引数で `query_set_runtime_state` を呼び、Rust 側 subscription の suspend/resume を駆動。Suspended → Live 復帰時は snapshot を再フェッチして itemIds を空からやり直す
 - `onScopeDispose` で `query_close` を呼び refcount を返す
 
 **現状（2026-04-27 時点）:**

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -373,12 +373,6 @@ note 本体は保持せず、id 列だけを順序付きで持つ。理由:
 
 **delta は note 本体を含む**: pending.inserts / QueryDelta.inserts は依然として `Vec<Value>` で note 本体を JS に流す（16ms debounce window でしか保持されない短期バッファ）。JS 側はこれを noteStore に put する。
 
-**将来の拡張余地（別 PR）:**
-
-- **disk 永続化**: アプリ再起動時の cold-start 高速化のため `recent_ids` を sqlite に永続化。snapshot 取得時に id list を返し、JS 側で notecli の note cache から hydrate する。
-- **同 query 並列共有**: 同じ query (例: Home Timeline) を複数カラムで並列表示するときに id list を共有して二重 fetch を回避。
-- **新着件数バッジ**: `revision` 差分や `recent_ids` の長さから新着数を計算し UI に表示。
-
 `StreamChange::from_event` が以下の stream-* を `Insert(item)` / `Delete(id)` に正規化し `apply()` で entry に反映:
 
 - `stream-note` / `stream-mention` → `payload.note`

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -83,7 +83,10 @@ pub struct QuerySnapshot {
 pub struct QueryReadModelSnapshot {
     pub query_id: String,
     pub revision: u64,
-    pub items: Vec<Value>,
+    /// Note ids in display order (newest first). 消費側は JS noteStore から
+    /// hydrate するか、未取得 id を adapter API でフェッチする。note 本体は
+    /// Rust 側に持たない (二重化回避)。
+    pub item_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
@@ -133,10 +136,16 @@ struct QueryEntry {
     subscriber_count: u32,
     revision: u64,
     source_subscription_id: Option<String>,
-    items: Vec<Value>,
+    /// Recent note ids in display order (newest first). `id_set` と一致する。
+    /// note 本体は保持せず、JS noteStore (src/stores/notes.ts) が唯一の真実。
+    /// dedupe (insert で同一 id を retain しない) と snapshot で消費側に hydrate
+    /// のヒントを返すために使う。
+    recent_ids: VecDeque<String>,
+    /// O(1) dedupe lookup。`recent_ids` と等しい集合 (insert/delete で同期管理)。
+    id_set: HashSet<String>,
     /// Accumulated changes since the last delta flush. `None` when no events
-    /// have arrived in the current window. Items / revision are still applied
-    /// immediately to the entry; only the emission is batched.
+    /// have arrived in the current window. Note 本体は pending.inserts に乗せて
+    /// JS 側に流す (16ms debounce window でしか保持されない短期バッファ)。
     pending: Option<PendingDelta>,
 }
 
@@ -233,7 +242,8 @@ impl QueryRuntime {
             subscriber_count: 1,
             revision: 1,
             source_subscription_id: None,
-            items: Vec::new(),
+            recent_ids: VecDeque::new(),
+            id_set: HashSet::new(),
             pending: None,
         };
         let result = snapshot(&entry);
@@ -371,7 +381,7 @@ impl QueryRuntime {
         Ok(Some(QueryReadModelSnapshot {
             query_id: entry.query_id.clone(),
             revision: entry.revision,
-            items: entry.items.iter().take(limit).cloned().collect(),
+            item_ids: entry.recent_ids.iter().take(limit).cloned().collect(),
         }))
     }
 
@@ -523,9 +533,9 @@ impl<'a> StreamChange<'a> {
         })
     }
 
-    /// items / revision を即時更新しつつ、emit するための変更を `entry.pending`
-    /// に積む。返り値は「flusher を起こすべきか」のフラグ (= 何かが pending に
-    /// 入ったか)。
+    /// recent_ids / id_set / revision を即時更新しつつ、emit するための変更を
+    /// `entry.pending` に積む。返り値は「flusher を起こすべきか」のフラグ
+    /// (= 何かが pending に入ったか)。
     fn apply(self, entry: &mut QueryEntry) -> bool {
         match self.kind {
             StreamChangeKind::Insert(item) => {
@@ -533,12 +543,17 @@ impl<'a> StreamChange<'a> {
                 else {
                     return false;
                 };
-                entry
-                    .items
-                    .retain(|i| i.get("id").and_then(Value::as_str) != Some(&id));
-                entry.items.insert(0, item.clone());
-                if entry.items.len() > MAX_READ_MODEL_ITEMS {
-                    entry.items.truncate(MAX_READ_MODEL_ITEMS);
+                if entry.id_set.contains(&id) {
+                    // 既存 id は順序を更新するため一度抜く (同じ Vec 上で先頭に詰め直す)。
+                    entry.recent_ids.retain(|i| i != &id);
+                } else {
+                    entry.id_set.insert(id.clone());
+                }
+                entry.recent_ids.push_front(id);
+                while entry.recent_ids.len() > MAX_READ_MODEL_ITEMS {
+                    if let Some(evicted) = entry.recent_ids.pop_back() {
+                        entry.id_set.remove(&evicted);
+                    }
                 }
                 entry.revision = entry.revision.saturating_add(1);
                 entry
@@ -549,13 +564,10 @@ impl<'a> StreamChange<'a> {
                 true
             }
             StreamChangeKind::Delete(id) => {
-                let before = entry.items.len();
-                entry
-                    .items
-                    .retain(|i| i.get("id").and_then(Value::as_str) != Some(id.as_str()));
-                if entry.items.len() == before {
+                if !entry.id_set.remove(&id) {
                     return false;
                 }
+                entry.recent_ids.retain(|i| i != &id);
                 entry.revision = entry.revision.saturating_add(1);
                 entry
                     .pending
@@ -1025,11 +1037,8 @@ mod tests {
         assert!(rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1")));
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert_eq!(snap.items.len(), 1);
-        assert_eq!(
-            snap.items[0].get("id").and_then(Value::as_str),
-            Some("n1")
-        );
+        assert_eq!(snap.item_ids.len(), 1);
+        assert_eq!(snap.item_ids[0], "n1");
     }
 
     /// T5: 存在しない id の delete は false。存在する id の delete は revision++。
@@ -1051,12 +1060,12 @@ mod tests {
         assert!(rev_after > rev_before, "delete で revision が上がるはず");
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert!(snap.items.is_empty());
+        assert!(snap.item_ids.is_empty());
     }
 
-    /// T6: stream-note-updated (reaction 等) は items は変えず、pending.updates にだけ積む。
+    /// T6: stream-note-updated (reaction 等) は recent_ids は変えず、pending.updates にだけ積む。
     #[test]
-    fn ingest_update_does_not_modify_items() {
+    fn ingest_update_does_not_modify_recent_ids() {
         let rt = QueryRuntime::default();
         let s = open_home(&rt, "acct-1");
         rt.attach_stream_subscription(&s.query_id, "sub-A".into())
@@ -1069,7 +1078,7 @@ mod tests {
         assert!(rt.ingest_stream_event("stream-note-updated", &reaction_payload("sub-A", "n1")));
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert_eq!(snap.items.len(), 1, "reaction で items は変わらない");
+        assert_eq!(snap.item_ids.len(), 1, "reaction で recent_ids は変わらない");
 
         let drained = rt.drain_pending();
         assert_eq!(drained.len(), 1);
@@ -1080,7 +1089,7 @@ mod tests {
         assert!(drained[0].deletes.is_empty());
     }
 
-    /// T7: MAX_READ_MODEL_ITEMS + 1 件 insert で items は MAX に切り詰められる。
+    /// T7: MAX_READ_MODEL_ITEMS + 1 件 insert で recent_ids は MAX に切り詰められる。
     #[test]
     fn truncate_at_max() {
         let rt = QueryRuntime::default();
@@ -1094,7 +1103,7 @@ mod tests {
         }
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert_eq!(snap.items.len(), MAX_READ_MODEL_ITEMS);
+        assert_eq!(snap.item_ids.len(), MAX_READ_MODEL_ITEMS);
     }
 
     /// T8: drain_pending は積まれた pending を 1 度だけ返し、再度呼ぶと空。新規イベントで再び返る。
@@ -1134,10 +1143,10 @@ mod tests {
         }
 
         let limited = rt.read_model_snapshot(&s.query_id, Some(10)).unwrap().unwrap();
-        assert_eq!(limited.items.len(), 10);
+        assert_eq!(limited.item_ids.len(), 10);
 
         let unlimited = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert_eq!(unlimited.items.len(), 50);
+        assert_eq!(unlimited.item_ids.len(), 50);
     }
 
     /// T10: attach されていない subscription_id の event は false で破棄される。
@@ -1149,6 +1158,6 @@ mod tests {
         assert!(!rt.ingest_stream_event("stream-note", &note_payload("sub-orphan", "n1")));
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert!(snap.items.is_empty());
+        assert!(snap.item_ids.is_empty());
     }
 }

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -926,3 +926,229 @@ fn account_id(key: &QueryKey) -> &str {
         | QueryKey::ChatRoom { account_id, .. } => account_id,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn home_key(account: &str) -> QueryKey {
+        QueryKey::Timeline {
+            account_id: account.into(),
+            timeline_type: TimelineType::new("home"),
+            list_id: None,
+        }
+    }
+
+    fn open_home(rt: &QueryRuntime, account: &str) -> QuerySnapshot {
+        rt.open(home_key(account)).expect("open should succeed")
+    }
+
+    fn note_payload(sub_id: &str, note_id: &str) -> Value {
+        json!({
+            "subscriptionId": sub_id,
+            "note": { "id": note_id }
+        })
+    }
+
+    fn delete_payload(sub_id: &str, note_id: &str) -> Value {
+        json!({
+            "subscriptionId": sub_id,
+            "noteId": note_id,
+            "updateType": "deleted"
+        })
+    }
+
+    fn reaction_payload(sub_id: &str, note_id: &str) -> Value {
+        json!({
+            "subscriptionId": sub_id,
+            "noteId": note_id,
+            "updateType": "reacted",
+            "body": { "reaction": ":+1:", "userId": "u1" }
+        })
+    }
+
+    /// T1: 同一 key で 2 回 open すると subscriber=2、query_id は同一、
+    /// revision は 1 回目で 1、2 回目で 2 になる。
+    #[test]
+    fn open_creates_entry_and_increments_revision() {
+        let rt = QueryRuntime::default();
+        let s1 = open_home(&rt, "acct-1");
+        assert_eq!(s1.subscriber_count, 1);
+        assert_eq!(s1.revision, 1);
+
+        let s2 = open_home(&rt, "acct-1");
+        assert_eq!(s2.query_id, s1.query_id);
+        assert_eq!(s2.subscriber_count, 2);
+        assert_eq!(s2.revision, 2);
+    }
+
+    /// T2: 2 回 open → 2 回 close で entry が消える。snapshot が None を返す。
+    #[test]
+    fn close_decrements_then_removes() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        let _ = open_home(&rt, "acct-1");
+
+        // 1 回目 close: subscriber 1 残るので Some(None)
+        let after_first = rt.close(&s.query_id).unwrap();
+        assert!(after_first.is_none(), "subscription はまだ生きているはず");
+        assert!(rt.snapshot(&s.query_id).unwrap().is_some());
+
+        // 2 回目 close: 0 になり entry が消える。subscription が attach されていないので戻り値は None。
+        let after_second = rt.close(&s.query_id).unwrap();
+        assert!(after_second.is_none());
+        assert!(rt.snapshot(&s.query_id).unwrap().is_none());
+    }
+
+    /// T3: attach 後の close は `(account_id, subscription_id)` を返す。
+    #[test]
+    fn close_returns_subscription_for_unsubscribe() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        let result = rt.close(&s.query_id).unwrap();
+        assert_eq!(result, Some(("acct-1".to_string(), "sub-A".to_string())));
+    }
+
+    /// T4: 同じ id を 2 回 insert しても read model は長さ 1。
+    #[test]
+    fn ingest_insert_dedupes_by_id() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        assert!(rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1")));
+        assert!(rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1")));
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(snap.items.len(), 1);
+        assert_eq!(
+            snap.items[0].get("id").and_then(Value::as_str),
+            Some("n1")
+        );
+    }
+
+    /// T5: 存在しない id の delete は false。存在する id の delete は revision++。
+    #[test]
+    fn ingest_delete_removes_only_when_present() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        // unknown id - 何も起きない
+        assert!(!rt.ingest_stream_event("stream-note-updated", &delete_payload("sub-A", "ghost")));
+
+        // 既存 id - 削除される
+        assert!(rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1")));
+        let rev_before = rt.snapshot(&s.query_id).unwrap().unwrap().revision;
+        assert!(rt.ingest_stream_event("stream-note-updated", &delete_payload("sub-A", "n1")));
+        let rev_after = rt.snapshot(&s.query_id).unwrap().unwrap().revision;
+        assert!(rev_after > rev_before, "delete で revision が上がるはず");
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert!(snap.items.is_empty());
+    }
+
+    /// T6: stream-note-updated (reaction 等) は items は変えず、pending.updates にだけ積む。
+    #[test]
+    fn ingest_update_does_not_modify_items() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1"));
+
+        // drain して initial insert を流し、テスト対象を分離
+        let _ = rt.drain_pending();
+
+        assert!(rt.ingest_stream_event("stream-note-updated", &reaction_payload("sub-A", "n1")));
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(snap.items.len(), 1, "reaction で items は変わらない");
+
+        let drained = rt.drain_pending();
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].updates.len(), 1);
+        assert_eq!(drained[0].updates[0].note_id, "n1");
+        assert_eq!(drained[0].updates[0].update_type, "reacted");
+        assert!(drained[0].inserts.is_empty());
+        assert!(drained[0].deletes.is_empty());
+    }
+
+    /// T7: MAX_READ_MODEL_ITEMS + 1 件 insert で items は MAX に切り詰められる。
+    #[test]
+    fn truncate_at_max() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        for i in 0..(MAX_READ_MODEL_ITEMS + 1) {
+            let id = format!("n{i}");
+            rt.ingest_stream_event("stream-note", &note_payload("sub-A", &id));
+        }
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(snap.items.len(), MAX_READ_MODEL_ITEMS);
+    }
+
+    /// T8: drain_pending は積まれた pending を 1 度だけ返し、再度呼ぶと空。新規イベントで再び返る。
+    #[test]
+    fn pending_query_ids_drained_atomically() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1"));
+        let first = rt.drain_pending();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].inserts.len(), 1);
+
+        // 2 回目はもう空
+        let second = rt.drain_pending();
+        assert!(second.is_empty(), "drain は冪等で 2 度目は空");
+
+        // 新規イベントで再度積まれる
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n2"));
+        let third = rt.drain_pending();
+        assert_eq!(third.len(), 1);
+    }
+
+    /// T9: read_model_snapshot は limit を尊重し、None なら MAX_READ_MODEL_ITEMS まで返す。
+    #[test]
+    fn read_model_snapshot_respects_limit() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+
+        for i in 0..50 {
+            let id = format!("n{i}");
+            rt.ingest_stream_event("stream-note", &note_payload("sub-A", &id));
+        }
+
+        let limited = rt.read_model_snapshot(&s.query_id, Some(10)).unwrap().unwrap();
+        assert_eq!(limited.items.len(), 10);
+
+        let unlimited = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(unlimited.items.len(), 50);
+    }
+
+    /// T10: attach されていない subscription_id の event は false で破棄される。
+    #[test]
+    fn unknown_subscription_id_is_dropped() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        // attach せずに event を流す
+        assert!(!rt.ingest_stream_event("stream-note", &note_payload("sub-orphan", "n1")));
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert!(snap.items.is_empty());
+    }
+}

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -308,15 +308,40 @@ impl QueryRuntime {
         state: QueryRuntimeState,
     ) -> Result<QuerySnapshot, NoteDeckError> {
         let mut inner = self.lock()?;
-        let entry = inner
-            .entries
-            .get_mut(query_id)
-            .ok_or_else(|| runtime_error(format!("unknown query id: {query_id}")))?;
-        if entry.runtime_state != state {
+        let became_suspended = {
+            let entry = inner
+                .entries
+                .get_mut(query_id)
+                .ok_or_else(|| runtime_error(format!("unknown query id: {query_id}")))?;
+            if entry.runtime_state == state {
+                return Ok(snapshot(entry));
+            }
             entry.runtime_state = state;
             entry.revision = entry.revision.saturating_add(1);
+            if state == QueryRuntimeState::Suspended {
+                // 不可視カラムは items を保持しない。Live 復帰時は JS 側 noteStore +
+                // 各カラムの orderedIds で表示が維持され、新規 delta だけが流入する。
+                entry.recent_ids.clear();
+                entry.recent_ids.shrink_to_fit();
+                entry.id_set.clear();
+                entry.id_set.shrink_to_fit();
+                entry.pending = None;
+                true
+            } else {
+                false
+            }
+        };
+        let snap = {
+            let entry = inner
+                .entries
+                .get(query_id)
+                .expect("entry just verified to exist");
+            snapshot(entry)
+        };
+        if became_suspended {
+            inner.pending_query_ids.remove(query_id);
         }
-        Ok(snapshot(entry))
+        Ok(snap)
     }
 
     /// 既存の warm timer を abort して取り除く。state が Warm 以外に
@@ -537,6 +562,12 @@ impl<'a> StreamChange<'a> {
     /// `entry.pending` に積む。返り値は「flusher を起こすべきか」のフラグ
     /// (= 何かが pending に入ったか)。
     fn apply(self, entry: &mut QueryEntry) -> bool {
+        // Suspended カラムには何も書き込まない (set_runtime_state(Suspended)
+        // で recent_ids/pending を空にしてあるため)。WebSocket subscription
+        // 自体も suspend されているはずだが、レース対策として gate しておく。
+        if entry.runtime_state == QueryRuntimeState::Suspended {
+            return false;
+        }
         match self.kind {
             StreamChangeKind::Insert(item) => {
                 let Some(id) = item.get("id").and_then(Value::as_str).map(str::to_string)
@@ -1159,5 +1190,88 @@ mod tests {
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
         assert!(snap.item_ids.is_empty());
+    }
+
+    /// T11: Suspended に遷移すると recent_ids と pending が完全にクリアされる。
+    #[test]
+    fn suspended_state_clears_recent_ids_and_pending() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+        // 5 件 insert
+        for i in 0..5 {
+            rt.ingest_stream_event("stream-note", &note_payload("sub-A", &format!("n{i}")));
+        }
+        // pending には 5 件積まれている (まだ drain していない)
+        let pre = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(pre.item_ids.len(), 5);
+
+        rt.set_runtime_state(&s.query_id, QueryRuntimeState::Suspended)
+            .unwrap();
+
+        let post = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert!(post.item_ids.is_empty(), "Suspended で recent_ids クリア");
+        // 蓄積していた pending も破棄される (drain は空)
+        let drained = rt.drain_pending();
+        assert!(drained.is_empty(), "Suspended で pending もクリア");
+    }
+
+    /// T12: Suspended 中の event は false を返し、recent_ids も pending も増えない。
+    #[test]
+    fn suspended_state_drops_incoming_events() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+        rt.set_runtime_state(&s.query_id, QueryRuntimeState::Suspended)
+            .unwrap();
+
+        // Suspended 中はレース対策で gate される
+        assert!(!rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1")));
+
+        let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert!(snap.item_ids.is_empty());
+        assert!(rt.drain_pending().is_empty());
+    }
+
+    /// T13: Suspended → Live 復帰直後は recent_ids 空、新規 insert で 1 件になる。
+    #[test]
+    fn live_after_suspended_starts_empty_until_new_event() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "old"));
+
+        rt.set_runtime_state(&s.query_id, QueryRuntimeState::Suspended)
+            .unwrap();
+        rt.set_runtime_state(&s.query_id, QueryRuntimeState::Live)
+            .unwrap();
+
+        let after_resume = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert!(after_resume.item_ids.is_empty(), "復帰直後は空");
+
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "fresh"));
+        let after_event = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
+        assert_eq!(after_event.item_ids, vec!["fresh".to_string()]);
+    }
+
+    /// T14: Suspended 遷移時に pending_query_ids からも除去される (drain が空 Vec)。
+    #[test]
+    fn pending_query_ids_purged_on_suspend() {
+        let rt = QueryRuntime::default();
+        let s = open_home(&rt, "acct-1");
+        rt.attach_stream_subscription(&s.query_id, "sub-A".into())
+            .unwrap();
+        // pending に何か積む
+        rt.ingest_stream_event("stream-note", &note_payload("sub-A", "n1"));
+
+        // Suspended に遷移すると pending_query_ids からも消える
+        rt.set_runtime_state(&s.query_id, QueryRuntimeState::Suspended)
+            .unwrap();
+
+        let drained = rt.drain_pending();
+        assert!(drained.is_empty(), "Suspended で drain は空 Vec");
     }
 }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1921,7 +1921,13 @@ export type QueryDelta = { queryId: string; revision: number; inserts: JsonValue
  */
 updates: NoteUpdate[] }
 export type QueryKey = { kind: "timeline"; account_id: string; timeline_type: TimelineType; list_id: string | null } | { kind: "antenna"; account_id: string; antenna_id: string } | { kind: "channel"; account_id: string; channel_id: string } | { kind: "role"; account_id: string; role_id: string } | { kind: "mentions"; account_id: string } | { kind: "notifications"; account_id: string } | { kind: "chatUser"; account_id: string; other_id: string } | { kind: "chatRoom"; account_id: string; room_id: string }
-export type QueryReadModelSnapshot = { queryId: string; revision: number; items: JsonValue[] }
+export type QueryReadModelSnapshot = { queryId: string; revision: number; 
+/**
+ * Note ids in display order (newest first). 消費側は JS noteStore から
+ * hydrate するか、未取得 id を adapter API でフェッチする。note 本体は
+ * Rust 側に持たない (二重化回避)。
+ */
+itemIds: string[] }
 export type QueryRuntimeState = "live" | "warm" | "suspended"
 export type QuerySnapshot = { queryId: string; key: QueryKey; runtimeState: QueryRuntimeState; subscriberCount: number; revision: number; sourceSubscriptionId: string | null }
 export type ReactionInfo = { user: NormalizedUser; reaction: string }

--- a/src/composables/useQuerySubscription.ts
+++ b/src/composables/useQuerySubscription.ts
@@ -15,23 +15,29 @@ export interface UseQuerySubscriptionOptions {
    * `true` → live, `false` → suspended (with no warm grace period).
    */
   isLive?: () => boolean
-  /** Item limit applied to the initial snapshot. Defaults to backend's MAX_READ_MODEL_ITEMS. */
+  /** Item id limit applied to the initial snapshot. Defaults to backend's MAX_READ_MODEL_ITEMS. */
   limit?: number
 }
 
 /**
  * Subscribe to a Rust-side QueryRuntime read model.
  *
+ * Read model は note 本体ではなく **id list** を返す。note 本体は JS 側の
+ * noteStore (src/stores/notes.ts) が唯一の真実で、ここでは順序情報のみを扱う。
+ * delta event は依然として note 本体を inserts に乗せて流すので、消費側は
+ * 受け取った insert を noteStore に put し、当 composable から得た itemIds で
+ * 表示順序を駆動する想定。
+ *
  * Lifecycle:
  *  1. `open()` is called → returns the queryId
- *  2. Initial snapshot is fetched via `query_get_read_model_snapshot`
- *  3. `query-delta` events update items incrementally (newer items prepended)
+ *  2. Initial snapshot (id list) is fetched via `query_get_read_model_snapshot`
+ *  3. `query-delta` events update itemIds incrementally (newer ids prepended)
  *  4. On dispose → `query_close` releases the subscription
  *
  * The composable trusts `revision` to drop out-of-order deltas.
  */
 export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
-  const items = shallowRef<JsonValue[]>([])
+  const itemIds = shallowRef<string[]>([])
   const revision = ref(0)
   const queryId = ref<string | null>(null)
   const ready = ref(false)
@@ -42,11 +48,11 @@ export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
   function applyInsert(insert: JsonValue) {
     const id = idOf(insert)
     if (id === null) return
-    items.value = [insert, ...items.value.filter((i) => idOf(i) !== id)]
+    itemIds.value = [id, ...itemIds.value.filter((i) => i !== id)]
   }
 
   function applyDelete(deleteId: string) {
-    items.value = items.value.filter((i) => idOf(i) !== deleteId)
+    itemIds.value = itemIds.value.filter((i) => i !== deleteId)
   }
 
   async function loadSnapshot() {
@@ -58,7 +64,7 @@ export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
     if (disposed || queryId.value !== id) return
     if (!snap) return
     if (snap.revision < revision.value) return
-    items.value = snap.items
+    itemIds.value = snap.itemIds
     revision.value = snap.revision
     ready.value = true
   }
@@ -128,7 +134,7 @@ export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
     }
   })
 
-  return { items, revision, queryId, ready }
+  return { itemIds, revision, queryId, ready }
 }
 
 function idOf(item: JsonValue): string | null {

--- a/src/composables/useQuerySubscription.ts
+++ b/src/composables/useQuerySubscription.ts
@@ -32,7 +32,10 @@ export interface UseQuerySubscriptionOptions {
  *  1. `open()` is called → returns the queryId
  *  2. Initial snapshot (id list) is fetched via `query_get_read_model_snapshot`
  *  3. `query-delta` events update itemIds incrementally (newer ids prepended)
- *  4. On dispose → `query_close` releases the subscription
+ *  4. Suspended → Live で復帰したときは Rust 側 recent_ids が空なので、snapshot
+ *     を再フェッチして空配列で reset する。表示は noteStore + 各カラム自身の
+ *     orderedIds が維持しているため UI は崩れず、新規 delta のみが流入する。
+ *  5. On dispose → `query_close` releases the subscription
  *
  * The composable trusts `revision` to drop out-of-order deltas.
  */
@@ -109,14 +112,26 @@ export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
     const isLiveFn = opts.isLive
     watch(
       () => isLiveFn(),
-      (live) => {
+      async (live, prev) => {
         const id = queryId.value
         if (!id) return
         const state: QueryRuntimeState = live ? 'live' : 'suspended'
-        commands.querySetRuntimeState(id, state).catch((e) => {
+        try {
+          await commands.querySetRuntimeState(id, state)
+        } catch (e) {
           if (import.meta.env.DEV)
             console.debug('[query-subscription] setRuntimeState failed:', e)
-        })
+          return
+        }
+        if (live && prev === false) {
+          // Suspended → Live: Rust 側 recent_ids は空にされている。snapshot 再取得で
+          // itemIds を空にリセットし、以降は新規 delta だけが流入する。表示は
+          // noteStore + 各カラムの orderedIds 側で維持される。
+          itemIds.value = []
+          revision.value = 0
+          ready.value = false
+          await loadSnapshot()
+        }
       },
       { flush: 'post' },
     )


### PR DESCRIPTION
## Summary

- Rust 側 query_runtime の Read Model から note 本体を削除し、dedupe 用に id list だけを保持する設計に変更
- 二重化解消: note 本体は JS noteStore (src/stores/notes.ts) が唯一の真実、Rust 側はカラム単位で id 集合のみ
- Suspended 状態で recent_ids / pending を全クリア + 以降の apply を gate (Suspended でも書き続けていたバグ的挙動を修正)
- query_runtime に単体テスト 14 ケース新設 (現状 0 件)

## Why

0.14.0 で導入された Read Model がカラム数 × 200 件のノートを `Vec<serde_json::Value>` で常駐させてメモリを圧迫していた。調査の結果:

1. `read_model_snapshot` を呼ぶのは `useQuerySubscription` だけで、当該 composable はどのカラムからも import されていない (= dead code)
2. 8 つの DeckColumn は `createQuerySubscription` 経由で delta event のみ消費しており、Rust 側 items は実質「delta dedupe (insert 重複除去)」用にしか機能していなかった
3. JS noteStore (Map<string, NormalizedNote>, 上限 3000) が note 本体の唯一の真実。Rust 側 items は完全に二重化していた

note 本体を Rust から削除すれば二重化が消え、メモリは数 MB 削減できる。

## Memory impact

- **Before**: カラム数 × 200 ノート × ~5KB ≒ 数 MB 常駐 (+ Suspended でも保持)
- **After**: カラム数 × 200 ノート ID × ~30 chars ≒ 数十 KB 常駐 (+ Suspended でゼロ)

## Architecture

```text
QueryEntry {
    recent_ids: VecDeque<String>,  // 上限 200, newest-first
    id_set: HashSet<String>,       // O(1) dedupe lookup
    revision: u64,
    runtime_state: Live | Warm | Suspended,
    source_subscription_id: Option<String>,
}
```

- delta は依然として note 本体を `inserts: Vec<Value>` で JS に流す (16ms debounce window でしか保持されない短期バッファ)
- JS 側 useQuerySubscription は items: JsonValue[] → itemIds: string[] に変更、Suspended → Live 復帰で snapshot 再フェッチ
- 詳細は ARCHITECTURE.md "A-11. Rust Query Runtime + Read Model" 参照

## Commits (logical order)

1. `test(query): pin current Read Model behavior with 10 unit tests` — 既存挙動を pin する安全網
2. `refactor(query): replace items Vec<Value> with id-only recent_ids/id_set` — 構造変更 + 既存テスト追従
3. `fix(query): clear recent_ids and gate apply on Suspended state` — Suspended 関連バグ修正 + 新挙動 4 テスト追加 (T11-T14)
4. `feat(query): reload snapshot on Suspended -> Live in useQuerySubscription` — JS 側の Live 復帰時 reload
5. `docs(arch): document Read Model id-only design` — ARCHITECTURE.md 追記
6. `docs(arch): remove misleading "future extensions" from Read Model section` — 筋を欠いた拡張余地を削除

## Test plan

- [x] `cargo test --lib` で 105 件 全 pass (T1-T14 を含む)
- [x] `cargo clippy --all-targets -- -D warnings` pass
- [x] `pnpm typecheck` pass
- [x] `pnpm lint` pass
- [x] `pnpm test` で 283 件 全 pass
- [ ] `pnpm tauri:dev` で 8 カラムを開いて以下を手動確認:
  - 起動後に各カラムへ delta が流れる
  - カラム再オープン (削除 → 追加) で表示が再描画される
  - Suspended escalate (8 秒放置) → 復帰でスクロール → 新着のみ流入する
- [ ] RSS Before/After を計測し、Suspended 多数時のメモリ削減を確認

## Out of scope (別 Issue / PR で追跡)

- 調査中に判明: notecli の `notes_cache` テーブルは TTL/LRU/件数上限なしで青天井。`cleanup_cache()` は no-op。別途 notecli 側で eviction 実装 + notedeck 側で可視化 UI を行う予定