### PR TITLE
feat(capabilities): Capability Registry types (#408 Phase 2 A-1)

### DIFF
--- a/src/capabilities/types.test.ts
+++ b/src/capabilities/types.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  CapabilitySignature,
+  ParameterDef,
+  PermissionKey,
+  ReturnTypeDef,
+} from './types'
+
+describe('CapabilitySignature shape', () => {
+  it('builds a minimal signature (description only)', () => {
+    const sig: CapabilitySignature = {
+      description: 'Get the current time',
+    }
+    expect(sig.description).toBe('Get the current time')
+    expect(sig.params).toBeUndefined()
+    expect(sig.returns).toBeUndefined()
+  })
+
+  it('builds a full signature with params and returns', () => {
+    const sig: CapabilitySignature = {
+      description: 'Post a note to the current account',
+      params: {
+        text: {
+          type: 'string',
+          description: 'Note body text',
+        },
+        visibility: {
+          type: 'string',
+          description: 'Visibility level',
+          enum: ['public', 'home', 'followers', 'specified'],
+          optional: true,
+        },
+      },
+      returns: {
+        type: 'object',
+        description: 'The created note object',
+      },
+    }
+    expect(sig.params?.text?.type).toBe('string')
+    expect(sig.params?.visibility?.enum).toContain('public')
+    expect(sig.params?.visibility?.optional).toBe(true)
+    expect(sig.returns?.type).toBe('object')
+  })
+})
+
+describe('ParameterDef shape', () => {
+  it('required parameter has no optional flag', () => {
+    const p: ParameterDef = { type: 'string', description: 'required' }
+    expect(p.optional).toBeUndefined()
+  })
+
+  it('optional parameter sets optional: true', () => {
+    const p: ParameterDef = {
+      type: 'string',
+      description: 'optional',
+      optional: true,
+    }
+    expect(p.optional).toBe(true)
+  })
+
+  it('accepts all primitive type values', () => {
+    const types: ParameterDef['type'][] = [
+      'string',
+      'number',
+      'boolean',
+      'object',
+      'array',
+    ]
+    for (const t of types) {
+      const p: ParameterDef = { type: t, description: t }
+      expect(p.type).toBe(t)
+    }
+  })
+})
+
+describe('ReturnTypeDef shape', () => {
+  it('void return is valid for action capabilities', () => {
+    const ret: ReturnTypeDef = { type: 'void' }
+    expect(ret.type).toBe('void')
+    expect(ret.description).toBeUndefined()
+  })
+
+  it('object return can carry a description', () => {
+    const ret: ReturnTypeDef = { type: 'object', description: 'a note' }
+    expect(ret.description).toBe('a note')
+  })
+})
+
+describe('PermissionKey re-export', () => {
+  it('is the same union as in useAiConfig', () => {
+    // 型レベルだけだが、代入できることを実行時にも確認する。
+    const key: PermissionKey = 'notes.read'
+    expect(key).toBe('notes.read')
+  })
+})

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Capability Registry の型定義 (Phase 2 入口)。
+ *
+ * Capability = 「NoteDeck で実行できる操作」の単位。
+ * 既存の `Command` interface に optional フィールドを追加することで、
+ * UI / CLI / HTTP API / AiScript / AI Tool calling の 5 つの呼び出し口で
+ * 共通利用できる Single Source of Truth へ進化させる。
+ *
+ * Phase 2 A-1 (本ファイル): 型定義のみ。実 dispatcher は A-2 で実装。
+ *
+ * 設計詳細: #408 "Capability Registry as Single Source of Truth"
+ *   https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896
+ */
+
+import type { PermissionKey } from '@/composables/useAiConfig'
+
+/**
+ * Capability の引数 1 つを表す型情報。
+ * - JSON Schema に近いシンプル形式
+ * - AI tool schema (Anthropic / OpenAI) や OpenAPI spec への自動変換の元データ
+ */
+export interface ParameterDef {
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array'
+  description: string
+  /** 省略可能なら true。未指定 = false (= 必須) */
+  optional?: boolean
+  /** 文字列 enum 風の許容値リスト */
+  enum?: readonly string[]
+}
+
+/**
+ * Capability の戻り値の型情報。
+ * 戻り値が無い (副作用のみ) capability は `'void'` を指定する。
+ */
+export interface ReturnTypeDef {
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array' | 'void'
+  description?: string
+}
+
+/**
+ * Capability の型シグネチャ。
+ * params / returns がある capability は AI tool schema や OpenAPI を自動生成できる。
+ *
+ * Phase 1 では値の保存のみ。Phase 2 で実 dispatcher が読み込む。
+ */
+export interface CapabilitySignature {
+  /** ユーザー / AI に見せる説明 (Anthropic `tool description` 相当) */
+  description: string
+  /** 名前付き引数 (順序ではなく key ベース) */
+  params?: Record<string, ParameterDef>
+  /** 戻り値の型 */
+  returns?: ReturnTypeDef
+}
+
+// 呼び出し元側で permissions 宣言型を参照するときの再 export
+export type { PermissionKey }

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import { ref, shallowRef, triggerRef } from 'vue'
+import type { CapabilitySignature, PermissionKey } from '@/capabilities/types'
 import type { QuickPickStep } from './quickPick'
 
 export interface Shortcut {
@@ -15,6 +16,17 @@ export interface Shortcut {
   scope: 'global' | 'body'
 }
 
+/**
+ * Command (= Capability) は NoteDeck で実行できる操作の単位。
+ *
+ * 5 つの呼び出し口で共通利用される Single Source of Truth:
+ *   UI (コマンドパレット) / CLI (notecli) / HTTP API (port 19820) /
+ *   AiScript (Nd:register_command) / AI Tool calling
+ *
+ * Phase 1 では UI 専用。Phase 2 以降で `aiTool: true` & `signature` & `permissions`
+ * を宣言した command が AI から呼べるようになる。すべて optional なので既存
+ * コマンドはそのまま (= UI のみ扱い) で動く。
+ */
 export interface Command {
   id: string
   label: string
@@ -22,11 +34,32 @@ export interface Command {
   icon: string
   category: 'general' | 'navigation' | 'column' | 'account' | 'note' | 'window'
   shortcuts: Shortcut[]
-  execute: () => void
+  /**
+   * 実行関数。引数は optional で、UI 経由は引数なし、AI tool 経由は params 付き
+   * で呼ばれる。戻り値は AI tool への応答として使われるため `unknown` を返せる。
+   */
+  execute: (params?: Record<string, unknown>) => unknown
   /** false を返すとパレットでグレー表示＋実行不可 */
   enabled?: () => boolean
   /** false にするとパレットに非表示 (ショートカットのみ) */
   visible?: boolean
+  /**
+   * この command を実行するのに必要な権限 (Phase 1 の `ai.json5` permissions と
+   * 同じスキーマ)。AI tool / HTTP API / プラグインから呼ぶときに照合される。
+   * UI のみで使う command は省略可。
+   */
+  permissions?: PermissionKey[]
+  /**
+   * AI tool として公開するか。true & signature 付き & permissions が満たされる
+   * とき、AI tool schema に自動変換されて Anthropic / OpenAI の tools[] に乗る。
+   * 未指定 / false なら UI のみ。
+   */
+  aiTool?: boolean
+  /**
+   * params / returns の型。AI tool schema / OpenAPI spec の自動生成に使う。
+   * UI のみの command は省略可 (引数なし扱い)。
+   */
+  signature?: CapabilitySignature
 }
 
 export const useCommandStore = defineStore('commands', () => {


### PR DESCRIPTION
## Summary

#408 Phase 2 の入口として、`Command` interface を **Capability Registry** に進化させるための optional フィールド群を追加する。Single Source of Truth として UI / CLI / HTTP API / AiScript / AI Tool calling の 5 つの呼び出し口で共通利用される基盤型。

設計詳細: [#408 Capability Registry as Single Source of Truth](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

## Changes

- feat(capabilities): introduce Capability Registry types (Phase 2 A-1)

### 新規

- **`src/capabilities/types.ts`** — Capability Registry の型定義
  - `CapabilitySignature` (description / params / returns)
  - `ParameterDef` (type / description / optional / enum)
  - `ReturnTypeDef` (type / description, `void` 含む)
  - `PermissionKey` の再 export
- **`src/capabilities/types.test.ts`** — 型レベル + 実行時スモークテスト (8 件)

### 拡張

- **`src/commands/registry.ts`** の `Command` interface
  - `permissions?: PermissionKey[]` (Phase 1 の `ai.json5` permissions と同じスキーマ)
  - `aiTool?: boolean` (AI tool として公開するか)
  - `signature?: CapabilitySignature` (params / returns の型)
  - `execute: (params?) => unknown` (引数取れる、戻り値も拾える形に拡張)

## 影響範囲

- 新フィールドはすべて optional で、既存 30+ commands は **無修正で動作**
- `execute()` は引数なしで呼べるので互換性あり (UI 経由は従来通り)
- 戻り値の型を `void` → `unknown` に変えたが、戻り値を使う既存コードが無いので影響なし

## スコープ外 (別 PR)

- A-2: AI tool dispatcher 実装 (Anthropic / OpenAI tool block 受信 → permissions 照合 → capability.execute → SSE で結果を返す)
- A-3: PoC capability (`Nd:db.query` 等を 1 つ作って動作確認)
- 既存 command への signature / permissions 宣言追加 (個別 PR で順次)
- AiScript `Nd:register_command` の拡張
- HTTP API / CLI 側の capability 化

## Test plan

- [x] 単体テスト 388 件 pass (新規 8 件、既存 380 件は全て影響なし)
- [x] typecheck / lint クリーン
- [x] 既存 commands が変更なしで動くこと (型エラーなし、テスト全 pass)
- [ ] レビュアー側: 既存コマンドパレットが正常動作すること

## 関連

- Phase 1 PR: #423 / #424
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)