### PR TITLE
feat(commands): mirror AI-capable commands to capability registry (#408 Phase 2 A-4)

### DIFF
--- a/src/commands/registry.test.ts
+++ b/src/commands/registry.test.ts
@@ -1,0 +1,93 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  _clearCapabilitiesForTest,
+  getCapability,
+} from '@/capabilities/registry'
+import { type Command, useCommandStore } from './registry'
+
+function makeUiCommand(overrides: Partial<Command> = {}): Command {
+  return {
+    id: 'ui.only',
+    label: 'UI only',
+    icon: 'ti-pencil',
+    category: 'general',
+    shortcuts: [],
+    execute: () => undefined,
+    ...overrides,
+  }
+}
+
+function makeAiCapableCommand(overrides: Partial<Command> = {}): Command {
+  return makeUiCommand({
+    id: 'cap.do',
+    aiTool: true,
+    signature: { description: 'something AI can do' },
+    ...overrides,
+  })
+}
+
+describe('useCommandStore mirror to capability registry', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+  afterEach(() => {
+    _clearCapabilitiesForTest()
+  })
+
+  it('register a UI-only command does NOT mirror to capability registry', () => {
+    const store = useCommandStore()
+    store.register(makeUiCommand({ id: 'ui-1' }))
+    expect(getCapability('ui-1')).toBeUndefined()
+  })
+
+  it('register an AI-capable command mirrors to capability registry', () => {
+    const store = useCommandStore()
+    const cmd = makeAiCapableCommand({ id: 'cap-1' })
+    store.register(cmd)
+    expect(getCapability('cap-1')).toBe(cmd)
+  })
+
+  it('register requires both aiTool: true AND a signature for mirroring', () => {
+    const store = useCommandStore()
+    // aiTool: true だけでは signature 不在で mirror されない
+    store.register(makeUiCommand({ id: 'half-1', aiTool: true }))
+    expect(getCapability('half-1')).toBeUndefined()
+    // signature だけで aiTool が false / 未指定なら mirror されない
+    store.register(
+      makeUiCommand({
+        id: 'half-2',
+        signature: { description: 'd' },
+      }),
+    )
+    expect(getCapability('half-2')).toBeUndefined()
+  })
+
+  it('unregister removes from capability registry too', () => {
+    const store = useCommandStore()
+    store.register(makeAiCapableCommand({ id: 'cap-2' }))
+    expect(getCapability('cap-2')).toBeDefined()
+    store.unregister('cap-2')
+    expect(getCapability('cap-2')).toBeUndefined()
+  })
+
+  it('unregister of UI-only command does not touch capability registry', () => {
+    const store = useCommandStore()
+    // capability 側に直接登録された別 command が消されないこと
+    store.register(makeAiCapableCommand({ id: 'standalone' }))
+    store.register(makeUiCommand({ id: 'ui-2' }))
+    store.unregister('ui-2')
+    expect(getCapability('standalone')).toBeDefined()
+  })
+
+  it('re-registering the same id with new aiTool flag updates both registries', () => {
+    const store = useCommandStore()
+    // First: UI only
+    store.register(makeUiCommand({ id: 'morphing', label: 'first' }))
+    expect(getCapability('morphing')).toBeUndefined()
+    // Then: same id with aiTool + signature → should appear in capability registry
+    const upgraded = makeAiCapableCommand({ id: 'morphing', label: 'second' })
+    store.register(upgraded)
+    expect(getCapability('morphing')).toBe(upgraded)
+  })
+})

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -1,5 +1,9 @@
 import { defineStore } from 'pinia'
 import { ref, shallowRef, triggerRef } from 'vue'
+import {
+  registerCapability,
+  unregisterCapability,
+} from '@/capabilities/registry'
 import type { CapabilitySignature, PermissionKey } from '@/capabilities/types'
 import type { QuickPickStep } from './quickPick'
 
@@ -75,11 +79,21 @@ export const useCommandStore = defineStore('commands', () => {
   function register(command: Command) {
     commands.value.set(command.id, command)
     triggerRef(commands)
+    // `aiTool: true` & `signature` 宣言済みの command は AI tool calling
+    // からも呼べるよう capability registry にミラー登録する。
+    // (Phase 2 A-4: Command と Capability を Single Source of Truth で扱う)
+    if (command.aiTool && command.signature) {
+      registerCapability(command)
+    }
   }
 
   function unregister(id: string) {
+    const existing = commands.value.get(id)
     commands.value.delete(id)
     triggerRef(commands)
+    if (existing?.aiTool) {
+      unregisterCapability(id)
+    }
   }
 
   function getEnabled(): Command[] {


### PR DESCRIPTION
## Summary

#408 Phase 2 A-4: `useCommandStore` (UI コマンドパレット) と `capabilities/registry` (AI tool calling) を **Single Source of Truth** で扱えるようにする。

コマンドパレットに登録される command が **`aiTool: true` かつ `signature` 宣言済み** なら、自動的に capability registry にもミラー登録される。これで A-5 以降は各 command に AI 公開フラグを立てるだけで AI から呼び出せるようになる。

## Changes

### `src/commands/registry.ts`

```ts
function register(command: Command) {
  commands.value.set(command.id, command)
  triggerRef(commands)
  // NEW: aiTool & signature 宣言済みなら capability registry にミラー
  if (command.aiTool && command.signature) {
    registerCapability(command)
  }
}

function unregister(id: string) {
  const existing = commands.value.get(id)
  commands.value.delete(id)
  triggerRef(commands)
  if (existing?.aiTool) {
    unregisterCapability(id)  // NEW
  }
}
```

### 既存挙動の保持

- 既存 30+ commands は `aiTool` / `signature` 未宣言 → mirror 対象外 (動作不変)
- `BUILTIN_CAPABILITIES` (`time.now`) は引き続き `main.ts` で `registerCapability()` を直接呼ぶ (UI 非公開のまま)

### テスト 6 件追加 (`src/commands/registry.test.ts` 新規)

- UI only command は mirror されない
- `aiTool: true` + `signature` で mirror される
- `aiTool` のみ / `signature` のみでは mirror されない (両方必要)
- unregister で capability も削除される
- standalone capability registry の登録は影響を受けない
- 同 id を mirror 不可 → 可能に upgrade すると capability に追加される

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` クリーン
- [x] `pnpm test` 429 件 pass (新規 6 件)
- [ ] レビュアー側: 既存コマンドパレット動作が変わらないこと
- [ ] レビュアー側: AI チャットで既存の `time.now` が引き続き呼べること

## 次のステップ (A-5)

各 command に `aiTool: true` / `signature` / `permissions` を順次宣言する PR で AI から呼べる対象を広げる。優先候補:

- `note.post` (`notes.write`)
- `column.add` (UI 専用 / `account.read`)
- `theme.apply` (`account.write`?)
- `account.switch` (`account.read`)

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1 ~ A-3.3c: #425 / #427 / #430 / #431 / #432 / #433
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)