### PR TITLE
feat(ai): read 系 capability を 5 個追加 (user / notifications / drive / notes.show / notes.children)

### DIFF
--- a/src/capabilities/builtins/drive.test.ts
+++ b/src/capabilities/builtins/drive.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { DRIVE_BUILTIN_CAPABILITIES, driveListCapability } from './drive'
+
+describe('drive.list capability', () => {
+  it('declares drive.read permission and aiTool: true', () => {
+    expect(driveListCapability.permissions).toEqual(['drive.read'])
+    expect(driveListCapability.aiTool).toBe(true)
+    expect(driveListCapability.id).toBe('drive.list')
+    expect(driveListCapability.signature?.returns?.type).toBe('array')
+  })
+
+  it('marks all params as optional (no required)', () => {
+    const params = driveListCapability.signature?.params
+    expect(params?.folderId?.optional).toBe(true)
+    expect(params?.limit?.optional).toBe(true)
+    expect(params?.fileType?.optional).toBe(true)
+  })
+})
+
+describe('DRIVE_BUILTIN_CAPABILITIES', () => {
+  it('contains drive.list', () => {
+    expect(DRIVE_BUILTIN_CAPABILITIES).toHaveLength(1)
+    expect(DRIVE_BUILTIN_CAPABILITIES).toContain(driveListCapability)
+  })
+})

--- a/src/capabilities/builtins/drive.ts
+++ b/src/capabilities/builtins/drive.ts
@@ -1,0 +1,84 @@
+import type { Command } from '@/commands/registry'
+import { useAccountsStore } from '@/stores/accounts'
+import { commands, unwrap } from '@/utils/tauriInvoke'
+
+/**
+ * Drive ファイルは ApiAdapter を介さず Rust 側の `api_get_drive_files` を直接
+ * 呼ぶ (DeckDriveColumn と同じ経路)。adapter には drive.* が無いので、
+ * AI tool としてもこのバイパス経路を使う。
+ */
+
+const MAX_DRIVE_LIMIT = 100
+const DEFAULT_LIMIT = 30
+
+function clampLimit(input: unknown, fallback = DEFAULT_LIMIT): number {
+  if (typeof input !== 'number' || !Number.isFinite(input)) return fallback
+  return Math.max(1, Math.min(MAX_DRIVE_LIMIT, Math.floor(input)))
+}
+
+function pickStringOrNull(input: unknown): string | null {
+  if (typeof input !== 'string') return null
+  const trimmed = input.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * `drive.list` — 現在 active なアカウントのドライブファイル一覧を取得する。
+ * folderId 省略時はルート、fileType 指定で MIME prefix 絞り込み。
+ */
+export const driveListCapability: Command = {
+  id: 'drive.list',
+  label: 'ドライブファイル一覧',
+  icon: 'ti-cloud',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['drive.read'],
+  signature: {
+    description:
+      '現在 active なアカウントの Misskey ドライブのファイル一覧を取得する。' +
+      ' folderId 省略でルート、fileType 指定 (例: `image/`) で MIME prefix' +
+      ' フィルタ。返り値は raw な配列 (id / name / type / size / url 等)。',
+    params: {
+      folderId: {
+        type: 'string',
+        description: 'フォルダー ID (省略でルート)',
+        optional: true,
+      },
+      limit: {
+        type: 'number',
+        description: '取得件数 (1-100, default 30)',
+        optional: true,
+      },
+      fileType: {
+        type: 'string',
+        description:
+          'MIME prefix フィルタ (例: `image/` / `video/` / `application/pdf`)',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'array',
+      description: 'ドライブファイル (NormalizedDriveFile) の配列',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const accountId = useAccountsStore().activeAccountId
+    if (!accountId) throw new Error('No active account')
+    const folderId = pickStringOrNull(params?.folderId)
+    const fileType = pickStringOrNull(params?.fileType)
+    const limit = clampLimit(params?.limit)
+    const result = await commands.apiGetDriveFiles(
+      accountId,
+      folderId,
+      limit,
+      fileType,
+    )
+    return unwrap(result)
+  },
+}
+
+export const DRIVE_BUILTIN_CAPABILITIES: readonly Command[] = [
+  driveListCapability,
+]

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -10,12 +10,17 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'account.list',
         'column.add',
         'column.list',
+        'drive.list',
+        'notes.children',
         'notes.search',
+        'notes.show',
         'notes.timeline',
         'notes.user',
+        'notifications.list',
         'theme.apply',
         'theme.list',
         'time.now',
+        'user.lookup',
       ].sort(),
     )
   })

--- a/src/capabilities/builtins/index.ts
+++ b/src/capabilities/builtins/index.ts
@@ -1,9 +1,12 @@
 import type { Command } from '@/commands/registry'
 import { ACCOUNT_BUILTIN_CAPABILITIES } from './account'
 import { COLUMN_BUILTIN_CAPABILITIES } from './column'
+import { DRIVE_BUILTIN_CAPABILITIES } from './drive'
 import { NOTES_BUILTIN_CAPABILITIES } from './notes'
+import { NOTIFICATIONS_BUILTIN_CAPABILITIES } from './notifications'
 import { THEME_BUILTIN_CAPABILITIES } from './theme'
 import { BUILTIN_CAPABILITIES as TIME_BUILTIN_CAPABILITIES } from './time'
+import { USER_BUILTIN_CAPABILITIES } from './user'
 
 /**
  * NoteDeck に同梱されている AI tool として公開可能な capability の集合。
@@ -19,4 +22,7 @@ export const ALL_BUILTIN_CAPABILITIES: readonly Command[] = [
   ...COLUMN_BUILTIN_CAPABILITIES,
   ...THEME_BUILTIN_CAPABILITIES,
   ...NOTES_BUILTIN_CAPABILITIES,
+  ...USER_BUILTIN_CAPABILITIES,
+  ...NOTIFICATIONS_BUILTIN_CAPABILITIES,
+  ...DRIVE_BUILTIN_CAPABILITIES,
 ]

--- a/src/capabilities/builtins/notes.test.ts
+++ b/src/capabilities/builtins/notes.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   NOTES_BUILTIN_CAPABILITIES,
+  notesChildrenCapability,
   notesSearchCapability,
+  notesShowCapability,
   notesTimelineCapability,
   notesUserCapability,
 } from './notes'
@@ -79,11 +81,61 @@ describe('notes.user capability', () => {
   })
 })
 
+describe('notes.show capability', () => {
+  it('declares notes.read permission and aiTool: true', () => {
+    expect(notesShowCapability.permissions).toEqual(['notes.read'])
+    expect(notesShowCapability.aiTool).toBe(true)
+    expect(notesShowCapability.id).toBe('notes.show')
+    expect(notesShowCapability.signature?.returns?.type).toBe('object')
+  })
+
+  it('marks noteId as required', () => {
+    const params = notesShowCapability.signature?.params
+    expect(params?.noteId?.optional).not.toBe(true)
+  })
+
+  it('throws when noteId is missing or blank', async () => {
+    await expect(notesShowCapability.execute({})).rejects.toThrow(
+      /noteId is required/,
+    )
+    await expect(
+      notesShowCapability.execute({ noteId: '   ' }),
+    ).rejects.toThrow(/noteId is required/)
+  })
+})
+
+describe('notes.children capability', () => {
+  it('declares notes.read permission and aiTool: true', () => {
+    expect(notesChildrenCapability.permissions).toEqual(['notes.read'])
+    expect(notesChildrenCapability.aiTool).toBe(true)
+    expect(notesChildrenCapability.id).toBe('notes.children')
+    expect(notesChildrenCapability.signature?.returns?.type).toBe('array')
+  })
+
+  it('marks noteId required, limit/untilId optional', () => {
+    const params = notesChildrenCapability.signature?.params
+    expect(params?.noteId?.optional).not.toBe(true)
+    expect(params?.limit?.optional).toBe(true)
+    expect(params?.untilId?.optional).toBe(true)
+  })
+
+  it('throws when noteId is missing or blank', async () => {
+    await expect(notesChildrenCapability.execute({})).rejects.toThrow(
+      /noteId is required/,
+    )
+    await expect(
+      notesChildrenCapability.execute({ noteId: '   ' }),
+    ).rejects.toThrow(/noteId is required/)
+  })
+})
+
 describe('NOTES_BUILTIN_CAPABILITIES', () => {
-  it('contains all three notes capabilities', () => {
-    expect(NOTES_BUILTIN_CAPABILITIES).toHaveLength(3)
+  it('contains all five notes capabilities', () => {
+    expect(NOTES_BUILTIN_CAPABILITIES).toHaveLength(5)
     expect(NOTES_BUILTIN_CAPABILITIES).toContain(notesSearchCapability)
     expect(NOTES_BUILTIN_CAPABILITIES).toContain(notesTimelineCapability)
     expect(NOTES_BUILTIN_CAPABILITIES).toContain(notesUserCapability)
+    expect(NOTES_BUILTIN_CAPABILITIES).toContain(notesShowCapability)
+    expect(NOTES_BUILTIN_CAPABILITIES).toContain(notesChildrenCapability)
   })
 })

--- a/src/capabilities/builtins/notes.ts
+++ b/src/capabilities/builtins/notes.ts
@@ -202,8 +202,96 @@ export const notesUserCapability: Command = {
   },
 }
 
+/** `notes.show` — 単一ノートを ID で取得 */
+export const notesShowCapability: Command = {
+  id: 'notes.show',
+  label: 'ノート取得',
+  icon: 'ti-note',
+  category: 'note',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notes.read'],
+  signature: {
+    description:
+      'noteId で 1 件のノートを取得する。リプライ先や引用元の本文を見たい' +
+      ' ときに使う。戻り値は単一の note projection (配列ではない)。',
+    params: {
+      noteId: {
+        type: 'string',
+        description: 'Misskey 内部の note ID',
+      },
+    },
+    returns: {
+      type: 'object',
+      description:
+        'note projection (id / userId / username / text / createdAt)',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const noteId =
+      typeof params?.noteId === 'string' ? params.noteId.trim() : ''
+    if (!noteId) throw new Error('notes.show: noteId is required')
+    const api = await getApiAdapter(undefined)
+    const note = await api.getNote(noteId)
+    // 配列を経由するが結果は 1 件目を返す (projection を再利用するため)
+    return projectVisibleItems([note], 'search', 1)[0] ?? null
+  },
+}
+
+/** `notes.children` — 指定ノートへのリプライ (子ノート) を取得 */
+export const notesChildrenCapability: Command = {
+  id: 'notes.children',
+  label: 'リプライ取得',
+  icon: 'ti-corner-down-right',
+  category: 'note',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notes.read'],
+  signature: {
+    description:
+      '指定ノートへの直接リプライ (= 子ノート) を取得する。会話のスレッドを' +
+      ' 辿りたいときに使う。' +
+      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。',
+    params: {
+      noteId: {
+        type: 'string',
+        description: '親ノートの Misskey 内部 ID',
+      },
+      limit: {
+        type: 'number',
+        description: '取得件数 (1-100, default 10)',
+        optional: true,
+      },
+      untilId: {
+        type: 'string',
+        description:
+          'この ID より前のリプライを取得 (ページング用)。前回呼び出しの最後のノートの id を渡す。',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'array',
+      description: 'ノート projection の配列',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const noteId =
+      typeof params?.noteId === 'string' ? params.noteId.trim() : ''
+    if (!noteId) throw new Error('notes.children: noteId is required')
+    const limit = clampLimit(params?.limit)
+    const untilId = pickUntilId(params?.untilId)
+    const api = await getApiAdapter(undefined)
+    const notes = await api.getNoteChildren(noteId, { limit, untilId })
+    return projectVisibleItems(notes, 'search', limit)
+  },
+}
+
 export const NOTES_BUILTIN_CAPABILITIES: readonly Command[] = [
   notesSearchCapability,
   notesTimelineCapability,
   notesUserCapability,
+  notesShowCapability,
+  notesChildrenCapability,
 ]

--- a/src/capabilities/builtins/notifications.test.ts
+++ b/src/capabilities/builtins/notifications.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NOTIFICATIONS_BUILTIN_CAPABILITIES,
+  notificationsListCapability,
+} from './notifications'
+
+describe('notifications.list capability', () => {
+  it('declares notifications permission and aiTool: true', () => {
+    expect(notificationsListCapability.permissions).toEqual(['notifications'])
+    expect(notificationsListCapability.aiTool).toBe(true)
+    expect(notificationsListCapability.id).toBe('notifications.list')
+    expect(notificationsListCapability.signature?.returns?.type).toBe('array')
+  })
+
+  it('marks limit and untilId as optional', () => {
+    const params = notificationsListCapability.signature?.params
+    expect(params?.limit?.optional).toBe(true)
+    expect(params?.untilId?.optional).toBe(true)
+  })
+})
+
+describe('NOTIFICATIONS_BUILTIN_CAPABILITIES', () => {
+  it('contains notifications.list', () => {
+    expect(NOTIFICATIONS_BUILTIN_CAPABILITIES).toHaveLength(1)
+    expect(NOTIFICATIONS_BUILTIN_CAPABILITIES).toContain(
+      notificationsListCapability,
+    )
+  })
+})

--- a/src/capabilities/builtins/notifications.ts
+++ b/src/capabilities/builtins/notifications.ts
@@ -1,0 +1,83 @@
+import { initAdapterFor } from '@/adapters/factory'
+import type { ApiAdapter } from '@/adapters/types'
+import type { Command } from '@/commands/registry'
+import { projectVisibleItems } from '@/composables/useAiSystemContext'
+import { useAccountsStore } from '@/stores/accounts'
+
+/**
+ * AI が 1 回の呼び出しで取得できる通知の上限 (Misskey API native 上限と一致)。
+ * untilId で続きを引けるので「もっと取って」と AI に頼めばページング可能。
+ */
+const MAX_NOTIFICATIONS_PER_CALL = 100
+const DEFAULT_LIMIT = 10
+
+async function getApiAdapter(): Promise<ApiAdapter> {
+  const store = useAccountsStore()
+  const id = store.activeAccountId
+  if (!id) throw new Error('No active account')
+  const acc = store.accounts.find((a) => a.id === id)
+  if (!acc) throw new Error(`Account "${id}" not found`)
+  const { adapter } = await initAdapterFor(acc.host, acc.id)
+  return adapter.api
+}
+
+function clampLimit(input: unknown, fallback = DEFAULT_LIMIT): number {
+  if (typeof input !== 'number' || !Number.isFinite(input)) return fallback
+  return Math.max(1, Math.min(MAX_NOTIFICATIONS_PER_CALL, Math.floor(input)))
+}
+
+function pickUntilId(input: unknown): string | undefined {
+  if (typeof input !== 'string') return undefined
+  const trimmed = input.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * `notifications.list` — 通知一覧を取得する read 系 capability。
+ * 通知本文 (リアクション元 / リプライ元のノート) は projectVisibleItems の
+ * 'notifications' kind で軽量化された projection が返る。
+ */
+export const notificationsListCapability: Command = {
+  id: 'notifications.list',
+  label: '通知一覧',
+  icon: 'ti-bell',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notifications'],
+  signature: {
+    description:
+      '現在 active なアカウントの通知一覧を取得する。type / userId / noteId /' +
+      ' reaction / createdAt 等の projection が返る。' +
+      ' 100 件を超えて取得したい場合は、最後の通知の id を untilId に渡して再呼び出し。',
+    params: {
+      limit: {
+        type: 'number',
+        description: '取得件数 (1-100, default 10)',
+        optional: true,
+      },
+      untilId: {
+        type: 'string',
+        description:
+          'この ID より前の通知を取得 (ページング用)。前回呼び出しの最後の通知の id を渡す。',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'array',
+      description: '通知 projection の配列',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const limit = clampLimit(params?.limit)
+    const untilId = pickUntilId(params?.untilId)
+    const api = await getApiAdapter()
+    const notifications = await api.getNotifications({ limit, untilId })
+    return projectVisibleItems(notifications, 'notifications', limit)
+  },
+}
+
+export const NOTIFICATIONS_BUILTIN_CAPABILITIES: readonly Command[] = [
+  notificationsListCapability,
+]

--- a/src/capabilities/builtins/user.test.ts
+++ b/src/capabilities/builtins/user.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { USER_BUILTIN_CAPABILITIES, userLookupCapability } from './user'
+
+describe('user.lookup capability', () => {
+  it('declares account.read permission and aiTool: true', () => {
+    expect(userLookupCapability.permissions).toEqual(['account.read'])
+    expect(userLookupCapability.aiTool).toBe(true)
+    expect(userLookupCapability.id).toBe('user.lookup')
+    expect(userLookupCapability.signature?.returns?.type).toBe('object')
+  })
+
+  it('marks username as required and host as optional', () => {
+    const params = userLookupCapability.signature?.params
+    expect(params?.username?.optional).not.toBe(true)
+    expect(params?.host?.optional).toBe(true)
+  })
+
+  it('throws when username is missing or blank', async () => {
+    await expect(userLookupCapability.execute({})).rejects.toThrow(
+      /username is required/,
+    )
+    await expect(
+      userLookupCapability.execute({ username: '   ' }),
+    ).rejects.toThrow(/username is required/)
+  })
+})
+
+describe('USER_BUILTIN_CAPABILITIES', () => {
+  it('contains user.lookup', () => {
+    expect(USER_BUILTIN_CAPABILITIES).toHaveLength(1)
+    expect(USER_BUILTIN_CAPABILITIES).toContain(userLookupCapability)
+  })
+})

--- a/src/capabilities/builtins/user.ts
+++ b/src/capabilities/builtins/user.ts
@@ -1,0 +1,78 @@
+import { initAdapterFor } from '@/adapters/factory'
+import type { ApiAdapter } from '@/adapters/types'
+import type { Command } from '@/commands/registry'
+import { stripCredentials } from '@/composables/useAiSystemContext'
+import { useAccountsStore } from '@/stores/accounts'
+
+/**
+ * `user.lookup` — username (+ optional host) から Misskey ユーザー情報を引く。
+ *
+ * AI が `@hitalin@yami.ski` 形式の文字列を受け取ったとき、`notes.user` に渡せる
+ * 内部 user ID を取り出す動線。`notes.user` は内部 ID 必須なのでこの 1 段挟む。
+ *
+ * Misskey の `users/show` を使う。host は `@hitalin@yami.ski` の `yami.ski` 部分
+ * (ローカル / 自インスタンスのときは省略可)。
+ */
+async function getApiAdapter(): Promise<ApiAdapter> {
+  const store = useAccountsStore()
+  const id = store.activeAccountId
+  if (!id) throw new Error('No active account')
+  const acc = store.accounts.find((a) => a.id === id)
+  if (!acc) throw new Error(`Account "${id}" not found`)
+  const { adapter } = await initAdapterFor(acc.host, acc.id)
+  return adapter.api
+}
+
+export const userLookupCapability: Command = {
+  id: 'user.lookup',
+  label: 'ユーザー検索',
+  icon: 'ti-user-search',
+  category: 'account',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['account.read'],
+  signature: {
+    description:
+      'username (+ 任意で host) から Misskey ユーザー情報を取得する。' +
+      ' `@user@example.com` 形式から userId を引いて notes.user に渡す動線で使う。' +
+      ' 戻り値の id が Misskey 内部の user ID。',
+    params: {
+      username: {
+        type: 'string',
+        description: 'username (先頭の `@` は不要)',
+      },
+      host: {
+        type: 'string',
+        description:
+          'リモートホスト (例: `yami.ski`)。同インスタンス内ユーザーなら省略。',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description:
+        'NormalizedUser (id / username / host / name / avatarUrl 等)',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const rawUsername =
+      typeof params?.username === 'string' ? params.username.trim() : ''
+    if (!rawUsername) throw new Error('user.lookup: username is required')
+    // 入力の先頭 `@` を除去 (`@hitalin` → `hitalin`)
+    const username = rawUsername.startsWith('@')
+      ? rawUsername.slice(1)
+      : rawUsername
+    const host =
+      typeof params?.host === 'string' && params.host.trim().length > 0
+        ? params.host.trim()
+        : null
+    const api = await getApiAdapter()
+    const user = await api.lookupUser(username, host)
+    return stripCredentials(user)
+  },
+}
+
+export const USER_BUILTIN_CAPABILITIES: readonly Command[] = [
+  userLookupCapability,
+]


### PR DESCRIPTION
## Summary

AI が単発で叩ける read 系 tool の手数を増やす。built-in capability は 10 → 15 個に。すべて `aiTool: true` で `/(slash)` コマンド経路からも使える。

| id | permission | 説明 |
|---|---|---|
| `user.lookup` | `account.read` | username + 任意 host から NormalizedUser を引く。`@hitalin@yami.ski` → userId 動線 |
| `notifications.list` | `notifications` | 通知一覧。limit 1-100, untilId pagination |
| `drive.list` | `drive.read` | ドライブファイル一覧。folderId / fileType フィルタ |
| `notes.show` | `notes.read` | noteId で単一ノート (リプライ先 / 引用元) |
| `notes.children` | `notes.read` | 指定ノートへの直接リプライ。limit / untilId pagination |

## なぜ

PR #437 の AI 利用フィードバックで、`@hitalin@yami.ski` を渡されても `notes.user` は内部 ID 必須なので AI が「ユーザー解決」できない問題があった。今回の `user.lookup` で 1 段挟む動線が組める。

`notifications.list` / `drive.list` も `notes.timeline` と並ぶ基本 read 操作。`notes.show` / `notes.children` はリプライツリーや引用元を辿るのに必須。

## 設計判断

- **ファイル分割**: subject ごとに 1 ファイル (user.ts / notifications.ts / drive.ts)、`notes.*` は既存 notes.ts に追加
- **drive.list は adapter 経由でない**: ApiAdapter には drive.* が無いので `commands.apiGetDriveFiles` を直接呼ぶ (DeckDriveColumn と同じ経路)
- **notes.show は projectVisibleItems 再利用**: 単一ノートでも projection を使うため `[note]` でラップして 1 件目を取り出す
- **user.lookup の `@` 除去**: 入力 `@hitalin` でも `hitalin` でも通るよう先頭の `@` を strip
- **default limit**: notifications/notes 系は 10、drive は 30 (UI ファイル一覧と感覚を合わせる)
- **テストは validation 中心**: 実 adapter / Tauri 呼び出しはテストしない (既存パターン踏襲)

## Test plan

- [x] `pnpm test` (492 passed)
- [x] `pnpm typecheck` / `pnpm lint`
- [ ] `/help` で 15 件全部出る
- [ ] `/user.lookup username=hitalin host=yami.ski` で id が返る → `/notes.user userId=<id>` 動作
- [ ] `/notifications.list limit=5` で通知が出る
- [ ] `/drive.list fileType=image/` で画像のみ
- [ ] `/notes.show noteId=<id>` で本文が出る
- [ ] `/notes.children noteId=<id>` でリプライが出る
- [ ] readonly preset 中に AI 経由で叩いても全部通る (read 系のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)