### PR TITLE
Release v0.15.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,7 +381,7 @@ jobs:
           sed -i "s/^pkgrel=.*/pkgrel=1/" packaging/aur/PKGBUILD
 
       - name: Publish to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v3
+        uses: KSXGitHub/github-actions-deploy-aur@v4
         with:
           pkgname: misskey-notedeck-bin
           pkgbuild: packaging/aur/PKGBUILD

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.1",
+  "version": "0.15.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.1"
+version = "0.15.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -449,9 +449,7 @@ function close() {
 }
 
 .addPopup {
-  background: color-mix(in srgb, var(--nd-navBg) 92%, transparent);
-  backdrop-filter: var(--nd-vibrancy);
-  -webkit-backdrop-filter: var(--nd-vibrancy);
+  background: var(--nd-navBg);
   border-radius: 16px;
   box-shadow: 0 8px 32px var(--nd-shadow);
   min-width: 320px;

--- a/src/components/deck/ColumnTabs.vue
+++ b/src/components/deck/ColumnTabs.vue
@@ -111,7 +111,13 @@ watch(
       v-for="t in tabs"
       :key="t.value"
       class="_button column-tab"
-      :class="[$style.tab, { [$style.active]: modelValue === t.value }]"
+      :class="[
+        $style.tab,
+        {
+          [$style.active]: modelValue === t.value,
+          [$style.iconOnly]: compact && modelValue !== t.value,
+        },
+      ]"
       :title="t.label"
       @click="switchTab(t.value)"
     >
@@ -155,9 +161,9 @@ watch(
   /* button 間の物理的な間隔。padding (button 内部) と責務を分離し、
      Chromium 系で glyph advance width が膨らんでも隣接タブへ干渉しない。 */
   gap: 4px;
-}
-
-.tabs.scrollable {
+  /* min-width フロアによりタブ合計幅がカラム幅を超えるケース (狭カラム +
+     5+ タブ) で破綻しないよう、水平スクロールを常時有効化。scrollbar は
+     両 WebView (WebKit / Chromium) で非表示。 */
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
@@ -165,6 +171,11 @@ watch(
   &::-webkit-scrollbar {
     display: none;
   }
+}
+
+.tabs.scrollable {
+  /* scroll 挙動 (overflow-x) は .tabs に統合。本クラスは active タブ
+     scroll-into-view (script side, watch L86-102) のためのマーカー。 */
 }
 
 .tab {
@@ -179,6 +190,11 @@ watch(
     opacity var(--nd-duration-base),
     background var(--nd-duration-base);
   position: relative;
+  /* タブ幅をフォントの glyph advance から切り離す。Segoe UI Bold (Windows)
+     と DejaVu/Noto Bold (Linux) は同 font-size でも advance width が違い、
+     短いラベルほど 4-6px 差が出る。4rem (=64px) フロアで両 OS のタブ幅を
+     同一に丸める。長いラベルは natural width で伸びる。 */
+  min-width: 4rem;
 
   &:hover {
     opacity: 0.7;
@@ -188,6 +204,12 @@ watch(
   &.active {
     opacity: 1;
   }
+}
+
+/* compact モードの非アクティブタブ (icon-only) は tabIcon の 20px 固定箱で
+   既にフォント非依存。フロアを当てると inactive タブが無駄に広がるので除外。 */
+.tab.iconOnly {
+  min-width: 0;
 }
 
 /* Icon wrapper: fixed-size box that clips any glyph bleed from hinting.

--- a/src/components/deck/ColumnTabs.vue
+++ b/src/components/deck/ColumnTabs.vue
@@ -79,20 +79,24 @@ function prev(): boolean {
 
 useSwipeTab(swipeTargetRef, next, prev)
 
-// Keep active tab visible when the tab bar can overflow
+// Keep active tab visible when the tab bar can overflow.
+// Avoid `scrollIntoView` — it walks every scrollable ancestor and would also
+// scroll the parent DeckColumnsArea horizontally, throwing the whole column
+// off-screen on Chromium/WebView2 (Windows).
 watch(
   () => props.modelValue,
   () => {
     if (!props.scrollable) return
     nextTick(() => {
-      const el = tabsRef.value?.querySelector(
+      const container = tabsRef.value
+      if (!container) return
+      const el = container.querySelector(
         `.column-tab.${$style.active}`,
       ) as HTMLElement | null
-      el?.scrollIntoView({
-        behavior: 'smooth',
-        inline: 'center',
-        block: 'nearest',
-      })
+      if (!el) return
+      const offset =
+        el.offsetLeft - (container.clientWidth - el.offsetWidth) / 2
+      container.scrollTo({ left: offset, behavior: 'smooth' })
     })
   },
 )

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -228,6 +228,7 @@ function toggleAccountMenu(id: string, e?: MouseEvent) {
 }
 
 function openAccountMenu(id: string, e?: MouseEvent) {
+  if (isCompact.value) return
   if (accountMenuId.value === id) return
   updateAccountMenuPosition(e)
   accountMenuId.value = id

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -877,9 +877,7 @@ defineExpose({
   padding: 6px 0;
   z-index: var(--nd-z-menu);
   min-width: 200px;
-  background: var(--nd-glassBg);
-  backdrop-filter: var(--nd-vibrancy);
-  -webkit-backdrop-filter: var(--nd-vibrancy);
+  background: var(--nd-navBg);
   border-radius: var(--nd-radius-md);
   box-shadow: var(--nd-shadow-m);
 }

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1201,8 +1201,6 @@ onUnmounted(() => {
 .notifItem {
   border-bottom: 1px solid var(--nd-divider);
   contain: layout style paint;
-  content-visibility: auto;
-  contain-intrinsic-size: auto 80px;
 }
 
 .notifLayout {

--- a/src/components/deck/DeckSettingsMenu.vue
+++ b/src/components/deck/DeckSettingsMenu.vue
@@ -388,7 +388,6 @@ usePortal(settingsMenuPortalRef)
           <button :class="$style.categoryHeader" @click="openToolWindow('cacheEditor')">
             <i class="ti ti-eraser" />
             <span>キャッシュ</span>
-            <span v-if="cacheSummary" :class="$style.cacheSummary">{{ cacheSummary }}</span>
             <i class="ti ti-chevron-right" :class="$style.chevronNav" />
           </button>
         </div>

--- a/src/components/deck/NavAccountMenu.vue
+++ b/src/components/deck/NavAccountMenu.vue
@@ -189,6 +189,9 @@ function modeIcon(key: string, active: boolean): string {
   padding: 8px 0;
   z-index: var(--nd-z-menu);
   min-width: 180px;
+  background: var(--nd-navBg);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .menuRight {


### PR DESCRIPTION
## Summary

v0.15.1 後に積んだバグ fix と CI 修正を取り込む patch リリース。

### Fixes

- fix(deck): カラムタブの幅をフォントメトリクスから切り離す
- fix(notification): 仮想スクロール内の content-visibility を撤去
- fix: スマホ設定メニューのキャッシュボタンから容量表示を削除
- fix: ナビバー周辺メニューと AddColumnDialog の透過を廃止
- fix(deck): タブ切替で Windows のカラムが消える問題を修正
- fix: スマホ表示時にアカウント一覧の hover でサブメニューが開かないように

### CI

- ci: bump deploy-aur action v3 -> v4 to fix `bash: --command: invalid option` (upstream KSXGitHub/github-actions-deploy-aur#50, fixed in v4.1.3)

## Test plan

- [ ] CI (lint / typecheck / test) green
- [ ] タグ push 後に Linux/macOS/Windows ビルドが通る
- [ ] AUR ジョブが今回は成功する（v3→v4 fix の検証）