### PR TITLE
Release v0.15.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.2",
+  "version": "0.15.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.2"
+version = "0.15.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/composables/useTabSlide.ts
+++ b/src/composables/useTabSlide.ts
@@ -57,6 +57,6 @@ export function useTabSlide(
         el.classList.remove(...SLIDE_CLASSES)
       }
     },
-    { flush: 'sync' },
+    { flush: 'post' },
   )
 }


### PR DESCRIPTION
## Summary

issue #407 (通知カラムの種別タブ切替で中身が空・カラムが消える Windows 限定バグ) の修正リリース。

## Changes since v0.15.2

- fix(tabs): タブ切替の watch を flush: post に変更し WebView2 の virtualizer measure 競合を回避 (#409, closes #407)
- chore: bump version to 0.15.3

## Background

`useTabSlide` の watch が `flush: 'sync'` で動作しており、タブ切替時に `.noteScroller` (`@tanstack/vue-virtual` のスクロールコンテナ自身) に translate アニメ class を即時付与していた。WebView2 (Chromium) の ResizeObserver は WebKitGTK / Android Chromium より同期的なため、translate 中の `offsetHeight` を `itemSizeCache` に汚染し virtualItems が空のまま回復しなくなっていた。`flush: 'post'` 化で順序を保証し競合を解消。

## Test plan

- [x] CI: lint / typecheck / test 全 pass
- [ ] マージ後 v0.15.3 タグ push → release.yml で macOS/Linux/Windows ビルド
- [ ] **Windows 環境 (本番)** で issue #407 の症状が解消していることを確認
- [ ] Linux/Android で従来通り動作 (リグレッション無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)