### PR TITLE
Release v0.15.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.9",
+  "version": "0.15.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.9"
+version = "0.15.10"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.9"
+version = "0.15.10"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.9",
+  "version": "0.15.10",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -139,6 +139,24 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
 function scrollToTop() {
   // No-op for now; list is auto-scrolled
 }
+
+// WebView2 (Windows) で Shift+wheel が cm-scroller の横スクロールに
+// 渡らないケースがあるため、detail 全体で wheel を補足して横スクロールに変換する。
+function onDetailWheel(e: WheelEvent) {
+  const target = e.currentTarget as HTMLElement
+  const scroller = target.querySelector<HTMLElement>('.cm-scroller')
+  if (!scroller) return
+  if (!e.shiftKey && e.deltaX === 0) return
+  const delta = e.deltaX !== 0 ? e.deltaX : e.deltaY
+  if (delta === 0) return
+  const max = scroller.scrollWidth - scroller.clientWidth
+  if (max <= 0) return
+  const before = scroller.scrollLeft
+  const next = Math.max(0, Math.min(max, before + delta))
+  if (next === before) return
+  scroller.scrollLeft = next
+  e.preventDefault()
+}
 </script>
 
 <template>
@@ -223,7 +241,12 @@ function scrollToTop() {
 
       <!-- Resize handle + Detail pane -->
       <div v-if="selectedEntry" :class="$style.divider" @pointerdown="onDividerPointerDown" />
-      <div v-if="selectedEntry" :class="$style.detail" :style="{ height: detailHeight + 'px' }">
+      <div
+        v-if="selectedEntry"
+        :class="$style.detail"
+        :style="{ height: detailHeight + 'px' }"
+        @wheel="onDetailWheel"
+      >
         <div :class="$style.detailHeader">
           <span :class="$style.detailTitle">{{ kindLabel(selectedEntry.kind) }}</span>
           <span :class="$style.detailTime">{{ formatTime(selectedEntry.ts) }}</span>
@@ -324,6 +347,7 @@ function scrollToTop() {
   cursor: pointer;
   border-bottom: 1px solid transparent;
   white-space: nowrap;
+  min-width: max-content;
   transition: background var(--nd-duration-fast);
 
   &:hover {
@@ -370,10 +394,7 @@ function scrollToTop() {
 .rowSummary {
   color: var(--nd-fg);
   opacity: 0.7;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
-  min-width: 0;
 }
 
 

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -140,6 +140,12 @@ function scrollToTop() {
   // No-op for now; list is auto-scrolled
 }
 
+function onServerIconError(e: Event) {
+  const img = e.target as HTMLImageElement
+  if (img.src.endsWith('/activitypub-icon.svg')) return
+  img.src = '/activitypub-icon.svg'
+}
+
 // WebView2 (Windows) で Shift+wheel が cm-scroller の横スクロールに
 // 渡らないケースがあるため、detail 全体で wheel を補足して横スクロールに変換する。
 function onDetailWheel(e: WheelEvent) {
@@ -220,14 +226,24 @@ function onDetailWheel(e: WheelEvent) {
           <span :class="$style.rowBadges">
             <template v-if="!isScopedToAccount">
               <img v-if="entry.observer.avatar" :src="entry.observer.avatar" :class="$style.badge" />
-              <img v-if="entry.observer.serverIcon" :src="entry.observer.serverIcon" :class="$style.badge" />
+              <img
+                v-if="entry.observer.serverIcon"
+                :src="entry.observer.serverIcon"
+                :class="$style.badge"
+                @error="onServerIconError"
+              />
               <template v-if="entry.subject">
                 <span :class="$style.badgeArrow">→</span>
               </template>
             </template>
             <template v-if="entry.subject">
               <img v-if="entry.subject.avatar" :src="entry.subject.avatar" :class="$style.badge" />
-              <img v-if="entry.subject.serverIcon" :src="entry.subject.serverIcon" :class="$style.badge" />
+              <img
+                v-if="entry.subject.serverIcon"
+                :src="entry.subject.serverIcon"
+                :class="$style.badge"
+                @error="onServerIconError"
+              />
             </template>
           </span>
           <span :class="$style.rowSummary">{{ summarize(entry) }}</span>


### PR DESCRIPTION
## Summary

NoteDeck v0.15.10 リリース。Stream Inspector のスクロールとアイコン fallback の修正。

## Changes

### Fixes
- fix(stream-inspector): event row 横スクロールと Windows 横ホイール対応
- fix(stream-inspector): event row のサーバーアイコン取得失敗時に AP アイコンを表示

### Chore
- chore: bump version to 0.15.10

## Test plan

- [ ] CI: lint / typecheck / test が通る
- [ ] tag push 後に release.yml が走り全プラットフォームのアーティファクトが生成される
- [ ] GitHub Release draft の内容を確認して publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)