### PR TITLE
fix(tabs): タブ切替時に通知カラムが消える問題を修正 (#407)

### DIFF
--- a/src/composables/useTabSlide.ts
+++ b/src/composables/useTabSlide.ts
@@ -57,6 +57,6 @@ export function useTabSlide(
         el.classList.remove(...SLIDE_CLASSES)
       }
     },
-    { flush: 'sync' },
+    { flush: 'post' },
   )
 }


### PR DESCRIPTION
## Summary

- 通知カラムの種別タブ切替時、Windows + WebView2 環境のみで「中身が空」「カラムが消える」現象 (#407) を修正
- [useTabSlide](src/composables/useTabSlide.ts) の watch を `flush: 'sync'` → `'post'` に変更（1 行差分）
- 他 10 箇所の `useTabSlide` 利用カラムでも同種バグの予防

## 根本原因

`useTabSlide` の watch が `flush: 'sync'` で動作しており、`activeFilter` 変更と同じ Vue sync フェーズで `.noteScroller` (= `@tanstack/vue-virtual` のスクロールコンテナ自身) に translate アニメ class を即時付与していた。同フェーズで `filteredNotifications` 再計算 → virtualizer の count 変更 → ResizeObserver が translate アニメ中の `offsetHeight` を測って `itemSizeCache` を汚染。

WebView2 (Chromium) は WebKitGTK / Android Chromium より ResizeObserver タイミングが同期的なため、Windows のみ症状が発生していた。Linux (WSL2) と Android で再現しないのは ResizeObserver の発火が遅延するため。

通知カラムだけが「仮想スクロール + フィルタで 0 件遷移しうる + `useTabSlide` 対象が scroller 自身 + `compact scrollable`」を全て満たすため、他カラムでは発症していなかった。

## 修正内容

```diff
   watch(
     tabIndex,
     (cur) => { /* ... */ },
-    { flush: 'sync' },
+    { flush: 'post' },
   )
```

`flush: 'post'` 化により実行順序が以下に固定される：

1. `filteredNotifications` 反映 → virtualizer の `count` 更新 → 新アイテムが DOM に挿入
2. `measureElement` が新要素のサイズを記録（translate 0 状態）
3. **その後** `useTabSlide` が translate アニメ class を付与

[NoteScroller.vue:131-137](src/components/common/NoteScroller.vue#L131-L137) で `dynamicEstimate` 更新が既に rAF deferred になっており設計者は post タイミング前提で組んでいる。`useTabSlide` のみが sync で逸脱していたのを揃える形。

## 副作用評価

`useTabSlide` 利用 11 箇所いずれも改善方向：

| カラム | 影響 |
|---|---|
| DeckNotificationColumn | バグ解消（本 issue） |
| DeckTimelineColumn | 同種バグの予防（NoteScroller 由来 swipeTarget） |
| その他 9 箇所（普通の `<div>`） | 影響なし |

- `useSwipeTab` との順序関係維持（`clearSwipeState` → tabIndex → アニメ）
- `useTabIndicator` は既に `nextTick(update)` で post 前提
- アニメ見た目は 1 frame (~16ms) 遅延のみで体感不能

## 段階的拡張の余地（将来 PR）

A だけで症状が残った場合の予備案として、構造的改善が考えられる（**今 PR では実装しない**）：

- NoteScroller に `.animTarget` inner wrapper を追加し、scroll container と animation target を完全分離
- `getAnimationTarget()` を `defineExpose` で公開
- `useTabSlide` / `useSwipeTab` の対象 DOM を `.animTarget` に切替え

## Test plan

- [x] `pnpm lint` クリーン
- [x] `pnpm typecheck` クリーン
- [x] `pnpm test` 全 283 tests pass
- [ ] Windows 環境で通知カラムを開き「すべて」→「リアクション」→「リプライ」と順次切替、中身が消えないこと、カラム自体が消えないことを確認
- [ ] 通常タブ切替アニメ（0.2s スライド）が動作していることを確認
- [ ] Linux/Android で従来通り動作していることを確認（リグレッション無し）

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)