### PR TITLE
feat(capabilities): registry / dispatcher / tool schema (#408 Phase 2 A-3.1)

### DIFF
--- a/src/capabilities/builtins/time.test.ts
+++ b/src/capabilities/builtins/time.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { BUILTIN_CAPABILITIES, timeNowCapability } from './time'
+
+describe('time.now capability', () => {
+  it('has aiTool: true and zero permissions', () => {
+    expect(timeNowCapability.aiTool).toBe(true)
+    expect(timeNowCapability.permissions).toEqual([])
+  })
+
+  it('declares a string return signature', () => {
+    expect(timeNowCapability.signature?.returns?.type).toBe('string')
+  })
+
+  it('execute returns an ISO 8601 string close to now', () => {
+    const before = Date.now()
+    const result = timeNowCapability.execute()
+    const after = Date.now()
+    expect(typeof result).toBe('string')
+    const parsed = Date.parse(result as string)
+    expect(parsed).toBeGreaterThanOrEqual(before)
+    expect(parsed).toBeLessThanOrEqual(after)
+    // ISO 8601 (UTC, 'Z' suffix) を確認
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/)
+  })
+
+  it('BUILTIN_CAPABILITIES includes time.now', () => {
+    expect(BUILTIN_CAPABILITIES).toContain(timeNowCapability)
+  })
+})

--- a/src/capabilities/builtins/time.ts
+++ b/src/capabilities/builtins/time.ts
@@ -1,0 +1,30 @@
+import type { Command } from '@/commands/registry'
+
+/**
+ * `time.now` — ユーザー環境の現在時刻を ISO 8601 形式で返す。
+ *
+ * Phase 2 A-3.1 の動作確認用 sample capability。副作用なし、permissions 不要。
+ * AI が「今何時?」と聞かれたとき、context block ではなく tool 経由で時刻を
+ * 取得できることを実証する。
+ */
+export const timeNowCapability: Command = {
+  id: 'time.now',
+  label: '現在時刻を取得',
+  icon: 'ti-clock',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description: 'ユーザー環境の現在時刻を ISO 8601 形式で返す。',
+    params: {},
+    returns: {
+      type: 'string',
+      description: 'ISO 8601 形式の現在時刻 (例: 2026-05-01T12:34:56.789Z)',
+    },
+  },
+  execute: () => new Date().toISOString(),
+}
+
+/** Builtin capability すべて。起動時に register する用。 */
+export const BUILTIN_CAPABILITIES: readonly Command[] = [timeNowCapability]

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Command } from '@/commands/registry'
+import {
+  type AiConfig,
+  defaultConfig,
+  setPermissionPreset,
+} from '@/composables/useAiConfig'
+import { dispatchCapability } from './dispatcher'
+import { _clearCapabilitiesForTest, registerCapability } from './registry'
+
+function makeCapability(overrides: Partial<Command> = {}): Command {
+  return {
+    id: 'test.cap',
+    label: 'test',
+    icon: 'ti-flask',
+    category: 'general',
+    shortcuts: [],
+    aiTool: true,
+    permissions: [],
+    signature: { description: 'test capability' },
+    execute: () => 'ok',
+    ...overrides,
+  }
+}
+
+function configWithPreset(preset: 'readonly' | 'safe' | 'full'): AiConfig {
+  const cfg = defaultConfig()
+  cfg.permissions = setPermissionPreset(cfg.permissions, preset)
+  return cfg
+}
+
+afterEach(() => {
+  _clearCapabilitiesForTest()
+})
+
+describe('dispatchCapability', () => {
+  it('returns ok + result for a registered no-permission capability', async () => {
+    registerCapability(makeCapability({ id: 'a', execute: () => 'hello' }))
+    const r = await dispatchCapability(
+      'a',
+      undefined,
+      configWithPreset('readonly'),
+    )
+    expect(r).toEqual({ ok: true, result: 'hello' })
+  })
+
+  it('returns unknown_capability for an unregistered id', async () => {
+    const r = await dispatchCapability('not-here', {}, configWithPreset('full'))
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('unknown_capability')
+      expect(r.error).toContain('not-here')
+    }
+  })
+
+  it('returns permission_denied when required permissions are not allowed', async () => {
+    registerCapability(
+      makeCapability({ id: 'notes.post', permissions: ['notes.write'] }),
+    )
+    const r = await dispatchCapability(
+      'notes.post',
+      { text: 'hi' },
+      configWithPreset('readonly'), // notes.write は false
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('permission_denied')
+      expect(r.error).toContain('notes.write')
+    }
+  })
+
+  it('passes when all required permissions are allowed', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.react',
+        permissions: ['notes.react'],
+        execute: () => 'reacted',
+      }),
+    )
+    const r = await dispatchCapability(
+      'notes.react',
+      undefined,
+      configWithPreset('safe'), // notes.react は true
+    )
+    expect(r).toEqual({ ok: true, result: 'reacted' })
+  })
+
+  it('returns execute_failed when the capability throws', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'broken',
+        execute: () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+    const r = await dispatchCapability(
+      'broken',
+      undefined,
+      configWithPreset('full'),
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('execute_failed')
+      expect(r.error).toContain('boom')
+    }
+  })
+
+  it('forwards params to execute and supports async execute', async () => {
+    let received: unknown = null
+    registerCapability(
+      makeCapability({
+        id: 'echo',
+        execute: async (params) => {
+          received = params
+          return params
+        },
+      }),
+    )
+    const r = await dispatchCapability(
+      'echo',
+      { greeting: 'hello' },
+      configWithPreset('full'),
+    )
+    expect(r).toEqual({ ok: true, result: { greeting: 'hello' } })
+    expect(received).toEqual({ greeting: 'hello' })
+  })
+
+  it('reports ALL missing permissions when more than one is denied', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'multi',
+        permissions: ['notes.write', 'network.external'],
+      }),
+    )
+    const r = await dispatchCapability(
+      'multi',
+      undefined,
+      configWithPreset('readonly'),
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.error).toContain('notes.write')
+      expect(r.error).toContain('network.external')
+    }
+  })
+})

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -1,0 +1,74 @@
+/**
+ * Capability dispatcher — capability ID + params を受けて execute() を呼ぶ。
+ *
+ * - permissions チェックを通過した capability のみ実行
+ * - 未登録 / permission 拒否 / 実行失敗を構造化エラーで区別して返す
+ * - execute() は同期 / 非同期どちらでも対応
+ *
+ * Phase 2 A-3.2 で AI tool dispatcher (tool_use → これ → tool_result) の中核
+ * として呼ばれる。Phase 1 の `ai.json5` permissions と同じスキーマで照合する
+ * ので、ユーザーが `safe` プリセットを選んでいれば書き込み系は自動 deny される。
+ */
+
+import {
+  type AiConfig,
+  type PermissionKey,
+  resolvePermissions,
+} from '@/composables/useAiConfig'
+import { getCapability } from './registry'
+
+export type DispatchErrorCode =
+  | 'unknown_capability'
+  | 'permission_denied'
+  | 'execute_failed'
+
+export type DispatchResult =
+  | { ok: true; result: unknown }
+  | { ok: false; code: DispatchErrorCode; error: string }
+
+/**
+ * Capability を呼ぶ。permissions が通れば execute → 結果を返す。
+ * AI tool calling 経路では戻り値を tool_result として AI に返送する。
+ */
+export async function dispatchCapability(
+  capabilityId: string,
+  params: Record<string, unknown> | undefined,
+  aiConfig: AiConfig,
+): Promise<DispatchResult> {
+  const cap = getCapability(capabilityId)
+  if (!cap) {
+    return {
+      ok: false,
+      code: 'unknown_capability',
+      error: `Capability "${capabilityId}" is not registered`,
+    }
+  }
+  const denied = checkPermissions(cap.permissions ?? [], aiConfig)
+  if (denied.length > 0) {
+    return {
+      ok: false,
+      code: 'permission_denied',
+      error: `Permission denied for ${capabilityId}: required [${denied.join(', ')}] not allowed by current ai.json5 settings`,
+    }
+  }
+  try {
+    const result = await cap.execute(params)
+    return { ok: true, result }
+  } catch (e) {
+    return {
+      ok: false,
+      code: 'execute_failed',
+      error: e instanceof Error ? e.message : String(e),
+    }
+  }
+}
+
+/** required permission のうち config で disallow になっているものを返す。 */
+function checkPermissions(
+  required: readonly PermissionKey[],
+  aiConfig: AiConfig,
+): PermissionKey[] {
+  if (required.length === 0) return []
+  const resolved = resolvePermissions(aiConfig.permissions)
+  return required.filter((key) => !resolved[key])
+}

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { Command } from '@/commands/registry'
+import {
+  _clearCapabilitiesForTest,
+  getCapability,
+  listCapabilities,
+  registerCapability,
+  unregisterCapability,
+} from './registry'
+
+function makeCapability(overrides: Partial<Command> = {}): Command {
+  return {
+    id: 'test.cap',
+    label: 'test',
+    icon: 'ti-flask',
+    category: 'general',
+    shortcuts: [],
+    aiTool: true,
+    signature: { description: 'test capability' },
+    execute: () => 'ok',
+    ...overrides,
+  }
+}
+
+afterEach(() => {
+  _clearCapabilitiesForTest()
+})
+
+describe('registry', () => {
+  it('registers and looks up a capability by id', () => {
+    const cap = makeCapability({ id: 'a.read' })
+    registerCapability(cap)
+    expect(getCapability('a.read')).toBe(cap)
+  })
+
+  it('throws when registering a command without aiTool: true', () => {
+    expect(() => registerCapability(makeCapability({ aiTool: false }))).toThrow(
+      /aiTool: true/,
+    )
+  })
+
+  it('throws when registering a command without signature', () => {
+    expect(() =>
+      registerCapability(makeCapability({ signature: undefined })),
+    ).toThrow(/signature/)
+  })
+
+  it('overwrites a capability when the same id is registered twice', () => {
+    registerCapability(makeCapability({ id: 'x', label: 'first' }))
+    registerCapability(makeCapability({ id: 'x', label: 'second' }))
+    expect(getCapability('x')?.label).toBe('second')
+  })
+
+  it('unregisters a capability', () => {
+    registerCapability(makeCapability({ id: 'gone' }))
+    unregisterCapability('gone')
+    expect(getCapability('gone')).toBeUndefined()
+  })
+
+  it('lists all registered capabilities', () => {
+    registerCapability(makeCapability({ id: 'a' }))
+    registerCapability(makeCapability({ id: 'b' }))
+    const ids = listCapabilities().map((c) => c.id)
+    expect(ids).toContain('a')
+    expect(ids).toContain('b')
+    expect(ids).toHaveLength(2)
+  })
+
+  it('returns undefined for unknown id', () => {
+    expect(getCapability('not-here')).toBeUndefined()
+  })
+})

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,0 +1,49 @@
+/**
+ * Capability registry — AI tool calling のための capability 登録・lookup API。
+ *
+ * Phase 2 A-3.1 ではモジュールスコープの Map で管理する (UI コマンドパレット
+ * の `useCommandStore` とは別レイヤー)。Phase 2 A-3.2 以降で `useCommandStore`
+ * の `aiTool: true` な command も自動的にこの registry へ流し込む統合を予定。
+ *
+ * `time.now` 等の builtin は `registerBuiltinCapabilities()` で起動時にまとめ
+ * て登録する。
+ */
+
+import type { Command } from '@/commands/registry'
+
+const capabilities = new Map<string, Command>()
+
+/** Capability を registry に登録する。`aiTool: true` 必須。 */
+export function registerCapability(cmd: Command): void {
+  if (!cmd.aiTool) {
+    throw new Error(
+      `Capability "${cmd.id}" must have aiTool: true to be registered`,
+    )
+  }
+  if (!cmd.signature) {
+    throw new Error(
+      `Capability "${cmd.id}" must have a signature to be registered`,
+    )
+  }
+  capabilities.set(cmd.id, cmd)
+}
+
+export function unregisterCapability(id: string): void {
+  capabilities.delete(id)
+}
+
+export function getCapability(id: string): Command | undefined {
+  return capabilities.get(id)
+}
+
+export function listCapabilities(): Command[] {
+  return [...capabilities.values()]
+}
+
+/**
+ * @internal テスト用。Production code から呼ばないこと。
+ * registry をクリアして isolated test を可能にする。
+ */
+export function _clearCapabilitiesForTest(): void {
+  capabilities.clear()
+}

--- a/src/capabilities/toolSchema.test.ts
+++ b/src/capabilities/toolSchema.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import type { Command } from '@/commands/registry'
+import { toAnthropicTool, toOpenAiTool } from './toolSchema'
+
+function makeCapability(overrides: Partial<Command> = {}): Command {
+  return {
+    id: 'notes.post',
+    label: 'ノートを投稿',
+    icon: 'ti-pencil',
+    category: 'note',
+    shortcuts: [],
+    aiTool: true,
+    permissions: ['notes.write'],
+    signature: {
+      description: 'Post a note to the current account',
+      params: {
+        text: { type: 'string', description: 'Note body' },
+        visibility: {
+          type: 'string',
+          description: 'Visibility level',
+          enum: ['public', 'home', 'followers', 'specified'],
+          optional: true,
+        },
+      },
+      returns: { type: 'object', description: 'Created note' },
+    },
+    execute: () => undefined,
+    ...overrides,
+  }
+}
+
+describe('toAnthropicTool', () => {
+  it('builds a flat Anthropic tool definition', () => {
+    const tool = toAnthropicTool(makeCapability())
+    expect(tool.name).toBe('notes.post')
+    expect(tool.description).toBe('Post a note to the current account')
+    expect(tool.input_schema.type).toBe('object')
+  })
+
+  it('marks required params (= optional !== true)', () => {
+    const tool = toAnthropicTool(makeCapability())
+    expect(tool.input_schema.required).toEqual(['text'])
+    expect(tool.input_schema.properties.text?.type).toBe('string')
+    expect(tool.input_schema.properties.visibility?.type).toBe('string')
+  })
+
+  it('forwards enum values for restricted params', () => {
+    const tool = toAnthropicTool(makeCapability())
+    expect(tool.input_schema.properties.visibility?.enum).toEqual([
+      'public',
+      'home',
+      'followers',
+      'specified',
+    ])
+  })
+
+  it('omits required when no params are required', () => {
+    const tool = toAnthropicTool(
+      makeCapability({
+        signature: {
+          description: 'no-arg',
+          params: {
+            verbose: {
+              type: 'boolean',
+              description: '',
+              optional: true,
+            },
+          },
+        },
+      }),
+    )
+    expect(tool.input_schema.required).toBeUndefined()
+  })
+
+  it('handles empty params', () => {
+    const tool = toAnthropicTool(
+      makeCapability({
+        signature: { description: 'no params', params: {} },
+      }),
+    )
+    expect(tool.input_schema.properties).toEqual({})
+    expect(tool.input_schema.required).toBeUndefined()
+  })
+
+  it('throws when capability has no signature', () => {
+    expect(() =>
+      toAnthropicTool(makeCapability({ signature: undefined })),
+    ).toThrow(/signature/)
+  })
+})
+
+describe('toOpenAiTool', () => {
+  it('wraps the capability in the OpenAI function-call envelope', () => {
+    const tool = toOpenAiTool(makeCapability())
+    expect(tool.type).toBe('function')
+    expect(tool.function.name).toBe('notes.post')
+    expect(tool.function.description).toBe('Post a note to the current account')
+    expect(tool.function.parameters.type).toBe('object')
+    expect(tool.function.parameters.required).toEqual(['text'])
+  })
+
+  it('throws when capability has no signature', () => {
+    expect(() =>
+      toOpenAiTool(makeCapability({ signature: undefined })),
+    ).toThrow(/signature/)
+  })
+})

--- a/src/capabilities/toolSchema.ts
+++ b/src/capabilities/toolSchema.ts
@@ -1,0 +1,94 @@
+/**
+ * Capability → tool schema 変換器。
+ *
+ * Phase 2 A-3.1 では Anthropic / OpenAI の 2 形式に対応する。
+ * Custom (OpenAI 互換: OpenRouter / Groq 等) は OpenAI 形式を流用。
+ *
+ * Refs:
+ *   Anthropic: https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+ *   OpenAI:    https://platform.openai.com/docs/guides/function-calling
+ */
+
+import type { Command } from '@/commands/registry'
+import type { CapabilitySignature, ParameterDef } from './types'
+
+interface ParamSchema {
+  type: string
+  description: string
+  enum?: readonly string[]
+}
+
+interface InputSchema {
+  type: 'object'
+  properties: Record<string, ParamSchema>
+  required?: string[]
+}
+
+// --- Anthropic ---
+
+export interface AnthropicTool {
+  name: string
+  description: string
+  input_schema: InputSchema
+}
+
+export function toAnthropicTool(cmd: Command): AnthropicTool {
+  if (!cmd.signature) {
+    throw new Error(`Capability "${cmd.id}" has no signature`)
+  }
+  return {
+    name: cmd.id,
+    description: cmd.signature.description,
+    input_schema: paramsToInputSchema(cmd.signature.params),
+  }
+}
+
+// --- OpenAI Chat Completions ---
+
+export interface OpenAiTool {
+  type: 'function'
+  function: {
+    name: string
+    description: string
+    parameters: InputSchema
+  }
+}
+
+export function toOpenAiTool(cmd: Command): OpenAiTool {
+  if (!cmd.signature) {
+    throw new Error(`Capability "${cmd.id}" has no signature`)
+  }
+  return {
+    type: 'function',
+    function: {
+      name: cmd.id,
+      description: cmd.signature.description,
+      parameters: paramsToInputSchema(cmd.signature.params),
+    },
+  }
+}
+
+// --- Helpers ---
+
+function paramsToInputSchema(
+  params: CapabilitySignature['params'],
+): InputSchema {
+  const properties: Record<string, ParamSchema> = {}
+  const required: string[] = []
+  for (const [key, def] of Object.entries(params ?? {})) {
+    properties[key] = paramToSchema(def)
+    if (!def.optional) required.push(key)
+  }
+  const schema: InputSchema = { type: 'object', properties }
+  if (required.length > 0) schema.required = required
+  return schema
+}
+
+function paramToSchema(def: ParameterDef): ParamSchema {
+  const out: ParamSchema = {
+    type: def.type,
+    description: def.description,
+  }
+  if (def.enum) out.enum = def.enum
+  return out
+}


### PR DESCRIPTION
## Summary

#408 Phase 2 A-3.1: AI tool calling の **frontend 基盤** を構築する。Rust 側の AI chat 経路は変更せず、frontend 内で完結する registry / dispatcher / tool schema 変換器を整える。実 E2E は次の 2 PR (A-3.2 / A-3.3) で接続する。

設計詳細: [#408 Capability Registry as Single Source of Truth](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

## Changes

- feat(capabilities): add registry / dispatcher / tool schema (Phase 2 A-3.1)

### 新規ファイル

| ファイル | 内容 |
|---|---|
| `src/capabilities/registry.ts` | `registerCapability` / `getCapability` / `listCapabilities` / `unregisterCapability` |
| `src/capabilities/builtins/time.ts` | `time.now` sample capability (副作用なし、permissions 不要、ISO 8601 文字列を返す) |
| `src/capabilities/toolSchema.ts` | `toAnthropicTool(cmd)` / `toOpenAiTool(cmd)` — capability から各 API の tool definition に変換 |
| `src/capabilities/dispatcher.ts` | `dispatchCapability(id, params, aiConfig)` — permissions 照合 + execute |
| `src/capabilities/*.test.ts` | 各単体テスト 26 件追加 (全体 388 → 414 pass) |

### dispatcher の構造化エラー

`DispatchResult` は discriminated union で、エラー時の `code` は次の 3 種:

- `unknown_capability` — registry に未登録
- `permission_denied` — required permissions が ai.json5 で deny
- `execute_failed` — `capability.execute` が throw

Phase 1 の `ai.json5` permissions と同じスキーマで照合するので、ユーザーが `safe` プリセットを選んでいれば書き込み系 capability は自動的に `permission_denied` になる (= AI が試みても通らない)。

## スコープ外 (次の PR)

| Phase | 内容 |
|---|---|
| **A-3.2** | Rust 側 (ai_chat.rs) に `tools` パラメータ追加、Anthropic / OpenAI に転送、`tool_use` を SSE event で流す |
| **A-3.3** | frontend で `tool_use` 受信 → `dispatchCapability` → `tool_result` 返送ループ + UI で表示 |

A-3.3 完了後に「AI に "今何時?" と聞いて藍が `time.now` を呼んで返す」の E2E が動く。

## Test plan

- [x] 単体テスト 414 件 pass (新規 26 件)
- [x] typecheck / lint クリーン
- [x] 既存機能への影響なし (frontend のみ追加、Rust 側変更なし)
- [ ] レビュアー側: `time.now` が `Date.parse` 可能な ISO 8601 を返すこと
- [ ] レビュアー側: `dispatchCapability` が permissions 照合で `safe` preset 下で write 系を deny すること

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1: #425 (Capability Registry types)
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)