### PR TITLE
feat(ai): split visible context block by column kind

### DIFF
--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -214,9 +214,10 @@ const DATA_SOURCE_LABELS: Record<DataSourceKey, DataSourceLabel> = {
     description: 'フォーカス中のカラムの種別と設定を渡す',
   },
   visibleNotes: {
-    label: '可視ノート (上限 10 件)',
+    label: '可視アイテム (上限 10 件)',
     icon: 'ti-list',
-    description: '画面に表示中のノートを context に含める',
+    description:
+      '画面に表示中のアイテム (ノート / 通知 / ドライブファイル等) を context に含める',
   },
   recentConversation: {
     label: 'AI チャット履歴 (上限 20 ターン)',

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -11,6 +11,7 @@ import {
   joinSystemPrompt,
   MAX_RECENT_TURNS,
   MAX_VISIBLE_NOTES,
+  pickVisibleBlockTag,
   projectRecentConversation,
   projectVisibleItems,
   projectVisibleNotes,
@@ -225,7 +226,7 @@ describe('buildAiContextBlock', () => {
     const cfg = configWithDataSources('safe')
     const block = buildAiContextBlock(cfg, {
       activeAccount: null,
-      currentColumn: null,
+      currentColumn: { id: 'c', type: 'timeline' } as unknown as DeckColumn,
       visibleNotes: [{ id: 'n1', text: 'hello' }],
     })
     expect(block).toContain('<visibleNotes>')
@@ -299,6 +300,89 @@ describe('projectVisibleNotes', () => {
     expect(out[0]?.id).toBe('unknown')
     expect(out[1]?.id).toBe('unknown')
     expect(out[2]?.id).toBe('ok')
+  })
+})
+
+describe('pickVisibleBlockTag', () => {
+  it.each([
+    'timeline',
+    'list',
+    'antenna',
+    'mentions',
+    'channel',
+    'favorites',
+    'clip',
+    'user',
+    'specified',
+    'search',
+    'role',
+    'chat',
+  ])('returns visibleNotes for note-like type %s', (type) => {
+    expect(pickVisibleBlockTag(type)).toBe('visibleNotes')
+  })
+
+  it('returns visibleNotifications for notifications', () => {
+    expect(pickVisibleBlockTag('notifications')).toBe('visibleNotifications')
+  })
+
+  it('returns visibleDriveItems for drive', () => {
+    expect(pickVisibleBlockTag('drive')).toBe('visibleDriveItems')
+  })
+
+  it('returns visibleItems for unknown / undefined types', () => {
+    expect(pickVisibleBlockTag(undefined)).toBe('visibleItems')
+    expect(pickVisibleBlockTag('explore')).toBe('visibleItems')
+    expect(pickVisibleBlockTag('aiscript')).toBe('visibleItems')
+  })
+})
+
+describe('buildAiContextBlock — visible block tag dispatch', () => {
+  it('emits <visibleNotes> for timeline column', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: { id: 'c', type: 'timeline' } as unknown as DeckColumn,
+      visibleNotes: [{ id: 'n1', text: 'hi' }],
+    })
+    expect(block).toContain('<visibleNotes>')
+    expect(block).not.toContain('<visibleNotifications>')
+    expect(block).not.toContain('<visibleDriveItems>')
+  })
+
+  it('emits <visibleNotifications> for notifications column', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: {
+        id: 'c',
+        type: 'notifications',
+      } as unknown as DeckColumn,
+      visibleNotes: [{ id: 'notif-1', type: 'reaction' }],
+    })
+    expect(block).toContain('<visibleNotifications>')
+    expect(block).not.toContain('<visibleNotes>')
+  })
+
+  it('emits <visibleDriveItems> for drive column', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: { id: 'c', type: 'drive' } as unknown as DeckColumn,
+      visibleNotes: [{ id: 'f1', name: 'a.png' }],
+    })
+    expect(block).toContain('<visibleDriveItems>')
+    expect(block).not.toContain('<visibleNotes>')
+  })
+
+  it('falls back to <visibleItems> for unsupported column types', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: { id: 'c', type: 'explore' } as unknown as DeckColumn,
+      visibleNotes: [{ id: 'x' }],
+    })
+    expect(block).toContain('<visibleItems>')
+    expect(block).not.toContain('<visibleNotes>')
   })
 })
 

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -116,6 +116,18 @@ function pickProjector(columnType?: string): (item: unknown) => ProjectedItem {
 }
 
 /**
+ * column type から `<visibleXxx>` ブロックの XML タグ名を決定する。
+ * AI が中身の種別をタグ名で即座に判別できる。
+ */
+export function pickVisibleBlockTag(columnType: string | undefined): string {
+  if (columnType && NOTE_LIKE_COLUMN_TYPES.has(columnType))
+    return 'visibleNotes'
+  if (columnType === 'notifications') return 'visibleNotifications'
+  if (columnType === 'drive') return 'visibleDriveItems'
+  return 'visibleItems'
+}
+
+/**
  * @deprecated `projectVisibleItems(items, 'timeline')` を使用。
  * Phase 1 内部 API なので近いうちに削除予定。
  */
@@ -252,9 +264,8 @@ export function buildAiContextBlock(
     )
   }
   if (ds.visibleNotes && ctx.visibleNotes && ctx.visibleNotes.length > 0) {
-    parts.push(
-      `  <visibleNotes>\n${jsonBlock(ctx.visibleNotes)}\n  </visibleNotes>`,
-    )
+    const tag = pickVisibleBlockTag(ctx.currentColumn?.type)
+    parts.push(`  <${tag}>\n${jsonBlock(ctx.visibleNotes)}\n  </${tag}>`)
   }
   if (
     ds.recentConversation &&


### PR DESCRIPTION
## Summary

AI に渡す `<notedeck-context>` の中身を、column type に応じて専用タグに振り分けるようにする。Phase 1 (#423) では `<visibleNotes>` 1 種類に何でも入っていたため、AI が「中身が note なのか notification なのか drive item なのか」を projection 内の `kind` フィールドで判別する必要があった。タグ名で即座に判別できる形に整える。

## Changes

- `pickVisibleBlockTag(columnType)` を追加
  - `timeline` / `list` / `antenna` / `mentions` / `channel` / `favorites` / `clip` / `user` / `specified` / `search` / `role` / `chat` → `<visibleNotes>`
  - `notifications` → `<visibleNotifications>`
  - `drive` → `<visibleDriveItems>`
  - その他 / 不明 → `<visibleItems>`
- `buildAiContextBlock` で `currentColumn.type` を見てタグを決定
- AI 設定 UI の `dataSource.visibleNotes` ラベルを「可視ノート」→「可視アイテム」に拡張し、説明文も「ノート / 通知 / ドライブファイル等」と明示
- 既存テスト (`currentColumn: null` で `<visibleNotes>` を期待していた箇所) を column type を渡す形に修正
- 新規テスト 19 件追加 (タグ dispatch / 各 kind ブロック名)

## 互換性

- ai.json5 の `dataSources.visibleNotes` キー名は維持 (UI ラベルだけ変更)
- 既存の `<visibleNotes>` は note-like カラムでは引き続き出力されるので、Skills 側の prompt や AI のキャラ性が `<visibleNotes>` を参照していても破綻しない

## Test plan

- [x] 単体テスト 380 件 pass
- [x] typecheck / lint クリーン
- [ ] レビュアー側: Notification カラム focus → AI に質問 → `<visibleNotifications>` で渡る
- [ ] レビュアー側: Drive カラム focus → AI に質問 → `<visibleDriveItems>` で渡る
- [ ] レビュアー側: AI 設定の「データソース」ラベルが「可視アイテム」になっている

## 関連

- Phase 1 PR: #423
- 設計: [#408 [最良設計] Phase 1 確定版](https://github.com/hitalin/notedeck/issues/408#issuecomment-4358063319) の自然な延長
- 後続 (別 PR): kind ごとの独立 dataSource toggle (`visibleNotifications` / `visibleDriveItems` を別キーに)

🤖 Generated with [Claude Code](https://claude.com/claude-code)