### PR TITLE
feat(ai-chat): forward tools and stream tool_use events (#408 Phase 2 A-3.2)

### DIFF
--- a/src-tauri/src/commands/ai_chat.rs
+++ b/src-tauri/src/commands/ai_chat.rs
@@ -58,6 +58,10 @@ pub struct AiChatRequest {
     pub messages: Vec<AiChatMessage>,
     pub system: Option<String>,
     pub max_tokens: Option<u32>,
+    /// Provider 形式 (Anthropic or OpenAI) の生 tool definition 配列。
+    /// フロントが provider に応じて事前変換した形で渡す。空 / None なら
+    /// tool calling は無効 (= 既存挙動と同じ)。
+    pub tools: Option<serde_json::Value>,
 }
 
 /// Wire-format event sent over the `nd:ai-chat-event` channel.
@@ -65,7 +69,7 @@ pub struct AiChatRequest {
 #[derive(Debug, Clone, Serialize, Type)]
 pub struct AiChatEvent {
     pub stream_id: String,
-    /// `"delta" | "done" | "error"`
+    /// `"delta" | "done" | "error" | "tool_use"`
     pub kind: String,
     /// Present when `kind == "delta"`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -73,6 +77,19 @@ pub struct AiChatEvent {
     /// Present when `kind == "error"`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Tool use call id (Anthropic `toolu_...`, OpenAI `call_...`).
+    /// Present when `kind == "tool_use"`. Frontend echoes this back as
+    /// `tool_result.tool_use_id` to close the round-trip.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_id: Option<String>,
+    /// Capability id (= tool name) requested by the AI.
+    /// Present when `kind == "tool_use"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_name: Option<String>,
+    /// Parsed JSON object passed as the tool input.
+    /// Present when `kind == "tool_use"`. Empty object if AI omitted args.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_use_input: Option<serde_json::Value>,
 }
 
 const EVENT_NAME: &str = "nd:ai-chat-event";
@@ -168,6 +185,9 @@ fn emit_delta(app: &tauri::AppHandle, stream_id: &str, text: String) {
             kind: "delta".into(),
             text: Some(text),
             error: None,
+            tool_use_id: None,
+            tool_use_name: None,
+            tool_use_input: None,
         },
     );
 }
@@ -180,6 +200,9 @@ fn emit_done(app: &tauri::AppHandle, stream_id: &str) {
             kind: "done".into(),
             text: None,
             error: None,
+            tool_use_id: None,
+            tool_use_name: None,
+            tool_use_input: None,
         },
     );
 }
@@ -192,6 +215,30 @@ fn emit_error(app: &tauri::AppHandle, stream_id: &str, message: String) {
             kind: "error".into(),
             text: None,
             error: Some(message),
+            tool_use_id: None,
+            tool_use_name: None,
+            tool_use_input: None,
+        },
+    );
+}
+
+fn emit_tool_use(
+    app: &tauri::AppHandle,
+    stream_id: &str,
+    id: String,
+    name: String,
+    input: serde_json::Value,
+) {
+    let _ = app.emit(
+        EVENT_NAME,
+        AiChatEvent {
+            stream_id: stream_id.to_string(),
+            kind: "tool_use".into(),
+            text: None,
+            error: None,
+            tool_use_id: Some(id),
+            tool_use_name: Some(name),
+            tool_use_input: Some(input),
         },
     );
 }
@@ -245,6 +292,11 @@ async fn run_anthropic(
     if let Some(sys) = req.system.as_deref().filter(|s| !s.is_empty()) {
         body["system"] = json!(sys);
     }
+    if let Some(tools) = req.tools.as_ref() {
+        if !is_empty_array(tools) {
+            body["tools"] = tools.clone();
+        }
+    }
 
     let resp = client
         .post(&url)
@@ -265,17 +317,32 @@ async fn run_anthropic(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
+    let mut tool_builder: Option<AnthropicToolUseBuilder> = None;
     while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| format!("stream error: {e}"))?;
         buf.push_str(&String::from_utf8_lossy(&bytes));
         for block in parse_sse_blocks(&mut buf) {
-            handle_anthropic_block(&block, app, &req.stream_id);
+            handle_anthropic_block(&block, app, &req.stream_id, &mut tool_builder);
         }
     }
     Ok(())
 }
 
-fn handle_anthropic_block(block: &str, app: &tauri::AppHandle, stream_id: &str) {
+/// Anthropic tool_use の SSE ストリームを assembling する一時状態。
+/// content_block_start で `{id, name}` を取り、input_json_delta を
+/// 連結し、content_block_stop で完成した tool_use イベントを emit する。
+struct AnthropicToolUseBuilder {
+    id: String,
+    name: String,
+    input_json_buf: String,
+}
+
+fn handle_anthropic_block(
+    block: &str,
+    app: &tauri::AppHandle,
+    stream_id: &str,
+    tool_builder: &mut Option<AnthropicToolUseBuilder>,
+) {
     let mut data: Option<&str> = None;
     for line in block.lines() {
         if let Some(rest) = line.strip_prefix("data:") {
@@ -289,18 +356,70 @@ fn handle_anthropic_block(block: &str, app: &tauri::AppHandle, stream_id: &str) 
     let Some(t) = value.get("type").and_then(|v| v.as_str()) else {
         return;
     };
-    if t == "content_block_delta" {
-        if let Some(text) = value.pointer("/delta/text").and_then(|v| v.as_str()) {
-            emit_delta(app, stream_id, text.to_string());
+    match t {
+        "content_block_start" => {
+            let cb = value.get("content_block");
+            let block_type = cb.and_then(|c| c.get("type")).and_then(|v| v.as_str());
+            if block_type == Some("tool_use") {
+                let id = cb
+                    .and_then(|c| c.get("id"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let name = cb
+                    .and_then(|c| c.get("name"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                *tool_builder = Some(AnthropicToolUseBuilder {
+                    id,
+                    name,
+                    input_json_buf: String::new(),
+                });
+            }
         }
-    } else if t == "error" {
-        if let Some(msg) = value
-            .pointer("/error/message")
-            .and_then(|v| v.as_str())
-        {
-            emit_error(app, stream_id, format!("Anthropic: {msg}"));
+        "content_block_delta" => {
+            let delta_type = value.pointer("/delta/type").and_then(|v| v.as_str());
+            if delta_type == Some("text_delta") {
+                if let Some(text) = value.pointer("/delta/text").and_then(|v| v.as_str()) {
+                    emit_delta(app, stream_id, text.to_string());
+                }
+            } else if delta_type == Some("input_json_delta") {
+                if let Some(b) = tool_builder.as_mut() {
+                    if let Some(partial) = value
+                        .pointer("/delta/partial_json")
+                        .and_then(|v| v.as_str())
+                    {
+                        b.input_json_buf.push_str(partial);
+                    }
+                }
+            }
         }
+        "content_block_stop" => {
+            if let Some(b) = tool_builder.take() {
+                let input = if b.input_json_buf.is_empty() {
+                    serde_json::json!({})
+                } else {
+                    serde_json::from_str::<serde_json::Value>(&b.input_json_buf)
+                        .unwrap_or_else(|_| serde_json::json!({}))
+                };
+                emit_tool_use(app, stream_id, b.id, b.name, input);
+            }
+        }
+        "error" => {
+            if let Some(msg) = value
+                .pointer("/error/message")
+                .and_then(|v| v.as_str())
+            {
+                emit_error(app, stream_id, format!("Anthropic: {msg}"));
+            }
+        }
+        _ => {}
     }
+}
+
+fn is_empty_array(v: &serde_json::Value) -> bool {
+    v.as_array().map(|a| a.is_empty()).unwrap_or(false)
 }
 
 // --- OpenAI Chat Completions (and OpenAI-compatible) ---
@@ -332,6 +451,11 @@ async fn run_openai_compat(
     if let Some(mt) = req.max_tokens {
         body["max_tokens"] = json!(mt);
     }
+    if let Some(tools) = req.tools.as_ref() {
+        if !is_empty_array(tools) {
+            body["tools"] = tools.clone();
+        }
+    }
 
     let mut request = client
         .post(&url)
@@ -354,6 +478,10 @@ async fn run_openai_compat(
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
+    // OpenAI は同 message 内で複数 tool_calls を index 別に送ってくるので
+    // index ごとの builder を Vec で持つ。今回は単一前提で実装するが、
+    // Vec のままにしておくと将来複数対応への拡張が容易。
+    let mut tool_builders: Vec<OpenAiToolCallBuilder> = Vec::new();
     'outer: while let Some(chunk) = stream.next().await {
         let bytes = chunk.map_err(|e| format!("stream error: {e}"))?;
         buf.push_str(&String::from_utf8_lossy(&bytes));
@@ -375,10 +503,97 @@ async fn run_openai_compat(
                 {
                     emit_delta(app, &req.stream_id, text.to_string());
                 }
+                accumulate_openai_tool_calls(&value, &mut tool_builders);
+                if let Some(reason) = value
+                    .pointer("/choices/0/finish_reason")
+                    .and_then(|v| v.as_str())
+                {
+                    if reason == "tool_calls" {
+                        flush_openai_tool_calls(
+                            app,
+                            &req.stream_id,
+                            &mut tool_builders,
+                        );
+                    }
+                }
             }
         }
     }
+    // Stream が `[DONE]` で打ち切られた場合 / finish_reason が来なかった
+    // ケースに備えて、残っている builder があれば flush する。
+    flush_openai_tool_calls(app, &req.stream_id, &mut tool_builders);
     Ok(())
+}
+
+/// OpenAI Chat Completions の tool_calls を index ごとに assembling する
+/// 一時状態。最初のチャンクで `id` と `function.name` が来て、その後
+/// `function.arguments` が partial で連結される。
+struct OpenAiToolCallBuilder {
+    id: String,
+    name: String,
+    args_json_buf: String,
+}
+
+fn accumulate_openai_tool_calls(
+    value: &serde_json::Value,
+    builders: &mut Vec<OpenAiToolCallBuilder>,
+) {
+    let Some(tool_calls) = value
+        .pointer("/choices/0/delta/tool_calls")
+        .and_then(|v| v.as_array())
+    else {
+        return;
+    };
+    for tc in tool_calls {
+        let index = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+        // 必要に応じて Vec を拡張 (穴は空 builder で埋める)
+        while builders.len() <= index {
+            builders.push(OpenAiToolCallBuilder {
+                id: String::new(),
+                name: String::new(),
+                args_json_buf: String::new(),
+            });
+        }
+        let b = &mut builders[index];
+        if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
+            if !id.is_empty() {
+                b.id = id.to_string();
+            }
+        }
+        if let Some(name) = tc
+            .pointer("/function/name")
+            .and_then(|v| v.as_str())
+        {
+            if !name.is_empty() {
+                b.name = name.to_string();
+            }
+        }
+        if let Some(args) = tc
+            .pointer("/function/arguments")
+            .and_then(|v| v.as_str())
+        {
+            b.args_json_buf.push_str(args);
+        }
+    }
+}
+
+fn flush_openai_tool_calls(
+    app: &tauri::AppHandle,
+    stream_id: &str,
+    builders: &mut Vec<OpenAiToolCallBuilder>,
+) {
+    for b in builders.drain(..) {
+        if b.id.is_empty() && b.name.is_empty() {
+            continue;
+        }
+        let input = if b.args_json_buf.is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str::<serde_json::Value>(&b.args_json_buf)
+                .unwrap_or_else(|_| serde_json::json!({}))
+        };
+        emit_tool_use(app, stream_id, b.id, b.name, input);
+    }
 }
 
 /// Patterns that look like API credentials. Redacted from any error body before

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1829,7 +1829,7 @@ export type AccountPublic = { id: string; host: string; userId: string; username
  */
 export type ActiveUsersChart = { readWrite: number[]; read: number[]; write: number[]; registeredWithinWeek: number[]; registeredWithinMonth: number[]; registeredWithinYear: number[]; registeredOutsideWeek: number[]; registeredOutsideMonth: number[]; registeredOutsideYear: number[] }
 export type AiChatMessage = { role: AiChatRole; content: string }
-export type AiChatRequest = { stream_id: string; provider: string; endpoint: string; model: string; messages: AiChatMessage[]; system: string | null; max_tokens: number | null }
+export type AiChatRequest = { stream_id: string; provider: string; endpoint: string; model: string; messages: AiChatMessage[]; system: string | null; max_tokens: number | null; tools: JsonValue | null }
 export type AiChatRole = "system" | "user" | "assistant"
 export type Antenna = { id: string; name: string }
 /**

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -1,6 +1,6 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { onScopeDispose, ref } from 'vue'
-import type { AiChatMessage } from '@/bindings'
+import type { AiChatMessage, JsonValue } from '@/bindings'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /** Single chat message stored in the conversation. */
@@ -20,13 +20,37 @@ export interface AiChatSendOptions {
   /** Composed system prompt (optional). */
   system?: string
   maxTokens?: number
+  /**
+   * Provider 形式 (Anthropic or OpenAI) の生 tool definition 配列。
+   * 呼び出し側で `toAnthropicTool` / `toOpenAiTool` を使って事前変換する。
+   * 空 / 省略時は tool calling 無効 (= 既存挙動)。
+   */
+  tools?: unknown[]
+  /**
+   * AI が tool_use を要求したときに呼ばれる。Phase 2 A-3.3 で実装する
+   * tool_result 返送ループの起点。本ターンでは呼ばれるだけ何もしない
+   * (= AI 応答は途中で止まる) のが正常動作。
+   */
+  onToolUse?: (event: ToolUseEvent) => void
+}
+
+export interface ToolUseEvent {
+  /** Anthropic `toolu_...` / OpenAI `call_...` 形式の id */
+  toolUseId: string
+  /** Capability id (= tool name) */
+  name: string
+  /** AI が渡した引数。空オブジェクトの可能性あり */
+  input: Record<string, unknown>
 }
 
 interface AiChatEventPayload {
   stream_id: string
-  kind: 'delta' | 'done' | 'error'
+  kind: 'delta' | 'done' | 'error' | 'tool_use'
   text?: string
   error?: string
+  tool_use_id?: string
+  tool_use_name?: string
+  tool_use_input?: Record<string, unknown>
 }
 
 const EVENT_NAME = 'nd:ai-chat-event'
@@ -116,6 +140,14 @@ export function useAiChat() {
         if (p.stream_id !== streamId) return
         if (p.kind === 'delta' && p.text) {
           currentText.value += p.text
+        } else if (p.kind === 'tool_use') {
+          if (opts.onToolUse && p.tool_use_id && p.tool_use_name) {
+            opts.onToolUse({
+              toolUseId: p.tool_use_id,
+              name: p.tool_use_name,
+              input: p.tool_use_input ?? {},
+            })
+          }
         } else if (p.kind === 'done') {
           const finalText = currentText.value
           cleanup()
@@ -137,6 +169,10 @@ export function useAiChat() {
             messages: opts.history.map(toWireMessage),
             system: opts.system && opts.system.length > 0 ? opts.system : null,
             max_tokens: opts.maxTokens ?? null,
+            tools:
+              opts.tools && opts.tools.length > 0
+                ? (opts.tools as unknown as JsonValue)
+                : null,
           })
         })
         .then((res) => {


### PR DESCRIPTION
## Summary

#408 Phase 2 A-3.2: Rust 側に **tool calling の伝送経路** を追加する。フロントが provider 形式で渡した tool definition を Anthropic / OpenAI に転送し、AI から返ってきた `tool_use` を SSE event としてフロントに流す。実 dispatch (= Phase 2 A-3.3) はまだ未接続なので、本 PR 単体では `tool_use` が流れるところまで動く (= AI 応答は途中で止まる)。

## Changes

- feat(ai-chat): forward tools to AI and stream tool_use events (Phase 2 A-3.2)

### Rust (src-tauri/src/commands/ai_chat.rs)

- `AiChatRequest` に `tools: Option<serde_json::Value>` 追加 (provider 形式 raw 配列を素通し)
- `AiChatEvent` に `tool_use_id` / `tool_use_name` / `tool_use_input` 追加 (kind: "tool_use" のとき Some)
- `emit_tool_use` ヘルパー追加
- Anthropic: body に `tools` 設定、SSE `content_block_start` / `content_block_delta` / `content_block_stop` を stateful に追跡して tool_use を組み立て emit (`input_json_delta.partial_json` を連結 → JSON.parse)
- OpenAI: body に `tools` 設定、`delta.tool_calls` を index 別に assembling、`finish_reason: "tool_calls"` で flush して emit (複数 tool call 並行に対応した Vec 構造、本実装では単一前提)

### Frontend (src/composables/useAiChat.ts)

- `AiChatSendOptions.tools` (provider 形式 raw 配列) 追加
- `AiChatSendOptions.onToolUse` コールバック追加 (Phase 2 A-3.3 で tool_result 返送ループの起点)
- listen ハンドラで `kind: "tool_use"` を処理 → onToolUse を呼ぶ
- `ToolUseEvent` 型を export

### bindings.ts

- `AiChatRequest` に `tools` フィールド追加 (specta が debug build 起動時に上書きするので、それまでの整合性のため手動更新)

## スコープ外 (A-3.3)

- `DeckAiColumn` から `tools` / `onToolUse` の実配線
- onToolUse → `dispatchCapability` → tool_result メッセージとして history に追加 → 次ターン送信のループ
- `tool_use` / `tool_result` の UI 表示

A-3.3 完了で「AI に "今何時?" → 藍が `time.now` を呼んで時刻を返す」E2E が動く。

## Test plan

- [x] `cargo build` 成功
- [x] `pnpm typecheck` / `pnpm lint` クリーン
- [x] 単体テスト 414 件 pass (既存テストへの影響なし)
- [ ] レビュアー側: 既存 AI チャット (tools なし) が変わらず動くこと
- [ ] レビュアー側: tool calling は A-3.3 マージ後に確認

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1: #425 (Capability Registry types)
- Phase 2 A-3.1: #427 (Capability dispatcher foundation)
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)