### PR TITLE
feat(ai-chat): wire AI tool calling end-to-end (#408 Phase 2 A-3.3b)

### DIFF
--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1828,8 +1828,34 @@ export type AccountPublic = { id: string; host: string; userId: string; username
  * `charts/active-users`
  */
 export type ActiveUsersChart = { readWrite: number[]; read: number[]; write: number[]; registeredWithinWeek: number[]; registeredWithinMonth: number[]; registeredWithinYear: number[]; registeredOutsideWeek: number[]; registeredOutsideMonth: number[]; registeredOutsideYear: number[] }
-export type AiChatMessage = { role: AiChatRole; content: string; tool_use_id?: string | null; tool_use_name?: string | null; tool_use_input?: JsonValue | null; tool_result_for?: string | null }
-export type AiChatRequest = { stream_id: string; provider: string; endpoint: string; model: string; messages: AiChatMessage[]; system: string | null; max_tokens: number | null; tools: JsonValue | null }
+export type AiChatMessage = { role: AiChatRole; content: string; 
+/**
+ * AI が呼び出した tool の id (Anthropic `toolu_...` / OpenAI `call_...`)。
+ * 同一 message が tool_use を含む assistant ターンであることを示す。
+ * content と併用された場合は「テキスト + tool_use」の混在 message として
+ * provider に投げる。
+ */
+tool_use_id?: string | null; 
+/**
+ * tool_use の name (capability id)。tool_use_id とセット。
+ */
+tool_use_name?: string | null; 
+/**
+ * tool_use の入力 JSON。tool_use_id とセット。
+ */
+tool_use_input?: JsonValue | null; 
+/**
+ * tool_result メッセージのときに、対応する tool_use の id を指す。
+ * 設定されている場合 content は実行結果テキスト、role は user 想定。
+ */
+tool_result_for?: string | null }
+export type AiChatRequest = { stream_id: string; provider: string; endpoint: string; model: string; messages: AiChatMessage[]; system: string | null; max_tokens: number | null; 
+/**
+ * Provider 形式 (Anthropic or OpenAI) の生 tool definition 配列。
+ * フロントが provider に応じて事前変換した形で渡す。空 / None なら
+ * tool calling は無効 (= 既存挙動と同じ)。
+ */
+tools: JsonValue | null }
 export type AiChatRole = "system" | "user" | "assistant"
 export type Antenna = { id: string; name: string }
 /**

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -126,6 +126,33 @@ describe('dispatchCapability', () => {
     expect(received).toEqual({ greeting: 'hello' })
   })
 
+  it('resolves a sanitized tool name back to its dotted capability id', async () => {
+    // AI は Anthropic / OpenAI 制約に従って sanitized name (`time_now`)
+    // を返す。dispatcher はそれを dotted id (`time.now`) に逆引きできる。
+    registerCapability(
+      makeCapability({
+        id: 'time.now',
+        execute: () => 'iso-string',
+      }),
+    )
+    const r = await dispatchCapability(
+      'time_now',
+      undefined,
+      configWithPreset('readonly'),
+    )
+    expect(r).toEqual({ ok: true, result: 'iso-string' })
+  })
+
+  it('still works for capabilities whose id has no dot (no sanitization needed)', async () => {
+    registerCapability(makeCapability({ id: 'simple', execute: () => 42 }))
+    const r = await dispatchCapability(
+      'simple',
+      undefined,
+      configWithPreset('readonly'),
+    )
+    expect(r).toEqual({ ok: true, result: 42 })
+  })
+
   it('reports ALL missing permissions when more than one is denied', async () => {
     registerCapability(
       makeCapability({

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -15,7 +15,8 @@ import {
   type PermissionKey,
   resolvePermissions,
 } from '@/composables/useAiConfig'
-import { getCapability } from './registry'
+import { sanitizeToolName } from './identifier'
+import { getCapability, listCapabilities } from './registry'
 
 export type DispatchErrorCode =
   | 'unknown_capability'
@@ -35,7 +36,15 @@ export async function dispatchCapability(
   params: Record<string, unknown> | undefined,
   aiConfig: AiConfig,
 ): Promise<DispatchResult> {
-  const cap = getCapability(capabilityId)
+  // capabilityId は (a) registry に格納されている dotted id (`time.now`) か、
+  // (b) Anthropic / OpenAI が返す sanitized name (`time_now`) のどちらかで
+  // 来る可能性がある。前者は直接 lookup、後者は逆引きで解決する。
+  let cap = getCapability(capabilityId)
+  if (!cap) {
+    cap = listCapabilities().find(
+      (c) => sanitizeToolName(c.id) === capabilityId,
+    )
+  }
   if (!cap) {
     return {
       ok: false,

--- a/src/capabilities/identifier.test.ts
+++ b/src/capabilities/identifier.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeToolName } from './identifier'
+
+describe('sanitizeToolName', () => {
+  it('replaces dots with underscores', () => {
+    expect(sanitizeToolName('time.now')).toBe('time_now')
+    expect(sanitizeToolName('notes.post')).toBe('notes_post')
+    expect(sanitizeToolName('account.read')).toBe('account_read')
+  })
+
+  it('leaves identifiers without dots unchanged', () => {
+    expect(sanitizeToolName('simple')).toBe('simple')
+    expect(sanitizeToolName('with-dash')).toBe('with-dash')
+    expect(sanitizeToolName('with_underscore')).toBe('with_underscore')
+  })
+
+  it('produces a string matching ^[a-zA-Z0-9_-]+$ for typical capability ids', () => {
+    const ids = ['time.now', 'notes.post', 'notes.write', 'network.external']
+    const re = /^[a-zA-Z0-9_-]+$/
+    for (const id of ids) {
+      expect(sanitizeToolName(id)).toMatch(re)
+    }
+  })
+
+  it('replaces every dot occurrence (multi-segment ids)', () => {
+    expect(sanitizeToolName('a.b.c')).toBe('a_b_c')
+  })
+})

--- a/src/capabilities/identifier.ts
+++ b/src/capabilities/identifier.ts
@@ -1,0 +1,12 @@
+/**
+ * Capability id (= ドット区切り `notes.read`) と AI tool name (= Anthropic
+ * / OpenAI で許可される `^[a-zA-Z0-9_-]{1,128}$`) の相互変換。
+ *
+ * 両 provider とも tool name にドットを許可しないため、`.` を `_` に
+ * 置換する 1 対 1 マッピングを使う。逆引きは registry の listCapabilities()
+ * を walk して `sanitizeToolName(cap.id) === name` で照合する想定。
+ */
+
+export function sanitizeToolName(id: string): string {
+  return id.replace(/\./g, '_')
+}

--- a/src/capabilities/toolSchema.test.ts
+++ b/src/capabilities/toolSchema.test.ts
@@ -32,7 +32,9 @@ function makeCapability(overrides: Partial<Command> = {}): Command {
 describe('toAnthropicTool', () => {
   it('builds a flat Anthropic tool definition', () => {
     const tool = toAnthropicTool(makeCapability())
-    expect(tool.name).toBe('notes.post')
+    // Anthropic の tool name 制約 (^[a-zA-Z0-9_-]{1,128}$) に合わせて
+    // dotted id (`notes.post`) は sanitize される (`.` → `_`)
+    expect(tool.name).toBe('notes_post')
     expect(tool.description).toBe('Post a note to the current account')
     expect(tool.input_schema.type).toBe('object')
   })
@@ -93,7 +95,9 @@ describe('toOpenAiTool', () => {
   it('wraps the capability in the OpenAI function-call envelope', () => {
     const tool = toOpenAiTool(makeCapability())
     expect(tool.type).toBe('function')
-    expect(tool.function.name).toBe('notes.post')
+    // OpenAI の function name 制約 (^[a-zA-Z0-9_-]{1,64}$) に合わせて
+    // dotted id (`notes.post`) は sanitize される (`.` → `_`)
+    expect(tool.function.name).toBe('notes_post')
     expect(tool.function.description).toBe('Post a note to the current account')
     expect(tool.function.parameters.type).toBe('object')
     expect(tool.function.parameters.required).toEqual(['text'])

--- a/src/capabilities/toolSchema.ts
+++ b/src/capabilities/toolSchema.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Command } from '@/commands/registry'
+import { sanitizeToolName } from './identifier'
 import type { CapabilitySignature, ParameterDef } from './types'
 
 interface ParamSchema {
@@ -37,7 +38,7 @@ export function toAnthropicTool(cmd: Command): AnthropicTool {
     throw new Error(`Capability "${cmd.id}" has no signature`)
   }
   return {
-    name: cmd.id,
+    name: sanitizeToolName(cmd.id),
     description: cmd.signature.description,
     input_schema: paramsToInputSchema(cmd.signature.params),
   }
@@ -61,7 +62,7 @@ export function toOpenAiTool(cmd: Command): OpenAiTool {
   return {
     type: 'function',
     function: {
-      name: cmd.id,
+      name: sanitizeToolName(cmd.id),
       description: cmd.signature.description,
       parameters: paramsToInputSchema(cmd.signature.params),
     },

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, useTemplateRef, watch } from 'vue'
+import { dispatchCapability } from '@/capabilities/dispatcher'
+import { listCapabilities } from '@/capabilities/registry'
+import { toAnthropicTool, toOpenAiTool } from '@/capabilities/toolSchema'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
-import { type ChatMessage, useAiChat } from '@/composables/useAiChat'
+import {
+  type ChatMessage,
+  type ToolUseEvent,
+  useAiChat,
+} from '@/composables/useAiChat'
 import {
   getApiKeyStatus,
   type ProviderKey,
@@ -421,11 +428,6 @@ async function sendMessage() {
 
   activeStreamSessionId.value = sessionId
 
-  // Build wire history: exclude the empty placeholder, exclude any system msgs
-  const history = (sessionsStore.get(sessionId)?.messages ?? []).filter(
-    (m) => m.role !== 'system' && m.id !== assistantMsg.id,
-  )
-
   const skillsPrompt = skillsStore.composedSystemPrompt() || ''
   // ユーザーが Timeline をクリックしていないケースに備えて、fallback として
   // 画面上に存在する最初の TIMELINE_LIKE カラムを使う。
@@ -439,42 +441,146 @@ async function sendMessage() {
   const visibleNotesRaw = focusedColumnId
     ? deckStore.visibleNotesByColumn[focusedColumnId]
     : undefined
-  const contextBlock = buildAiContextBlock(aiConfig.value, {
-    activeAccount: accountsStore.activeAccount,
-    currentColumn: focusedColumn ?? props.column,
-    visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
-    recentConversation: projectRecentConversation(history),
-  })
-  const system = joinSystemPrompt(skillsPrompt, contextBlock)
+
+  // Tool calling に使う tools 配列を provider に応じて組み立て。
+  // 登録済み capability のうち aiTool: true なものを変換。
+  const eligibleCaps = listCapabilities().filter((c) => c.aiTool && c.signature)
+  const toolsForProvider: unknown[] | undefined =
+    eligibleCaps.length === 0
+      ? undefined
+      : provider === 'anthropic'
+        ? eligibleCaps.map(toAnthropicTool)
+        : eligibleCaps.map(toOpenAiTool)
+
+  // tool_use ループで暴走しないための上限。1 ターン中に AI が連続で tool を
+  // 呼び続けるケースを抑える (普通は 1〜2 回で止まる)。
+  const MAX_TOOL_ROUNDS = 5
+  let toolRound = 0
+  let placeholderId = assistantMsg.id
+  let finalAssistantText = ''
 
   try {
-    const finalText = await aiChat.sendMessage({
-      provider,
-      endpoint: settings.endpoint,
-      model: settings.model,
-      history,
-      system,
-    })
+    while (true) {
+      // 現セッションから wire history を組み立て (placeholder のみ除外)。
+      // system role の中間メッセージは入らない設計だが、念のため除外する。
+      const history = (sessionsStore.get(sessionId)?.messages ?? []).filter(
+        (m) => m.role !== 'system' && m.id !== placeholderId,
+      )
+
+      const contextBlock = buildAiContextBlock(aiConfig.value, {
+        activeAccount: accountsStore.activeAccount,
+        currentColumn: focusedColumn ?? props.column,
+        visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
+        recentConversation: projectRecentConversation(history),
+      })
+      const system = joinSystemPrompt(skillsPrompt, contextBlock)
+
+      let pendingToolUse: ToolUseEvent | null = null
+      const turnText = await aiChat.sendMessage({
+        provider,
+        endpoint: settings.endpoint,
+        model: settings.model,
+        history,
+        system,
+        tools: toolsForProvider,
+        onToolUse: (e) => {
+          pendingToolUse = e
+        },
+      })
+
+      if (turnText) finalAssistantText = turnText
+
+      if (!pendingToolUse) break
+
+      if (toolRound >= MAX_TOOL_ROUNDS) {
+        finalAssistantText =
+          (turnText || finalAssistantText) +
+          `\n\n⚠️ tool 呼び出しが上限 (${MAX_TOOL_ROUNDS} 回) に達しました。`
+        break
+      }
+      toolRound++
+
+      // pendingToolUse を非 null として明示 (TS narrowing)
+      const toolUse: ToolUseEvent = pendingToolUse
+
+      // capability dispatch (permissions チェック込み)
+      const dispatch = await dispatchCapability(
+        toolUse.name,
+        toolUse.input,
+        aiConfig.value,
+      )
+      const resultText = dispatch.ok
+        ? typeof dispatch.result === 'string'
+          ? dispatch.result
+          : JSON.stringify(dispatch.result)
+        : `Error (${dispatch.code}): ${dispatch.error}`
+
+      // session 更新: placeholder を「中間テキスト + tool_use」として確定し、
+      // tool_result + 新しい placeholder を追加する。
+      const cur = sessionsStore.get(sessionId)
+      if (!cur) break
+      const ts = Date.now()
+      const messagesWithoutPlaceholder = cur.messages.filter(
+        (m) => m.id !== placeholderId,
+      )
+      const assistantWithToolUse: ChatMessage = {
+        id: placeholderId,
+        role: 'assistant',
+        content: turnText,
+        timestamp: ts,
+        toolUseId: toolUse.toolUseId,
+        toolUseName: toolUse.name,
+        toolUseInput: toolUse.input,
+      }
+      const toolResultMsg: ChatMessage = {
+        id: `msg-${ts}-r${toolRound}`,
+        role: 'user',
+        content: resultText,
+        timestamp: ts,
+        toolResultFor: toolUse.toolUseId,
+      }
+      const nextPlaceholderId = `msg-${ts}-a${toolRound}`
+      const nextAssistant: ChatMessage = {
+        id: nextPlaceholderId,
+        role: 'assistant',
+        content: '',
+        timestamp: ts,
+      }
+      sessionsStore.updateMessages(sessionId, [
+        ...messagesWithoutPlaceholder,
+        assistantWithToolUse,
+        toolResultMsg,
+        nextAssistant,
+      ])
+      placeholderId = nextPlaceholderId
+      scrollToBottom()
+    }
+
+    // 最終 assistant テキストを placeholder に書き戻す。
     const cur = sessionsStore.get(sessionId)
     if (cur) {
       const last = cur.messages[cur.messages.length - 1]
-      if (last?.role === 'assistant' && last.content !== finalText) {
+      if (
+        last?.role === 'assistant' &&
+        last.id === placeholderId &&
+        last.content !== finalAssistantText
+      ) {
         sessionsStore.updateMessages(sessionId, [
           ...cur.messages.slice(0, -1),
-          { ...last, content: finalText },
+          { ...last, content: finalAssistantText },
         ])
       }
     }
     // 初回 round 完了後にバックグラウンドで AI にタイトルを再生成させる
-    if (wasFirstRound && finalText) {
-      void generateAiTitleAsync(sessionId, text, finalText)
+    if (wasFirstRound && finalAssistantText) {
+      void generateAiTitleAsync(sessionId, text, finalAssistantText)
     }
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)
     const cur = sessionsStore.get(sessionId)
     if (cur) {
       const last = cur.messages[cur.messages.length - 1]
-      if (last?.role === 'assistant') {
+      if (last?.role === 'assistant' && last.id === placeholderId) {
         sessionsStore.updateMessages(sessionId, [
           ...cur.messages.slice(0, -1),
           { ...last, content: `⚠️ ${message}` },

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -9,6 +9,14 @@ export interface ChatMessage {
   role: 'user' | 'assistant' | 'system'
   content: string
   timestamp: number
+  /** AI が呼び出した tool の id (assistant turn) */
+  toolUseId?: string
+  /** capability id (= tool name) */
+  toolUseName?: string
+  /** AI が渡した引数 */
+  toolUseInput?: Record<string, unknown>
+  /** 対応する tool_use の id (user turn = tool_result) */
+  toolResultFor?: string
 }
 
 export interface AiChatSendOptions {
@@ -60,7 +68,14 @@ function generateStreamId(): string {
 }
 
 function toWireMessage(m: ChatMessage): AiChatMessage {
-  return { role: m.role, content: m.content }
+  const wire: AiChatMessage = { role: m.role, content: m.content }
+  if (m.toolUseId) wire.tool_use_id = m.toolUseId
+  if (m.toolUseName) wire.tool_use_name = m.toolUseName
+  if (m.toolUseInput) {
+    wire.tool_use_input = m.toolUseInput as unknown as JsonValue
+  }
+  if (m.toolResultFor) wire.tool_result_for = m.toolResultFor
+  return wire
 }
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import App from './App.vue'
+import { BUILTIN_CAPABILITIES } from './capabilities/builtins/time'
+import { registerCapability } from './capabilities/registry'
 import { router, setupAccountRedirect } from './router'
 import { initEarlyAccountListener, useAccountsStore } from './stores/accounts'
 import { useKeybindsStore } from './stores/keybinds'
@@ -13,6 +15,14 @@ import { isTauri } from './utils/settingsFs'
 import { commands, unwrap } from './utils/tauriInvoke'
 import '@tabler/icons-webfont/dist/tabler-icons.min.css'
 import './styles/global.css'
+
+// Register builtin AI capabilities (time.now etc.) at module load.
+// Capability registry is module-scoped and provider-agnostic, so we don't need
+// Pinia or Tauri here. Repeating the loop is fine — registerCapability
+// overwrites by id (Phase 2 A-3.1 contract).
+for (const cap of BUILTIN_CAPABILITIES) {
+  registerCapability(cap)
+}
 
 if (isTauri) {
   // Register the `nd:accounts-early` listener as early as possible so the Rust


### PR DESCRIPTION
## Summary

#408 Phase 2 A-3.3b: **Phase 2 で初めて AI が tool を実行できるようになる**。A-3.3a の wire format (#431) と A-3.2 の tool_use SSE event (#430) を結合し、`DeckAiColumn` 内で tool_use ループを実装する。

これで AI に「今何時?」と聞くと **`time.now` を呼んで時刻を返答する E2E が動く**。

## Changes

- feat(ai-chat): wire AI tool calling end-to-end (Phase 2 A-3.3b)

### main.ts

- アプリ起動時に `BUILTIN_CAPABILITIES` (`time.now`) を `registerCapability`

### DeckAiColumn.vue (sendMessage 改造)

1. 登録済み capability のうち `aiTool && signature` を抽出
2. provider に応じて `toAnthropicTool` / `toOpenAiTool` で変換
3. `tools` を `aiChat.sendMessage` に渡す
4. `onToolUse` で受け取った `tool_use` を `dispatchCapability` (permissions 照合 + execute)
5. 結果を **session に user role の `tool_result` メッセージとして追加** + 新しい placeholder
6. 同セッションで再送信 → AI が最終応答を返す
7. ループ上限 **5 回** (暴走防止)、超えたら警告 + ユーザー応答

### ChatMessage 拡張 (useAiChat.ts)

- `toolUseId` / `toolUseName` / `toolUseInput` / `toolResultFor` を optional 追加
- `toWireMessage` で snake_case の wire 形式にマッピング

### Permissions 照合

Phase 1 の `ai.json5` permissions と同じスキーマで照合されるので、`safe` プリセットでは `notes.write` / `account.write` 等の write 系 capability は自動的に `permission_denied` になる (Phase 3 の細粒度 allow/deny の前段)。

## スコープ外 (A-3.3c)

- tool_use / tool_result の **専用 UI 表示** (現状は `toolUseId` を持つ assistant message と `toolResultFor` を持つ user message として既存 chat に並ぶだけ)

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` クリーン
- [x] `pnpm test` 417 件 pass
- [ ] レビュアー側: AI に「今何時？」と聞いて time.now を呼ぶことを確認
- [ ] レビュアー側: tool 結果が session 内に表示されることを確認
- [ ] レビュアー側: 既存のテキストのみ会話が変わらず動くこと

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1 / A-3.1 / A-3.2 / A-3.3a: #425 / #427 / #430 / #431
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)