### PR TITLE
Release v0.15.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.8",
+  "version": "0.15.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.8"
+version = "0.15.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.8"
+version = "0.15.9"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.8",
+  "version": "0.15.9",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/NoteReactionPickerPopup.vue
+++ b/src/components/common/NoteReactionPickerPopup.vue
@@ -141,7 +141,7 @@ defineExpose({ open })
   }
 }
 
-.mobileBackdrop {
+:global(dialog._nativeDialog[open]).mobileBackdrop {
   align-items: flex-end;
   justify-content: stretch;
 }

--- a/src/components/common/NoteReactionPickerPopup.vue
+++ b/src/components/common/NoteReactionPickerPopup.vue
@@ -24,6 +24,7 @@ const pos = ref({ x: 0, y: 0 })
 const theme = ref<Record<string, string>>({})
 const pickerRef = ref<HTMLElement | null>(null)
 const dialogRef = ref<HTMLDialogElement | null>(null)
+const triggerRef = ref<HTMLElement | null>(null)
 
 const { visible, leaving } = useVaporTransition(show, {
   enterDuration: 200,
@@ -38,6 +39,7 @@ useNativePopover(
     onClose: () => close(),
     leaveDuration: 200,
     dismissOnOutsideClick: true,
+    ignoreOutsideClickFor: triggerRef,
   },
 )
 
@@ -64,6 +66,7 @@ const contentClass = computed(() => [
 
 function open(e: MouseEvent) {
   const btn = e.currentTarget as HTMLElement
+  triggerRef.value = btn
   const rect = btn.getBoundingClientRect()
   const column = btn.closest(COLUMN_SELECTOR) as HTMLElement | null
   const colRect = column?.getBoundingClientRect()

--- a/src/components/common/PopupMenu.vue
+++ b/src/components/common/PopupMenu.vue
@@ -14,6 +14,7 @@ const showMenu = ref(false)
 const menuPos = ref({ x: 0, y: 0 })
 const menuTheme = ref<Record<string, string>>({})
 const menuRef = ref<HTMLElement | null>(null)
+const triggerRef = ref<HTMLElement | null>(null)
 
 const { visible, entering, leaving } = useVaporTransition(showMenu, {
   enterDuration: 200,
@@ -36,17 +37,24 @@ useNativePopover(menuRef, visible, {
   onClose: () => close(),
   leaveDuration: 200,
   dismissOnOutsideClick: true,
+  ignoreOutsideClickFor: triggerRef,
 })
 
 function open(e: MouseEvent) {
   const el = e.currentTarget as HTMLElement | null
+  triggerRef.value = el
+  // 同じトリガー再押下はトグル (close)
+  if (showMenu.value) {
+    close()
+    return
+  }
   const column = (el ?? (e.target as HTMLElement))?.closest(
     COLUMN_SELECTOR,
   ) as HTMLElement | null
   if (column) menuTheme.value = extractThemeVars(column)
 
-  // Place at mouse position initially; adjust after render with actual size
-  menuPos.value = { x: e.clientX, y: e.clientY }
+  // 押下点に被ると最初のメニュー項目を誤タップしやすいので少し下にずらす
+  menuPos.value = { x: e.clientX + 4, y: e.clientY + 10 }
   showMenu.value = true
 
   nextTick(() => {

--- a/src/components/deck/DeckLaunchPad.vue
+++ b/src/components/deck/DeckLaunchPad.vue
@@ -1,0 +1,266 @@
+<script setup lang="ts">
+import { storeToRefs } from 'pinia'
+import { computed, nextTick, ref, useCssModule, watch } from 'vue'
+import {
+  ACCOUNT_INDEPENDENT_TYPES,
+  ALL_COLUMN_TYPES,
+  COLUMN_REGISTRY,
+  CROSS_ACCOUNT_TYPES,
+} from '@/columns/registry'
+import { useNativeDialog } from '@/composables/useNativeDialog'
+import { useVaporTransition } from '@/composables/useVaporTransition'
+import { type ColumnType, isNavDivider, useDeckStore } from '@/stores/deck'
+import { useUiStore } from '@/stores/ui'
+import { hapticLight } from '@/utils/haptics'
+
+const props = defineProps<{
+  anchor?: { x: number; y: number } | null
+}>()
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const $style = useCssModule()
+const deckStore = useDeckStore()
+const { isCompactLayout: isCompact } = storeToRefs(useUiStore())
+
+const dialogRef = ref<HTMLDialogElement | null>(null)
+const popupRef = ref<HTMLElement | null>(null)
+const show = ref(true)
+
+const { visible, leaving } = useVaporTransition(show, {
+  enterDuration: 200,
+  leaveDuration: 200,
+})
+
+useNativeDialog(dialogRef, visible, {
+  onCancel: () => close(),
+  leaveDuration: 200,
+})
+
+const navTypes = computed<Set<string>>(() => {
+  const set = new Set<string>()
+  for (const item of deckStore.navItems) {
+    if (!isNavDivider(item)) set.add(item.type)
+  }
+  return set
+})
+
+const items = computed<ColumnType[]>(() =>
+  ALL_COLUMN_TYPES.filter((t) => {
+    if (navTypes.value.has(t)) return false
+    const spec = COLUMN_REGISTRY[t]
+    if (spec.selectable) return false
+    return CROSS_ACCOUNT_TYPES.has(t) || ACCOUNT_INDEPENDENT_TYPES.has(t)
+  }),
+)
+
+const contentClass = computed(() => {
+  if (isCompact.value) {
+    return [
+      $style.popup,
+      leaving.value ? $style.sheetContentLeave : $style.sheetContentEnter,
+    ]
+  }
+  if (props.anchor) {
+    return [
+      $style.popup,
+      $style.anchored,
+      leaving.value ? $style.anchoredLeave : $style.anchoredEnter,
+    ]
+  }
+  return [
+    $style.popup,
+    leaving.value ? $style.popupContentLeave : $style.popupContentEnter,
+  ]
+})
+
+const popupStyle = computed(() => {
+  if (isCompact.value || !props.anchor) return undefined
+  return {
+    position: 'fixed' as const,
+    left: `${props.anchor.x}px`,
+    top: `${props.anchor.y}px`,
+  }
+})
+
+// アンカー指定時：popup の高さを測って画面内に収まるよう top を clamp
+watch(
+  [visible, () => props.anchor],
+  async ([v, anchor]) => {
+    if (!v || !anchor || isCompact.value) return
+    await nextTick()
+    const el = popupRef.value
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const vh = document.documentElement.clientHeight
+    const halfH = rect.height / 2
+    const clamped = Math.max(8 + halfH, Math.min(anchor.y, vh - 8 - halfH))
+    el.style.top = `${clamped}px`
+  },
+  { immediate: true },
+)
+
+function selectItem(type: ColumnType) {
+  hapticLight()
+  deckStore.toggleSidebarColumn(type, null)
+  close()
+}
+
+function close() {
+  show.value = false
+  setTimeout(() => emit('close'), 220)
+}
+</script>
+
+<template>
+  <dialog
+    v-if="visible"
+    ref="dialogRef"
+    class="_nativeDialog"
+    :class="[
+      $style.overlay,
+      isCompact && $style.mobileBackdrop,
+      leaving ? $style.sheetLeave : $style.sheetEnter,
+    ]"
+  >
+    <div
+      ref="popupRef"
+      autofocus
+      tabindex="-1"
+      class="_popup"
+      :class="contentClass"
+      :style="popupStyle"
+    >
+      <div :class="$style.grid">
+        <button
+          v-for="t in items"
+          :key="t"
+          class="_button"
+          :class="$style.item"
+          @click="selectItem(t)"
+        >
+          <i class="ti" :class="[$style.icon, `ti-${COLUMN_REGISTRY[t].icon}`]" />
+          <span :class="$style.label">{{ COLUMN_REGISTRY[t].label }}</span>
+        </button>
+      </div>
+    </div>
+  </dialog>
+</template>
+
+<style lang="scss" module>
+.overlay {
+  background: transparent;
+  border: none;
+  padding: 0;
+  max-width: 100vw;
+  max-height: 100vh;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+dialog.overlay::backdrop {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.mobileBackdrop {
+  align-items: flex-end;
+  justify-content: stretch;
+}
+
+.popup {
+  width: min(360px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  padding: 8px;
+  color: var(--nd-fg);
+  border-radius: 16px;
+  overflow: auto;
+  overscroll-behavior: contain;
+  box-sizing: border-box;
+  outline: none;
+
+  .mobileBackdrop & {
+    width: 100%;
+    max-height: 75vh;
+    border-radius: 16px 16px 0 0;
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+    padding-bottom: max(20px, var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
+  }
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2px;
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  padding: 4px;
+  border-radius: 6px;
+  color: var(--nd-fg);
+  transition: background var(--nd-duration-fast), color var(--nd-duration-fast);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+    color: var(--nd-fgHighlighted);
+  }
+}
+
+.icon {
+  font-size: 22px;
+  height: 22px;
+  line-height: 1;
+}
+
+.label {
+  margin-top: 6px;
+  font-size: 0.76em;
+  line-height: 1.3em;
+  text-align: center;
+  word-break: break-word;
+}
+
+/* Desktop popup content — scale + fade (no anchor) */
+.popupContentEnter { animation: launchPadIn 0.2s var(--nd-ease-spring); }
+.popupContentLeave { animation: launchPadOut var(--nd-duration-fast) var(--nd-ease-decel) forwards; }
+@keyframes launchPadIn { from { opacity: 0; transform: scale(0.9); } }
+@keyframes launchPadOut { to { opacity: 0; transform: scale(0.95); } }
+
+/* Desktop popup content — anchored (origin: navbar 'もっと' button) */
+.anchored {
+  transform: translateY(-50%);
+  transform-origin: left center;
+}
+
+.anchoredEnter { animation: anchoredIn 0.2s var(--nd-ease-spring); }
+.anchoredLeave { animation: anchoredOut var(--nd-duration-fast) var(--nd-ease-decel) forwards; }
+@keyframes anchoredIn {
+  from { opacity: 0; transform: translateY(-50%) scale(0.85); }
+  to { opacity: 1; transform: translateY(-50%) scale(1); }
+}
+@keyframes anchoredOut {
+  to { opacity: 0; transform: translateY(-50%) scale(0.92); }
+}
+
+/* Mobile sheet backdrop fade */
+.sheetEnter { animation: sheetBdIn var(--nd-duration-base) var(--nd-ease-decel); }
+.sheetLeave { animation: sheetBdOut var(--nd-duration-base) ease-out forwards; }
+@keyframes sheetBdIn { from { opacity: 0; } }
+@keyframes sheetBdOut { to { opacity: 0; } }
+
+/* Mobile sheet content — slide up from bottom */
+.sheetContentEnter { animation: sheetIn 0.25s var(--nd-ease-spring); }
+.sheetContentLeave { animation: sheetOut 0.2s var(--nd-ease-decel) forwards; }
+@keyframes sheetIn { from { transform: translateY(100%); } }
+@keyframes sheetOut { to { transform: translateY(100%); } }
+</style>

--- a/src/components/deck/DeckLaunchPad.vue
+++ b/src/components/deck/DeckLaunchPad.vue
@@ -168,7 +168,7 @@ dialog.overlay::backdrop {
   background: rgba(0, 0, 0, 0.08);
 }
 
-.mobileBackdrop {
+:global(dialog._nativeDialog[open]).mobileBackdrop {
   align-items: flex-end;
   justify-content: stretch;
 }

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -163,6 +163,18 @@ const fileDropT = useVaporTransition(fileDropShow, { leaveDuration: 200 })
 const crossDropShow = computed(() => !!deckStore.crossWindowDragColumnId)
 const crossDropT = useVaporTransition(crossDropShow, { leaveDuration: 200 })
 
+// チャット/AIチャット系カラムでは入力欄の送信ボタンと FAB が重なるため隠す。
+// デスクトップ→モバイルサイズ切替直後など activeColumnId が未確定な瞬間は
+// 「スマホサイズで実際に表示される先頭カラム」(windowLayout[0][0]) にフォールバック
+const fabShow = computed(() => {
+  if (!isCompact.value) return false
+  const id = deckStore.activeColumnId ?? deckStore.windowLayout[0]?.[0]
+  if (!id) return true
+  const col = deckStore.columnMap.get(id)
+  return col?.type !== 'chat' && col?.type !== 'ai'
+})
+const fabT = useVaporTransition(fabShow, { leaveDuration: 200 })
+
 provideScrollDirection()
 
 // Initialize deck data + app-level side effects
@@ -251,9 +263,9 @@ function acceptCrossWindowDrop() {
 
     <!-- Mobile FAB -->
     <button
-      v-if="isCompact"
+      v-if="fabT.visible.value"
       class="_button"
-      :class="$style.fab"
+      :class="[$style.fab, fabT.entering.value && $style.fadeEnter, fabT.leaving.value && $style.fadeLeave]"
       title="新しいノート"
       @click="openCompose"
     >

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -28,6 +28,7 @@ import { AppError } from '@/utils/errors'
 import { hapticLight, hapticMedium } from '@/utils/haptics'
 import { proxyThumbUrl } from '@/utils/imageProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import DeckLaunchPad from './DeckLaunchPad.vue'
 import DeckProfileMenu from './DeckProfileMenu.vue'
 import DeckSettingsMenu from './DeckSettingsMenu.vue'
 import LogoutDialog from './LogoutDialog.vue'
@@ -186,6 +187,27 @@ watch(
 
 function toggleNav() {
   navWidth.value = navCollapsed.value ? DEFAULT_WIDTH : MIN_WIDTH
+}
+
+// Launch pad ("もっと")
+const showLaunchPad = ref(false)
+const launchPadAnchor = ref<{ x: number; y: number } | null>(null)
+
+function openLaunchPad(e: MouseEvent) {
+  if (!isCompact.value) {
+    const btn = e.currentTarget as HTMLElement
+    const btnRect = btn.getBoundingClientRect()
+    const navRect = btn.closest('nav')?.getBoundingClientRect() ?? btnRect
+    launchPadAnchor.value = {
+      x: navRect.right + 8,
+      y: btnRect.top + btnRect.height / 2,
+    }
+  } else {
+    launchPadAnchor.value = null
+  }
+  closeDrawerAndDo(() => {
+    showLaunchPad.value = true
+  })
 }
 
 // Account menu
@@ -449,13 +471,34 @@ defineExpose({
                 <span :class="$style.label">{{ navLabel(navItem) }}</span>
               </button>
             </template>
+            <button
+              v-if="!isCompact"
+              class="_button"
+              :class="$style.item"
+              title="もっと"
+              @click="hapticLight(); openLaunchPad($event)"
+            >
+              <div :class="$style.iconWrap">
+                <i class="ti ti-grid-dots" />
+              </div>
+              <span :class="$style.label">もっと</span>
+            </button>
           </div>
         </div>
 
         <!-- Bottom fixed section: buttons -->
         <div :class="[$style.section, $style.bottomSection]">
-          <!-- Mobile-only: profile & settings -->
+          <!-- Mobile-only: more, profile & settings -->
           <div v-if="isCompact" :class="$style.mobileOnly">
+            <button
+              class="_button"
+              :class="$style.item"
+              title="もっと"
+              @click="hapticLight(); openLaunchPad($event)"
+            >
+              <i class="ti ti-grid-dots" />
+              <span :class="$style.label">もっと</span>
+            </button>
             <div :class="$style.menuWrap">
               <button
                 ref="profileBtnRef"
@@ -675,6 +718,8 @@ defineExpose({
       @delete-all="logoutDeleteAll"
       @cancel="logoutTargetId = null"
     />
+
+    <DeckLaunchPad v-if="showLaunchPad" :anchor="launchPadAnchor" @close="showLaunchPad = false" />
   </div>
 </template>
 

--- a/src/composables/useNativePopover.ts
+++ b/src/composables/useNativePopover.ts
@@ -11,6 +11,12 @@ interface NativePopoverOptions {
    * Not needed for popover="auto" (which has built-in light dismiss).
    */
   dismissOnOutsideClick?: boolean
+  /**
+   * Outside-click 判定から除外する要素 (典型的にはトリガーボタン)。
+   * 指定しないと、トリガーボタン押下時に pointerdown でいったん閉じ、
+   * 続く click でトグル開放されてしまい「閉じない」挙動になる。
+   */
+  ignoreOutsideClickFor?: Ref<HTMLElement | null | undefined>
 }
 
 /**
@@ -41,9 +47,11 @@ export function useNativePopover(
   // Manual outside-click dismiss for popover="manual"
   function onPointerDown(e: PointerEvent) {
     const el = popoverRef.value
-    if (el && !el.contains(e.target as Node)) {
-      options.onClose?.()
-    }
+    if (!el) return
+    const target = e.target as Node
+    if (el.contains(target)) return
+    if (options.ignoreOutsideClickFor?.value?.contains(target)) return
+    options.onClose?.()
   }
 
   function addOutsideClickListener() {

--- a/src/defaults/navbar.json5
+++ b/src/defaults/navbar.json5
@@ -8,10 +8,7 @@
   { type: 'followRequests', accountId: null },
   { type: 'search', accountId: null },
   { type: 'lookup', accountId: null },
-  { type: 'themeManager', accountId: null },
-  { type: 'pluginManager', accountId: null },
   { type: 'widget', accountId: null },
-  { type: 'skill', accountId: null },
   { type: 'ai', accountId: null },
   { type: 'memos', accountId: null },
 ]


### PR DESCRIPTION
## Summary

NoteDeck v0.15.9 リリース。ナビバーに LaunchPad を追加、モバイル UI とポップアップメニューの再押下挙動の修正など。

## Changes

### Features
- feat(deck): ナビバーに「もっと」ボタンと LaunchPad を追加 (#420)

### Fixes
- fix(menu): … メニューが再押下で閉じず開き直す問題を修正
- fix(reaction): リアクションピッカーが + ボタン再押下で閉じない問題を修正
- fix(ui): モバイルの bottom sheet が画面中央に出る不具合を修正
- fix(deck): チャット/AIチャット表示時はモバイル FAB を隠す

### Chore
- chore: bump version to 0.15.9

## Test plan

- [ ] CI: lint / typecheck / test が通る
- [ ] tag push 後に release.yml が走り全プラットフォームのアーティファクトが生成される
- [ ] GitHub Release draft の内容を確認して publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)