### PR TITLE
Release v0.15.8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ pnpm typecheck    # vue-tsc --noEmit
 - **ナビバー**: VSCode Activity Bar 式。カラムのトグルボタン。ボタン構成はカスタマイズ可能（`NavItem` 型でプロファイルに永続化）
 - **設定永続化**: 全設定は `settings.json` に一元化（`useSettingsStore` が単一 source of truth）。旧ファイル（`ai.json` / `keybinds.json5` / `performance.json`）は初回起動時の移行読込のみで、新規書込は `settings.json` のみ。独立ファイル: `custom.css` / `accounts.json5`（環境依存）。ナビバー構成はプロファイル内 `navItems` キーに格納
 - **シークレット**: Misskey トークン・AI API キーは OS キーチェーン (`notecli::keychain`) に格納。フロントは本体に触れない（詳細は [DEVELOPMENT.md](DEVELOPMENT.md) の "AI Credentials"）
-- **AI チャット**: Anthropic / OpenAI / Custom (OpenAI 互換: OpenRouter 等) の 3 プロバイダーを Rust 側で SSE ストリーミング対応。`commands.aiChatSend` invoke + `nd:ai-chat-event` listen のパターン。会話履歴は `notedeck/ai-conversations/<columnId>.json5` (詳細は [DEVELOPMENT.md](DEVELOPMENT.md) の "AI Chat Streaming")
+- **AI チャット**: Anthropic / OpenAI / Custom (OpenAI 互換: OpenRouter 等) の 3 プロバイダーを Rust 側で SSE ストリーミング対応。`commands.aiChatSend` invoke + `nd:ai-chat-event` listen のパターン (`commands.aiChatCancel(stream_id)` で abort)。AI セッションは `notedeck/sessions/<YYYYMMDDhhmmss>.json5` (Zettelkasten 形式 ID) にカラムから独立して永続化され、master-detail UI で一覧/切替/CRUD する。タイトルは初回応答完了後に AI が要約生成 (`useAiSessionsStore` + `DeckAiColumn`)。詳細は [DEVELOPMENT.md](DEVELOPMENT.md) の "AI Chat Streaming"
 - 詳細は [DEVELOPMENT.md](DEVELOPMENT.md) 参照
 
 ## リリース手順

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -645,9 +645,23 @@ API キーは [AI Credentials](#ai-credentials) の keychain から `read_ai_api
 
 | ファイル | 役割 |
 |---------|------|
-| `src/composables/useAiChat.ts` | `sendMessage(opts)` で 1 回の chat 呼び出し。`currentText` ref が delta で更新される |
-| `src/composables/useAiConversation.ts` | column 単位の会話履歴を `notedeck/ai-conversations/<columnId>.json5` に永続化 (debounce 500ms、上限 200 件) |
+| `src/composables/useAiChat.ts` | `sendMessage(opts)` で 1 回の chat 呼び出し。`currentText` ref が delta で更新される。`cancel()` で進行中 stream を中断 (Rust 側 `ai_chat_cancel` 経由) |
+| `src/composables/useAiConversation.ts` | 指定 sessionId のメッセージ配列に対する reactive な参照を返す薄いラッパー。本文の永続化と debounce は `useAiSessionsStore` 側で集中管理 |
+| `src/stores/aiSessions.ts` | AI セッション (`notedeck/sessions/<YYYYMMDDhhmmss>.json5`) の集中管理。メタは全件常駐、本文は遅延ロード、debounce 500ms 永続化。`createNew` / `updateMessages` / `setTitle` / `deleteSession` / `listSorted` を提供 |
 | `src/stores/skills.ts` の `composedSystemPrompt()` | `mode: 'always'` + active な skill body を結合した system prompt |
+| `src/utils/aiSessionId.ts` | Zettelkasten ID (`YYYYMMDDhhmmss`) 生成。同一秒衝突は `a`, `b`, `c`, ... サフィックスで回避 |
+| `src/utils/aiSessionTitle.ts` | `timestampTitle(now)` 初期プレースホルダー / `generateSessionTitle()` 決定論的フォールバック |
+
+#### セッション管理 UI (DeckAiColumn)
+
+`DeckAiColumn` は単一カラム内の master-detail で動作する:
+
+- **viewMode = 'sessions'**: セッション一覧 (グループ: 今日/昨日/過去 7 日/それ以前)、検索バー (タイトル絞込)、行ホバーで rename / delete インラインボタン
+- **viewMode = 'chat'**: 選択中セッションのメッセージ表示 + 入力欄。ストリーミング中は送信ボタンが停止ボタンに切替
+
+セッションはカラムから独立した**グローバル資産**で、`column.aiCurrentSessionId` が「現在表示中の sessionId」を保持する。`null` ならセッション一覧を表示。同じ sessionId を 2 カラムで開いても破綻しない (`useAiSessionsStore` 経由で書込先は 1 ファイル)。
+
+セッションタイトルは初回 round (user 発話 → assistant 応答) 完了後に AI で自動生成される。失敗時は `timestampTitle` (`<YYYY-MM-DD HH:mm> のチャット`) がそのまま残る。AI への依頼は別 `useAiChat` インスタンス (`titleGen`) で会話を 1 つの user メッセージに集約して投げる (Anthropic は last message が assistant role だと続行扱いになるため)。
 
 #### エラー UI
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.7",
+  "version": "0.15.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.7"
+version = "0.15.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.7"
+version = "0.15.8"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/src/commands/ai_chat.rs
+++ b/src-tauri/src/commands/ai_chat.rs
@@ -1,16 +1,39 @@
-use std::sync::LazyLock;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
 
 use futures_util::StreamExt;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-use tauri::{Emitter, State};
+use tauri::{async_runtime::JoinHandle, Emitter, State};
 
 use notecli::error::NoteDeckError;
 
 use super::ai::{read_ai_api_key, validate_ai_provider};
 use super::Result;
+
+/// In-flight chat streaming tasks keyed by `stream_id`. Used by `ai_chat_cancel`
+/// to abort the background SSE consumer for a specific stream (e.g. when the
+/// user switches to a different AI session mid-response).
+static ACTIVE_STREAMS: LazyLock<Mutex<HashMap<String, JoinHandle<()>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn register_stream(stream_id: String, handle: JoinHandle<()>) {
+    if let Ok(mut map) = ACTIVE_STREAMS.lock() {
+        if let Some(prev) = map.insert(stream_id, handle) {
+            // Same stream_id already in flight (shouldn't happen normally) —
+            // abort the older one to keep the map clean.
+            prev.abort();
+        }
+    }
+}
+
+fn deregister_stream(stream_id: &str) {
+    if let Ok(mut map) = ACTIVE_STREAMS.lock() {
+        map.remove(stream_id);
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "lowercase")]
@@ -98,20 +121,42 @@ pub async fn ai_chat_send(
 
     let client = http.inner().clone();
     let app_handle = app.clone();
+    let stream_id = req.stream_id.clone();
+    let stream_id_for_task = stream_id.clone();
 
-    tauri::async_runtime::spawn(async move {
-        let stream_id = req.stream_id.clone();
+    let handle = tauri::async_runtime::spawn(async move {
         let result = match req.provider.as_str() {
             "anthropic" => run_anthropic(&client, &req, &api_key, &app_handle).await,
             "openai" | "custom" => run_openai_compat(&client, &req, &api_key, &app_handle).await,
             other => Err(format!("Unknown provider: {other}")),
         };
         match result {
-            Ok(()) => emit_done(&app_handle, &stream_id),
-            Err(message) => emit_error(&app_handle, &stream_id, message),
+            Ok(()) => emit_done(&app_handle, &stream_id_for_task),
+            Err(message) => emit_error(&app_handle, &stream_id_for_task, message),
         }
+        deregister_stream(&stream_id_for_task);
     });
 
+    register_stream(stream_id, handle);
+
+    Ok(())
+}
+
+/// Cancel an in-flight streaming chat. Idempotent — silently no-ops if the
+/// stream has already completed or never existed.
+#[tauri::command]
+#[specta::specta]
+pub async fn ai_chat_cancel(stream_id: String) -> Result<()> {
+    let handle = {
+        if let Ok(mut map) = ACTIVE_STREAMS.lock() {
+            map.remove(&stream_id)
+        } else {
+            None
+        }
+    };
+    if let Some(h) = handle {
+        h.abort();
+    }
     Ok(())
 }
 

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -10,7 +10,16 @@ use super::Result;
 const SETTINGS_DIR: &str = "notedeck";
 
 /// Allowed subdirectory names for settings files. Also the set included in settings backup.
-const ALLOWED_SUBDIRS: &[&str] = &["profiles", "themes", "plugins", "snippets", "memos", "widgets", "skills"];
+const ALLOWED_SUBDIRS: &[&str] = &[
+    "profiles",
+    "themes",
+    "plugins",
+    "snippets",
+    "memos",
+    "widgets",
+    "skills",
+    "sessions",
+];
 
 /// Validate a subdirectory name against the whitelist.
 fn validate_subdir(subdir: &str) -> Result<()> {
@@ -119,10 +128,10 @@ pub fn write_settings_file(
         NoteDeckError::InvalidInput(format!("Failed to write {}: {e}", path.display()))
     })?;
 
-    // Tighten permissions for sensitive subdirectories — chat history may
-    // contain user secrets accidentally typed into prompts.
+    // Tighten permissions for sensitive subdirectories — AI session content
+    // may contain user secrets accidentally typed into prompts.
     #[cfg(unix)]
-    if subdir == "ai-conversations" {
+    if subdir == "sessions" {
         use std::os::unix::fs::PermissionsExt;
         let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
     }
@@ -467,6 +476,7 @@ mod tests {
         assert!(validate_subdir("snippets").is_ok());
         assert!(validate_subdir("widgets").is_ok());
         assert!(validate_subdir("skills").is_ok());
+        assert!(validate_subdir("sessions").is_ok());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -280,6 +280,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::ai_delete_api_key,
             // AI chat (LLM streaming via reqwest + emit)
             commands::ai_chat_send,
+            commands::ai_chat_cancel,
             query_runtime::query_subscribe_timeline,
             query_runtime::query_subscribe_antenna,
             query_runtime::query_subscribe_channel,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1663,6 +1663,18 @@ async aiChatSend(req: AiChatRequest) : Promise<Result<null, { code: string; mess
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Cancel an in-flight streaming chat. Idempotent — silently no-ops if the
+ * stream has already completed or never existed.
+ */
+async aiChatCancel(streamId: string) : Promise<Result<null, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("ai_chat_cancel", { streamId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async querySubscribeTimeline(accountId: string, timelineType: TimelineType, listId: string | null) : Promise<Result<QuerySnapshot, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("query_subscribe_timeline", { accountId, timelineType, listId }) };

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -9,9 +9,13 @@ import {
   watchApiKeyChanges,
 } from '@/composables/useAiConfig'
 import { useAiConversation } from '@/composables/useAiConversation'
-import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
-import type { DeckColumn } from '@/stores/deck'
+import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
+import { useConfirm } from '@/stores/confirm'
+import { type DeckColumn, useDeckStore } from '@/stores/deck'
+import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
+import { useToast } from '@/stores/toast'
+import { generateSessionTitle } from '@/utils/aiSessionTitle'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -29,25 +33,184 @@ const providerStatus = ref<'connected' | 'disconnected' | 'checking'>(
 const skillsStore = useSkillsStore()
 skillsStore.ensureLoaded()
 
+const sessionsStore = useAiSessionsStore()
+const deckStore = useDeckStore()
+
+void sessionsStore.loadAllMeta()
+
 const { config: aiConfig } = useAiConfig()
 const aiChat = useAiChat()
-const conversation = useAiConversation(props.column.id)
 
+// `column.aiCurrentSessionId` を reactive に橋渡し。useAiConversation は
+// この ref の変化を購読してメッセージ参照を切り替える。
+const currentSessionId = computed(() => props.column.aiCurrentSessionId ?? null)
+
+const conversation = useAiConversation(currentSessionId)
 const messages = conversation.messages
 const isGenerating = aiChat.isStreaming
 
-const currentProviderLabel = computed(() => {
-  switch (aiConfig.value.provider) {
-    case 'anthropic':
-      return 'Anthropic Claude'
-    case 'openai':
-      return 'OpenAI ChatGPT'
-    case 'custom':
-      return 'カスタムプロバイダー'
-    default:
-      return 'AI'
+// view mode は currentSessionId の有無で決まる:
+// - sessions = アイコンの一覧 + 「新しいチャット」 (Misskey の DM 一覧と同じ役割)
+// - chat = 選択中セッションのメッセージ + 入力欄
+const viewMode = computed<'sessions' | 'chat'>(() =>
+  currentSessionId.value ? 'chat' : 'sessions',
+)
+
+// --- セッション一覧グルーピング ---
+interface SessionGroup {
+  label: string
+  items: AiSessionMeta[]
+}
+
+function startOfDay(dt: Date): number {
+  const d = new Date(dt)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+const groupedSessions = computed<SessionGroup[]>(() => {
+  const sessions = sessionsStore.listSorted()
+  const today = startOfDay(new Date())
+  const yesterday = today - 24 * 60 * 60 * 1000
+  const last7 = today - 7 * 24 * 60 * 60 * 1000
+
+  const todayItems: AiSessionMeta[] = []
+  const yesterdayItems: AiSessionMeta[] = []
+  const lastWeekItems: AiSessionMeta[] = []
+  const olderItems: AiSessionMeta[] = []
+
+  for (const s of sessions) {
+    if (s.updatedAt >= today) todayItems.push(s)
+    else if (s.updatedAt >= yesterday) yesterdayItems.push(s)
+    else if (s.updatedAt >= last7) lastWeekItems.push(s)
+    else olderItems.push(s)
   }
+
+  const groups: SessionGroup[] = []
+  if (todayItems.length) groups.push({ label: '今日', items: todayItems })
+  if (yesterdayItems.length)
+    groups.push({ label: '昨日', items: yesterdayItems })
+  if (lastWeekItems.length)
+    groups.push({ label: '過去 7 日', items: lastWeekItems })
+  if (olderItems.length) groups.push({ label: 'それ以前', items: olderItems })
+  return groups
 })
+
+const totalSessions = computed(() => sessionsStore.listSorted().length)
+const searchQuery = ref('')
+
+const filteredGroupedSessions = computed<SessionGroup[]>(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return groupedSessions.value
+  return groupedSessions.value
+    .map((g) => ({
+      label: g.label,
+      items: g.items.filter((s) =>
+        (s.title || '無題のチャット').toLowerCase().includes(q),
+      ),
+    }))
+    .filter((g) => g.items.length > 0)
+})
+
+const hasNoSearchHits = computed(
+  () =>
+    searchQuery.value.trim().length > 0 &&
+    filteredGroupedSessions.value.length === 0,
+)
+
+function relativeTime(epoch: number): string {
+  const diff = Date.now() - epoch
+  const sec = Math.floor(diff / 1000)
+  if (sec < 60) return 'たった今'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} 分前`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} 時間前`
+  const d = new Date(epoch)
+  return `${d.getMonth() + 1}/${d.getDate()}`
+}
+
+const currentSessionTitle = computed(() => {
+  const id = currentSessionId.value
+  if (!id) return null
+  return sessionsStore.get(id)?.title || '無題のチャット'
+})
+
+const headerTitle = computed(() => {
+  if (viewMode.value === 'chat' && currentSessionTitle.value) {
+    return currentSessionTitle.value
+  }
+  return props.column.name || 'AIチャット'
+})
+
+// --- ナビゲーション ---
+
+function openSession(sessionId: string): void {
+  if (aiChat.isStreaming.value) {
+    void aiChat.cancel()
+  }
+  deckStore.updateColumn(props.column.id, { aiCurrentSessionId: sessionId })
+}
+
+function backToSessions(): void {
+  if (aiChat.isStreaming.value) {
+    void aiChat.cancel()
+  }
+  deckStore.updateColumn(props.column.id, { aiCurrentSessionId: null })
+  input.value = ''
+}
+
+// --- セッション操作 (rename / delete) ---
+
+const { prompt } = usePrompt()
+const { confirm } = useConfirm()
+const toast = useToast()
+
+async function onRenameSession(
+  e: MouseEvent,
+  sessionId: string,
+): Promise<void> {
+  e.preventDefault()
+  e.stopPropagation()
+  const cur = sessionsStore.get(sessionId)
+  if (!cur) return
+  const next = await prompt({
+    title: 'セッション名を変更',
+    defaultValue: cur.title,
+    placeholder: 'セッション名',
+  })
+  if (next == null) return
+  sessionsStore.setTitle(sessionId, next.trim())
+  toast.show('セッション名を変更しました')
+}
+
+async function onDeleteSession(
+  e: MouseEvent,
+  sessionId: string,
+): Promise<void> {
+  e.preventDefault()
+  e.stopPropagation()
+  const cur = sessionsStore.get(sessionId)
+  if (!cur) return
+  const ok = await confirm({
+    title: 'セッションを削除',
+    message: `「${cur.title || '無題のチャット'}」を削除しますか？この操作は取り消せません。`,
+    okLabel: '削除',
+    type: 'danger',
+  })
+  if (!ok) return
+  // 削除対象が現在開いているセッションなら一覧画面に戻す
+  if (currentSessionId.value === sessionId) {
+    if (aiChat.isStreaming.value) {
+      void aiChat.cancel()
+    }
+    deckStore.updateColumn(props.column.id, { aiCurrentSessionId: null })
+  }
+  await sessionsStore.deleteSession(sessionId)
+  toast.show('セッションを削除しました')
+}
+
+// --- プロバイダー接続チェック ---
 
 async function checkProvider(): Promise<void> {
   providerStatus.value = 'checking'
@@ -59,7 +222,6 @@ async function checkProvider(): Promise<void> {
       return
     }
     if (provider === 'custom') {
-      // Custom: API key is optional (e.g. self-hosted endpoints)
       providerStatus.value = 'connected'
       return
     }
@@ -82,11 +244,11 @@ watch(
   { immediate: true },
 )
 
-// Re-check provider status whenever an API key is set or cleared elsewhere
-// (e.g. user opens AiSettings while DeckAiColumn is mounted).
 watch(watchApiKeyChanges(), () => {
   void checkProvider()
 })
+
+// --- スクロール ---
 
 function scrollToBottom() {
   nextTick(() => {
@@ -94,20 +256,52 @@ function scrollToBottom() {
   })
 }
 
+watch(currentSessionId, () => {
+  scrollToBottom()
+})
+
+// 進行中ストリームのセッション ID。currentSessionId の reactive 反映を
+// 待たずに watch から直接 store を更新するために保持する。
+const activeStreamSessionId = ref<string | null>(null)
+
 // Stream deltas → update last assistant message in-place
 watch(aiChat.currentText, (text) => {
   if (!aiChat.isStreaming.value || !text) return
-  const last = messages.value[messages.value.length - 1]
-  if (last?.role === 'assistant') {
-    conversation.replaceLast({ ...last, content: text })
-  }
+  const sid = activeStreamSessionId.value
+  if (!sid) return
+  const cur = sessionsStore.get(sid)
+  if (!cur) return
+  const last = cur.messages[cur.messages.length - 1]
+  if (last?.role !== 'assistant') return
+  const updated = [...cur.messages.slice(0, -1), { ...last, content: text }]
+  sessionsStore.updateMessages(sid, updated)
   scrollToBottom()
 })
+
+// --- 送信 ---
+
+/** 必要なら新規セッションを作って ID を返す。 */
+function ensureSession(): string {
+  if (currentSessionId.value) return currentSessionId.value
+  const session = sessionsStore.createNew({
+    model: aiConfig.value[aiConfig.value.provider]?.model ?? '',
+    provider: aiConfig.value.provider,
+  })
+  deckStore.updateColumn(props.column.id, {
+    aiCurrentSessionId: session.id,
+  })
+  return session.id
+}
 
 async function sendMessage() {
   const text = input.value.trim()
   if (!text || aiChat.isStreaming.value) return
   if (providerStatus.value !== 'connected') return
+
+  // ensureSession の戻り値 (sessionId) を以降のすべての store 更新に直接使う。
+  // currentSessionId は computed(props.column.aiCurrentSessionId) で、
+  // updateColumn 直後の再評価タイミングに依存したくないため。
+  const sessionId = ensureSession()
 
   const provider: ProviderKey = aiConfig.value.provider
   const settings = aiConfig.value[provider]
@@ -119,9 +313,17 @@ async function sendMessage() {
     content: text,
     timestamp: now,
   }
-  conversation.append(userMsg)
+
+  const before = sessionsStore.get(sessionId)
+  if (!before) return
+  sessionsStore.updateMessages(sessionId, [...before.messages, userMsg])
   input.value = ''
   scrollToBottom()
+
+  // 初回発話で title が空ならユーザー発話から自動生成
+  if (!before.title) {
+    sessionsStore.setTitle(sessionId, generateSessionTitle(text, new Date(now)))
+  }
 
   // Pre-add empty assistant placeholder so streaming has a target slot
   const assistantMsg: ChatMessage = {
@@ -130,11 +332,15 @@ async function sendMessage() {
     content: '',
     timestamp: now,
   }
-  conversation.append(assistantMsg)
+  const afterUser = sessionsStore.get(sessionId)
+  if (!afterUser) return
+  sessionsStore.updateMessages(sessionId, [...afterUser.messages, assistantMsg])
   scrollToBottom()
 
+  activeStreamSessionId.value = sessionId
+
   // Build wire history: exclude the empty placeholder, exclude any system msgs
-  const history = messages.value.filter(
+  const history = (sessionsStore.get(sessionId)?.messages ?? []).filter(
     (m) => m.role !== 'system' && m.id !== assistantMsg.id,
   )
 
@@ -148,36 +354,34 @@ async function sendMessage() {
       history,
       system,
     })
-    // Ensure final text is persisted (last delta may have been before reactivity flushed)
-    const last = messages.value[messages.value.length - 1]
-    if (last?.role === 'assistant' && last.content !== finalText) {
-      conversation.replaceLast({ ...last, content: finalText })
+    const cur = sessionsStore.get(sessionId)
+    if (cur) {
+      const last = cur.messages[cur.messages.length - 1]
+      if (last?.role === 'assistant' && last.content !== finalText) {
+        sessionsStore.updateMessages(sessionId, [
+          ...cur.messages.slice(0, -1),
+          { ...last, content: finalText },
+        ])
+      }
     }
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)
-    const last = messages.value[messages.value.length - 1]
-    if (last?.role === 'assistant') {
-      conversation.replaceLast({
-        ...last,
-        content: `⚠️ ${message}`,
-      })
+    const cur = sessionsStore.get(sessionId)
+    if (cur) {
+      const last = cur.messages[cur.messages.length - 1]
+      if (last?.role === 'assistant') {
+        sessionsStore.updateMessages(sessionId, [
+          ...cur.messages.slice(0, -1),
+          { ...last, content: `⚠️ ${message}` },
+        ])
+      }
     }
   }
+  activeStreamSessionId.value = null
   scrollToBottom()
 }
 
-// --- Clear conversation (double-confirm) ---
-
-const { confirming: confirmingClear, trigger: triggerClear } =
-  useDoubleConfirm()
-
-function clearConversation() {
-  triggerClear(() => {
-    conversation.clear()
-  })
-}
-
-// --- Copy to clipboard ---
+// --- コピー ---
 
 const copiedMessageId = ref<string | null>(null)
 
@@ -193,13 +397,10 @@ async function copyMessage(msg: ChatMessage) {
   }
 }
 
-// --- Markdown rendering (assistant messages only) ---
-
 function renderAssistant(content: string): string {
   return renderSimpleMarkdown(content)
 }
 
-/** Event delegation for in-Markdown code-block copy buttons. */
 function onAssistantContentClick(e: MouseEvent) {
   const target = e.target
   if (!(target instanceof HTMLElement)) return
@@ -223,23 +424,17 @@ function onAssistantContentClick(e: MouseEvent) {
     })
 }
 
-// --- Auto-resize input textarea ---
-
-const INPUT_MAX_HEIGHT = 160
-
-function adjustInputHeight() {
-  const el = inputRef.value
-  if (!el) return
-  el.style.height = 'auto'
-  el.style.height = `${Math.min(el.scrollHeight, INPUT_MAX_HEIGHT)}px`
-}
-
-watch(input, () => nextTick(adjustInputHeight))
+// 入力欄の自動高さ調整は textarea の `field-sizing: content` (CSS) に委ねる。
 
 const aiMessagesRef = useTemplateRef<HTMLElement>('aiMessagesRef')
+const sessionsListRef = useTemplateRef<HTMLElement>('sessionsListRef')
 
 function scrollToTop() {
-  aiMessagesRef.value?.scrollTo({ top: 0, behavior: 'smooth' })
+  if (viewMode.value === 'chat') {
+    aiMessagesRef.value?.scrollTo({ top: 0, behavior: 'smooth' })
+  } else {
+    sessionsListRef.value?.scrollTo({ top: 0, behavior: 'smooth' })
+  }
 }
 
 function onKeydown(e: KeyboardEvent) {
@@ -251,61 +446,161 @@ function onKeydown(e: KeyboardEvent) {
 </script>
 
 <template>
-  <DeckColumnComponent :column-id="column.id" :title="column.name || 'AIチャット'" @header-click="scrollToTop">
+  <DeckColumnComponent
+    :column-id="column.id"
+    :title="headerTitle"
+    @header-click="scrollToTop"
+  >
     <template #header-icon>
       <i class="ti ti-brain" />
     </template>
 
-    <template #header-meta>
+    <template v-if="viewMode === 'chat'" #header-meta>
       <button
-        v-if="messages.length > 0"
         class="_button"
-        :class="[$style.headerAction, { [$style.confirmingClear]: confirmingClear }]"
-        :title="confirmingClear ? 'もう一度クリックで削除' : '会話をクリア'"
-        @click="clearConversation"
+        :class="$style.headerAction"
+        title="セッション一覧へ戻る"
+        @click="backToSessions"
       >
-        <i :class="confirmingClear ? 'ti ti-alert-triangle' : 'ti ti-trash'" />
+        <i class="ti ti-arrow-left" />
       </button>
     </template>
 
-    <div :class="$style.aiColumnBody">
-      <!-- Empty state -->
+    <template v-if="viewMode === 'sessions'" #header-extra>
+      <div :class="$style.searchBar">
+        <i :class="$style.searchIcon" class="ti ti-search" />
+        <input
+          v-model="searchQuery"
+          :class="$style.searchInput"
+          type="text"
+          placeholder="セッションを検索..."
+        />
+      </div>
+    </template>
+
+    <!-- View: sessions list (master) -->
+    <div v-if="viewMode === 'sessions'" :class="$style.sessionsBody">
+      <ColumnEmptyState
+        v-if="totalSessions === 0"
+        message="セッションはまだありません"
+        fallback-kind="info"
+      />
+      <ColumnEmptyState
+        v-else-if="hasNoSearchHits"
+        message="一致するセッションがありません"
+        fallback-kind="info"
+      />
+      <div v-else ref="sessionsListRef" :class="$style.sessionsList">
+        <div
+          v-for="group in filteredGroupedSessions"
+          :key="group.label"
+          :class="$style.group"
+        >
+          <div :class="$style.groupLabel">{{ group.label }}</div>
+          <div
+            v-for="session in group.items"
+            :key="session.id"
+            :class="[
+              $style.row,
+              {
+                [$style.rowActive]: session.id === currentSessionId,
+              },
+            ]"
+            role="button"
+            tabindex="0"
+            @click="openSession(session.id)"
+            @keydown.enter="openSession(session.id)"
+          >
+            <div :class="$style.rowMain">
+              <span :class="$style.rowTitle">
+                {{ session.title || '無題のチャット' }}
+              </span>
+              <span :class="$style.rowMeta">
+                {{ relativeTime(session.updatedAt) }}
+              </span>
+            </div>
+            <div :class="$style.rowActions">
+              <button
+                class="_button"
+                :class="$style.rowActionBtn"
+                title="名前を変更"
+                @click="onRenameSession($event, session.id)"
+              >
+                <i class="ti ti-pencil" />
+              </button>
+              <button
+                class="_button"
+                :class="[$style.rowActionBtn, $style.rowActionBtnDanger]"
+                title="削除"
+                @click="onDeleteSession($event, session.id)"
+              >
+                <i class="ti ti-trash" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Quick-start input: 一覧から直接送信すると新規セッション自動生成 -->
+      <div :class="$style.chatInput">
+        <div :class="$style.chatInputRow">
+          <textarea
+            ref="inputRef"
+            v-model="input"
+            :class="$style.chatTextarea"
+            :placeholder="providerStatus === 'connected'
+              ? '質問してみましょう'
+              : 'AI 設定で API キーを設定してください'"
+            rows="1"
+            :disabled="providerStatus !== 'connected'"
+            @keydown="onKeydown"
+          />
+          <button
+            :class="$style.chatSend"
+            :disabled="!input.trim() || providerStatus !== 'connected'"
+            @click="sendMessage"
+          >
+            <i class="ti ti-send" />
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- View: chat (detail) -->
+    <div v-else :class="$style.aiColumnBody">
       <ColumnEmptyState
         v-if="messages.length === 0"
         :message="providerStatus === 'connected'
-          ? `${currentProviderLabel} と会話できます`
+          ? '質問してみましょう'
           : 'AI 設定で API キーを設定してください'"
         :is-error="providerStatus === 'disconnected'"
         :fallback-kind="providerStatus === 'connected' ? 'info' : 'error'"
       />
 
-      <!-- Messages -->
       <div v-else ref="aiMessagesRef" :class="$style.aiMessages">
         <div
           v-for="msg in messages"
           :key="msg.id"
-          :class="[$style.aiMessage, $style[msg.role]]"
+          :class="[$style.chatMsg, { [$style.mine]: msg.role === 'user' }]"
         >
-          <div :class="$style.messageAvatar">
-            <i v-if="msg.role === 'assistant'" class="ti ti-brain" />
-            <i v-else class="ti ti-user" />
-          </div>
-          <div :class="$style.messageBody">
-            <div
-              v-if="msg.role === 'assistant' && !msg.content && isGenerating"
-              :class="$style.messageTyping"
-            >
-              <span :class="$style.typingDot" />
-              <span :class="$style.typingDot" />
-              <span :class="$style.typingDot" />
+          <div :class="$style.chatBubbleWrapper">
+            <div :class="$style.chatBubble">
+              <div
+                v-if="msg.role === 'assistant' && !msg.content && isGenerating"
+                :class="$style.messageTyping"
+              >
+                <span :class="$style.typingDot" />
+                <span :class="$style.typingDot" />
+                <span :class="$style.typingDot" />
+              </div>
+              <div
+                v-else-if="msg.role === 'assistant'"
+                :class="$style.markdownContent"
+                v-html="renderAssistant(msg.content)"
+                @click="onAssistantContentClick"
+              />
+              <div v-else :class="$style.chatText">{{ msg.content }}</div>
             </div>
-            <div
-              v-else-if="msg.role === 'assistant'"
-              :class="[$style.messageContent, $style.markdownContent]"
-              v-html="renderAssistant(msg.content)"
-              @click="onAssistantContentClick"
-            />
-            <div v-else :class="$style.messageContent">{{ msg.content }}</div>
             <button
               v-if="msg.role === 'assistant' && msg.content && !isGenerating"
               class="_button"
@@ -321,29 +616,30 @@ function onKeydown(e: KeyboardEvent) {
         <div ref="messagesEndRef" />
       </div>
 
-      <!-- Input -->
-      <div :class="$style.aiInputArea">
-        <textarea
-          ref="inputRef"
-          v-model="input"
-          :class="$style.aiInput"
-          :placeholder="providerStatus === 'connected'
-            ? `${currentProviderLabel} に質問...`
-            : 'AI 設定で API キーを設定してください'"
-          rows="1"
-          :disabled="providerStatus !== 'connected'"
-          @keydown="onKeydown"
-        />
-        <button
-          class="_button"
-          :class="$style.aiSend"
-          :disabled="!input.trim() || isGenerating || providerStatus !== 'connected'"
-          @click="sendMessage"
-        >
-          <i class="ti ti-send" />
-        </button>
+      <div :class="$style.chatInput">
+        <div :class="$style.chatInputRow">
+          <textarea
+            ref="inputRef"
+            v-model="input"
+            :class="$style.chatTextarea"
+            :placeholder="providerStatus === 'connected'
+              ? '質問してみましょう'
+              : 'AI 設定で API キーを設定してください'"
+            rows="1"
+            :disabled="providerStatus !== 'connected'"
+            @keydown="onKeydown"
+          />
+          <button
+            :class="$style.chatSend"
+            :disabled="!input.trim() || isGenerating || providerStatus !== 'connected'"
+            @click="sendMessage"
+          >
+            <i class="ti ti-send" />
+          </button>
+        </div>
       </div>
     </div>
+
   </DeckColumnComponent>
 </template>
 
@@ -359,21 +655,171 @@ function onKeydown(e: KeyboardEvent) {
   opacity: 0.45;
   font-size: 0.9em;
   flex-shrink: 0;
-  transition: opacity var(--nd-duration-base), background var(--nd-duration-base), color var(--nd-duration-base);
+  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
 
   &:hover {
     background: var(--nd-buttonHoverBg);
     opacity: 1;
   }
+}
 
-  &.confirmingClear {
-    color: var(--nd-love);
-    opacity: 1;
-    background: color-mix(in srgb, var(--nd-love) 18%, transparent);
+// --- セッション一覧ビュー ---
+
+.searchBar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--nd-divider);
+  background: var(--nd-bg);
+}
+
+.searchIcon {
+  flex-shrink: 0;
+  opacity: 0.4;
+}
+
+.searchInput {
+  flex: 1;
+  min-width: 0;
+  background: var(--nd-buttonBg);
+  border: none;
+  border-radius: var(--nd-radius-sm);
+  padding: 6px 10px;
+  font-size: 0.85em;
+  color: var(--nd-fg);
+  outline: none;
+
+  &:focus {
+    box-shadow: 0 0 0 2px var(--nd-accent);
+  }
+
+  &::placeholder {
+    color: var(--nd-fg);
+    opacity: 0.4;
   }
 }
 
-.confirmingClear { /* modifier */ }
+.sessionsBody {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.sessionsList {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 0;
+  scrollbar-color: var(--nd-scrollbarHandle) transparent;
+  scrollbar-width: thin;
+}
+
+.group {
+  padding: 4px 0;
+}
+
+.groupLabel {
+  padding: 6px 12px 4px;
+  font-size: 0.7em;
+  font-weight: 700;
+  opacity: 0.5;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--nd-duration-base);
+
+  &:hover,
+  &:focus-visible {
+    background: var(--nd-buttonHoverBg);
+
+    .rowActions {
+      opacity: 1;
+    }
+  }
+}
+
+.rowActive {
+  background: color-mix(in srgb, var(--nd-accent) 15%, transparent);
+
+  &:hover {
+    background: color-mix(in srgb, var(--nd-accent) 22%, transparent);
+  }
+}
+
+.rowMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rowTitle {
+  font-size: 0.9em;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rowMeta {
+  font-size: 0.75em;
+  opacity: 0.55;
+}
+
+// スキルカラムの行アクションと同じパターン: hover で出現するインラインボタン群。
+.rowActions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+
+  // タッチ環境では常時表示（hover が無いため）
+  @media (hover: none) {
+    opacity: 1;
+  }
+}
+
+.rowActionBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex-shrink: 0;
+  border-radius: 4px;
+  color: var(--nd-fg);
+  font-size: 0.95em;
+  opacity: 0.7;
+  transition: background 0.1s, opacity 0.1s, color 0.1s;
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-overlay);
+  }
+}
+
+// 危険操作（削除）— hover で赤くする。`--nd-love` / `--nd-love-hover` は
+// global.css で定義されたシステムカラー。
+.rowActionBtnDanger:hover {
+  color: var(--nd-love);
+  background: var(--nd-love-hover);
+}
+
+// --- チャットビュー (旧来) ---
 
 .aiColumnBody {
   display: flex;
@@ -386,54 +832,59 @@ function onKeydown(e: KeyboardEvent) {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
-  padding: 12px;
+  padding: 8px 0;
   scrollbar-color: var(--nd-scrollbarHandle) transparent;
   scrollbar-width: thin;
 }
 
-.aiMessage {
+// MkChatMessage.vue (DM チャット) のバブルレイアウトに揃える。
+.chatMsg {
   display: flex;
-  gap: 8px;
-  margin-bottom: 12px;
-
-  &.user {
-    flex-direction: row-reverse;
-  }
-}
-
-.messageAvatar {
-  flex-shrink: 0;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  background: var(--nd-buttonBg);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75em;
-  opacity: 0.6;
-
-  .assistant & {
-    background: var(--nd-accent-hover);
-    color: var(--nd-accent);
-    opacity: 1;
-  }
-}
-
-.messageBody {
-  display: flex;
-  flex-direction: column;
   align-items: flex-start;
+  padding: 4px 12px;
+
+  &.mine {
+    flex-direction: row-reverse;
+
+    .chatBubble {
+      background: var(--nd-accentedBg, rgba(134, 179, 0, 0.15));
+      border-bottom-right-radius: 4px;
+    }
+  }
+
+  &:not(.mine) .chatBubble {
+    border-bottom-left-radius: 4px;
+  }
+}
+
+.chatBubbleWrapper {
   max-width: 85%;
-  min-width: 0;
+  position: relative;
+  display: flex;
+  align-items: flex-start;
   gap: 4px;
 
-  .user & {
-    align-items: flex-end;
+  &:hover .copyBtn {
+    opacity: 0.5;
   }
+}
+
+.chatBubble {
+  padding: 8px 12px;
+  border-radius: 14px;
+  background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.05));
+  font-size: 0.95em;
+  line-height: 1.5;
+  word-break: break-word;
+  min-width: 0;
+}
+
+.chatText {
+  white-space: pre-wrap;
 }
 
 .copyBtn {
+  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -442,207 +893,186 @@ function onKeydown(e: KeyboardEvent) {
   border-radius: var(--nd-radius-sm);
   opacity: 0;
   font-size: 0.85em;
-  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
+  transition: opacity var(--nd-duration-base);
 
   &:hover {
     background: var(--nd-buttonHoverBg);
-    opacity: 1;
+    opacity: 1 !important;
   }
 }
 
-.aiMessage:hover .copyBtn {
-  opacity: 0.55;
-}
-
 .markdownContent {
+  white-space: normal;
+
   :global(p) {
     margin: 0;
   }
   :global(p + p) {
-    margin-top: 0.5em;
+    margin-top: 0.4em;
+  }
+  :global(pre) {
+    position: relative;
+    margin: 0.5em 0;
+    padding: 8px 10px;
+    padding-right: 28px;
+    background: var(--nd-base);
+    border-radius: var(--nd-radius-sm);
+    overflow-x: auto;
+    font-size: 0.85em;
+  }
+  :global(pre code) {
+    font-family: var(--nd-font-mono, monospace);
+  }
+  :global(pre button[data-md-copy]) {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 22px;
+    height: 22px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    opacity: 0.3;
+    border-radius: var(--nd-radius-sm);
+    cursor: pointer;
+    font-size: 0.7em;
+  }
+  :global(pre:hover button[data-md-copy]) {
+    opacity: 0.7;
+  }
+  :global(pre button[data-md-copy]:hover) {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+  :global(code) {
+    font-family: var(--nd-font-mono, monospace);
+    background: var(--nd-base);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+  :global(pre code) {
+    background: transparent;
+    padding: 0;
+  }
+  :global(ul),
+  :global(ol) {
+    margin: 0.4em 0;
+    padding-left: 1.4em;
+  }
+  :global(li) {
+    margin: 0.15em 0;
   }
   :global(strong) {
-    font-weight: bold;
+    font-weight: 700;
   }
   :global(em) {
     font-style: italic;
   }
-  :global(code.nd-md-inline-code) {
-    padding: 1px 5px;
-    border-radius: 3px;
-    background: color-mix(in srgb, var(--nd-fg) 12%, transparent);
-    font-family: var(--nd-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-    font-size: 0.9em;
-  }
-  :global(pre.nd-md-code) {
-    position: relative;
-    margin: 6px 0;
-    padding: 8px 10px;
-    border-radius: var(--nd-radius-sm);
-    background: color-mix(in srgb, var(--nd-fg) 8%, transparent);
-    overflow-x: auto;
-    font-size: 0.85em;
-    line-height: 1.45;
-
-    code {
-      font-family: var(--nd-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-      background: transparent;
-      padding: 0;
-    }
-  }
-  :global(button.nd-md-code-copy) {
-    position: absolute;
-    top: 4px;
-    right: 4px;
-    padding: 2px 8px;
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--nd-bg) 80%, transparent);
-    color: var(--nd-fg);
-    font-size: 0.78em;
-    font-family: inherit;
-    border: 1px solid color-mix(in srgb, var(--nd-fg) 12%, transparent);
-    opacity: 0;
-    cursor: pointer;
-    transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
-  }
-  :global(pre.nd-md-code:hover button.nd-md-code-copy),
-  :global(button.nd-md-code-copy:focus-visible) {
-    opacity: 0.85;
-  }
-  :global(button.nd-md-code-copy:hover) {
-    opacity: 1;
-    background: var(--nd-bg);
-  }
-  :global(.nd-md-h) {
-    margin: 8px 0 4px;
-    font-weight: bold;
-    font-size: 1em;
-  }
-  :global(ul),
-  :global(ol) {
-    margin: 4px 0;
-    padding-left: 18px;
-  }
-  :global(li) {
-    margin: 2px 0;
-  }
   :global(a) {
     color: var(--nd-accent);
     text-decoration: underline;
-    word-break: break-all;
-  }
-}
-
-.messageContent {
-  padding: 8px 12px;
-  border-radius: 12px;
-  font-size: 0.83em;
-  line-height: 1.5;
-  white-space: pre-wrap;
-  word-break: break-word;
-
-  .user & {
-    background: var(--nd-accent);
-    color: var(--nd-fgOnAccent, #fff);
-    border-bottom-right-radius: 4px;
-  }
-
-  .assistant & {
-    background: var(--nd-buttonBg);
-    border-bottom-left-radius: 4px;
   }
 }
 
 .messageTyping {
   display: flex;
   gap: 4px;
-  padding: 10px 14px;
+  padding: 10px 12px;
   background: var(--nd-buttonBg);
-  border-radius: 12px;
-  border-bottom-left-radius: 4px;
+  border-radius: var(--nd-radius);
 }
 
 .typingDot {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--nd-fg);
-  opacity: 0.3;
-  animation: typing 1.2s infinite ease-in-out;
-
-  &:nth-child(2) {
-    animation-delay: 0.2s;
-  }
-
-  &:nth-child(3) {
-    animation-delay: 0.4s;
-  }
+  background: currentColor;
+  opacity: 0.4;
+  animation: typing 1.4s infinite;
+}
+.typingDot:nth-child(2) {
+  animation-delay: 0.2s;
+}
+.typingDot:nth-child(3) {
+  animation-delay: 0.4s;
 }
 
 @keyframes typing {
-  0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
-  30% { opacity: 0.8; transform: translateY(-3px); }
+  0%, 60%, 100% {
+    opacity: 0.3;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
 }
 
-.aiInputArea {
+// Chat カラム (DeckChatColumn.vue) の入力欄スタイルに揃える。
+.chatInput {
+  display: flex;
+  flex-direction: column;
+  padding: 6px 8px 8px;
+  border-top: 1px solid var(--nd-divider, rgba(255, 255, 255, 0.05));
+  background: var(--nd-panel);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.chatInputRow {
   display: flex;
   align-items: flex-end;
   gap: 6px;
-  padding: 8px 12px;
-  border-top: 1px solid var(--nd-divider);
-  flex-shrink: 0;
 }
 
-.aiInput {
+.chatTextarea {
   flex: 1;
-  min-width: 0;
-  background: var(--nd-buttonBg);
-  border: none;
-  border-radius: var(--nd-radius-md);
-  padding: 8px 10px;
-  font-size: 0.83em;
-  line-height: 1.5;
-  color: var(--nd-fg);
-  outline: none;
   resize: none;
-  max-height: 160px;
-  overflow-y: auto;
+  border: none;
+  background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.05));
+  color: var(--nd-fg);
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 0.9em;
   font-family: inherit;
-  scrollbar-color: var(--nd-scrollbarHandle) transparent;
-  scrollbar-width: thin;
-
-  &:focus {
-    box-shadow: 0 0 0 2px var(--nd-accent);
-  }
+  line-height: 1.4;
+  max-height: 120px;
+  outline: none;
+  field-sizing: content;
 
   &::placeholder {
-    color: var(--nd-fg);
     opacity: 0.4;
   }
 
   &:disabled {
-    opacity: 0.4;
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 }
 
-.aiSend {
+.chatSend {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: var(--nd-accent);
+  color: var(--nd-fgOnAccent, #fff);
+  cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 30px;
-  height: 30px;
-  border-radius: var(--nd-radius-md);
-  background: var(--nd-accent);
-  color: var(--nd-fgOnAccent, #fff);
   flex-shrink: 0;
-  transition: opacity var(--nd-duration-base), transform var(--nd-duration-base);
-
-  &:hover:not(:disabled) {
-    transform: scale(1.05);
-  }
+  font-size: 1em;
+  transition: filter var(--nd-duration-base);
 
   &:disabled {
     opacity: 0.3;
+    cursor: default;
+  }
+
+  &:not(:disabled):hover {
+    filter: brightness(1.1);
   }
 }
 </style>

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -15,7 +15,7 @@ import { type DeckColumn, useDeckStore } from '@/stores/deck'
 import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
-import { generateSessionTitle } from '@/utils/aiSessionTitle'
+import { timestampTitle } from '@/utils/aiSessionTitle'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -24,7 +24,10 @@ const props = defineProps<{
 }>()
 
 const input = ref('')
-const inputRef = ref<HTMLTextAreaElement | null>(null)
+// `ref="inputRef"` を template で利用しているが、現状 script からの read 利用は無し。
+// 将来 focus 制御を再導入したくなった時のため shape は残しておく。
+const _inputRef = useTemplateRef<HTMLTextAreaElement>('inputRef')
+void _inputRef
 const messagesEndRef = ref<HTMLElement | null>(null)
 const providerStatus = ref<'connected' | 'disconnected' | 'checking'>(
   'checking',
@@ -40,6 +43,9 @@ void sessionsStore.loadAllMeta()
 
 const { config: aiConfig } = useAiConfig()
 const aiChat = useAiChat()
+// 初回応答後にバックグラウンドでタイトルを AI 生成するための独立インスタンス。
+// `aiChat` の isStreaming や activeStreamId と干渉しないよう別 composable 化。
+const titleGen = useAiChat()
 
 // `column.aiCurrentSessionId` を reactive に橋渡し。useAiConversation は
 // この ref の変化を購読してメッセージ参照を切り替える。
@@ -280,6 +286,66 @@ watch(aiChat.currentText, (text) => {
 
 // --- 送信 ---
 
+/**
+ * 初回 round 完了後にバックグラウンドで AI にタイトルを生成させる。
+ * - 会話 (user + assistant) を 1 つの user メッセージにまとめて送る。
+ *   Anthropic は last message が assistant だと assistant 応答の続きとして
+ *   扱うため、history には絶対に assistant role を置かない。
+ * - 失敗は silent (best-effort)
+ * - ユーザーが手動 rename したら上書きしない (titleBefore で race 対策)
+ * - LLM 応答に余計な引用符や改行が混じる場合があるので軽く整形する
+ */
+const TITLE_SYSTEM_PROMPT =
+  'あなたは会話セッションのタイトル生成アシスタントです。与えられた会話の内容を端的に表す短い日本語のタイトルを 1 行で出力してください。20 文字程度 (最大 40 文字) に収めること。引用符、前置き、改行、絵文字、文末句点は付けないでください。タイトルのみを返してください。'
+
+async function generateAiTitleAsync(
+  sessionId: string,
+  userText: string,
+  assistantText: string,
+): Promise<void> {
+  // 初期プレースホルダー (timestampTitle) は sendMessage 側で既にセット済み。
+  // AI 生成に失敗した場合は何もせず、プレースホルダーがそのまま残る。
+  if (providerStatus.value !== 'connected') return
+  const before = sessionsStore.get(sessionId)
+  if (!before) return
+  const titleBefore = before.title
+  const provider: ProviderKey = aiConfig.value.provider
+  const settings = aiConfig.value[provider]
+  if (!settings.endpoint || !settings.model) return
+
+  // 会話を 1 つの user メッセージに集約する。assistant role を history に
+  // 置くと Anthropic 側が「続きを書く」モードになりタイトルが取れない。
+  const conversationPrompt =
+    `次の会話に短いタイトルを付けてください。タイトルだけを 1 行で出力。\n\n` +
+    `ユーザー:\n${userText}\n\nアシスタント:\n${assistantText}`
+
+  try {
+    const raw = await titleGen.sendMessage({
+      provider,
+      endpoint: settings.endpoint,
+      model: settings.model,
+      history: [
+        { id: 'u', role: 'user', content: conversationPrompt, timestamp: 0 },
+      ],
+      system: TITLE_SYSTEM_PROMPT,
+      maxTokens: 80,
+    })
+    const cleaned = raw
+      .replace(/[\r\n]+/g, ' ')
+      .replace(/^[\s「『"'“”]+|[\s」』"'“”。．、]+$/g, '')
+      .trim()
+      .slice(0, 40)
+    if (!cleaned) return
+    // ユーザーが間に手動 rename していたら触らない
+    const cur = sessionsStore.get(sessionId)
+    if (cur && cur.title === titleBefore) {
+      sessionsStore.setTitle(sessionId, cleaned)
+    }
+  } catch (e) {
+    console.warn('[ai-title-gen] failed:', e)
+  }
+}
+
 /** 必要なら新規セッションを作って ID を返す。 */
 function ensureSession(): string {
   if (currentSessionId.value) return currentSessionId.value
@@ -320,9 +386,13 @@ async function sendMessage() {
   input.value = ''
   scrollToBottom()
 
-  // 初回発話で title が空ならユーザー発話から自動生成
+  // この round が assistant 応答のない初回かどうかを記録 (AI 生成タイトル用)。
+  const wasFirstRound = !before.messages.some((m) => m.role === 'assistant')
+
+  // 初期プレースホルダーは Zettelkasten 形式の日時タイトル。
+  // 初回応答完了後に AI 生成タイトルが届けば上書きされる (失敗時は残る)。
   if (!before.title) {
-    sessionsStore.setTitle(sessionId, generateSessionTitle(text, new Date(now)))
+    sessionsStore.setTitle(sessionId, timestampTitle(new Date(now)))
   }
 
   // Pre-add empty assistant placeholder so streaming has a target slot
@@ -363,6 +433,10 @@ async function sendMessage() {
           { ...last, content: finalText },
         ])
       }
+    }
+    // 初回 round 完了後にバックグラウンドで AI にタイトルを再生成させる
+    if (wasFirstRound && finalText) {
+      void generateAiTitleAsync(sessionId, text, finalText)
     }
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -704,8 +704,18 @@ function onKeydown(e: KeyboardEvent) {
             @keydown="onKeydown"
           />
           <button
+            v-if="isGenerating"
+            :class="[$style.chatSend, $style.chatStop]"
+            title="停止"
+            @click="aiChat.cancel()"
+          >
+            <i class="ti ti-player-stop" />
+          </button>
+          <button
+            v-else
             :class="$style.chatSend"
-            :disabled="!input.trim() || isGenerating || providerStatus !== 'connected'"
+            :disabled="!input.trim() || providerStatus !== 'connected'"
+            title="送信"
             @click="sendMessage"
           >
             <i class="ti ti-send" />

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -43,7 +43,8 @@ function toWireMessage(m: ChatMessage): AiChatMessage {
  * Single-shot streaming chat call. The accumulator ref is updated as deltas
  * arrive; the returned promise resolves with the final text on completion.
  *
- * Cancellation is not yet supported (planned for a follow-up PR).
+ * Use `cancel()` to abort an in-flight stream (e.g. when the user switches
+ * to a different AI session mid-response).
  */
 export function useAiChat() {
   const isStreaming = ref(false)
@@ -54,23 +55,48 @@ export function useAiChat() {
   // Hoisted to composable scope so onScopeDispose can clean it up if the
   // component unmounts while a stream is in flight.
   let activeUnlisten: UnlistenFn | null = null
+  let activeStreamId: string | null = null
 
   function cleanup() {
     if (activeUnlisten) {
       activeUnlisten()
       activeUnlisten = null
     }
+    activeStreamId = null
     isStreaming.value = false
   }
 
   // Auto-cleanup on component unmount: tears down any in-flight listener
-  // so we don't leak across columns being added/removed.
+  // so we don't leak across columns being added/removed. Also fire-and-forget
+  // a server-side cancel so the Rust task doesn't keep streaming bytes
+  // (and burning API tokens) for an unmounted component.
   onScopeDispose(() => {
+    if (activeStreamId) {
+      void commands.aiChatCancel(activeStreamId)
+    }
     if (activeUnlisten) {
       activeUnlisten()
       activeUnlisten = null
     }
   })
+
+  /**
+   * Cancel any in-flight stream. Resolves immediately; the Rust side aborts
+   * the background task and stops emitting events for this stream_id.
+   */
+  async function cancel(): Promise<void> {
+    const id = activeStreamId
+    cleanup()
+    if (id) {
+      try {
+        unwrap(await commands.aiChatCancel(id))
+      } catch (e) {
+        // Cancellation is best-effort. Log but don't throw — the caller has
+        // already moved on (e.g. switched session) and doesn't care.
+        console.warn('[ai-chat] cancel failed:', e)
+      }
+    }
+  }
 
   async function sendMessage(opts: AiChatSendOptions): Promise<string> {
     if (isStreaming.value) {
@@ -81,6 +107,7 @@ export function useAiChat() {
     currentText.value = ''
 
     const streamId = generateStreamId()
+    activeStreamId = streamId
 
     return new Promise<string>((resolve, reject) => {
       // Subscribe BEFORE invoking, so we never miss the first delta.
@@ -129,5 +156,6 @@ export function useAiChat() {
     lastError,
     currentText,
     sendMessage,
+    cancel,
   }
 }

--- a/src/composables/useAiConversation.ts
+++ b/src/composables/useAiConversation.ts
@@ -1,36 +1,20 @@
-import { type ComputedRef, computed, type Ref, ref } from 'vue'
+import { type ComputedRef, computed, type Ref } from 'vue'
 import type { ChatMessage } from '@/composables/useAiChat'
 import { useAiSessionsStore } from '@/stores/aiSessions'
 
-const MAX_MESSAGES = 200
-
 /**
- * Pinia store の AiSession に対する薄いラッパー。`useAiSessionsStore` が
- * sessionId 単位で本文と debounce 永続化を集中管理するため、本 composable は
- * 「指定 sessionId のメッセージ配列を読んだり編集したりする」薄い API
- * を提供するだけ。
+ * 指定 sessionId のメッセージ配列に対する reactive な参照を提供する薄い
+ * ラッパー。`useAiSessionsStore` が永続化と本文管理を担うので、本 composable
+ * は ref 化された sessionId の変化を購読してメッセージ配列を切り替えるだけ。
  *
- * `sessionIdRef` を ref で受け取ると、カラム側でセッション切替したときに
- * 自動的に新しいセッションを参照しに行く（複数カラムで同一セッションを
- * 開いても破綻しない）。
+ * 書き込み (append / replaceLast / clear) は呼び出し側で
+ * `useAiSessionsStore.updateMessages(sessionId, messages)` を直接使う想定。
  */
 export function useAiConversation(
   sessionIdRef: Ref<string | null> | ComputedRef<string | null>,
-): {
-  messages: ComputedRef<ChatMessage[]>
-  loaded: Ref<boolean>
-  append: (msg: ChatMessage) => void
-  replaceLast: (msg: ChatMessage) => void
-  clear: () => void
-} {
+): { messages: ComputedRef<ChatMessage[]> } {
   const store = useAiSessionsStore()
-  // metaLoaded が false の間は loaded=false。store 側で並列の重複 load を防ぐ。
-  const loaded = ref(store.metaLoaded)
-  if (!store.metaLoaded) {
-    void store.loadAllMeta().then(() => {
-      loaded.value = true
-    })
-  }
+  if (!store.metaLoaded) void store.loadAllMeta()
 
   const messages = computed<ChatMessage[]>(() => {
     const id = sessionIdRef.value
@@ -38,37 +22,5 @@ export function useAiConversation(
     return store.get(id)?.messages ?? []
   })
 
-  function append(msg: ChatMessage): void {
-    const id = sessionIdRef.value
-    if (!id) return
-    const cur = store.get(id)
-    if (!cur) return
-    let next = [...cur.messages, msg]
-    if (next.length > MAX_MESSAGES) next = next.slice(-MAX_MESSAGES)
-    store.updateMessages(id, next)
-  }
-
-  function replaceLast(msg: ChatMessage): void {
-    const id = sessionIdRef.value
-    if (!id) return
-    const cur = store.get(id)
-    if (!cur) return
-    const next =
-      cur.messages.length === 0 ? [msg] : [...cur.messages.slice(0, -1), msg]
-    store.updateMessages(id, next)
-  }
-
-  function clear(): void {
-    const id = sessionIdRef.value
-    if (!id) return
-    store.updateMessages(id, [])
-  }
-
-  return {
-    messages,
-    loaded,
-    append,
-    replaceLast,
-    clear,
-  }
+  return { messages }
 }

--- a/src/composables/useAiConversation.ts
+++ b/src/composables/useAiConversation.ts
@@ -1,109 +1,68 @@
-import JSON5 from 'json5'
-import { ref } from 'vue'
+import { type ComputedRef, computed, type Ref, ref } from 'vue'
 import type { ChatMessage } from '@/composables/useAiChat'
-import {
-  aiConversationFilename,
-  deleteAiConversationFile,
-  isTauri,
-  readAiConversationFile,
-  writeAiConversationFile,
-} from '@/utils/settingsFs'
+import { useAiSessionsStore } from '@/stores/aiSessions'
 
 const MAX_MESSAGES = 200
-const PERSIST_DEBOUNCE_MS = 500
-
-interface PersistShape {
-  messages: ChatMessage[]
-}
 
 /**
- * Per-column AI chat history backed by `notedeck/ai-conversations/<columnId>.json5`.
+ * Pinia store の AiSession に対する薄いラッパー。`useAiSessionsStore` が
+ * sessionId 単位で本文と debounce 永続化を集中管理するため、本 composable は
+ * 「指定 sessionId のメッセージ配列を読んだり編集したりする」薄い API
+ * を提供するだけ。
  *
- * Each column has its own independent conversation. Messages auto-save with
- * a debounce so rapid streaming doesn't hammer the disk.
+ * `sessionIdRef` を ref で受け取ると、カラム側でセッション切替したときに
+ * 自動的に新しいセッションを参照しに行く（複数カラムで同一セッションを
+ * 開いても破綻しない）。
  */
-export function useAiConversation(columnId: string) {
-  const messages = ref<ChatMessage[]>([])
-  const loaded = ref(false)
-  let persistTimer: ReturnType<typeof setTimeout> | null = null
-
-  async function load(): Promise<void> {
-    if (!isTauri) {
+export function useAiConversation(
+  sessionIdRef: Ref<string | null> | ComputedRef<string | null>,
+): {
+  messages: ComputedRef<ChatMessage[]>
+  loaded: Ref<boolean>
+  append: (msg: ChatMessage) => void
+  replaceLast: (msg: ChatMessage) => void
+  clear: () => void
+} {
+  const store = useAiSessionsStore()
+  // metaLoaded が false の間は loaded=false。store 側で並列の重複 load を防ぐ。
+  const loaded = ref(store.metaLoaded)
+  if (!store.metaLoaded) {
+    void store.loadAllMeta().then(() => {
       loaded.value = true
-      return
-    }
-    try {
-      const raw = await readAiConversationFile(aiConversationFilename(columnId))
-      if (raw) {
-        const parsed = JSON5.parse(raw) as PersistShape
-        if (Array.isArray(parsed.messages)) {
-          messages.value = parsed.messages
-        }
-      }
-    } catch (e) {
-      // Missing file for a fresh column is expected — silent unless other error
-      if (!String(e).toLowerCase().includes('no such file')) {
-        console.warn('[ai-conversations] load failed:', e)
-      }
-    }
-    loaded.value = true
+    })
   }
 
-  function schedulePersist(): void {
-    if (persistTimer) clearTimeout(persistTimer)
-    persistTimer = setTimeout(() => {
-      persistTimer = null
-      void persist()
-    }, PERSIST_DEBOUNCE_MS)
-  }
-
-  async function persist(): Promise<void> {
-    if (!isTauri) return
-    if (messages.value.length > MAX_MESSAGES) {
-      messages.value = messages.value.slice(-MAX_MESSAGES)
-    }
-    const content = `${JSON5.stringify({ messages: messages.value }, null, 2)}\n`
-    try {
-      await writeAiConversationFile(aiConversationFilename(columnId), content)
-    } catch (e) {
-      console.warn('[ai-conversations] persist failed:', e)
-    }
-  }
+  const messages = computed<ChatMessage[]>(() => {
+    const id = sessionIdRef.value
+    if (!id) return []
+    return store.get(id)?.messages ?? []
+  })
 
   function append(msg: ChatMessage): void {
-    messages.value = [...messages.value, msg]
-    schedulePersist()
+    const id = sessionIdRef.value
+    if (!id) return
+    const cur = store.get(id)
+    if (!cur) return
+    let next = [...cur.messages, msg]
+    if (next.length > MAX_MESSAGES) next = next.slice(-MAX_MESSAGES)
+    store.updateMessages(id, next)
   }
 
   function replaceLast(msg: ChatMessage): void {
-    if (messages.value.length === 0) {
-      messages.value = [msg]
-    } else {
-      messages.value = [...messages.value.slice(0, -1), msg]
-    }
-    schedulePersist()
+    const id = sessionIdRef.value
+    if (!id) return
+    const cur = store.get(id)
+    if (!cur) return
+    const next =
+      cur.messages.length === 0 ? [msg] : [...cur.messages.slice(0, -1), msg]
+    store.updateMessages(id, next)
   }
 
   function clear(): void {
-    messages.value = []
-    schedulePersist()
+    const id = sessionIdRef.value
+    if (!id) return
+    store.updateMessages(id, [])
   }
-
-  async function deleteFile(): Promise<void> {
-    if (persistTimer) {
-      clearTimeout(persistTimer)
-      persistTimer = null
-    }
-    messages.value = []
-    if (!isTauri) return
-    try {
-      await deleteAiConversationFile(aiConversationFilename(columnId))
-    } catch (e) {
-      console.warn('[ai-conversations] delete failed:', e)
-    }
-  }
-
-  void load()
 
   return {
     messages,
@@ -111,6 +70,5 @@ export function useAiConversation(columnId: string) {
     append,
     replaceLast,
     clear,
-    deleteFile,
   }
 }

--- a/src/stores/aiSessions.ts
+++ b/src/stores/aiSessions.ts
@@ -1,0 +1,314 @@
+/**
+ * useAiSessionsStore — AI セッション (`sessions/<id>.json5`) の集中管理。
+ *
+ * - **メタは全件常駐**: 数百件規模なら最大数 MB なので問題なし
+ * - **本文 (messages) は遅延ロード**: セッション切替時に必要なものだけ
+ * - **永続化は sessionId 単位 debounce**: 複数カラムから同じセッションを開いても
+ *   ファイル書込は 1 ファイルに集約される
+ * - **id (= ファイル名 stem) と内部 id は完全一致**: ファイル単体で自己同定可能
+ *
+ * カラム側からは `useAiConversation(sessionId)` 経由でアクセスし、本ストアの
+ * リアクティブ参照と同期する（本ストアは単一の真の source）。
+ */
+
+import JSON5 from 'json5'
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { ChatMessage } from '@/composables/useAiChat'
+import { generateSessionId } from '@/utils/aiSessionId'
+import {
+  aiSessionFilename,
+  deleteAiSessionFile,
+  isTauri,
+  listAiSessionFiles,
+  readAiSessionFile,
+  writeAiSessionFile,
+} from '@/utils/settingsFs'
+
+const PERSIST_DEBOUNCE_MS = 500
+const CURRENT_SCHEMA_VERSION = 1
+
+export type AiSessionKind = 'chat' | 'command' | 'task' | 'heartbeat'
+
+/** セッション一覧 (ドロワー) で使う軽量メタ。 */
+export interface AiSessionMeta {
+  id: string
+  kind: AiSessionKind
+  title: string
+  model: string
+  provider: string
+  createdAt: number
+  updatedAt: number
+  messageCount: number
+}
+
+/** メタ + 本文。chat 以外の kind が増えたら discriminated union 化する。 */
+export interface AiSession extends AiSessionMeta {
+  schemaVersion: number
+  messages: ChatMessage[]
+  /** 知らないフィールドは forward-compat で保持して書き戻す。 */
+  unknownFields?: Record<string, unknown>
+}
+
+interface PersistShape {
+  schemaVersion: number
+  id: string
+  kind: AiSessionKind
+  title: string
+  model: string
+  provider: string
+  createdAt: number
+  updatedAt: number
+  messages: ChatMessage[]
+  [key: string]: unknown
+}
+
+const KNOWN_FIELDS = new Set([
+  'schemaVersion',
+  'id',
+  'kind',
+  'title',
+  'model',
+  'provider',
+  'createdAt',
+  'updatedAt',
+  'messages',
+])
+
+function serialize(session: AiSession): string {
+  const out: Record<string, unknown> = {
+    schemaVersion: session.schemaVersion,
+    id: session.id,
+    kind: session.kind,
+    title: session.title,
+    model: session.model,
+    provider: session.provider,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    messages: session.messages,
+  }
+  if (session.unknownFields) {
+    for (const [k, v] of Object.entries(session.unknownFields)) {
+      out[k] = v
+    }
+  }
+  return `${JSON.stringify(out, null, 2)}\n`
+}
+
+function deserialize(raw: string): AiSession | null {
+  let parsed: unknown
+  try {
+    parsed = JSON5.parse(raw)
+  } catch (e) {
+    console.warn('[ai-sessions] parse failed:', e)
+    return null
+  }
+  if (!parsed || typeof parsed !== 'object') return null
+  const r = parsed as PersistShape
+  const messages = Array.isArray(r.messages) ? r.messages : []
+  const unknownFields: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(r)) {
+    if (!KNOWN_FIELDS.has(k)) unknownFields[k] = v
+  }
+  return {
+    schemaVersion: typeof r.schemaVersion === 'number' ? r.schemaVersion : 1,
+    id: typeof r.id === 'string' ? r.id : '',
+    kind: (r.kind as AiSessionKind) || 'chat',
+    title: typeof r.title === 'string' ? r.title : '',
+    model: typeof r.model === 'string' ? r.model : '',
+    provider: typeof r.provider === 'string' ? r.provider : '',
+    createdAt: typeof r.createdAt === 'number' ? r.createdAt : Date.now(),
+    updatedAt: typeof r.updatedAt === 'number' ? r.updatedAt : Date.now(),
+    messages,
+    messageCount: messages.length,
+    unknownFields:
+      Object.keys(unknownFields).length > 0 ? unknownFields : undefined,
+  }
+}
+
+export const useAiSessionsStore = defineStore('aiSessions', () => {
+  /** セッション本体 (メタ + 本文) のキャッシュ。id をキーとする。 */
+  const sessions = ref<Map<string, AiSession>>(new Map())
+  /** メタ全件 list 済みフラグ。`loadAllMeta()` で立てる。 */
+  const metaLoaded = ref(false)
+
+  /** sessionId 単位の debounce タイマー。 */
+  const persistTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  /**
+   * 全セッションのメタ + 本文を一括ロード。typical 数百件なら数 MB なので
+   * 常駐させて問題ない。失敗ファイルはスキップしつつ進める。
+   */
+  async function loadAllMeta(): Promise<void> {
+    if (metaLoaded.value) return
+    if (!isTauri) {
+      metaLoaded.value = true
+      return
+    }
+    try {
+      const files = await listAiSessionFiles()
+      for (const file of files) {
+        try {
+          const raw = await readAiSessionFile(file)
+          const session = deserialize(raw)
+          if (session?.id) {
+            sessions.value.set(session.id, session)
+          }
+        } catch (e) {
+          console.warn(`[ai-sessions] load ${file} failed:`, e)
+        }
+      }
+    } catch (e) {
+      console.warn('[ai-sessions] listAiSessionFiles failed:', e)
+    }
+    // ref<Map> は in-place mutation 後に再代入で reactivity を発火
+    sessions.value = new Map(sessions.value)
+    metaLoaded.value = true
+  }
+
+  function get(id: string): AiSession | undefined {
+    return sessions.value.get(id)
+  }
+
+  /** 並べ替え済みメタリスト (updatedAt 降順)。ドロワーが購読する。 */
+  function listSorted(): AiSessionMeta[] {
+    const arr = Array.from(sessions.value.values()).map<AiSessionMeta>((s) => ({
+      id: s.id,
+      kind: s.kind,
+      title: s.title,
+      model: s.model,
+      provider: s.provider,
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+      messageCount: s.messages.length,
+    }))
+    arr.sort((a, b) => b.updatedAt - a.updatedAt)
+    return arr
+  }
+
+  /**
+   * 新規セッションを生成してキャッシュに登録。ファイル書込は最初の
+   * `updateMessages()` または `setTitle()` 呼び出し時に走る。
+   */
+  function createNew(opts: {
+    model: string
+    provider: string
+    title?: string
+    kind?: AiSessionKind
+  }): AiSession {
+    const existing = new Set(sessions.value.keys())
+    const id = generateSessionId(new Date(), existing)
+    const now = Date.now()
+    const session: AiSession = {
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      id,
+      kind: opts.kind ?? 'chat',
+      title: opts.title ?? '',
+      model: opts.model,
+      provider: opts.provider,
+      createdAt: now,
+      updatedAt: now,
+      messageCount: 0,
+      messages: [],
+    }
+    sessions.value.set(id, session)
+    sessions.value = new Map(sessions.value)
+    schedulePersist(id)
+    return session
+  }
+
+  /** 既存セッションを直接登録（マイグレーション専用、外部からは呼ばない）。 */
+  function upsertRaw(session: AiSession): void {
+    sessions.value.set(session.id, session)
+    sessions.value = new Map(sessions.value)
+  }
+
+  /** メッセージ配列を差し替え。`updatedAt` を更新して debounce 永続化。 */
+  function updateMessages(id: string, messages: ChatMessage[]): void {
+    const cur = sessions.value.get(id)
+    if (!cur) return
+    const updated: AiSession = {
+      ...cur,
+      messages,
+      messageCount: messages.length,
+      updatedAt: Date.now(),
+    }
+    sessions.value.set(id, updated)
+    sessions.value = new Map(sessions.value)
+    schedulePersist(id)
+  }
+
+  function setTitle(id: string, title: string): void {
+    const cur = sessions.value.get(id)
+    if (!cur || cur.title === title) return
+    const updated: AiSession = {
+      ...cur,
+      title,
+      updatedAt: Date.now(),
+    }
+    sessions.value.set(id, updated)
+    sessions.value = new Map(sessions.value)
+    schedulePersist(id)
+  }
+
+  function schedulePersist(id: string): void {
+    const existing = persistTimers.get(id)
+    if (existing) clearTimeout(existing)
+    const timer = setTimeout(() => {
+      persistTimers.delete(id)
+      void persist(id)
+    }, PERSIST_DEBOUNCE_MS)
+    persistTimers.set(id, timer)
+  }
+
+  async function persist(id: string): Promise<void> {
+    if (!isTauri) return
+    const session = sessions.value.get(id)
+    if (!session) return
+    try {
+      await writeAiSessionFile(aiSessionFilename(id), serialize(session))
+    } catch (e) {
+      console.warn(`[ai-sessions] persist ${id} failed:`, e)
+    }
+  }
+
+  /** 即時にディスクに書き出す (debounce タイマーを flush)。 */
+  async function flush(id: string): Promise<void> {
+    const t = persistTimers.get(id)
+    if (t) {
+      clearTimeout(t)
+      persistTimers.delete(id)
+    }
+    await persist(id)
+  }
+
+  async function deleteSession(id: string): Promise<void> {
+    const t = persistTimers.get(id)
+    if (t) {
+      clearTimeout(t)
+      persistTimers.delete(id)
+    }
+    sessions.value.delete(id)
+    sessions.value = new Map(sessions.value)
+    if (!isTauri) return
+    try {
+      await deleteAiSessionFile(aiSessionFilename(id))
+    } catch (e) {
+      console.warn(`[ai-sessions] delete ${id} failed:`, e)
+    }
+  }
+
+  return {
+    sessions,
+    metaLoaded,
+    loadAllMeta,
+    get,
+    listSorted,
+    createNew,
+    upsertRaw,
+    updateMessages,
+    setTitle,
+    flush,
+    deleteSession,
+  }
+})

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -124,6 +124,13 @@ export interface DeckColumn {
   account?: string
   /** true if created by nav icon toggle (managed as sidebar slot) */
   sidebar?: boolean
+  /**
+   * AI カラムが現在表示中の `AiSession.id`。
+   * `null` または未定義 = まだセッション未選択（空状態 UI を表示）。
+   * セッションは `useAiSessionsStore` でグローバルに管理され、
+   * カラム削除しても残る（別カラムから開ける）。
+   */
+  aiCurrentSessionId?: string | null
 }
 
 let columnCounter = 0

--- a/src/utils/aiSessionId.ts
+++ b/src/utils/aiSessionId.ts
@@ -1,0 +1,71 @@
+/**
+ * AI セッション ID は Zettelkasten 風の 14 桁ローカル日時文字列
+ * (`YYYYMMDDhhmmss`)。同一秒内に複数生成された場合のみ末尾に
+ * `a`, `b`, `c`, ... と suffix を付ける。
+ *
+ * - 辞書ソートで自然に時系列に並ぶ
+ * - ファイル名 stem としてそのまま使える
+ * - 内部 `id` フィールドと完全一致（自己同定可能）
+ */
+
+/** 与えた Date をローカルタイムゾーンの `YYYYMMDDhhmmss` にフォーマット。 */
+export function formatLocalTimestamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  return (
+    d.getFullYear().toString() +
+    pad(d.getMonth() + 1) +
+    pad(d.getDate()) +
+    pad(d.getHours()) +
+    pad(d.getMinutes()) +
+    pad(d.getSeconds())
+  )
+}
+
+/**
+ * 同一秒衝突を回避するための suffix を計算する。
+ * `existingIds` に `<base>` がなければそのまま、あれば `a`, `b`, ... を試す。
+ * 26 個以上で衝突したら `aa`, `ab`, ... と二桁に拡張する。
+ */
+export function resolveCollisionSuffix(
+  base: string,
+  existingIds: ReadonlySet<string>,
+): string {
+  if (!existingIds.has(base)) return base
+  // 単文字 a-z
+  for (let i = 0; i < 26; i++) {
+    const candidate = base + String.fromCharCode(0x61 + i)
+    if (!existingIds.has(candidate)) return candidate
+  }
+  // 二文字 aa-zz (26*26 = 676 通り、同一秒内では現実的に起き得ない)
+  for (let i = 0; i < 26; i++) {
+    for (let j = 0; j < 26; j++) {
+      const candidate =
+        base + String.fromCharCode(0x61 + i) + String.fromCharCode(0x61 + j)
+      if (!existingIds.has(candidate)) return candidate
+    }
+  }
+  // 完全に枯渇したら timestamp 自体を 1 秒進める（呼び出し側で再試行する想定）
+  throw new Error(
+    `aiSessionId: collision suffixes exhausted for ${base} (>702 sessions in one second)`,
+  )
+}
+
+/**
+ * 現在時刻 + 既存 ID 集合から新しいセッション ID を生成する。
+ * ファイル名 stem としてそのまま使える文字列を返す（拡張子は呼び出し側で付ける）。
+ */
+export function generateSessionId(
+  now: Date,
+  existingIds: ReadonlySet<string>,
+): string {
+  const base = formatLocalTimestamp(now)
+  return resolveCollisionSuffix(base, existingIds)
+}
+
+/**
+ * Date から生成した base 部分のみを返す（衝突解決前）。マイグレーションで
+ * 旧ファイルの `createdAt` から ID を割り当てるときなどに使う。
+ */
+export function timestampToSessionIdBase(epochMs: number): string {
+  return formatLocalTimestamp(new Date(epochMs))
+}

--- a/src/utils/aiSessionTitle.ts
+++ b/src/utils/aiSessionTitle.ts
@@ -1,0 +1,50 @@
+/**
+ * AI セッションの自動タイトル生成。最初のユーザー発話から決定論的に短い
+ * タイトル文字列を作る。AI で要約させる UI を後で入れる余地を残すため、
+ * 純粋関数として切り出してある。
+ */
+
+const MAX_TITLE_LEN = 40
+const MIN_MEANINGFUL_LEN = 4
+
+/** ユーザー発話の整形: コードブロック・URL を除去して 1 行に圧縮する。 */
+function normalize(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, '') // ``` ... ``` ブロック
+    .replace(/`[^`]*`/g, '') // インラインコード
+    .replace(/https?:\/\/\S+/g, '') // URL
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * 日時フォールバックタイトル。`<YYYY-MM-DD HH:mm> のチャット` 形式。
+ * 同日に複数のセッションがあっても分単位で識別できる
+ * （秒精度はファイル名 (Zettelkasten) 側で担保しているのでここは分まで）。
+ */
+function fallbackTitle(now: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0')
+  const y = now.getFullYear()
+  const m = pad(now.getMonth() + 1)
+  const d = pad(now.getDate())
+  const hh = pad(now.getHours())
+  const mm = pad(now.getMinutes())
+  return `${y}-${m}-${d} ${hh}:${mm} のチャット`
+}
+
+/**
+ * ユーザー発話を整形してタイトルを返す。整形後 4 文字未満なら日付フォールバック。
+ */
+export function generateSessionTitle(
+  firstUserMessage: string,
+  now: Date = new Date(),
+): string {
+  const normalized = normalize(firstUserMessage)
+  if (normalized.length < MIN_MEANINGFUL_LEN) {
+    return fallbackTitle(now)
+  }
+  if (normalized.length <= MAX_TITLE_LEN) {
+    return normalized
+  }
+  return normalized.slice(0, MAX_TITLE_LEN)
+}

--- a/src/utils/aiSessionTitle.ts
+++ b/src/utils/aiSessionTitle.ts
@@ -18,11 +18,14 @@ function normalize(text: string): string {
 }
 
 /**
- * 日時フォールバックタイトル。`<YYYY-MM-DD HH:mm> のチャット` 形式。
+ * Zettelkasten 風の日時タイトル。`<YYYY-MM-DD HH:mm> のチャット` 形式。
  * 同日に複数のセッションがあっても分単位で識別できる
  * （秒精度はファイル名 (Zettelkasten) 側で担保しているのでここは分まで）。
+ *
+ * 「初期プレースホルダー」「AI タイトル生成失敗時のフォールバック」「短すぎる
+ * 発話のフォールバック」のすべてで利用される。
  */
-function fallbackTitle(now: Date): string {
+export function timestampTitle(now: Date): string {
   const pad = (n: number) => n.toString().padStart(2, '0')
   const y = now.getFullYear()
   const m = pad(now.getMonth() + 1)
@@ -41,7 +44,7 @@ export function generateSessionTitle(
 ): string {
   const normalized = normalize(firstUserMessage)
   if (normalized.length < MIN_MEANINGFUL_LEN) {
-    return fallbackTitle(now)
+    return timestampTitle(now)
   }
   if (normalized.length <= MAX_TITLE_LEN) {
     return normalized

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -373,37 +373,37 @@ export async function renameSkillFile(
   return renameSettingsFile(SKILLS_DIR, oldFilename, newFilename)
 }
 
-// --- AI conversation helpers (per-column chat history) ---
+// --- AI session helpers (sessions/<sessionId>.json5) ---
+//
+// AI セッション（chat / 将来の command/task/HEARTBEAT）の永続化。
+// コード側の抽象は `AiSession` だが、on-disk のディレクトリ名は他トップレベル
+// 項目と深度を揃えるため `sessions/`。
 
-const AI_CONVERSATIONS_DIR = 'ai-conversations'
-const AI_CONVERSATION_EXT = '.json5'
+const SESSIONS_DIR = 'sessions'
+const AI_SESSION_EXT = '.json5'
 
-export function aiConversationFilename(columnId: string): string {
-  return sanitizeFilename(columnId) + AI_CONVERSATION_EXT
+export function aiSessionFilename(sessionId: string): string {
+  return sanitizeFilename(sessionId) + AI_SESSION_EXT
 }
 
-export async function listAiConversationFiles(): Promise<string[]> {
-  const files = await listSettingsFiles(AI_CONVERSATIONS_DIR)
-  return files.filter((f) => f.endsWith(AI_CONVERSATION_EXT))
+export async function listAiSessionFiles(): Promise<string[]> {
+  const files = await listSettingsFiles(SESSIONS_DIR)
+  return files.filter((f) => f.endsWith(AI_SESSION_EXT))
 }
 
-export async function readAiConversationFile(
-  filename: string,
-): Promise<string> {
-  return readSettingsFile(AI_CONVERSATIONS_DIR, filename)
+export async function readAiSessionFile(filename: string): Promise<string> {
+  return readSettingsFile(SESSIONS_DIR, filename)
 }
 
-export async function writeAiConversationFile(
+export async function writeAiSessionFile(
   filename: string,
   content: string,
 ): Promise<void> {
-  return writeSettingsFile(AI_CONVERSATIONS_DIR, filename, content)
+  return writeSettingsFile(SESSIONS_DIR, filename, content)
 }
 
-export async function deleteAiConversationFile(
-  filename: string,
-): Promise<void> {
-  return deleteSettingsFile(AI_CONVERSATIONS_DIR, filename)
+export async function deleteAiSessionFile(filename: string): Promise<void> {
+  return deleteSettingsFile(SESSIONS_DIR, filename)
 }
 
 // --- Widget helpers ---

--- a/tests/utils/aiSessionId.test.ts
+++ b/tests/utils/aiSessionId.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatLocalTimestamp,
+  generateSessionId,
+  resolveCollisionSuffix,
+  timestampToSessionIdBase,
+} from '@/utils/aiSessionId'
+
+describe('formatLocalTimestamp', () => {
+  it('returns 14-digit YYYYMMDDhhmmss in local timezone', () => {
+    const d = new Date(2026, 3, 30, 15, 30, 12) // 2026-04-30 15:30:12 local
+    expect(formatLocalTimestamp(d)).toBe('20260430153012')
+  })
+
+  it('zero-pads single-digit components', () => {
+    const d = new Date(2026, 0, 5, 3, 7, 9)
+    expect(formatLocalTimestamp(d)).toBe('20260105030709')
+  })
+})
+
+describe('resolveCollisionSuffix', () => {
+  it('returns base when no collision', () => {
+    expect(resolveCollisionSuffix('20260430153012', new Set())).toBe(
+      '20260430153012',
+    )
+  })
+
+  it('appends "a" on first collision', () => {
+    expect(
+      resolveCollisionSuffix('20260430153012', new Set(['20260430153012'])),
+    ).toBe('20260430153012a')
+  })
+
+  it('appends "b" when "a" also taken', () => {
+    expect(
+      resolveCollisionSuffix(
+        '20260430153012',
+        new Set(['20260430153012', '20260430153012a']),
+      ),
+    ).toBe('20260430153012b')
+  })
+
+  it('falls back to two-letter suffix after exhausting a-z', () => {
+    const taken = new Set(['20260430153012'])
+    for (let i = 0; i < 26; i++) {
+      taken.add(`20260430153012${String.fromCharCode(0x61 + i)}`)
+    }
+    expect(resolveCollisionSuffix('20260430153012', taken)).toBe(
+      '20260430153012aa',
+    )
+  })
+})
+
+describe('generateSessionId', () => {
+  it('uses timestamp from given Date', () => {
+    const d = new Date(2026, 3, 30, 15, 30, 12)
+    expect(generateSessionId(d, new Set())).toBe('20260430153012')
+  })
+
+  it('avoids collision with existing IDs', () => {
+    const d = new Date(2026, 3, 30, 15, 30, 12)
+    expect(generateSessionId(d, new Set(['20260430153012']))).toBe(
+      '20260430153012a',
+    )
+  })
+})
+
+describe('timestampToSessionIdBase', () => {
+  it('formats epoch ms back to session id base', () => {
+    const epoch = new Date(2026, 3, 30, 15, 30, 12).getTime()
+    expect(timestampToSessionIdBase(epoch)).toBe('20260430153012')
+  })
+})

--- a/tests/utils/aiSessionTitle.test.ts
+++ b/tests/utils/aiSessionTitle.test.ts
@@ -1,7 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { generateSessionTitle } from '@/utils/aiSessionTitle'
+import { generateSessionTitle, timestampTitle } from '@/utils/aiSessionTitle'
 
 const FROZEN = new Date(2026, 3, 30, 15, 30, 12) // 2026-04-30 local
+
+describe('timestampTitle', () => {
+  it('formats local datetime to "<YYYY-MM-DD HH:mm> のチャット"', () => {
+    expect(timestampTitle(FROZEN)).toBe('2026-04-30 15:30 のチャット')
+  })
+
+  it('zero-pads single-digit components', () => {
+    const d = new Date(2026, 0, 5, 3, 7, 0)
+    expect(timestampTitle(d)).toBe('2026-01-05 03:07 のチャット')
+  })
+})
 
 describe('generateSessionTitle', () => {
   it('returns the message as-is when short and clean', () => {

--- a/tests/utils/aiSessionTitle.test.ts
+++ b/tests/utils/aiSessionTitle.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { generateSessionTitle } from '@/utils/aiSessionTitle'
+
+const FROZEN = new Date(2026, 3, 30, 15, 30, 12) // 2026-04-30 local
+
+describe('generateSessionTitle', () => {
+  it('returns the message as-is when short and clean', () => {
+    expect(
+      generateSessionTitle('Tauri の起動エラーについて教えて', FROZEN),
+    ).toBe('Tauri の起動エラーについて教えて')
+  })
+
+  it('truncates to 40 chars when too long', () => {
+    const long = 'あ'.repeat(50)
+    expect(generateSessionTitle(long, FROZEN)).toBe('あ'.repeat(40))
+  })
+
+  it('strips fenced code blocks', () => {
+    const msg = 'これを直して\n```ts\nconst x = 1\n```\nお願いします'
+    const title = generateSessionTitle(msg, FROZEN)
+    expect(title).not.toContain('```')
+    expect(title).toContain('これを直して')
+    expect(title).toContain('お願いします')
+  })
+
+  it('strips inline code', () => {
+    expect(generateSessionTitle('`foo` を確認したい', FROZEN)).toBe(
+      'を確認したい',
+    )
+  })
+
+  it('strips URLs', () => {
+    expect(
+      generateSessionTitle(
+        'https://example.com を見て分析してください',
+        FROZEN,
+      ),
+    ).toBe('を見て分析してください')
+  })
+
+  it('collapses whitespace and newlines into single space', () => {
+    expect(generateSessionTitle('foo\n\n   bar\n\n\nbaz', FROZEN)).toBe(
+      'foo bar baz',
+    )
+  })
+
+  it('falls back to date title when too short after trim', () => {
+    expect(generateSessionTitle('hi', FROZEN)).toBe(
+      '2026-04-30 15:30 のチャット',
+    )
+  })
+
+  it('falls back to date title for empty string', () => {
+    expect(generateSessionTitle('', FROZEN)).toBe('2026-04-30 15:30 のチャット')
+  })
+
+  it('falls back to date title when only code blocks', () => {
+    expect(generateSessionTitle('```ts\nconsole.log(1)\n```', FROZEN)).toBe(
+      '2026-04-30 15:30 のチャット',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

AI セッション管理機能を追加するリリース。

## Changes

- feat(ai): AI セッション管理を追加 (master-detail UI + CRUD)
- refactor(ai): useAiConversation の未使用メソッドを削除
- feat(ai): セッションタイトルを AI で要約生成
- feat(ai): ストリーミング中に停止ボタンを表示
- docs(ai): セッション管理 v1 に合わせてドキュメントを更新
- chore: bump version to 0.15.8

## Test plan

- [ ] CI (lint, typecheck, test) が通る
- [ ] AI セッションの作成・切替・削除が動作する
- [ ] ストリーミング中の停止ボタンが機能する
- [ ] 初回応答完了後にセッションタイトルが AI で生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)