### PR TITLE
Release v0.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.4",
+  "version": "0.15.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.4"
+version = "0.15.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.4"
+version = "0.15.5"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/src/commands/content.rs
+++ b/src-tauri/src/commands/content.rs
@@ -531,7 +531,9 @@ pub async fn api_fetch_account_theme(
 
     let mut result = serde_json::json!({});
 
-    let meta = client.get_meta(&host, &token).await?;
+    // detail: true でないと MetaLite が返り defaultDarkTheme/defaultLightTheme が
+    // 含まれない (Misskey の MetaDetailed にしか乗らないフィールド)。
+    let meta = client.get_meta_detail(&host, &token).await?;
     if let Some(dark) = meta.get("defaultDarkTheme") {
         result["metaDark"] = dark.clone();
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -83,9 +83,10 @@ export const useThemeStore = defineStore('theme', () => {
   //   dark/light    : registry sync (default:darkTheme / default:lightTheme の
   //                   global scope エントリ)。ユーザーが Web UI
   //                   で選択したテーマ。優先度高、per-column 適用にも使われる
-  //   metaDark/Light: meta.themeDark / meta.themeLight。サーバー管理者が設定した
-  //                   インスタンスデフォルト (例: yami.ski の DXM)。sync が無い
-  //                   場合の fallback としても使われる
+  //   metaDark/Light: meta.defaultDarkTheme / meta.defaultLightTheme
+  //                   (要 detail: true)。サーバー管理者が設定したインスタンス
+  //                   デフォルト (例: yami.ski の DXM)。sync が無い場合の
+  //                   fallback としても使われる
   //   _v            : cache 構造のバージョン。古い entry を強制無効化するため
   //
   // shallowRef + full Map replacement で Vue リアクティビティを保証
@@ -491,8 +492,8 @@ export const useThemeStore = defineStore('theme', () => {
         metaLight?: MisskeyTheme
       } = { _v: ACCOUNT_THEME_CACHE_VERSION }
 
-      // metaDark/metaLight: meta.themeDark / meta.themeLight (インスタンス
-      // 管理者設定のブランディングテーマ。例: yami.ski の DXM)。
+      // metaDark/metaLight: meta.defaultDarkTheme / meta.defaultLightTheme
+      // (インスタンス管理者設定のブランディングテーマ。例: yami.ski の DXM)。
       if (data.metaDark) {
         entry.metaDark =
           parseMetaTheme(


### PR DESCRIPTION
## Summary

- fix(theme): meta default を detail: true で取得しサーバーテーマ未取得を解消
- chore: bump version to 0.15.5

## Test plan

- [ ] CI（lint, typecheck, test）が通ること
- [ ] サーバー保存テーマが新規ログイン直後でも取得できること