### PR TITLE
feat(ai): permissions / dataSources schema (#408 Phase 1)

### DIFF
--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -18,7 +18,11 @@ import {
 import { useAccountsStore } from '@/stores/accounts'
 import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
 import { useConfirm } from '@/stores/confirm'
-import { type DeckColumn, useDeckStore } from '@/stores/deck'
+import {
+  type DeckColumn,
+  TIMELINE_LIKE_COLUMN_TYPES,
+  useDeckStore,
+} from '@/stores/deck'
 import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
@@ -423,7 +427,12 @@ async function sendMessage() {
   )
 
   const skillsPrompt = skillsStore.composedSystemPrompt() || ''
-  const focusedColumnId = deckStore.lastFocusedTimelineColumnId
+  // ユーザーが Timeline をクリックしていないケースに備えて、fallback として
+  // 画面上に存在する最初の TIMELINE_LIKE カラムを使う。
+  const focusedColumnId =
+    deckStore.lastFocusedTimelineColumnId ??
+    deckStore.columns.find((c) => TIMELINE_LIKE_COLUMN_TYPES.has(c.type))?.id ??
+    null
   const focusedColumn = focusedColumnId
     ? deckStore.getColumn(focusedColumnId)
     : null

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -13,7 +13,7 @@ import {
   buildAiContextBlock,
   joinSystemPrompt,
   projectRecentConversation,
-  projectVisibleNotes,
+  projectVisibleItems,
 } from '@/composables/useAiSystemContext'
 import { useAccountsStore } from '@/stores/accounts'
 import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
@@ -442,7 +442,7 @@ async function sendMessage() {
   const contextBlock = buildAiContextBlock(aiConfig.value, {
     activeAccount: accountsStore.activeAccount,
     currentColumn: focusedColumn ?? props.column,
-    visibleNotes: projectVisibleNotes(visibleNotesRaw),
+    visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
     recentConversation: projectRecentConversation(history),
   })
   const system = joinSystemPrompt(skillsPrompt, contextBlock)

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -9,6 +9,11 @@ import {
   watchApiKeyChanges,
 } from '@/composables/useAiConfig'
 import { useAiConversation } from '@/composables/useAiConversation'
+import {
+  buildAiContextBlock,
+  joinSystemPrompt,
+} from '@/composables/useAiSystemContext'
+import { useAccountsStore } from '@/stores/accounts'
 import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
 import { useConfirm } from '@/stores/confirm'
 import { type DeckColumn, useDeckStore } from '@/stores/deck'
@@ -38,6 +43,7 @@ skillsStore.ensureLoaded()
 
 const sessionsStore = useAiSessionsStore()
 const deckStore = useDeckStore()
+const accountsStore = useAccountsStore()
 
 void sessionsStore.loadAllMeta()
 
@@ -414,7 +420,12 @@ async function sendMessage() {
     (m) => m.role !== 'system' && m.id !== assistantMsg.id,
   )
 
-  const system = skillsStore.composedSystemPrompt() || undefined
+  const skillsPrompt = skillsStore.composedSystemPrompt() || ''
+  const contextBlock = buildAiContextBlock(aiConfig.value, {
+    activeAccount: accountsStore.activeAccount,
+    currentColumn: props.column,
+  })
+  const system = joinSystemPrompt(skillsPrompt, contextBlock)
 
   try {
     const finalText = await aiChat.sendMessage({

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -12,6 +12,7 @@ import { useAiConversation } from '@/composables/useAiConversation'
 import {
   buildAiContextBlock,
   joinSystemPrompt,
+  projectRecentConversation,
   projectVisibleNotes,
 } from '@/composables/useAiSystemContext'
 import { useAccountsStore } from '@/stores/accounts'
@@ -433,6 +434,7 @@ async function sendMessage() {
     activeAccount: accountsStore.activeAccount,
     currentColumn: focusedColumn ?? props.column,
     visibleNotes: projectVisibleNotes(visibleNotesRaw),
+    recentConversation: projectRecentConversation(history),
   })
   const system = joinSystemPrompt(skillsPrompt, contextBlock)
 

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -12,6 +12,7 @@ import { useAiConversation } from '@/composables/useAiConversation'
 import {
   buildAiContextBlock,
   joinSystemPrompt,
+  projectVisibleNotes,
 } from '@/composables/useAiSystemContext'
 import { useAccountsStore } from '@/stores/accounts'
 import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
@@ -421,9 +422,17 @@ async function sendMessage() {
   )
 
   const skillsPrompt = skillsStore.composedSystemPrompt() || ''
+  const focusedColumnId = deckStore.lastFocusedTimelineColumnId
+  const focusedColumn = focusedColumnId
+    ? deckStore.getColumn(focusedColumnId)
+    : null
+  const visibleNotesRaw = focusedColumnId
+    ? deckStore.visibleNotesByColumn[focusedColumnId]
+    : undefined
   const contextBlock = buildAiContextBlock(aiConfig.value, {
     activeAccount: accountsStore.activeAccount,
-    currentColumn: props.column,
+    currentColumn: focusedColumn ?? props.column,
+    visibleNotes: projectVisibleNotes(visibleNotesRaw),
   })
   const system = joinSystemPrompt(skillsPrompt, contextBlock)
 

--- a/src/components/deck/DeckDriveColumn.vue
+++ b/src/components/deck/DeckDriveColumn.vue
@@ -16,7 +16,7 @@ import {
 } from '@/composables/useDriveFolder'
 import { useServerImages } from '@/composables/useServerImages'
 import { getAccountAvatarUrl } from '@/stores/accounts'
-import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -50,6 +50,17 @@ const {
   accountId: () => props.column.accountId ?? undefined,
   initialFolderId: props.column.folderId,
 })
+
+const deckStore = useDeckStore()
+
+// Report visible drive files to deckStore (汎用 visibleItems API)
+watch(
+  files,
+  (items) => {
+    deckStore.reportVisibleItems(props.column.id, items)
+  },
+  { immediate: true },
+)
 
 // --- Detail view ---
 const detailFile = ref<NormalizedDriveFile | null>(null)

--- a/src/components/deck/DeckListColumn.vue
+++ b/src/components/deck/DeckListColumn.vue
@@ -19,7 +19,7 @@ const noteColumnRef = ref<InstanceType<typeof DeckNoteColumn> | null>(null)
 watch(
   () => noteColumnRef.value?.notes as NormalizedNote[] | undefined,
   (notes) => {
-    deckStore.reportVisibleNotes(props.column.id, notes ?? [])
+    deckStore.reportVisibleItems(props.column.id, notes ?? [])
   },
   { immediate: true },
 )

--- a/src/components/deck/DeckListColumn.vue
+++ b/src/components/deck/DeckListColumn.vue
@@ -1,15 +1,28 @@
 <script setup lang="ts">
+import { ref, watch } from 'vue'
 import { createQuerySubscription } from '@/adapters/misskey/query'
 import type { NormalizedNote } from '@/adapters/types'
 import { useEntityCrud } from '@/composables/useEntityCrud'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { useDeckStore } from '@/stores/deck'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
   column: DeckColumnType
 }>()
+
+const deckStore = useDeckStore()
+const noteColumnRef = ref<InstanceType<typeof DeckNoteColumn> | null>(null)
+
+watch(
+  () => noteColumnRef.value?.notes as NormalizedNote[] | undefined,
+  (notes) => {
+    deckStore.reportVisibleNotes(props.column.id, notes ?? [])
+  },
+  { immediate: true },
+)
 
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
@@ -59,6 +72,7 @@ const { rename, deleteEntity, config } = useEntityCrud(
 
 <template>
   <DeckNoteColumn
+    ref="noteColumnRef"
     :column="column"
     title="リスト"
     icon="ti-list"

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -35,7 +35,7 @@ import { useNoteSound } from '@/composables/useNoteSound'
 import { usePortal } from '@/composables/usePortal'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
-import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
 import { usePerformanceStore } from '@/stores/performance'
 import { useServersStore } from '@/stores/servers'
@@ -234,7 +234,17 @@ function closeUserPopup() {
 }
 
 const perfStore = usePerformanceStore()
+const deckStore = useDeckStore()
 const notifications = shallowRef<NormalizedNotification[]>([])
+
+// Report visible notifications to deckStore (汎用 visibleItems API)
+watch(
+  notifications,
+  (items) => {
+    deckStore.reportVisibleItems(props.column.id, items)
+  },
+  { immediate: true },
+)
 const followRequestStates = ref<Record<string, 'accepted' | 'rejected'>>({})
 
 // --- Notification cache helpers ---

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -119,6 +119,16 @@ const noteColumnConfig: NoteColumnConfig = {
 
 // --- DeckNoteColumn ref (expose: account, scroller, reconnect, switchWithSnapshot, notes, columnThemeVars) ---
 const noteColumnRef = ref<InstanceType<typeof DeckNoteColumn> | null>(null)
+
+// Report visible notes to deckStore so AI / inspector / audit log can read them
+// without special-casing AI columns (memory feedback_no_special_case_columns).
+watch(
+  () => noteColumnRef.value?.notes as NormalizedNote[] | undefined,
+  (notes) => {
+    deckStore.reportVisibleNotes(props.column.id, notes ?? [])
+  },
+  { immediate: true },
+)
 const account = computed(() => noteColumnRef.value?.account)
 const columnThemeVars = computed(
   () => noteColumnRef.value?.columnThemeVars ?? {},

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -120,12 +120,12 @@ const noteColumnConfig: NoteColumnConfig = {
 // --- DeckNoteColumn ref (expose: account, scroller, reconnect, switchWithSnapshot, notes, columnThemeVars) ---
 const noteColumnRef = ref<InstanceType<typeof DeckNoteColumn> | null>(null)
 
-// Report visible notes to deckStore so AI / inspector / audit log can read them
+// Report visible items to deckStore so AI / inspector / audit log can read them
 // without special-casing AI columns (memory feedback_no_special_case_columns).
 watch(
   () => noteColumnRef.value?.notes as NormalizedNote[] | undefined,
   (notes) => {
-    deckStore.reportVisibleNotes(props.column.id, notes ?? [])
+    deckStore.reportVisibleItems(props.column.id, notes ?? [])
   },
   { immediate: true },
 )

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -7,13 +7,23 @@ import EditorTabs from '@/components/common/EditorTabs.vue'
 import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import {
   type AiConfig,
+  DATA_SOURCE_KEYS,
+  type DataSourceKey,
   defaultConfig,
   deleteApiKey,
   getApiKeyStatus,
+  HIGH_RISK_PERMISSION_KEYS,
+  PERMISSION_KEYS,
+  type PermissionKey,
   PROVIDER_KEYS,
+  type PresetKey,
   type ProviderKey,
   type ProviderSettings,
+  resolveDataSources,
+  resolvePermissions,
   setApiKey,
+  setDataSourcePreset,
+  setPermissionPreset,
   useAiConfig,
 } from '@/composables/useAiConfig'
 import { useClickOutside } from '@/composables/useClickOutside'
@@ -144,6 +154,79 @@ const PROVIDER_FIELDS: Record<ProviderKey, FieldDef[]> = {
   ],
 }
 
+// --- Permissions / DataSources schema (data-driven UI) ---
+
+interface PresetOption {
+  value: PresetKey
+  label: string
+  icon: string
+}
+
+const PRESET_OPTIONS: readonly PresetOption[] = [
+  { value: 'readonly', label: '読取のみ (デフォルト)', icon: 'ti-eye' },
+  { value: 'safe', label: '安全 (リアクション可)', icon: 'ti-shield-check' },
+  { value: 'full', label: 'フル (全許可)', icon: 'ti-bolt' },
+  { value: 'custom', label: 'カスタム', icon: 'ti-adjustments' },
+]
+
+const FALLBACK_PRESET_OPTION: PresetOption = {
+  value: 'readonly',
+  label: '読取のみ (デフォルト)',
+  icon: 'ti-eye',
+}
+
+interface PermissionLabel {
+  label: string
+  icon: string
+}
+
+const PERMISSION_LABELS: Record<PermissionKey, PermissionLabel> = {
+  'notes.read': { label: 'ノートの読取', icon: 'ti-eye' },
+  'notes.write': { label: 'ノートの投稿/編集/削除', icon: 'ti-pencil' },
+  'notes.react': { label: 'リアクション/お気に入り', icon: 'ti-heart' },
+  'account.read': { label: 'アカウント情報の読取', icon: 'ti-user' },
+  'account.write': {
+    label: 'フォロー/ブロック/ミュート',
+    icon: 'ti-user-plus',
+  },
+  'drive.read': { label: 'ドライブの読取', icon: 'ti-folder' },
+  'drive.write': { label: 'ドライブの書込/削除', icon: 'ti-folder-plus' },
+  'network.external': { label: '外部ネットワークアクセス', icon: 'ti-world' },
+  clipboard: { label: 'クリップボード', icon: 'ti-clipboard' },
+  notifications: { label: 'デスクトップ通知', icon: 'ti-bell' },
+}
+
+interface DataSourceLabel {
+  label: string
+  icon: string
+  description: string
+}
+
+const DATA_SOURCE_LABELS: Record<DataSourceKey, DataSourceLabel> = {
+  currentAccount: {
+    label: '現在のアカウント',
+    icon: 'ti-user',
+    description: 'ログイン中のアカウント情報を AI に渡す (トークン等は除外)',
+  },
+  currentColumn: {
+    label: '現在のカラム',
+    icon: 'ti-columns',
+    description: 'フォーカス中のカラムの種別と設定を渡す',
+  },
+  visibleNotes: {
+    label: '可視ノート (上限 10 件)',
+    icon: 'ti-list',
+    description: '画面に表示中のノートを context に含める',
+  },
+  recentConversation: {
+    label: 'AI チャット履歴 (上限 20 ターン)',
+    icon: 'ti-messages',
+    description: '直近の会話を context に含める',
+  },
+}
+
+const HIGH_RISK_SET = new Set<PermissionKey>(HIGH_RISK_PERMISSION_KEYS)
+
 // --- Config (delegated to composable) ---
 
 const { config, save: saveConfig, mergeConfig } = useAiConfig()
@@ -240,6 +323,64 @@ function selectProvider(value: ProviderKey) {
 
 useClickOutside(providerDropdownRef, () => {
   showProviderDropdown.value = false
+})
+
+// --- Permissions / DataSources preset dropdowns ---
+
+const showPermissionsPresetDropdown = ref(false)
+const permissionsPresetRef = ref<HTMLElement | null>(null)
+const showDataSourcesPresetDropdown = ref(false)
+const dataSourcesPresetRef = ref<HTMLElement | null>(null)
+
+const currentPermissionPreset = computed(
+  () =>
+    PRESET_OPTIONS.find((p) => p.value === config.value.permissions.preset) ??
+    FALLBACK_PRESET_OPTION,
+)
+
+const currentDataSourcePreset = computed(
+  () =>
+    PRESET_OPTIONS.find((p) => p.value === config.value.dataSources.preset) ??
+    FALLBACK_PRESET_OPTION,
+)
+
+const resolvedPermissions = computed(() =>
+  resolvePermissions(config.value.permissions),
+)
+
+const resolvedDataSources = computed(() =>
+  resolveDataSources(config.value.dataSources),
+)
+
+function selectPermissionPreset(preset: PresetKey) {
+  config.value.permissions = setPermissionPreset(
+    config.value.permissions,
+    preset,
+  )
+  showPermissionsPresetDropdown.value = false
+}
+
+function togglePermissionCustom(key: PermissionKey) {
+  config.value.permissions.custom[key] = !config.value.permissions.custom[key]
+}
+
+function selectDataSourcePreset(preset: PresetKey) {
+  config.value.dataSources = setDataSourcePreset(
+    config.value.dataSources,
+    preset,
+  )
+  showDataSourcesPresetDropdown.value = false
+}
+
+function toggleDataSourceCustom(key: DataSourceKey) {
+  config.value.dataSources.custom[key] = !config.value.dataSources.custom[key]
+}
+
+useClickOutside(permissionsPresetRef, () => {
+  showPermissionsPresetDropdown.value = false
+})
+useClickOutside(dataSourcesPresetRef, () => {
+  showDataSourcesPresetDropdown.value = false
 })
 
 // --- API key (keychain) ---
@@ -557,6 +698,159 @@ function handleReset() {
               </button>
             </div>
           </template>
+        </template>
+      </div>
+
+      <!-- Permissions -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('permissions')">
+          <i class="ti ti-shield-lock" />
+          権限
+          <span :class="$style.statusBadge">
+            <i class="ti ti-info-circle" :class="$style.badgeNone" />
+            {{ currentPermissionPreset.label }}
+          </span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.permissions }]" />
+        </button>
+        <template v-if="expandedSections.permissions">
+          <div :class="$style.notice">
+            <i class="ti ti-info-circle" />
+            <div>
+              AI に許可する操作のセット。Phase 1 では値の保存のみで、実際の制御は今後のリリースで段階的に有効化されます。
+            </div>
+          </div>
+          <div ref="permissionsPresetRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showPermissionsPresetDropdown = !showPermissionsPresetDropdown"
+            >
+              <i :class="'ti ' + currentPermissionPreset.icon" />
+              <span>{{ currentPermissionPreset.label }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showPermissionsPresetDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in PRESET_OPTIONS"
+                :key="opt.value"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: config.permissions.preset === opt.value }]"
+                @click="selectPermissionPreset(opt.value)"
+              >
+                <i :class="'ti ' + opt.icon" />
+                <span>{{ opt.label }}</span>
+                <i v-if="config.permissions.preset === opt.value" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+
+          <div :class="$style.toggleList">
+            <button
+              v-for="key in PERMISSION_KEYS"
+              :key="key"
+              class="_button"
+              :class="[
+                $style.toggleItem,
+                {
+                  [$style.toggleItemOn]: resolvedPermissions[key],
+                  [$style.toggleItemDisabled]: config.permissions.preset !== 'custom',
+                },
+              ]"
+              :disabled="config.permissions.preset !== 'custom'"
+              @click="togglePermissionCustom(key)"
+            >
+              <i :class="'ti ' + PERMISSION_LABELS[key].icon" />
+              <span :class="$style.toggleLabel">{{ PERMISSION_LABELS[key].label }}</span>
+              <i
+                v-if="HIGH_RISK_SET.has(key)"
+                class="ti ti-alert-triangle"
+                :class="$style.warningIcon"
+                title="高リスク操作 — 将来の Phase で確認ダイアログが追加される予定"
+              />
+              <i
+                class="ti"
+                :class="[
+                  $style.toggleCheck,
+                  resolvedPermissions[key] ? 'ti-check' : 'ti-minus',
+                ]"
+              />
+            </button>
+          </div>
+        </template>
+      </div>
+
+      <!-- Data Sources -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('dataSources')">
+          <i class="ti ti-database-export" />
+          データソース
+          <span :class="$style.statusBadge">
+            <i class="ti ti-info-circle" :class="$style.badgeNone" />
+            {{ currentDataSourcePreset.label }}
+          </span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.dataSources }]" />
+        </button>
+        <template v-if="expandedSections.dataSources">
+          <div :class="$style.notice">
+            <i class="ti ti-info-circle" />
+            <div>
+              AI に送る system prompt の <code>&lt;notedeck-context&gt;</code> ブロックに含める情報。送信前にトークン等の機密情報は自動的に除外されます。
+            </div>
+          </div>
+          <div ref="dataSourcesPresetRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showDataSourcesPresetDropdown = !showDataSourcesPresetDropdown"
+            >
+              <i :class="'ti ' + currentDataSourcePreset.icon" />
+              <span>{{ currentDataSourcePreset.label }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showDataSourcesPresetDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in PRESET_OPTIONS"
+                :key="opt.value"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: config.dataSources.preset === opt.value }]"
+                @click="selectDataSourcePreset(opt.value)"
+              >
+                <i :class="'ti ' + opt.icon" />
+                <span>{{ opt.label }}</span>
+                <i v-if="config.dataSources.preset === opt.value" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+
+          <div :class="$style.toggleList">
+            <button
+              v-for="key in DATA_SOURCE_KEYS"
+              :key="key"
+              class="_button"
+              :class="[
+                $style.toggleItem,
+                {
+                  [$style.toggleItemOn]: resolvedDataSources[key],
+                  [$style.toggleItemDisabled]: config.dataSources.preset !== 'custom',
+                },
+              ]"
+              :disabled="config.dataSources.preset !== 'custom'"
+              @click="toggleDataSourceCustom(key)"
+            >
+              <i :class="'ti ' + DATA_SOURCE_LABELS[key].icon" />
+              <div :class="$style.toggleLabelStack">
+                <span :class="$style.toggleLabel">{{ DATA_SOURCE_LABELS[key].label }}</span>
+                <span :class="$style.toggleSubLabel">{{ DATA_SOURCE_LABELS[key].description }}</span>
+              </div>
+              <i
+                class="ti"
+                :class="[
+                  $style.toggleCheck,
+                  resolvedDataSources[key] ? 'ti-check' : 'ti-minus',
+                ]"
+              />
+            </button>
+          </div>
         </template>
       </div>
 
@@ -895,6 +1189,89 @@ function handleReset() {
 }
 
 .checkIcon { margin-left: auto; opacity: 0.7; flex-shrink: 0; }
+
+// Permission / DataSource toggle list
+.toggleList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  overflow: hidden;
+}
+
+.toggleItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--nd-bg);
+  color: var(--nd-fg);
+  font-size: 0.78em;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--nd-duration-base), opacity var(--nd-duration-base);
+
+  &:hover { background: var(--nd-buttonHoverBg); }
+  &:disabled {
+    cursor: default;
+    &:hover { background: var(--nd-bg); }
+  }
+  & + & { border-top: 1px solid color-mix(in srgb, var(--nd-divider) 40%, transparent); }
+
+  > i:first-child {
+    flex-shrink: 0;
+    width: 16px;
+    text-align: center;
+    opacity: 0.6;
+  }
+}
+
+.toggleItemOn {
+  > i:first-child { opacity: 1; color: var(--nd-accent); }
+}
+
+.toggleItemDisabled {
+  opacity: 0.55;
+}
+
+.toggleLabel {
+  flex: 1;
+  min-width: 0;
+}
+
+.toggleLabelStack {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toggleSubLabel {
+  font-size: 0.85em;
+  opacity: 0.55;
+  line-height: 1.3;
+}
+
+.toggleCheck {
+  flex-shrink: 0;
+  font-size: 0.95em;
+  width: 16px;
+  text-align: center;
+
+  .toggleItemOn & {
+    color: var(--nd-accent);
+  }
+}
+
+.warningIcon {
+  flex-shrink: 0;
+  color: var(--nd-love);
+  opacity: 0.85;
+  font-size: 0.9em;
+}
 
 // Connection test
 .testBtn {

--- a/src/composables/useAiConfig.test.ts
+++ b/src/composables/useAiConfig.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   _internal,
   type AiConfig,
+  DATA_SOURCE_KEYS,
   type DataSourcesConfig,
   defaultConfig,
+  PERMISSION_KEYS,
   type PermissionsConfig,
   resolveDataSources,
   resolvePermissions,
@@ -112,6 +114,70 @@ describe('setPermissionPreset / setDataSourcePreset', () => {
     expect(next.preset).toBe('full')
     expect(next.custom.visibleNotes).toBe(true)
     expect(next.custom.recentConversation).toBe(true)
+  })
+})
+
+describe('preset key coverage', () => {
+  // 将来 PERMISSION_KEYS に新キーを足したのに preset 定義に書き忘れた場合に
+  // 検出するためのガードテスト。
+  it.each([
+    'readonly',
+    'safe',
+    'full',
+  ] as const)('every PERMISSION_KEYS entry has a boolean in the %s preset', (preset) => {
+    const resolved = resolvePermissions({
+      preset,
+      custom: {} as PermissionsConfig['custom'],
+    })
+    for (const key of PERMISSION_KEYS) {
+      expect(typeof resolved[key], `permissions.${key} on ${preset}`).toBe(
+        'boolean',
+      )
+    }
+  })
+
+  it.each([
+    'readonly',
+    'safe',
+    'full',
+  ] as const)('every DATA_SOURCE_KEYS entry has a boolean in the %s preset', (preset) => {
+    const resolved = resolveDataSources({
+      preset,
+      custom: {} as DataSourcesConfig['custom'],
+    })
+    for (const key of DATA_SOURCE_KEYS) {
+      expect(typeof resolved[key], `dataSources.${key} on ${preset}`).toBe(
+        'boolean',
+      )
+    }
+  })
+
+  it('readonly preset is the strictest (no write / network / clipboard / notifications)', () => {
+    const resolved = resolvePermissions({
+      preset: 'readonly',
+      custom: {} as PermissionsConfig['custom'],
+    })
+    for (const key of [
+      'notes.write',
+      'notes.react',
+      'account.write',
+      'drive.write',
+      'network.external',
+      'clipboard',
+      'notifications',
+    ] as const) {
+      expect(resolved[key], `${key} must be false on readonly`).toBe(false)
+    }
+  })
+
+  it('full preset is the most permissive (all true)', () => {
+    const resolved = resolvePermissions({
+      preset: 'full',
+      custom: {} as PermissionsConfig['custom'],
+    })
+    for (const key of PERMISSION_KEYS) {
+      expect(resolved[key], `${key} must be true on full`).toBe(true)
+    }
   })
 })
 

--- a/src/composables/useAiConfig.test.ts
+++ b/src/composables/useAiConfig.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest'
+import {
+  _internal,
+  type AiConfig,
+  type DataSourcesConfig,
+  defaultConfig,
+  type PermissionsConfig,
+  resolveDataSources,
+  resolvePermissions,
+  setDataSourcePreset,
+  setPermissionPreset,
+} from './useAiConfig'
+
+const { mergeConfig } = _internal
+
+describe('defaultConfig', () => {
+  it('returns readonly preset for both permissions and dataSources', () => {
+    const cfg = defaultConfig()
+    expect(cfg.permissions.preset).toBe('readonly')
+    expect(cfg.dataSources.preset).toBe('readonly')
+  })
+
+  it('default permissions allow only read operations', () => {
+    const resolved = resolvePermissions(defaultConfig().permissions)
+    expect(resolved['notes.read']).toBe(true)
+    expect(resolved['account.read']).toBe(true)
+    expect(resolved['drive.read']).toBe(true)
+    expect(resolved['notes.write']).toBe(false)
+    expect(resolved['account.write']).toBe(false)
+    expect(resolved['network.external']).toBe(false)
+  })
+
+  it('default dataSources include account/column but not visibleNotes/recentConversation', () => {
+    const resolved = resolveDataSources(defaultConfig().dataSources)
+    expect(resolved.currentAccount).toBe(true)
+    expect(resolved.currentColumn).toBe(true)
+    expect(resolved.visibleNotes).toBe(false)
+    expect(resolved.recentConversation).toBe(false)
+  })
+})
+
+describe('resolvePermissions / resolveDataSources', () => {
+  it('safe preset enables react/clipboard/notifications but not write operations', () => {
+    const resolved = resolvePermissions({
+      preset: 'safe',
+      custom: {} as PermissionsConfig['custom'],
+    })
+    expect(resolved['notes.react']).toBe(true)
+    expect(resolved.clipboard).toBe(true)
+    expect(resolved.notifications).toBe(true)
+    expect(resolved['notes.write']).toBe(false)
+    expect(resolved['network.external']).toBe(false)
+  })
+
+  it('full preset enables all permissions including network.external', () => {
+    const resolved = resolvePermissions({
+      preset: 'full',
+      custom: {} as PermissionsConfig['custom'],
+    })
+    expect(resolved['notes.write']).toBe(true)
+    expect(resolved['account.write']).toBe(true)
+    expect(resolved['drive.write']).toBe(true)
+    expect(resolved['network.external']).toBe(true)
+  })
+
+  it('custom preset returns the custom map verbatim', () => {
+    const resolved = resolvePermissions({
+      preset: 'custom',
+      custom: {
+        'notes.read': true,
+        'notes.write': false,
+        'notes.react': true,
+        'account.read': true,
+        'account.write': false,
+        'drive.read': true,
+        'drive.write': false,
+        'network.external': true,
+        clipboard: false,
+        notifications: false,
+      },
+    })
+    expect(resolved['network.external']).toBe(true)
+    expect(resolved['notes.react']).toBe(true)
+    expect(resolved['account.write']).toBe(false)
+  })
+})
+
+describe('setPermissionPreset / setDataSourcePreset', () => {
+  it('switching from readonly to safe replaces custom with safe defaults', () => {
+    const next = setPermissionPreset(defaultConfig().permissions, 'safe')
+    expect(next.preset).toBe('safe')
+    expect(next.custom['notes.react']).toBe(true)
+    expect(next.custom.clipboard).toBe(true)
+  })
+
+  it('switching to custom pre-fills custom from the previously resolved preset', () => {
+    // Start at 'safe' (resolved values), switch to 'custom'.
+    const safe: PermissionsConfig = {
+      preset: 'safe',
+      custom: {} as PermissionsConfig['custom'],
+    }
+    const next = setPermissionPreset(safe, 'custom')
+    expect(next.preset).toBe('custom')
+    // Pre-filled with safe's resolved values
+    expect(next.custom['notes.react']).toBe(true)
+    expect(next.custom.clipboard).toBe(true)
+    expect(next.custom['notes.write']).toBe(false)
+  })
+
+  it('switching dataSources to full enables visibleNotes and recentConversation', () => {
+    const next = setDataSourcePreset(defaultConfig().dataSources, 'full')
+    expect(next.preset).toBe('full')
+    expect(next.custom.visibleNotes).toBe(true)
+    expect(next.custom.recentConversation).toBe(true)
+  })
+})
+
+describe('mergeConfig', () => {
+  it('legacy ai.json5 without permissions/dataSources is filled with defaults', () => {
+    const partial: Partial<AiConfig> = {
+      provider: 'openai',
+      openai: { endpoint: 'https://api.example.com', model: 'gpt-test' },
+    }
+    const merged = mergeConfig(defaultConfig(), partial)
+    expect(merged.provider).toBe('openai')
+    expect(merged.openai.model).toBe('gpt-test')
+    // Permissions/dataSources fall back to defaults (readonly preset)
+    expect(merged.permissions.preset).toBe('readonly')
+    expect(merged.dataSources.preset).toBe('readonly')
+    expect(merged.permissions.custom['notes.read']).toBe(true)
+  })
+
+  it('partial permissions.custom values are deep-merged with defaults', () => {
+    const partial: Partial<AiConfig> = {
+      permissions: {
+        preset: 'custom',
+        custom: { 'notes.write': true } as PermissionsConfig['custom'],
+      },
+    }
+    const merged = mergeConfig(defaultConfig(), partial)
+    expect(merged.permissions.preset).toBe('custom')
+    // Overridden key
+    expect(merged.permissions.custom['notes.write']).toBe(true)
+    // Default key preserved
+    expect(merged.permissions.custom['notes.read']).toBe(true)
+    expect(merged.permissions.custom['network.external']).toBe(false)
+  })
+
+  it('partial dataSources.preset only applies preset, custom defaults preserved', () => {
+    const partial: Partial<AiConfig> = {
+      dataSources: {
+        preset: 'safe',
+      } as Partial<DataSourcesConfig> as DataSourcesConfig,
+    }
+    const merged = mergeConfig(defaultConfig(), partial)
+    expect(merged.dataSources.preset).toBe('safe')
+    // custom is preserved from defaults (readonly's custom)
+    expect(merged.dataSources.custom.currentAccount).toBe(true)
+  })
+})

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -14,11 +14,65 @@ export interface ProviderSettings {
 
 export type ProviderKey = 'anthropic' | 'openai' | 'custom'
 
+export type PresetKey = 'readonly' | 'safe' | 'full' | 'custom'
+
+export const PRESET_KEYS: readonly PresetKey[] = [
+  'readonly',
+  'safe',
+  'full',
+  'custom',
+]
+
+export const PERMISSION_KEYS = [
+  'notes.read',
+  'notes.write',
+  'notes.react',
+  'account.read',
+  'account.write',
+  'drive.read',
+  'drive.write',
+  'network.external',
+  'clipboard',
+  'notifications',
+] as const
+export type PermissionKey = (typeof PERMISSION_KEYS)[number]
+
+/**
+ * 高リスク権限。Phase 1 では UI に warning アイコンを出すだけ。
+ * Phase 5 で確認ダイアログによる enforcement を導入する。
+ */
+export const HIGH_RISK_PERMISSION_KEYS: readonly PermissionKey[] = [
+  'notes.write',
+  'account.write',
+  'drive.write',
+  'network.external',
+]
+
+export const DATA_SOURCE_KEYS = [
+  'currentAccount',
+  'currentColumn',
+  'visibleNotes',
+  'recentConversation',
+] as const
+export type DataSourceKey = (typeof DATA_SOURCE_KEYS)[number]
+
+export interface PermissionsConfig {
+  preset: PresetKey
+  custom: Record<PermissionKey, boolean>
+}
+
+export interface DataSourcesConfig {
+  preset: PresetKey
+  custom: Record<DataSourceKey, boolean>
+}
+
 export interface AiConfig {
   provider: ProviderKey
   anthropic: ProviderSettings
   openai: ProviderSettings
   custom: ProviderSettings
+  permissions: PermissionsConfig
+  dataSources: DataSourcesConfig
 }
 
 export const PROVIDER_KEYS: readonly ProviderKey[] = [
@@ -26,6 +80,119 @@ export const PROVIDER_KEYS: readonly ProviderKey[] = [
   'openai',
   'custom',
 ]
+
+// --- Preset definitions ---
+
+type ResolvedPreset = Exclude<PresetKey, 'custom'>
+
+const PERMISSION_PRESETS: Record<
+  ResolvedPreset,
+  Record<PermissionKey, boolean>
+> = {
+  readonly: {
+    'notes.read': true,
+    'notes.write': false,
+    'notes.react': false,
+    'account.read': true,
+    'account.write': false,
+    'drive.read': true,
+    'drive.write': false,
+    'network.external': false,
+    clipboard: false,
+    notifications: false,
+  },
+  safe: {
+    'notes.read': true,
+    'notes.write': false,
+    'notes.react': true,
+    'account.read': true,
+    'account.write': false,
+    'drive.read': true,
+    'drive.write': false,
+    'network.external': false,
+    clipboard: true,
+    notifications: true,
+  },
+  full: {
+    'notes.read': true,
+    'notes.write': true,
+    'notes.react': true,
+    'account.read': true,
+    'account.write': true,
+    'drive.read': true,
+    'drive.write': true,
+    'network.external': true,
+    clipboard: true,
+    notifications: true,
+  },
+}
+
+const DATA_SOURCE_PRESETS: Record<
+  ResolvedPreset,
+  Record<DataSourceKey, boolean>
+> = {
+  readonly: {
+    currentAccount: true,
+    currentColumn: true,
+    visibleNotes: false,
+    recentConversation: false,
+  },
+  safe: {
+    currentAccount: true,
+    currentColumn: true,
+    visibleNotes: true,
+    recentConversation: true,
+  },
+  full: {
+    currentAccount: true,
+    currentColumn: true,
+    visibleNotes: true,
+    recentConversation: true,
+  },
+}
+
+/**
+ * Resolve permission map for a config (custom returns its own custom map).
+ * Used at consumption time (UI / system prompt builder).
+ */
+export function resolvePermissions(
+  cfg: PermissionsConfig,
+): Record<PermissionKey, boolean> {
+  if (cfg.preset === 'custom') return { ...cfg.custom }
+  return { ...PERMISSION_PRESETS[cfg.preset] }
+}
+
+export function resolveDataSources(
+  cfg: DataSourcesConfig,
+): Record<DataSourceKey, boolean> {
+  if (cfg.preset === 'custom') return { ...cfg.custom }
+  return { ...DATA_SOURCE_PRESETS[cfg.preset] }
+}
+
+/**
+ * Switch preset. When switching to 'custom', pre-fill the custom map with
+ * the previously resolved values so the user starts from where they were
+ * (instead of from an empty / all-false state).
+ */
+export function setPermissionPreset(
+  cfg: PermissionsConfig,
+  next: PresetKey,
+): PermissionsConfig {
+  if (next === 'custom') {
+    return { preset: 'custom', custom: resolvePermissions(cfg) }
+  }
+  return { preset: next, custom: { ...PERMISSION_PRESETS[next] } }
+}
+
+export function setDataSourcePreset(
+  cfg: DataSourcesConfig,
+  next: PresetKey,
+): DataSourcesConfig {
+  if (next === 'custom') {
+    return { preset: 'custom', custom: resolveDataSources(cfg) }
+  }
+  return { preset: next, custom: { ...DATA_SOURCE_PRESETS[next] } }
+}
 
 // --- Defaults (loaded from src/defaults/ai.json5) ---
 
@@ -37,10 +204,38 @@ export function defaultConfig(): AiConfig {
     anthropic: { ...defaultFileConfig.anthropic },
     openai: { ...defaultFileConfig.openai },
     custom: { ...defaultFileConfig.custom },
+    permissions: {
+      preset: defaultFileConfig.permissions.preset,
+      custom: { ...defaultFileConfig.permissions.custom },
+    },
+    dataSources: {
+      preset: defaultFileConfig.dataSources.preset,
+      custom: { ...defaultFileConfig.dataSources.custom },
+    },
   }
 }
 
 // --- Merge ---
+
+function mergePermissions(
+  base: PermissionsConfig,
+  partial: Partial<PermissionsConfig> | undefined,
+): PermissionsConfig {
+  return {
+    preset: partial?.preset ?? base.preset,
+    custom: { ...base.custom, ...(partial?.custom ?? {}) },
+  }
+}
+
+function mergeDataSources(
+  base: DataSourcesConfig,
+  partial: Partial<DataSourcesConfig> | undefined,
+): DataSourcesConfig {
+  return {
+    preset: partial?.preset ?? base.preset,
+    custom: { ...base.custom, ...(partial?.custom ?? {}) },
+  }
+}
 
 /** Deep-merge partial config into defaults, preserving nested provider fields. */
 function mergeConfig(base: AiConfig, partial: Partial<AiConfig>): AiConfig {
@@ -48,6 +243,8 @@ function mergeConfig(base: AiConfig, partial: Partial<AiConfig>): AiConfig {
   for (const key of PROVIDER_KEYS) {
     result[key] = { ...base[key], ...(partial[key] ?? {}) }
   }
+  result.permissions = mergePermissions(base.permissions, partial.permissions)
+  result.dataSources = mergeDataSources(base.dataSources, partial.dataSources)
   return result
 }
 
@@ -109,6 +306,14 @@ async function migrateFromLocalStorageOnce(): Promise<void> {
     }
   }
   removeStorage(STORAGE_KEYS.aiSettings)
+}
+
+// --- Exposed for tests ---
+
+export const _internal = {
+  mergeConfig,
+  PERMISSION_PRESETS,
+  DATA_SOURCE_PRESETS,
 }
 
 // --- Composable ---

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -12,6 +12,7 @@ import {
   MAX_RECENT_TURNS,
   MAX_VISIBLE_NOTES,
   projectRecentConversation,
+  projectVisibleItems,
   projectVisibleNotes,
   stripCredentials,
 } from './useAiSystemContext'
@@ -298,6 +299,123 @@ describe('projectVisibleNotes', () => {
     expect(out[0]?.id).toBe('unknown')
     expect(out[1]?.id).toBe('unknown')
     expect(out[2]?.id).toBe('ok')
+  })
+})
+
+describe('projectVisibleItems (kind dispatch)', () => {
+  it('dispatches to note projection for note-like column types', () => {
+    const out = projectVisibleItems(
+      [{ id: 'n1', text: 'hi', cw: 'spoiler', user: { username: 'u' } }],
+      'timeline',
+    )
+    expect(out[0]).toEqual({
+      id: 'n1',
+      userId: undefined,
+      username: 'u',
+      text: '[CW: spoiler]',
+      createdAt: undefined,
+    })
+  })
+
+  it.each([
+    'list',
+    'antenna',
+    'mentions',
+    'channel',
+    'favorites',
+    'clip',
+  ])('treats %s as note-like', (type) => {
+    const out = projectVisibleItems([{ id: 'n1', text: 'hi' }], type)
+    expect(out[0]?.text).toBe('hi')
+  })
+
+  it('dispatches to notification projection', () => {
+    const out = projectVisibleItems(
+      [
+        {
+          id: 'notif-1',
+          type: 'reaction',
+          userId: 'u1',
+          noteId: 'n1',
+          reaction: '👍',
+          createdAt: '2026-05-01T00:00:00Z',
+          user: { username: 'reactor' },
+          note: { text: 'original note' },
+        },
+      ],
+      'notifications',
+    )
+    expect(out[0]).toMatchObject({
+      kind: 'notification',
+      id: 'notif-1',
+      type: 'reaction',
+      userId: 'u1',
+      noteId: 'n1',
+      reaction: '👍',
+      username: 'reactor',
+      noteText: 'original note',
+    })
+  })
+
+  it('replaces note text with [CW: ...] for CW notifications', () => {
+    const out = projectVisibleItems(
+      [
+        {
+          id: 'notif-2',
+          type: 'reply',
+          note: { cw: 'sensitive', text: 'hidden body' },
+        },
+      ],
+      'notifications',
+    )
+    expect(out[0]?.noteText).toBe('[CW: sensitive]')
+    expect(out[0]?.noteText).not.toContain('hidden body')
+  })
+
+  it('dispatches to drive projection', () => {
+    const out = projectVisibleItems(
+      [
+        {
+          id: 'file-1',
+          name: 'photo.png',
+          type: 'image/png',
+          size: 12345,
+          createdAt: '2026-05-01T00:00:00Z',
+        },
+      ],
+      'drive',
+    )
+    expect(out[0]).toEqual({
+      kind: 'driveItem',
+      id: 'file-1',
+      name: 'photo.png',
+      type: 'image/png',
+      size: 12345,
+      createdAt: '2026-05-01T00:00:00Z',
+    })
+  })
+
+  it('falls back to raw projection for unknown column types', () => {
+    const out = projectVisibleItems(
+      [{ id: 'x', name: 'something', type: 'unknown', extra: 'leak' }],
+      'someUnsupportedType',
+    )
+    expect(out[0]).toEqual({
+      id: 'x',
+      name: 'something',
+      type: 'unknown',
+    })
+    // 想定外フィールドは落とす (raw fallback は最小限)
+    expect(out[0]).not.toHaveProperty('extra')
+  })
+
+  it('caps at MAX_VISIBLE_NOTES across all kinds', () => {
+    const many = Array.from({ length: 30 }, (_, i) => ({
+      id: `n${i}`,
+      type: 'reaction',
+    }))
+    const out = projectVisibleItems(many, 'notifications')
+    expect(out).toHaveLength(MAX_VISIBLE_NOTES)
   })
 })
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import type { Account } from '@/stores/accounts'
+import type { DeckColumn } from '@/stores/deck'
+import {
+  type AiConfig,
+  defaultConfig,
+  setDataSourcePreset,
+} from './useAiConfig'
+import {
+  buildAiContextBlock,
+  joinSystemPrompt,
+  stripCredentials,
+} from './useAiSystemContext'
+
+const SAMPLE_ACCOUNT: Account = {
+  id: 'acc-1',
+  host: 'misskey.example',
+  userId: 'u1',
+  username: 'taka',
+  displayName: 'Taka',
+  avatarUrl: null,
+  software: 'misskey-dev/misskey',
+  hasToken: true,
+}
+
+function configWithDataSources(preset: 'readonly' | 'safe' | 'full'): AiConfig {
+  const cfg = defaultConfig()
+  cfg.dataSources = setDataSourcePreset(cfg.dataSources, preset)
+  return cfg
+}
+
+describe('stripCredentials', () => {
+  it('removes top-level credential fields', () => {
+    const input = {
+      id: 'a',
+      token: 'secret',
+      i: 'misskey-token',
+      apiKey: 'sk-...',
+      accessToken: 'a',
+      refreshToken: 'r',
+      password: 'p',
+      secret: 's',
+    }
+    expect(stripCredentials(input)).toEqual({ id: 'a' })
+  })
+
+  it('removes nested credentials in deep objects', () => {
+    const input = {
+      user: { name: 'foo', token: 'leak', nested: { i: 'leak2', ok: 1 } },
+    }
+    expect(stripCredentials(input)).toEqual({
+      user: { name: 'foo', nested: { ok: 1 } },
+    })
+  })
+
+  it('handles arrays of objects', () => {
+    const input = [
+      { name: 'a', password: 'p1' },
+      { name: 'b', token: 't' },
+    ]
+    expect(stripCredentials(input)).toEqual([{ name: 'a' }, { name: 'b' }])
+  })
+
+  it('returns primitives untouched (string / number / null / undefined / boolean)', () => {
+    expect(stripCredentials('hello')).toBe('hello')
+    expect(stripCredentials(42)).toBe(42)
+    expect(stripCredentials(null)).toBe(null)
+    expect(stripCredentials(undefined)).toBe(undefined)
+    expect(stripCredentials(true)).toBe(true)
+  })
+})
+
+describe('buildAiContextBlock', () => {
+  it('returns empty string when nothing to inject (no account, no column)', () => {
+    const cfg = configWithDataSources('full')
+    expect(
+      buildAiContextBlock(cfg, { activeAccount: null, currentColumn: null }),
+    ).toBe('')
+  })
+
+  it('outputs currentAccount block by default (readonly preset)', () => {
+    const cfg = defaultConfig() // readonly: currentAccount on, visibleNotes off
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: null,
+    })
+    expect(block).toContain('<currentAccount>')
+    expect(block).toContain('"username": "taka"')
+    expect(block).not.toContain('<visibleNotes>')
+    expect(block).not.toContain('<recentConversation>')
+  })
+
+  it('strips Misskey-style credential fields from a leaky account-like object', () => {
+    const cfg = defaultConfig()
+    const leaky = {
+      ...SAMPLE_ACCOUNT,
+      // 想定外の漏洩シナリオ: account に直接トークンを混入
+      token: 'SHOULD-NOT-LEAK-1',
+      i: 'SHOULD-NOT-LEAK-2',
+      accessToken: 'SHOULD-NOT-LEAK-3',
+    } as unknown as Account
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: leaky,
+      currentColumn: null,
+    })
+    expect(block).toContain('"id": "acc-1"')
+    expect(block).not.toContain('SHOULD-NOT-LEAK-1')
+    expect(block).not.toContain('SHOULD-NOT-LEAK-2')
+    expect(block).not.toContain('SHOULD-NOT-LEAK-3')
+  })
+
+  it('respects dataSources off — skips currentAccount when disabled', () => {
+    const cfg = defaultConfig()
+    cfg.dataSources = {
+      preset: 'custom',
+      custom: {
+        ...cfg.dataSources.custom,
+        currentAccount: false,
+        currentColumn: false,
+      },
+    }
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: null,
+    })
+    expect(block).toBe('')
+  })
+
+  it('omits visibleNotes block when array is empty even if enabled', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: null,
+      visibleNotes: [],
+    })
+    expect(block).not.toContain('<visibleNotes>')
+  })
+
+  it('includes visibleNotes block when enabled and non-empty', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      visibleNotes: [{ id: 'n1', text: 'hello' }],
+    })
+    expect(block).toContain('<visibleNotes>')
+    expect(block).toContain('"id": "n1"')
+  })
+
+  it('emits column meta when currentColumn dataSource is on', () => {
+    const cfg = defaultConfig()
+    const column = {
+      id: 'col-1',
+      type: 'timeline',
+      name: 'TL',
+      accountId: null,
+    } as unknown as DeckColumn
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: column,
+    })
+    expect(block).toContain('<currentColumn>')
+    expect(block).toContain('"id": "col-1"')
+  })
+})
+
+describe('joinSystemPrompt', () => {
+  it('returns undefined when both inputs are empty', () => {
+    expect(joinSystemPrompt('', '')).toBeUndefined()
+  })
+
+  it('returns skills prompt alone when context is empty', () => {
+    expect(joinSystemPrompt('You are helpful.', '')).toBe('You are helpful.')
+  })
+
+  it('returns context block alone when skills prompt is empty', () => {
+    expect(joinSystemPrompt('', '<notedeck-context></notedeck-context>')).toBe(
+      '<notedeck-context></notedeck-context>',
+    )
+  })
+
+  it('joins both with double newline separator', () => {
+    expect(joinSystemPrompt('You are helpful.', '<notedeck-context/>')).toBe(
+      'You are helpful.\n\n<notedeck-context/>',
+    )
+  })
+})

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -9,7 +9,9 @@ import {
 import {
   buildAiContextBlock,
   joinSystemPrompt,
+  MAX_RECENT_TURNS,
   MAX_VISIBLE_NOTES,
+  projectRecentConversation,
   projectVisibleNotes,
   stripCredentials,
 } from './useAiSystemContext'
@@ -216,6 +218,46 @@ describe('projectVisibleNotes', () => {
     expect(out[0]?.id).toBe('unknown')
     expect(out[1]?.id).toBe('unknown')
     expect(out[2]?.id).toBe('ok')
+  })
+})
+
+describe('projectRecentConversation', () => {
+  it('returns empty array for empty / undefined input', () => {
+    expect(projectRecentConversation(undefined)).toEqual([])
+    expect(projectRecentConversation([])).toEqual([])
+  })
+
+  it('keeps the last MAX_RECENT_TURNS messages by default (= 20)', () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      role: 'user' as const,
+      content: `m${i}`,
+    }))
+    const out = projectRecentConversation(many)
+    expect(out).toHaveLength(MAX_RECENT_TURNS)
+    expect(out[0]?.content).toBe('m30')
+    expect(out[19]?.content).toBe('m49')
+  })
+
+  it('drops messages whose role is not user / assistant / system', () => {
+    const out = projectRecentConversation([
+      { role: 'user', content: 'hi' },
+      { role: 'tool' as unknown as 'user', content: 'ignored' },
+      { role: 'assistant', content: 'hello' },
+    ])
+    expect(out).toEqual([
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'hello' },
+    ])
+  })
+
+  it('coerces non-string content to empty string', () => {
+    const out = projectRecentConversation([
+      {
+        role: 'user',
+        content: { foo: 1 } as unknown as string,
+      },
+    ])
+    expect(out).toEqual([{ role: 'user', content: '' }])
   })
 })
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -9,6 +9,8 @@ import {
 import {
   buildAiContextBlock,
   joinSystemPrompt,
+  MAX_VISIBLE_NOTES,
+  projectVisibleNotes,
   stripCredentials,
 } from './useAiSystemContext'
 
@@ -161,6 +163,59 @@ describe('buildAiContextBlock', () => {
     })
     expect(block).toContain('<currentColumn>')
     expect(block).toContain('"id": "col-1"')
+  })
+})
+
+describe('projectVisibleNotes', () => {
+  it('returns empty array when input is empty / undefined', () => {
+    expect(projectVisibleNotes(undefined)).toEqual([])
+    expect(projectVisibleNotes([])).toEqual([])
+  })
+
+  it('caps the result at MAX_VISIBLE_NOTES (10) by default', () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      id: `n${i}`,
+      text: `t${i}`,
+    }))
+    const out = projectVisibleNotes(many)
+    expect(out).toHaveLength(MAX_VISIBLE_NOTES)
+    expect(out[0]?.id).toBe('n0')
+    expect(out[9]?.id).toBe('n9')
+  })
+
+  it('extracts id / userId / text / createdAt and inner user.username', () => {
+    const out = projectVisibleNotes([
+      {
+        id: 'n1',
+        userId: 'u1',
+        text: 'hi',
+        createdAt: '2026-05-01T00:00:00Z',
+        user: { username: 'taka' },
+      },
+    ])
+    expect(out[0]).toEqual({
+      id: 'n1',
+      userId: 'u1',
+      username: 'taka',
+      text: 'hi',
+      createdAt: '2026-05-01T00:00:00Z',
+    })
+  })
+
+  it('replaces text with [CW: <reason>] when cw is set', () => {
+    const out = projectVisibleNotes([
+      { id: 'n1', cw: 'spoiler', text: 'big secret' },
+    ])
+    expect(out[0]?.text).toBe('[CW: spoiler]')
+    expect(out[0]?.text).not.toContain('big secret')
+  })
+
+  it('handles primitives / nullish entries gracefully', () => {
+    const out = projectVisibleNotes([null, 'string', { id: 'ok' }])
+    expect(out).toHaveLength(3)
+    expect(out[0]?.id).toBe('unknown')
+    expect(out[1]?.id).toBe('unknown')
+    expect(out[2]?.id).toBe('ok')
   })
 })
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -113,6 +113,86 @@ describe('buildAiContextBlock', () => {
     expect(block).not.toContain('SHOULD-NOT-LEAK-3')
   })
 
+  it('returns empty string when ALL dataSources are off via custom preset', () => {
+    const cfg = defaultConfig()
+    cfg.dataSources = {
+      preset: 'custom',
+      custom: {
+        currentAccount: false,
+        currentColumn: false,
+        visibleNotes: false,
+        recentConversation: false,
+      },
+    }
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: { id: 'c', type: 'timeline' } as unknown as DeckColumn,
+      visibleNotes: [{ id: 'n1', text: 'hi' }],
+      recentConversation: [{ role: 'user', content: 'msg' }],
+    })
+    expect(block).toBe('')
+    // notedeck-context タグ自体が出ない
+    expect(block).not.toContain('<notedeck-context')
+  })
+
+  it('does not leak credentials anywhere (worst-case account / column / notes / conversation)', () => {
+    const cfg = configWithDataSources('full')
+    const leakyAccount = {
+      ...SAMPLE_ACCOUNT,
+      i: 'LEAK-i',
+      token: 'LEAK-token',
+      accessToken: 'LEAK-at',
+      refreshToken: 'LEAK-rt',
+      apiKey: 'LEAK-ak',
+      password: 'LEAK-pw',
+      secret: 'LEAK-sec',
+    } as unknown as Account
+    const leakyColumn = {
+      id: 'col-1',
+      type: 'timeline',
+      accountId: null,
+      name: 'TL',
+      token: 'LEAK-col-tok',
+      filters: { secret: 'LEAK-filter-sec' },
+    } as unknown as DeckColumn
+    const leakyNotes = [
+      { id: 'n1', text: 'hello', token: 'LEAK-note-tok' },
+      { id: 'n2', text: 'world', user: { username: 'foo', i: 'LEAK-user-i' } },
+    ]
+    const leakyConv = [
+      { role: 'user', content: 'msg1' },
+      { role: 'assistant', content: 'reply1' },
+    ]
+
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: leakyAccount,
+      currentColumn: leakyColumn,
+      visibleNotes: leakyNotes, // 注: stripCredentials は raw でも効く
+      recentConversation: leakyConv,
+    })
+
+    const leaks = [
+      'LEAK-i',
+      'LEAK-token',
+      'LEAK-at',
+      'LEAK-rt',
+      'LEAK-ak',
+      'LEAK-pw',
+      'LEAK-sec',
+      'LEAK-col-tok',
+      'LEAK-filter-sec',
+      'LEAK-note-tok',
+      'LEAK-user-i',
+    ]
+    for (const leak of leaks) {
+      expect(block, `must not leak ${leak}`).not.toContain(leak)
+    }
+    // 正常データはちゃんと出ている
+    expect(block).toContain('"username": "taka"')
+    expect(block).toContain('"id": "col-1"')
+    expect(block).toContain('"text": "hello"')
+  })
+
   it('respects dataSources off — skips currentAccount when disabled', () => {
     const cfg = defaultConfig()
     cfg.dataSources = {

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -60,12 +60,20 @@ export const MAX_VISIBLE_NOTES = 10
 export const MAX_RECENT_TURNS = 20
 
 /**
- * AI 送信用に可視ノートを軽量化する projection。
- * - 上限 {@link MAX_VISIBLE_NOTES} 件まで
- * - text / cw 等の表示用フィールドのみ抽出 (循環参照と巨大 payload を回避)
- * - CW がある場合は本文を `[CW: <reason>]` に置換
+ * AI 送信用に可視 item を軽量化する projection。
+ * カラム種別ごとに必要なフィールドだけ抽出する (循環参照と巨大 payload を回避)。
+ * 未対応 / 不明な種別は最低限の id / name / type のみ抜き出す raw fallback。
+ *
+ * - timeline / list / antenna / mentions / channel / favorites / clip /
+ *   user / specified / search / role / chat → ノート projection
+ *   (text を `[CW: <reason>]` に置換、user.username 抽出)
+ * - notifications → 通知 projection (type / userId / noteId / reaction)
+ * - drive → ドライブファイル projection (name / type / size)
+ * - その他 → raw fallback
  */
-export interface ProjectedNote {
+export type ProjectedItem = Record<string, unknown>
+
+export interface ProjectedNote extends ProjectedItem {
   id: string
   userId?: string
   username?: string
@@ -73,6 +81,44 @@ export interface ProjectedNote {
   createdAt?: string
 }
 
+const NOTE_LIKE_COLUMN_TYPES: ReadonlySet<string> = new Set([
+  'timeline',
+  'list',
+  'antenna',
+  'mentions',
+  'channel',
+  'favorites',
+  'clip',
+  'user',
+  'specified',
+  'search',
+  'role',
+  'chat',
+])
+
+export function projectVisibleItems(
+  items: unknown[] | undefined,
+  columnType: string | undefined,
+  limit = MAX_VISIBLE_NOTES,
+): ProjectedItem[] {
+  if (!items || items.length === 0) return []
+  const projector = pickProjector(columnType)
+  return items.slice(0, limit).map(projector)
+}
+
+function pickProjector(columnType?: string): (item: unknown) => ProjectedItem {
+  if (columnType && NOTE_LIKE_COLUMN_TYPES.has(columnType)) {
+    return projectOneNote
+  }
+  if (columnType === 'notifications') return projectOneNotification
+  if (columnType === 'drive') return projectOneDriveItem
+  return projectOneRaw
+}
+
+/**
+ * @deprecated `projectVisibleItems(items, 'timeline')` を使用。
+ * Phase 1 内部 API なので近いうちに削除予定。
+ */
 export function projectVisibleNotes(
   notes: unknown[] | undefined,
   limit = MAX_VISIBLE_NOTES,
@@ -128,6 +174,56 @@ function projectOneNote(n: unknown): ProjectedNote {
   const text =
     cw != null ? `[CW: ${cw}]` : typeof o.text === 'string' ? o.text : undefined
   return { id, userId, username, text, createdAt }
+}
+
+function projectOneNotification(n: unknown): ProjectedItem {
+  if (!n || typeof n !== 'object')
+    return { kind: 'notification', id: 'unknown' }
+  const o = n as Record<string, unknown>
+  const out: ProjectedItem = { kind: 'notification' }
+  out.id = typeof o.id === 'string' ? o.id : 'unknown'
+  if (typeof o.type === 'string') out.type = o.type
+  if (typeof o.userId === 'string') out.userId = o.userId
+  if (typeof o.noteId === 'string') out.noteId = o.noteId
+  if (typeof o.reaction === 'string') out.reaction = o.reaction
+  if (typeof o.createdAt === 'string') out.createdAt = o.createdAt
+  // 内部に user/note を持つ場合は username/text のみ拾う (stripCredentials も後段で適用)
+  if (o.user && typeof o.user === 'object') {
+    const u = o.user as Record<string, unknown>
+    if (typeof u.username === 'string') out.username = u.username
+  }
+  if (o.note && typeof o.note === 'object') {
+    const note = o.note as Record<string, unknown>
+    const cw =
+      typeof note.cw === 'string' && note.cw.length > 0 ? note.cw : null
+    if (cw != null) out.noteText = `[CW: ${cw}]`
+    else if (typeof note.text === 'string') out.noteText = note.text
+  }
+  return out
+}
+
+function projectOneDriveItem(n: unknown): ProjectedItem {
+  if (!n || typeof n !== 'object') return { kind: 'driveItem', id: 'unknown' }
+  const o = n as Record<string, unknown>
+  const out: ProjectedItem = { kind: 'driveItem' }
+  out.id = typeof o.id === 'string' ? o.id : 'unknown'
+  if (typeof o.name === 'string') out.name = o.name
+  if (typeof o.type === 'string') out.type = o.type
+  if (typeof o.size === 'number') out.size = o.size
+  if (typeof o.createdAt === 'string') out.createdAt = o.createdAt
+  if (typeof o.comment === 'string') out.comment = o.comment
+  return out
+}
+
+function projectOneRaw(n: unknown): ProjectedItem {
+  if (!n || typeof n !== 'object') return { id: 'unknown' }
+  const o = n as Record<string, unknown>
+  const out: ProjectedItem = {}
+  if (typeof o.id === 'string') out.id = o.id
+  if (typeof o.name === 'string') out.name = o.name
+  if (typeof o.type === 'string') out.type = o.type
+  if (typeof o.createdAt === 'string') out.createdAt = o.createdAt
+  return out
 }
 
 function jsonBlock(obj: unknown): string {

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -1,0 +1,112 @@
+/**
+ * AI に送る system prompt 末尾に注入する <notedeck-context> ブロックを組み立てる。
+ *
+ * - dataSources プリセット (ai.json5) で許可された項目のみを含める
+ * - currentAccount / 任意のオブジェクトから credential 系フィールドを再帰的に除去
+ * - 全項目 off の場合は空文字列を返す (空ブロックは出さない)
+ *
+ * Phase 1 では currentAccount / currentColumn / visibleNotes / recentConversation
+ * の 4 種を扱う。visibleNotes / recentConversation は呼び出し側で取得して渡す。
+ */
+
+import type { Account } from '@/stores/accounts'
+import type { DeckColumn } from '@/stores/deck'
+import { type AiConfig, resolveDataSources } from './useAiConfig'
+
+/**
+ * AI に送ってはいけないフィールド名 (credential / 機密データ)。
+ * Misskey の認証トークンキー `i` を含む。Phase 3 の credential proxy 実行モデルでも
+ * これらは AI に渡らないようにする。
+ */
+const SENSITIVE_KEYS: ReadonlySet<string> = new Set([
+  'token',
+  'i',
+  'accessToken',
+  'refreshToken',
+  'apiKey',
+  'password',
+  'secret',
+])
+
+/** 任意のオブジェクトから SENSITIVE_KEYS に一致するキーを再帰的に除去する。 */
+export function stripCredentials<T>(input: T): T {
+  if (Array.isArray(input)) {
+    return input.map((v) => stripCredentials(v)) as unknown as T
+  }
+  if (input !== null && typeof input === 'object') {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(input as Record<string, unknown>)) {
+      if (SENSITIVE_KEYS.has(k)) continue
+      out[k] = stripCredentials(v)
+    }
+    return out as T
+  }
+  return input
+}
+
+export interface AiContextInput {
+  activeAccount: Account | null
+  currentColumn: DeckColumn | null
+  /** Phase 1 C4 で接続予定。未指定なら出力しない。 */
+  visibleNotes?: unknown[]
+  /** Phase 1 C5 で接続予定。未指定なら出力しない。 */
+  recentConversation?: unknown[]
+}
+
+function jsonBlock(obj: unknown): string {
+  return JSON.stringify(stripCredentials(obj), null, 2)
+}
+
+/**
+ * dataSources 設定と context 入力から `<notedeck-context>` XML ブロックを組む。
+ * 何も入らない場合は空文字列を返す (skills prompt との結合で no-op になる)。
+ */
+export function buildAiContextBlock(
+  config: AiConfig,
+  ctx: AiContextInput,
+): string {
+  const ds = resolveDataSources(config.dataSources)
+  const parts: string[] = []
+
+  if (ds.currentAccount && ctx.activeAccount) {
+    parts.push(
+      `  <currentAccount>\n${jsonBlock(ctx.activeAccount)}\n  </currentAccount>`,
+    )
+  }
+  if (ds.currentColumn && ctx.currentColumn) {
+    parts.push(
+      `  <currentColumn>\n${jsonBlock(ctx.currentColumn)}\n  </currentColumn>`,
+    )
+  }
+  if (ds.visibleNotes && ctx.visibleNotes && ctx.visibleNotes.length > 0) {
+    parts.push(
+      `  <visibleNotes>\n${jsonBlock(ctx.visibleNotes)}\n  </visibleNotes>`,
+    )
+  }
+  if (
+    ds.recentConversation &&
+    ctx.recentConversation &&
+    ctx.recentConversation.length > 0
+  ) {
+    parts.push(
+      `  <recentConversation>\n${jsonBlock(ctx.recentConversation)}\n  </recentConversation>`,
+    )
+  }
+
+  if (parts.length === 0) return ''
+  return `<notedeck-context>\n${parts.join('\n')}\n</notedeck-context>`
+}
+
+/**
+ * skills 由来の system prompt と <notedeck-context> ブロックを連結する。
+ * どちらも空なら undefined を返す (= system prompt なしで API を呼ぶ既存挙動)。
+ */
+export function joinSystemPrompt(
+  skillsPrompt: string,
+  contextBlock: string,
+): string | undefined {
+  if (skillsPrompt && contextBlock) {
+    return `${skillsPrompt}\n\n${contextBlock}`
+  }
+  return skillsPrompt || contextBlock || undefined
+}

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -47,10 +47,53 @@ export function stripCredentials<T>(input: T): T {
 export interface AiContextInput {
   activeAccount: Account | null
   currentColumn: DeckColumn | null
-  /** Phase 1 C4 で接続予定。未指定なら出力しない。 */
+  /** 既に projection 済みの可視ノート配列。空配列なら出力しない。 */
   visibleNotes?: unknown[]
   /** Phase 1 C5 で接続予定。未指定なら出力しない。 */
   recentConversation?: unknown[]
+}
+
+/** AI に渡す可視ノートの上限件数。 */
+export const MAX_VISIBLE_NOTES = 10
+
+/**
+ * AI 送信用に可視ノートを軽量化する projection。
+ * - 上限 {@link MAX_VISIBLE_NOTES} 件まで
+ * - text / cw 等の表示用フィールドのみ抽出 (循環参照と巨大 payload を回避)
+ * - CW がある場合は本文を `[CW: <reason>]` に置換
+ */
+export interface ProjectedNote {
+  id: string
+  userId?: string
+  username?: string
+  text?: string
+  createdAt?: string
+}
+
+export function projectVisibleNotes(
+  notes: unknown[] | undefined,
+  limit = MAX_VISIBLE_NOTES,
+): ProjectedNote[] {
+  if (!notes || notes.length === 0) return []
+  return notes.slice(0, limit).map(projectOneNote)
+}
+
+function projectOneNote(n: unknown): ProjectedNote {
+  if (!n || typeof n !== 'object') return { id: 'unknown' }
+  const o = n as Record<string, unknown>
+  const id = typeof o.id === 'string' ? o.id : 'unknown'
+  const userId = typeof o.userId === 'string' ? o.userId : undefined
+  const createdAt = typeof o.createdAt === 'string' ? o.createdAt : undefined
+  const cw = typeof o.cw === 'string' && o.cw.length > 0 ? o.cw : null
+  const username =
+    o.user && typeof o.user === 'object'
+      ? typeof (o.user as Record<string, unknown>).username === 'string'
+        ? ((o.user as Record<string, unknown>).username as string)
+        : undefined
+      : undefined
+  const text =
+    cw != null ? `[CW: ${cw}]` : typeof o.text === 'string' ? o.text : undefined
+  return { id, userId, username, text, createdAt }
 }
 
 function jsonBlock(obj: unknown): string {

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -56,6 +56,9 @@ export interface AiContextInput {
 /** AI に渡す可視ノートの上限件数。 */
 export const MAX_VISIBLE_NOTES = 10
 
+/** AI 送信時に context に含める直近会話の上限ターン数 (= 直近 N メッセージ)。 */
+export const MAX_RECENT_TURNS = 20
+
 /**
  * AI 送信用に可視ノートを軽量化する projection。
  * - 上限 {@link MAX_VISIBLE_NOTES} 件まで
@@ -76,6 +79,37 @@ export function projectVisibleNotes(
 ): ProjectedNote[] {
   if (!notes || notes.length === 0) return []
   return notes.slice(0, limit).map(projectOneNote)
+}
+
+/**
+ * 直近の会話履歴を <recentConversation> 用に射影する。
+ * 現セッションの history は API の messages としても渡るが、ここでは AI が
+ * テキストとして「直近やり取り」を参照できるよう別形式でも提供する。
+ * dataSource.recentConversation = false の場合は呼び出し側でこの関数を
+ * 通さなければそもそも何も渡らない (= 過去会話を context に出さない)。
+ */
+export interface ProjectedTurn {
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+export function projectRecentConversation(
+  messages: { role: string; content: string }[] | undefined,
+  limit = MAX_RECENT_TURNS,
+): ProjectedTurn[] {
+  if (!messages || messages.length === 0) return []
+  const tail = messages.slice(-limit)
+  const out: ProjectedTurn[] = []
+  for (const m of tail) {
+    if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'system') {
+      continue
+    }
+    out.push({
+      role: m.role,
+      content: typeof m.content === 'string' ? m.content : '',
+    })
+  }
+  return out
 }
 
 function projectOneNote(n: unknown): ProjectedNote {

--- a/src/defaults/ai.json5
+++ b/src/defaults/ai.json5
@@ -14,4 +14,35 @@
     endpoint: '',
     model: '',
   },
+
+  // 権限: AI に渡してよい操作の許可セット
+  // Phase 1 では値の保存のみで enforce しない (Phase 2-5 で段階実装)
+  // preset: 'readonly' (default) / 'safe' / 'full' / 'custom'
+  permissions: {
+    preset: 'readonly',
+    custom: {
+      'notes.read': true,
+      'notes.write': false,
+      'notes.react': false,
+      'account.read': true,
+      'account.write': false,
+      'drive.read': true,
+      'drive.write': false,
+      'network.external': false,
+      'clipboard': false,
+      'notifications': false,
+    },
+  },
+
+  // データソース: AI に送る system prompt に含める情報
+  // permissions と違い、Phase 1 から即動作する (system prompt 末尾に <notedeck-context> として注入)
+  dataSources: {
+    preset: 'readonly',
+    custom: {
+      'currentAccount': true,
+      'currentColumn': true,
+      'visibleNotes': false,
+      'recentConversation': false,
+    },
+  },
 }

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -57,6 +57,26 @@ export type ColumnType =
   | 'skill'
 
 /**
+ * ノートを連続ストリーミング表示するカラム型 (= 「直近フォーカスしたタイムライン」
+ * の追跡対象)。AI チャットや IDE 系ツールカラムは除外。
+ */
+export const TIMELINE_LIKE_COLUMN_TYPES: ReadonlySet<ColumnType> = new Set([
+  'timeline',
+  'notifications',
+  'list',
+  'antenna',
+  'mentions',
+  'channel',
+  'favorites',
+  'clip',
+  'user',
+  'specified',
+  'search',
+  'role',
+  'chat',
+])
+
+/**
  * @deprecated useWidgetsStore に移行済み。マイグレーション用にのみ残置 (1〜2 リリース後に削除)
  */
 export interface WidgetData {
@@ -256,8 +276,29 @@ export const useDeckStore = defineStore('deck', () => {
     return m
   })
 
+  /**
+   * 各カラムが報告した可視ノートのキャッシュ。
+   * AI への context 注入や監査ログなど横断的な機能から参照される。
+   * 新規参照者は「特別扱い」せずこの汎用 API を使うこと
+   * (memory feedback_no_special_case_columns)。
+   */
+  const visibleNotesByColumn = ref<Record<string, unknown[]>>({})
+  /** 直近フォーカスしたタイムライン系カラムの id (AI が context として読む)。 */
+  const lastFocusedTimelineColumnId = ref<string | null>(null)
+
+  function reportVisibleNotes(columnId: string, notes: unknown[]) {
+    visibleNotesByColumn.value = {
+      ...visibleNotesByColumn.value,
+      [columnId]: notes,
+    }
+  }
+
   function setActiveColumn(id: string) {
     activeColumnId.value = id
+    const col = columnMap.value.get(id)
+    if (col && TIMELINE_LIKE_COLUMN_TYPES.has(col.type)) {
+      lastFocusedTimelineColumnId.value = id
+    }
   }
 
   function focusNextColumn() {
@@ -353,6 +394,14 @@ export const useDeckStore = defineStore('deck', () => {
         .filter((ids) => ids.length > 0)
     })
     profileStore.flushPersist()
+    if (visibleNotesByColumn.value[id] !== undefined) {
+      const next = { ...visibleNotesByColumn.value }
+      delete next[id]
+      visibleNotesByColumn.value = next
+    }
+    if (lastFocusedTimelineColumnId.value === id) {
+      lastFocusedTimelineColumnId.value = null
+    }
     hapticMedium()
   }
 
@@ -645,6 +694,9 @@ export const useDeckStore = defineStore('deck', () => {
     navCollapsed,
     activeColumnId,
     activeColumnUri,
+    visibleNotesByColumn,
+    lastFocusedTimelineColumnId,
+    reportVisibleNotes,
     setActiveColumn,
     focusNextColumn,
     focusPrevColumn,

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -277,7 +277,8 @@ export const useDeckStore = defineStore('deck', () => {
   })
 
   /**
-   * 各カラムが報告した可視ノートのキャッシュ。
+   * 各カラムが報告した可視 item のキャッシュ。
+   * 中身はカラム種別ごとに異なる (note / notification / driveItem / ...)。
    * AI への context 注入や監査ログなど横断的な機能から参照される。
    * 新規参照者は「特別扱い」せずこの汎用 API を使うこと
    * (memory feedback_no_special_case_columns)。
@@ -286,10 +287,10 @@ export const useDeckStore = defineStore('deck', () => {
   /** 直近フォーカスしたタイムライン系カラムの id (AI が context として読む)。 */
   const lastFocusedTimelineColumnId = ref<string | null>(null)
 
-  function reportVisibleNotes(columnId: string, notes: unknown[]) {
+  function reportVisibleItems(columnId: string, items: unknown[]) {
     visibleNotesByColumn.value = {
       ...visibleNotesByColumn.value,
-      [columnId]: notes,
+      [columnId]: items,
     }
   }
 
@@ -696,7 +697,7 @@ export const useDeckStore = defineStore('deck', () => {
     activeColumnUri,
     visibleNotesByColumn,
     lastFocusedTimelineColumnId,
-    reportVisibleNotes,
+    reportVisibleItems,
     setActiveColumn,
     focusNextColumn,
     focusPrevColumn,


### PR DESCRIPTION
## Summary

ClaudeCode の `settings.json` 相当機能を NoteDeck に移植する Phase 1。`ai.json5` に `permissions` / `dataSources` ブロックを追加し、AI 送信時の system prompt 末尾に `<notedeck-context>` XML ブロックを注入する仕組みを実装。

設計の最終仕様: [#408 [最良設計] Phase 1 確定版](https://github.com/hitalin/notedeck/issues/408#issuecomment-4358063319)

## Changes

- feat(ai): generalize visible items pipeline to non-note columns
- test(ai): add credential leak / preset coverage guards
- fix(ai): fall back to first timeline column when none is focused
- feat(ai): include recent conversation in <notedeck-context>
- feat(ai): pipe visible notes from timeline / list columns to AI
- feat(ai): inject <notedeck-context> into AI system prompt
- feat(ai): permissions / dataSources UI in AiSettingsContent
- feat(ai): add permissions / dataSources schema to ai.json5

## Phase 1 で入るもの

- **schema**: `permissions` (10 項目) / `dataSources` (4 項目) を ai.json5 に追加。preset (`readonly` / `safe` / `full` / `custom`) + custom map
- **UI**: AiSettingsContent の 'API' タブにフォーム追加 (raw json5 双方向同期は既存パターン再利用)
- **system prompt 注入**: `skillsStore.composedSystemPrompt()` の延長として `<notedeck-context>` を後置
- **credential 自動除去**: `token` / `i` / `accessToken` / `refreshToken` / `apiKey` / `password` / `secret` を再帰的に削除 (Misskey トークン `i` 含む)
- **CW マスキング**: CW 付きノートは本文を `[CW: <理由>]` に置換
- **visibleNotes パイプライン**: deck store に汎用 `reportVisibleItems(columnId, items)` API を追加。Timeline / List / Notification / Drive カラムから配線
- **fallback**: ユーザーが Timeline カラムをクリックしていなくても、画面に存在する最初の TIMELINE_LIKE カラムを自動採用
- **kind 別 projection**: column type に応じて note / notification / drive / raw に振り分け

## Phase 1 で入らないもの (別 PR で着手)

- tool calling (`Command` interface に `permissions?` / `aiTool?` / `signature?` 追加 + dispatcher)
- 細粒度 allow/deny pattern (Phase 3)
- 監査ログ / dry-run / 確認ダイアログ (Phase 5)
- per-account override (Phase 6)
- ローカル AI モード統合 (Phase 7)

## Test plan

- [x] 単体テスト 361 件 pass (preset 網羅 / credential 流出最悪ケース / kind 別 projection / 全 OFF ブロック非出力)
- [x] typecheck / lint クリーン
- [x] 実機: Timeline カラムを focus → AI が可視ノートを参照して応答
- [x] 実機: Notification カラムを focus → AI が通知 entity を参照して応答
- [x] 実機: Timeline 未クリックでも fallback で最初の TL を採用
- [ ] レビュアー側: Custom 編集 / プリセット切替 / raw json5 同期の UI 操作確認
- [ ] レビュアー側: `dataSources` 全 OFF にして `<notedeck-context>` ブロックが消えることを確認

## 関連

- Closes 部分: #408 (Phase 1 のみ。Phase 2 以降は別 PR)
- 後続: #411 (HEARTBEAT) は本 PR が develop マージ後に着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)