### PR TITLE
feat: 空状態・エラー状態に Misskey 本家風 SVG フォールバックを追加

### DIFF
--- a/src/components/common/ColumnEmptyState.vue
+++ b/src/components/common/ColumnEmptyState.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { proxyUrl } from '@/utils/imageProxy'
+import SystemIcon from './SystemIcon.vue'
 
 const props = withDefaults(
   defineProps<{
@@ -10,6 +11,11 @@ const props = withDefaults(
     imageUrl?: string
     /** エラー状態かどうか */
     isError?: boolean
+    /**
+     * imageUrl が解決できない場合に表示するフォールバック SVG 種別。
+     * 未指定なら isError から自動判定（true → 'error', false → 'info'）。
+     */
+    fallbackKind?: 'info' | 'notFound' | 'error'
     /** CTA ボタンのラベル */
     ctaLabel?: string
     /** CTA ボタンのアイコン（Tabler icon クラス名、例: 'ti-pencil'） */
@@ -25,6 +31,12 @@ const emit = defineEmits<{
 }>()
 
 const resolvedImageUrl = computed(() => proxyUrl(props.imageUrl))
+
+const resolvedFallbackType = computed<'info' | 'question' | 'error'>(() => {
+  if (props.fallbackKind === 'notFound') return 'question'
+  if (props.fallbackKind) return props.fallbackKind
+  return props.isError ? 'error' : 'info'
+})
 </script>
 
 <template>
@@ -36,6 +48,11 @@ const resolvedImageUrl = computed(() => proxyUrl(props.imageUrl))
       alt=""
       loading="lazy"
       draggable="false"
+    />
+    <SystemIcon
+      v-else
+      :type="resolvedFallbackType"
+      :class="$style.fallbackIcon"
     />
     <div :class="$style.message">{{ message }}</div>
     <button
@@ -81,6 +98,14 @@ const resolvedImageUrl = computed(() => proxyUrl(props.imageUrl))
   max-height: 160px;
   object-fit: contain;
   opacity: 0.8;
+  user-select: none;
+  pointer-events: none;
+}
+
+.fallbackIcon {
+  width: 64px;
+  height: 64px;
+  opacity: 0.85;
   user-select: none;
   pointer-events: none;
 }

--- a/src/components/common/SystemIcon.vue
+++ b/src/components/common/SystemIcon.vue
@@ -1,0 +1,149 @@
+<!--
+SPDX-FileCopyrightText: syuilo and misskey-project
+SPDX-License-Identifier: AGPL-3.0-only
+
+Adapted from Misskey's MkSystemIcon.vue:
+https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/components/global/MkSystemIcon.vue
+NoteDeck テーマ変数に合わせて色を置換。info / question / error の 3 種のみ移植。
+-->
+
+<script setup lang="ts">
+defineProps<{
+  type: 'info' | 'question' | 'error'
+}>()
+</script>
+
+<template>
+  <svg
+    v-if="type === 'info'"
+    :class="[$style.icon, $style.info]"
+    viewBox="0 0 160 160"
+  >
+    <path
+      d="M80,108L80,72"
+      pathLength="1"
+      :class="[$style.line, $style.animLine]"
+    />
+    <path d="M80,52L80,52" :class="[$style.line, $style.animFade]" />
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      pathLength="1"
+      :class="[$style.line, $style.animCircle]"
+    />
+  </svg>
+  <svg
+    v-else-if="type === 'question'"
+    :class="[$style.icon, $style.question]"
+    viewBox="0 0 160 160"
+  >
+    <path
+      d="M80,92L79.991,84C88.799,83.98 96,76.962 96,68C96,59.038 88.953,52 79.991,52C71.03,52 64,59.038 64,68"
+      pathLength="1"
+      :class="[$style.line, $style.animLine]"
+    />
+    <path d="M80,108L80,108" :class="[$style.line, $style.animFade]" />
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      pathLength="1"
+      :class="[$style.line, $style.animCircle]"
+    />
+  </svg>
+  <svg
+    v-else-if="type === 'error'"
+    :class="[$style.icon, $style.error]"
+    viewBox="0 0 160 160"
+  >
+    <path
+      d="M63,63L96,96"
+      pathLength="1"
+      style="--duration: 0.3s"
+      :class="[$style.line, $style.animLine]"
+    />
+    <path
+      d="M96,63L63,96"
+      pathLength="1"
+      style="--duration: 0.3s; --delay: 0.2s"
+      :class="[$style.line, $style.animLine]"
+    />
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      pathLength="1"
+      :class="[$style.line, $style.animCircle]"
+    />
+  </svg>
+</template>
+
+<style lang="scss" module>
+.icon {
+  stroke-linecap: round;
+  stroke-linejoin: round;
+
+  &.info {
+    color: var(--nd-accent);
+  }
+
+  &.question {
+    color: var(--nd-fg);
+  }
+
+  &.error {
+    color: var(--nd-error);
+  }
+}
+
+.line {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 8px;
+  shape-rendering: geometricPrecision;
+}
+
+.animLine {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: line var(--duration, 0.5s) cubic-bezier(0, 0, 0.25, 1) 1 forwards;
+  animation-delay: var(--delay, 0s);
+}
+
+.animCircle {
+  stroke-dasharray: 1;
+  stroke-dashoffset: 1;
+  animation: line var(--duration, 0.5s) cubic-bezier(0, 0, 0.25, 1) 1 forwards;
+  animation-delay: var(--delay, 0s);
+  transform-origin: center;
+  transform: rotate(-90deg);
+}
+
+.animFade {
+  opacity: 0;
+  animation: fade-in var(--duration, 0.5s) cubic-bezier(0, 0, 0.25, 1) 1 forwards
+    ;
+  animation-delay: var(--delay, 0s);
+}
+
+@keyframes line {
+  0% {
+    stroke-dashoffset: 1;
+    opacity: 0;
+  }
+  100% {
+    stroke-dashoffset: 0;
+    opacity: 1;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+</style>

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -278,6 +278,7 @@ function openAsPip() {
         v-if="shouldShowAccountNotFound"
         message="アカウントが見つかりません"
         :image-url="serverNotFoundImageUrl"
+        fallback-kind="notFound"
       />
       <div v-else-if="isAwaitingAccounts" :class="$style.awaitingAccounts" />
       <slot v-else />

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -239,7 +239,7 @@ async function onDelete() {
         v-else-if="notFound"
         message="このメモは見つかりません"
         :image-url="serverNotFoundImageUrl"
-        is-error
+        fallback-kind="notFound"
       />
       <!-- Swallow clicks so MkNote's internal navigateToDetail (synthetic id
            → 404) doesn't fire. Right-click still opens our memo menu. -->
@@ -260,7 +260,7 @@ async function onDelete() {
         v-else-if="notFound"
         message="このメモは見つかりません"
         :image-url="serverNotFoundImageUrl"
-        is-error
+        fallback-kind="notFound"
       />
       <CodeEditor
         v-else


### PR DESCRIPTION
## Summary

- 横断カラムやサーバー画像未設定で `infoImageUrl` / `notFoundImageUrl` / `serverErrorImageUrl` が undefined のとき、`ColumnEmptyState` が画像を一切出さなかったのを修正
- Misskey 本家 (yamisskey) の `MkResult.vue` が同条件で `MkSystemIcon` (info / question / error の線画 SVG) を描画する挙動を NoteDeck に移植
- 必要 3 種のみ移植、色は `--nd-accent` / `--nd-fg` / `--nd-error` へ置換、AGPL クレジット維持

## Why

Misskey 本家でも `infoImageUrl` 等が未設定のサーバーは多く、横断カラムでは本家でも常に画像 URL が取れない。本家 WebUI ではこのケースで線画 SVG アイコンが描画されて空状態と分かるようになっているが、NoteDeck では何も出ず文字列だけ表示されていた。

## Changes

- `src/components/common/SystemIcon.vue` 新規 (本家 `MkSystemIcon.vue` ベース、AGPL-3.0 SPDX クレジット維持)
- `ColumnEmptyState.vue` に `fallbackKind?: 'info' | 'notFound' | 'error'` prop 追加。`imageUrl` 解決失敗時に `<SystemIcon>` を描画。未指定なら `isError` から自動判定 (error / info)
- `serverNotFoundImageUrl` を渡している 3 caller (`DeckColumn.vue`, `MemoEditorContent.vue` 2 箇所) に `fallback-kind="notFound"` を明示
- それ以外の caller は `isError` 自動判定で動くため変更不要

## Test plan

- [ ] 横断アカウントカラム (Federation 等) で空状態に SVG アイコンが出ること
- [ ] 画像 URL を設定していないサーバーのカラムで空状態に SVG アイコンが出ること
- [ ] エラー時 (例: 接続失敗カラム) に赤の × SVG が出ること
- [ ] アカウント未検出時 / メモ未検出時に `?` SVG が出ること
- [ ] 画像 URL がある通常サーバーのカラムでこれまで通り `<img>` が表示されること

Refs: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)