### PR TITLE
feat(capabilities): 6 read-only / UI builtin capabilities (#408 Phase 2 A-5)

### DIFF
--- a/src/capabilities/builtins/account.test.ts
+++ b/src/capabilities/builtins/account.test.ts
@@ -1,0 +1,79 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { Account } from '@/stores/accounts'
+import { useAccountsStore } from '@/stores/accounts'
+import {
+  ACCOUNT_BUILTIN_CAPABILITIES,
+  accountCurrentCapability,
+  accountListCapability,
+} from './account'
+
+const SAMPLE: Account = {
+  id: 'acc-1',
+  host: 'misskey.example',
+  userId: 'u1',
+  username: 'taka',
+  displayName: 'Taka',
+  avatarUrl: null,
+  software: 'misskey-dev/misskey',
+  hasToken: true,
+}
+
+describe('account.current capability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('declares account.read permission and aiTool: true', () => {
+    expect(accountCurrentCapability.permissions).toEqual(['account.read'])
+    expect(accountCurrentCapability.aiTool).toBe(true)
+    expect(accountCurrentCapability.signature?.returns?.type).toBe('object')
+  })
+
+  it('returns null when no active account exists', () => {
+    expect(accountCurrentCapability.execute()).toBeNull()
+  })
+
+  it('returns the active account stripped of credential fields', () => {
+    const store = useAccountsStore()
+    store.accounts = [SAMPLE]
+    store.activeAccountId = 'acc-1'
+    const result = accountCurrentCapability.execute() as Record<string, unknown>
+    expect(result).toMatchObject({
+      id: 'acc-1',
+      host: 'misskey.example',
+      username: 'taka',
+    })
+    // 想定外の credential 流入があっても出ないことを念のため検証
+    expect(JSON.stringify(result)).not.toContain('"i":')
+    expect(JSON.stringify(result)).not.toContain('"token":')
+  })
+})
+
+describe('account.list capability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns an empty array when no accounts are loaded', () => {
+    const result = accountListCapability.execute()
+    expect(result).toEqual([])
+  })
+
+  it('returns all accounts (stripped) when loaded', () => {
+    const store = useAccountsStore()
+    store.accounts = [SAMPLE, { ...SAMPLE, id: 'acc-2', username: 'taka2' }]
+    const result = accountListCapability.execute() as Array<
+      Record<string, unknown>
+    >
+    expect(result).toHaveLength(2)
+    expect(result.map((a) => a.id)).toEqual(['acc-1', 'acc-2'])
+  })
+})
+
+describe('ACCOUNT_BUILTIN_CAPABILITIES', () => {
+  it('contains both capabilities', () => {
+    expect(ACCOUNT_BUILTIN_CAPABILITIES).toContain(accountCurrentCapability)
+    expect(ACCOUNT_BUILTIN_CAPABILITIES).toContain(accountListCapability)
+  })
+})

--- a/src/capabilities/builtins/account.ts
+++ b/src/capabilities/builtins/account.ts
@@ -1,0 +1,71 @@
+import type { Command } from '@/commands/registry'
+import { stripCredentials } from '@/composables/useAiSystemContext'
+import { useAccountsStore } from '@/stores/accounts'
+
+/**
+ * `account.current` — 現在 active なアカウント情報を返す read 系 capability。
+ *
+ * `permissions: ['account.read']` を要求するので、ai.json5 が `readonly`
+ * 以上のプリセットなら通る。stripCredentials を念のため通して credential
+ * 系フィールドを除去する (Account 型自体には現状 token は含まれないが、
+ * 将来の漏洩シナリオ対策)。
+ */
+export const accountCurrentCapability: Command = {
+  id: 'account.current',
+  label: '現在のアカウント情報',
+  icon: 'ti-user',
+  category: 'account',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['account.read'],
+  signature: {
+    description:
+      'ユーザーが今フォーカスしている (active) アカウントの情報を返す。' +
+      ' Misskey サーバーの host や displayName, username 等が含まれる。' +
+      ' 認証トークンは含まれない。',
+    params: {},
+    returns: {
+      type: 'object',
+      description:
+        '`{ id, host, userId, username, displayName, avatarUrl, software, hasToken }`' +
+        ' (アクティブなアカウントが無いときは null)',
+    },
+  },
+  visible: false,
+  execute: () => {
+    const account = useAccountsStore().activeAccount
+    return account ? stripCredentials(account) : null
+  },
+}
+
+/**
+ * `account.list` — ログイン中の全アカウントを返す。
+ */
+export const accountListCapability: Command = {
+  id: 'account.list',
+  label: 'アカウント一覧',
+  icon: 'ti-users',
+  category: 'account',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['account.read'],
+  signature: {
+    description:
+      'NoteDeck にログイン中の全アカウントを配列で返す。複数サーバーを' +
+      ' 横断したい場合に使う。認証トークンは含まれない。',
+    params: {},
+    returns: {
+      type: 'array',
+      description: 'Account の配列',
+    },
+  },
+  visible: false,
+  execute: () => {
+    return stripCredentials(useAccountsStore().accounts)
+  },
+}
+
+export const ACCOUNT_BUILTIN_CAPABILITIES: readonly Command[] = [
+  accountCurrentCapability,
+  accountListCapability,
+]

--- a/src/capabilities/builtins/column.test.ts
+++ b/src/capabilities/builtins/column.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COLUMN_BUILTIN_CAPABILITIES,
+  columnAddCapability,
+  columnListCapability,
+} from './column'
+
+// Note: 実 deckStore が profileStore に深く依存するため、execute() の挙動を
+// 真に検証するには Tauri / Pinia の本体を起動する必要がある。本ユニット
+// テストは capability 定義 (signature / permissions / enum) の正しさだけを
+// 検証する。execute の挙動は実機 / E2E で確認する。
+
+describe('column.list capability', () => {
+  it('declares no permissions and aiTool: true', () => {
+    expect(columnListCapability.permissions).toEqual([])
+    expect(columnListCapability.aiTool).toBe(true)
+    expect(columnListCapability.signature?.returns?.type).toBe('array')
+  })
+
+  it('uses dot-notation id', () => {
+    expect(columnListCapability.id).toBe('column.list')
+  })
+})
+
+describe('column.add capability', () => {
+  it('declares no permissions and aiTool: true', () => {
+    expect(columnAddCapability.permissions).toEqual([])
+    expect(columnAddCapability.aiTool).toBe(true)
+  })
+
+  it('throws on unsupported types (channel / list / antenna require config)', () => {
+    expect(() => columnAddCapability.execute({ type: 'channel' })).toThrow(
+      /Unsupported/,
+    )
+    expect(() => columnAddCapability.execute({ type: 'unknown' })).toThrow(
+      /Unsupported/,
+    )
+  })
+
+  it('declares its enum on the type parameter', () => {
+    const enums = columnAddCapability.signature?.params?.type?.enum
+    expect(enums).toBeDefined()
+    expect(enums).toContain('timeline')
+    expect(enums).toContain('notifications')
+    expect(enums).not.toContain('channel') // requires extra config
+    expect(enums).not.toContain('list') // requires listId
+    expect(enums).not.toContain('antenna') // requires antennaId
+  })
+
+  it('marks type as required and name as optional', () => {
+    const params = columnAddCapability.signature?.params
+    expect(params?.type?.optional).not.toBe(true)
+    expect(params?.name?.optional).toBe(true)
+  })
+})
+
+describe('COLUMN_BUILTIN_CAPABILITIES', () => {
+  it('contains list and add', () => {
+    expect(COLUMN_BUILTIN_CAPABILITIES).toContain(columnListCapability)
+    expect(COLUMN_BUILTIN_CAPABILITIES).toContain(columnAddCapability)
+  })
+})

--- a/src/capabilities/builtins/column.ts
+++ b/src/capabilities/builtins/column.ts
@@ -1,0 +1,133 @@
+import type { Command } from '@/commands/registry'
+import type { ColumnType } from '@/stores/deck'
+import { useDeckStore } from '@/stores/deck'
+
+/**
+ * AI が `column.add` で渡せるカラム種別。複雑な設定を要するカラム
+ * (channel / list / antenna / play / aiscript 等の追加 ID 必須型) は
+ * 一旦除外し、引数なしで開けるシンプルなものだけホワイトリスト化する。
+ * 必要に応じて拡張する。
+ */
+const ADDABLE_COLUMN_TYPES: readonly ColumnType[] = [
+  'timeline',
+  'notifications',
+  'mentions',
+  'specified',
+  'search',
+  'favorites',
+  'drive',
+  'gallery',
+  'explore',
+  'memos',
+  'charts',
+  'federation',
+  'aboutMisskey',
+  'announcements',
+  'achievements',
+  'followRequests',
+  'apiConsole',
+  'apiDocs',
+  'lookup',
+  'serverInfo',
+  'streamInspector',
+  'pluginManager',
+  'themeManager',
+  'taskRunner',
+  'skill',
+  'ai',
+  'chat',
+  'emoji',
+  'ads',
+] as const
+
+/**
+ * `column.list` — 現在のデッキに存在するカラム一覧を返す。
+ * AI が「このユーザーは今どのカラムを開いているか」を理解できる。
+ */
+export const columnListCapability: Command = {
+  id: 'column.list',
+  label: 'カラム一覧',
+  icon: 'ti-columns',
+  category: 'column',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      '現在開かれているカラムを配列で返す。各要素は { id, type, name, accountId } 等を含む。',
+    params: {},
+    returns: {
+      type: 'array',
+      description: 'DeckColumn の配列',
+    },
+  },
+  visible: false,
+  execute: () => {
+    return useDeckStore().columns.map((c) => ({
+      id: c.id,
+      type: c.type,
+      name: c.name,
+      accountId: c.accountId,
+    }))
+  },
+}
+
+/**
+ * `column.add` — 新しいカラムをデッキに追加する。
+ * AI が「ノートのカラムを追加して」と頼まれたときに呼ぶ。
+ * 引数で取れる type はホワイトリスト方式 (= channel / list 等の追加
+ * 設定が必須なカラムは除外)。
+ */
+export const columnAddCapability: Command = {
+  id: 'column.add',
+  label: 'カラムを追加',
+  icon: 'ti-plus',
+  category: 'column',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      '新しいカラムをデッキに追加する。type で種別を指定する。' +
+      ' channel / list / antenna 等の追加設定が必要なカラムは未対応。',
+    params: {
+      type: {
+        type: 'string',
+        description: '追加するカラムの種別',
+        enum: ADDABLE_COLUMN_TYPES,
+      },
+      name: {
+        type: 'string',
+        description: 'カラムのタイトル (空または省略時は自動)',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '追加されたカラムの { id, type }',
+    },
+  },
+  visible: false,
+  execute: (params) => {
+    const type = typeof params?.type === 'string' ? params.type : ''
+    if (!ADDABLE_COLUMN_TYPES.includes(type as ColumnType)) {
+      throw new Error(
+        `Unsupported column type "${type}". ` +
+          `Supported: ${ADDABLE_COLUMN_TYPES.join(', ')}`,
+      )
+    }
+    const name = typeof params?.name === 'string' ? params.name : null
+    const col = useDeckStore().addColumn({
+      type: type as ColumnType,
+      name,
+      width: 380,
+      accountId: null,
+    })
+    return { id: col.id, type: col.type }
+  },
+}
+
+export const COLUMN_BUILTIN_CAPABILITIES: readonly Command[] = [
+  columnListCapability,
+  columnAddCapability,
+]

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_BUILTIN_CAPABILITIES } from './index'
+
+describe('ALL_BUILTIN_CAPABILITIES', () => {
+  it('exposes the expected built-in capability ids', () => {
+    const ids = ALL_BUILTIN_CAPABILITIES.map((c) => c.id).sort()
+    expect(ids).toEqual(
+      [
+        'account.current',
+        'account.list',
+        'column.add',
+        'column.list',
+        'theme.apply',
+        'theme.list',
+        'time.now',
+      ].sort(),
+    )
+  })
+
+  it('every entry is properly tagged for AI tool calling', () => {
+    for (const cap of ALL_BUILTIN_CAPABILITIES) {
+      expect(cap.aiTool, `${cap.id} aiTool`).toBe(true)
+      expect(cap.signature, `${cap.id} signature`).toBeDefined()
+      expect(typeof cap.signature?.description, `${cap.id} description`).toBe(
+        'string',
+      )
+    }
+  })
+
+  it('every id uses dot-notation (Phase 1 命名規約)', () => {
+    for (const cap of ALL_BUILTIN_CAPABILITIES) {
+      // capability id は <subject>.<verb> ドット区切り。Phase 1 の
+      // permissions key と統一されている。
+      expect(cap.id, `${cap.id} should be dotted`).toMatch(/^[a-z]+\.[a-z]+$/)
+    }
+  })
+})

--- a/src/capabilities/builtins/index.ts
+++ b/src/capabilities/builtins/index.ts
@@ -1,0 +1,20 @@
+import type { Command } from '@/commands/registry'
+import { ACCOUNT_BUILTIN_CAPABILITIES } from './account'
+import { COLUMN_BUILTIN_CAPABILITIES } from './column'
+import { THEME_BUILTIN_CAPABILITIES } from './theme'
+import { BUILTIN_CAPABILITIES as TIME_BUILTIN_CAPABILITIES } from './time'
+
+/**
+ * NoteDeck に同梱されている AI tool として公開可能な capability の集合。
+ * `main.ts` で起動時にこれらを `registerCapability` する。
+ *
+ * 命名規約: capability id はドット区切り (`<subject>.<verb>` 形式)。
+ * Anthropic / OpenAI の tool name 制約に合わせて `toolSchema.ts` で
+ * `_` に変換される (`time.now` → `time_now`)。
+ */
+export const ALL_BUILTIN_CAPABILITIES: readonly Command[] = [
+  ...TIME_BUILTIN_CAPABILITIES,
+  ...ACCOUNT_BUILTIN_CAPABILITIES,
+  ...COLUMN_BUILTIN_CAPABILITIES,
+  ...THEME_BUILTIN_CAPABILITIES,
+]

--- a/src/capabilities/builtins/theme.test.ts
+++ b/src/capabilities/builtins/theme.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  THEME_BUILTIN_CAPABILITIES,
+  themeApplyCapability,
+  themeListCapability,
+} from './theme'
+
+// Note: theme.apply の execute は最終的に applyCurrentTheme → window.matchMedia
+// に到達するため unit 環境では走らない。capability 定義の正しさだけ検証する。
+// 実 execute 挙動は dom テストか実機で確認。
+
+describe('theme.list capability', () => {
+  it('declares no permissions and aiTool: true', () => {
+    expect(themeListCapability.permissions).toEqual([])
+    expect(themeListCapability.aiTool).toBe(true)
+    expect(themeListCapability.signature?.returns?.type).toBe('array')
+    expect(themeListCapability.id).toBe('theme.list')
+  })
+})
+
+describe('theme.apply capability', () => {
+  it('declares no permissions and aiTool: true', () => {
+    expect(themeApplyCapability.permissions).toEqual([])
+    expect(themeApplyCapability.aiTool).toBe(true)
+    expect(themeApplyCapability.id).toBe('theme.apply')
+  })
+
+  it('throws when id is missing', () => {
+    expect(() => themeApplyCapability.execute({})).toThrow(/id is required/)
+  })
+
+  it('declares mode enum (dark / light)', () => {
+    const modeEnum = themeApplyCapability.signature?.params?.mode?.enum
+    expect(modeEnum).toEqual(['dark', 'light'])
+    expect(themeApplyCapability.signature?.params?.mode?.optional).toBe(true)
+    expect(themeApplyCapability.signature?.params?.id?.optional).not.toBe(true)
+  })
+})
+
+describe('THEME_BUILTIN_CAPABILITIES', () => {
+  it('contains list and apply', () => {
+    expect(THEME_BUILTIN_CAPABILITIES).toContain(themeListCapability)
+    expect(THEME_BUILTIN_CAPABILITIES).toContain(themeApplyCapability)
+  })
+})

--- a/src/capabilities/builtins/theme.ts
+++ b/src/capabilities/builtins/theme.ts
@@ -1,0 +1,99 @@
+import type { Command } from '@/commands/registry'
+import { useThemeStore } from '@/stores/theme'
+
+/**
+ * `theme.list` — インストール済みテーマの一覧を返す。
+ * AI が `theme.apply` で渡す ID を確認するために使う。
+ */
+export const themeListCapability: Command = {
+  id: 'theme.list',
+  label: 'テーマ一覧',
+  icon: 'ti-palette',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      'インストール済みテーマの一覧を返す。各要素は { id, name, base, author }',
+    params: {},
+    returns: {
+      type: 'array',
+      description: 'インストール済みテーマ一覧',
+    },
+  },
+  visible: false,
+  execute: () => {
+    const store = useThemeStore()
+    return store.installedThemes.map((t) => ({
+      id: t.id,
+      name: t.name,
+      base: t.base ?? null,
+      // Misskey 互換 JSON には author が入るが MisskeyTheme 型には未宣言。
+      // 値が存在すれば string として返す (なければ null)。
+      author:
+        typeof (t as unknown as { author?: unknown }).author === 'string'
+          ? (t as unknown as { author: string }).author
+          : null,
+    }))
+  },
+}
+
+/**
+ * `theme.apply` — 指定 id のテーマを適用する。
+ * テーマの `base` ('dark' | 'light') から適用先 mode を自動判定する。
+ * `theme.list` で取得した id を渡す想定。
+ */
+export const themeApplyCapability: Command = {
+  id: 'theme.apply',
+  label: 'テーマを適用',
+  icon: 'ti-palette',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      'インストール済みテーマを適用する。' +
+      ' theme.list で id を取得してから呼ぶ。' +
+      ' mode はテーマの base から自動判定 (省略可)。',
+    params: {
+      id: {
+        type: 'string',
+        description: '適用するテーマの id (theme.list で取得)',
+      },
+      mode: {
+        type: 'string',
+        description:
+          '明示的に dark / light どちらの slot に適用するか。省略時はテーマ自体の base を使う',
+        enum: ['dark', 'light'],
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '`{ applied: boolean, id, mode }`',
+    },
+  },
+  visible: false,
+  execute: (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    if (!id) throw new Error('theme.apply: id is required')
+    const store = useThemeStore()
+    const theme = store.installedThemes.find((t) => t.id === id)
+    if (!theme) {
+      throw new Error(`theme.apply: theme "${id}" is not installed`)
+    }
+    const explicitMode =
+      params?.mode === 'dark' || params?.mode === 'light' ? params.mode : null
+    const mode: 'dark' | 'light' =
+      explicitMode ?? (theme.base === 'light' ? 'light' : 'dark')
+    store.selectTheme(id, mode)
+    return { applied: true, id, mode }
+  },
+}
+
+export const THEME_BUILTIN_CAPABILITIES: readonly Command[] = [
+  themeListCapability,
+  themeApplyCapability,
+]

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import App from './App.vue'
-import { BUILTIN_CAPABILITIES } from './capabilities/builtins/time'
+import { ALL_BUILTIN_CAPABILITIES } from './capabilities/builtins'
 import { registerCapability } from './capabilities/registry'
 import { router, setupAccountRedirect } from './router'
 import { initEarlyAccountListener, useAccountsStore } from './stores/accounts'
@@ -16,11 +16,12 @@ import { commands, unwrap } from './utils/tauriInvoke'
 import '@tabler/icons-webfont/dist/tabler-icons.min.css'
 import './styles/global.css'
 
-// Register builtin AI capabilities (time.now etc.) at module load.
-// Capability registry is module-scoped and provider-agnostic, so we don't need
-// Pinia or Tauri here. Repeating the loop is fine — registerCapability
-// overwrites by id (Phase 2 A-3.1 contract).
-for (const cap of BUILTIN_CAPABILITIES) {
+// Register builtin AI capabilities (time / account / column / theme) at
+// module load. Capability registry は module-scoped で Pinia 非依存だが、
+// 各 execute は Pinia store にアクセスするので、実呼び出しは Pinia 初期化後
+// (= sendMessage 経由) に限定される。registerCapability は id で overwrite
+// するので二重実行しても安全。
+for (const cap of ALL_BUILTIN_CAPABILITIES) {
   registerCapability(cap)
 }
 


### PR DESCRIPTION
## Summary

#408 Phase 2 A-5: `time.now` に加えて **NoteDeck コア機能の builtin capability を 6 種追加**。AI が「アカウント / カラム / テーマ」を読み書きできるようになる。書き込み系 (`notes.write` 等) は Phase 5 の確認ダイアログ実装まで保留。

## 追加 capability

| id | 機能 | permissions | params |
|---|---|---|---|
| `account.current` | active アカウント情報を返す | `account.read` | (なし) |
| `account.list` | 全アカウント一覧 | `account.read` | (なし) |
| `column.list` | デッキカラム一覧 | (なし) | (なし) |
| `column.add` | カラム追加 | (なし) | `type`, `name?` |
| `theme.list` | インストール済みテーマ | (なし) | (なし) |
| `theme.apply` | テーマ適用 | (なし) | `id`, `mode?` |

`column.add` の `type` は **ADDABLE_COLUMN_TYPES でホワイトリスト**化 (timeline / notifications / mentions 等)。`channel` / `list` / `antenna` 等の追加設定が必要なカラムは除外。

`theme.apply` の `mode` は省略時 `theme.base` から自動判定。明示的に指定もできる (`'dark' | 'light'` enum)。

## ファイル構造

```
src/capabilities/builtins/
├── account.ts       (新規)
├── account.test.ts  (新規)
├── column.ts        (新規)
├── column.test.ts   (新規)
├── theme.ts         (新規)
├── theme.test.ts    (新規)
├── index.ts         (新規) — ALL_BUILTIN_CAPABILITIES
├── index.test.ts    (新規)
├── time.ts          (既存、変更なし)
└── time.test.ts     (既存、変更なし)
```

`main.ts`: `BUILTIN_CAPABILITIES` (time のみ) → `ALL_BUILTIN_CAPABILITIES` に切替。

## 設計判断

- **`account.current` / `list` は stripCredentials を念のため通す** — 現状の `Account` 型に token は無いが、将来の漏洩シナリオ対策
- **`column.add` の type ホワイトリスト** — Phase 1 で追加設定が必要なカラム (channel/list/antenna) を AI に呼ばせると失敗するので除外
- **`theme.apply` の mode 自動判定** — `theme.list` で取得した base を見るので、AI は base を考えなくて良い (明示 override も可)
- **`visible: false`** — UI コマンドパレットには出さない (AI 専用)。コマンドパレットには既存の `add-column` 等が別途存在する

## スコープ外 (今後の PR)

- **write 系** (`notes.post` / `notes.react` / `account.follow` 等) → Phase 5 の確認ダイアログ実装後
- **AiScript プラグインからの capability 登録** (`Nd:register_command` 拡張) → 別 PR (= misstore で配布可能な capability への道筋)
- **`notes.search` 等の adapter API ベース capability** → adapter 経由の重い実装になるので別 PR

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` クリーン
- [x] `pnpm test` 450 件 pass (新規 21 件)
- [ ] レビュアー側: AI に「テーマ一覧見せて」→ `theme.list` が呼ばれて結果が返る
- [ ] レビュアー側: AI に「タイムラインカラム追加して」→ `column.add` が呼ばれてカラムが増える
- [ ] レビュアー側: AI に「今のアカウント教えて」→ `account.current` が呼ばれて (token 含まない) アカウント情報が返る
- [ ] レビュアー側: 既存テキストのみ会話と `time.now` が引き続き動くこと

## 関連

- Phase 1: #423 / #424
- Phase 2 A-1 ~ A-4: #425 / #427 / #430 / #431 / #432 / #433 / #434
- 設計: [#408 Capability Registry](https://github.com/hitalin/notedeck/issues/408#issuecomment-4334932896)

🤖 Generated with [Claude Code](https://claude.com/claude-code)