### PR TITLE
feat(ai-chat): visualize tool_use / tool_result in chat UI (#408 Phase 2 A-3.3c)

### DIFF
--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -592,6 +592,37 @@ async function sendMessage() {
   scrollToBottom()
 }
 
+// --- Tool message UI ---
+// 折りたたみ状態: msg.id → 展開中か。明示的に展開されたものだけが詳細を見せる。
+const expandedToolDetails = ref<Record<string, boolean>>({})
+
+function toggleToolDetail(msgId: string) {
+  expandedToolDetails.value = {
+    ...expandedToolDetails.value,
+    [msgId]: !expandedToolDetails.value[msgId],
+  }
+}
+
+function isToolUseMessage(msg: ChatMessage): boolean {
+  return msg.role === 'assistant' && Boolean(msg.toolUseId && msg.toolUseName)
+}
+
+function isToolResultMessage(msg: ChatMessage): boolean {
+  return msg.role === 'user' && Boolean(msg.toolResultFor)
+}
+
+const TOOL_RESULT_PREVIEW_LIMIT = 120
+
+function truncateToolPreview(s: string): string {
+  if (s.length <= TOOL_RESULT_PREVIEW_LIMIT) return s
+  return `${s.slice(0, TOOL_RESULT_PREVIEW_LIMIT)}…`
+}
+
+function formatToolInput(input: Record<string, unknown> | undefined): string {
+  if (!input || Object.keys(input).length === 0) return '(no arguments)'
+  return JSON.stringify(input, null, 2)
+}
+
 // --- コピー ---
 
 const copiedMessageId = ref<string | null>(null)
@@ -789,40 +820,93 @@ function onKeydown(e: KeyboardEvent) {
       />
 
       <div v-else ref="aiMessagesRef" :class="$style.aiMessages">
-        <div
-          v-for="msg in messages"
-          :key="msg.id"
-          :class="[$style.chatMsg, { [$style.mine]: msg.role === 'user' }]"
-        >
-          <div :class="$style.chatBubbleWrapper">
-            <div :class="$style.chatBubble">
-              <div
-                v-if="msg.role === 'assistant' && !msg.content && isGenerating"
-                :class="$style.messageTyping"
-              >
-                <span :class="$style.typingDot" />
-                <span :class="$style.typingDot" />
-                <span :class="$style.typingDot" />
-              </div>
-              <div
-                v-else-if="msg.role === 'assistant'"
-                :class="$style.markdownContent"
-                v-html="renderAssistant(msg.content)"
-                @click="onAssistantContentClick"
-              />
-              <div v-else :class="$style.chatText">{{ msg.content }}</div>
-            </div>
+        <template v-for="msg in messages" :key="msg.id">
+          <!-- AI が呼び出した tool (assistant + tool_use) -->
+          <div
+            v-if="isToolUseMessage(msg)"
+            :class="$style.toolEvent"
+          >
             <button
-              v-if="msg.role === 'assistant' && msg.content && !isGenerating"
               class="_button"
-              :class="$style.copyBtn"
-              :title="copiedMessageId === msg.id ? 'コピーしました' : 'コピー'"
-              @click="copyMessage(msg)"
+              :class="$style.toolEventHeader"
+              :title="expandedToolDetails[msg.id] ? '詳細を閉じる' : '詳細を開く'"
+              @click="toggleToolDetail(msg.id)"
             >
-              <i :class="copiedMessageId === msg.id ? 'ti ti-check' : 'ti ti-copy'" />
+              <i class="ti ti-tool" :class="$style.toolIcon" />
+              <span :class="$style.toolEventLabel">ツール呼び出し</span>
+              <code :class="$style.toolEventName">{{ msg.toolUseName }}</code>
+              <i
+                class="ti"
+                :class="[
+                  $style.toolEventChevron,
+                  expandedToolDetails[msg.id] ? 'ti-chevron-up' : 'ti-chevron-down',
+                ]"
+              />
             </button>
+            <div v-if="msg.content" :class="$style.toolEventCommentary">{{ msg.content }}</div>
+            <pre v-if="expandedToolDetails[msg.id]" :class="$style.toolEventBody">{{ formatToolInput(msg.toolUseInput) }}</pre>
           </div>
-        </div>
+
+          <!-- ツール実行結果 (user + tool_result) -->
+          <div
+            v-else-if="isToolResultMessage(msg)"
+            :class="$style.toolEvent"
+          >
+            <button
+              class="_button"
+              :class="$style.toolEventHeader"
+              :title="expandedToolDetails[msg.id] ? '詳細を閉じる' : '詳細を開く'"
+              @click="toggleToolDetail(msg.id)"
+            >
+              <i class="ti ti-arrow-back-up" :class="$style.toolIcon" />
+              <span :class="$style.toolEventLabel">結果</span>
+              <span v-if="!expandedToolDetails[msg.id]" :class="$style.toolEventPreview">{{ truncateToolPreview(msg.content) }}</span>
+              <i
+                class="ti"
+                :class="[
+                  $style.toolEventChevron,
+                  expandedToolDetails[msg.id] ? 'ti-chevron-up' : 'ti-chevron-down',
+                ]"
+              />
+            </button>
+            <pre v-if="expandedToolDetails[msg.id]" :class="$style.toolEventBody">{{ msg.content }}</pre>
+          </div>
+
+          <!-- 通常メッセージ -->
+          <div
+            v-else
+            :class="[$style.chatMsg, { [$style.mine]: msg.role === 'user' }]"
+          >
+            <div :class="$style.chatBubbleWrapper">
+              <div :class="$style.chatBubble">
+                <div
+                  v-if="msg.role === 'assistant' && !msg.content && isGenerating"
+                  :class="$style.messageTyping"
+                >
+                  <span :class="$style.typingDot" />
+                  <span :class="$style.typingDot" />
+                  <span :class="$style.typingDot" />
+                </div>
+                <div
+                  v-else-if="msg.role === 'assistant'"
+                  :class="$style.markdownContent"
+                  v-html="renderAssistant(msg.content)"
+                  @click="onAssistantContentClick"
+                />
+                <div v-else :class="$style.chatText">{{ msg.content }}</div>
+              </div>
+              <button
+                v-if="msg.role === 'assistant' && msg.content && !isGenerating"
+                class="_button"
+                :class="$style.copyBtn"
+                :title="copiedMessageId === msg.id ? 'コピーしました' : 'コピー'"
+                @click="copyMessage(msg)"
+              >
+                <i :class="copiedMessageId === msg.id ? 'ti ti-check' : 'ti ti-copy'" />
+              </button>
+            </div>
+          </div>
+        </template>
 
         <div ref="messagesEndRef" />
       </div>
@@ -1120,6 +1204,95 @@ function onKeydown(e: KeyboardEvent) {
     background: var(--nd-buttonHoverBg);
     opacity: 1 !important;
   }
+}
+
+// --- Tool call / result event (中央寄せの控えめバブル) ---
+
+.toolEvent {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 4px 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-sm);
+  background: color-mix(in srgb, var(--nd-fg) 4%, transparent);
+  font-size: 0.78em;
+  opacity: 0.8;
+  transition: opacity var(--nd-duration-base);
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.toolEventHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+.toolIcon {
+  flex-shrink: 0;
+  color: var(--nd-accent);
+  opacity: 0.9;
+}
+
+.toolEventLabel {
+  flex-shrink: 0;
+  opacity: 0.7;
+  font-weight: 500;
+}
+
+.toolEventName {
+  flex-shrink: 0;
+  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-size: 0.92em;
+  padding: 1px 6px;
+  border-radius: var(--nd-radius-sm);
+  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
+  color: var(--nd-accent);
+}
+
+.toolEventPreview {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.6;
+  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-size: 0.92em;
+}
+
+.toolEventChevron {
+  flex-shrink: 0;
+  margin-left: auto;
+  opacity: 0.5;
+  font-size: 0.95em;
+}
+
+.toolEventCommentary {
+  padding-left: 22px;
+  white-space: pre-wrap;
+  opacity: 0.85;
+}
+
+.toolEventBody {
+  margin: 0;
+  padding: 8px;
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-bg);
+  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-size: 0.9em;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: auto;
+  scrollbar-width: thin;
 }
 
 .markdownContent {


### PR DESCRIPTION
## Summary

#408 Phase 2 A-3.3c: AI tool 呼び出しの **透明性確保**。A-3.3b で session に保存されている `tool_use` / `tool_result` メッセージを専用 UI で可視化する。

これまでは `role: assistant` / `user` として通常のチャットバブルに紛れて表示されていた (tool name や JSON 引数が裸で出ていた)。本 PR で AI が tool を使った形跡が一目で分かる UX に。

## UI 構造

### AI が呼び出した tool (assistant + tool_use)

```
┌─────────────────────────────────────┐
│ 🔧 ツール呼び出し  [time_now]    ▼ │
│  Let me check the time. (任意の text)│
└─────────────────────────────────────┘
```

- ヘッダー: アイコン + ラベル + tool name (monospace + accent バッジ) + 開閉トグル
- assistant が呼び出し時に添えたテキストがあれば下に表示
- 展開時: 入力 JSON を pretty-print

### ツール実行結果 (user + tool_result)

```
┌─────────────────────────────────────┐
│ ↩ 結果  2026-05-01T07:56:12.892Z…  ▼│
└─────────────────────────────────────┘
```

- ヘッダー: アイコン + ラベル + プレビュー (120 文字省略) + 開閉トグル
- 展開時: 結果テキストの全文

### 両方共通

- **中央寄せの控えめバブル** (通常 chat と視覚的に区別)
- 透過度 0.8、hover で 1.0 (主役は AI 応答テキスト)
- ヘッダークリックで折りたたみトグル

## 実装

- `isToolUseMessage(msg)` / `isToolResultMessage(msg)` ガード関数
- `expandedToolDetails: Record<string, boolean>` per-message state
- `toggleToolDetail(msgId)` / `truncateToolPreview` / `formatToolInput`
- 既存テンプレートの `v-for` を `<template>` ベースに分岐 (通常メッセージは既存ロジック完全維持)
- CSS: `.toolEvent` / `.toolEventHeader` / `.toolEventBody` 等を追加

## スコープ外

- copy ボタン (tool 結果のクリップボードコピー、需要があれば追加)
- input/result の syntax highlight
- tool 実行中インジケータ (ストリーミング中の "tool calling..." 表示)

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` クリーン
- [x] `pnpm test` 423 件 pass
- [ ] レビュアー側: 「今何時？」と聞いて、tool_use と tool_result の専用バブルが表示されること
- [ ] レビュアー側: ヘッダークリックで input JSON / 結果全文が展開されること
- [ ] レビュアー側: 通常テキストのみ会話の見た目が変わっていないこと

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1 / A-3.1 / A-3.2 / A-3.3a / A-3.3b: #425 / #427 / #430 / #431 / #432
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)