### PR TITLE
Release v0.15.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.3",
+  "version": "0.15.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.3"
+version = "0.15.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.3"
+version = "0.15.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/NoteScroller.vue
+++ b/src/components/common/NoteScroller.vue
@@ -240,7 +240,6 @@ defineSlots<{
   top: 0;
   left: 0;
   width: 100%;
-  contain: layout style paint;
 }
 
 /* Misskey-style slide-in animation for streaming notes.

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1200,7 +1200,6 @@ onUnmounted(() => {
 
 .notifItem {
   border-bottom: 1px solid var(--nd-divider);
-  contain: layout style paint;
 }
 
 .notifLayout {


### PR DESCRIPTION
## Summary

issue #407 (通知カラムの中身が完全に空になる Windows 限定バグ) の真因修正リリース。v0.15.3 で打った仮説修正 (`useTabSlide` flush 変更) は外れ、本リリースで CSS Containment による Chromium paint skip が真因と確定し対症療法を適用。

## Changes since v0.15.3

- fix(notification): 仮想スクロールアイテムの contain: paint を撤去 (#413, closes #407)
- chore: bump version to 0.15.4

## Background

ユーザの Windows 環境 DevTools 観察で `document.querySelectorAll('[data-index]').length === 30` で DOM は 30 件存在し、要素の rect も画面内、display/visibility/opacity 正常なのに描画されないことが確定。`getComputedStyle().contain === 'content'` (= `layout style paint` shorthand) が WebView2 (Chromium) の paint phase で skip させていた。

`.noteItem` (NoteScroller の virtualizer wrapper、`position: absolute` + 動的 `translate`) と `.notifItem` (通知本体) の `contain: layout style paint` を撤去。1534c485 の `content-visibility` 撤去と完全に同じ系統の対症療法。

## Test plan

- [x] CI: lint / typecheck / test 全 pass
- [ ] マージ後 v0.15.4 タグ push → release.yml で macOS/Linux/Windows ビルド
- [ ] **Windows 環境 (本番)** で issue #407 の症状解消を確認
- [ ] Linux/Android で従来通り動作 (リグレッション無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)