### PR TITLE
feat(ai): AI チャットの tool 入出力 JSON を shiki で syntax highlight

### DIFF
--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -35,6 +35,7 @@ import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
+import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -694,6 +695,13 @@ function formatToolInput(input: Record<string, unknown> | undefined): string {
   return JSON.stringify(input, null, 2)
 }
 
+/** tool 結果文字列が JSON-shaped か判定 (`{` / `[` 始まりなら highlight 対象) */
+function looksLikeJson(s: string): boolean {
+  if (!s) return false
+  const t = s.trimStart()
+  return t.startsWith('{') || t.startsWith('[')
+}
+
 // --- コピー ---
 
 const copiedMessageId = ref<string | null>(null)
@@ -930,7 +938,12 @@ function onKeydown(e: KeyboardEvent) {
               />
             </button>
             <div v-if="msg.content" :class="$style.toolEventCommentary">{{ msg.content }}</div>
-            <pre v-if="expandedToolDetails[msg.id]" :class="$style.toolEventBody">{{ formatToolInput(msg.toolUseInput) }}</pre>
+            <div
+              v-if="expandedToolDetails[msg.id]"
+              :key="`tool-input-${msg.id}-${highlighterLoaded}`"
+              :class="$style.toolEventBody"
+              v-html="highlightCode(formatToolInput(msg.toolUseInput), 'json')"
+            />
           </div>
 
           <!-- ツール実行結果 (user + tool_result) -->
@@ -955,7 +968,15 @@ function onKeydown(e: KeyboardEvent) {
                 ]"
               />
             </button>
-            <pre v-if="expandedToolDetails[msg.id]" :class="$style.toolEventBody">{{ msg.content }}</pre>
+            <template v-if="expandedToolDetails[msg.id]">
+              <div
+                v-if="looksLikeJson(msg.content)"
+                :key="`tool-result-${msg.id}-${highlighterLoaded}`"
+                :class="$style.toolEventBody"
+                v-html="highlightCode(msg.content, 'json')"
+              />
+              <pre v-else :class="$style.toolEventBody">{{ msg.content }}</pre>
+            </template>
           </div>
 
           <!-- 通常メッセージ -->
@@ -1379,6 +1400,21 @@ function onKeydown(e: KeyboardEvent) {
   word-break: break-all;
   overflow-x: auto;
   scrollbar-width: thin;
+
+  // shiki が <pre class="shiki"><code>...</code></pre> を埋め込むので、
+  // 内側 pre の browser default margin / padding を打ち消して toolEventBody の
+  // padding にだけ依存させる。background は親 (toolEventBody) の var(--nd-bg) を
+  // そのまま使うため透過に。
+  :global(pre.shiki) {
+    margin: 0;
+    padding: 0;
+    background: transparent;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+  :global(pre.shiki code) {
+    font-family: inherit;
+  }
 }
 
 .markdownContent {


### PR DESCRIPTION
## Summary

ツール呼び出しの折りたたみを開いたときに表示される **input パラメタ** と **結果** の JSON を、shiki (dark-plus テーマ) で色分けする。

before: プレーンな白テキストで読みづらかった
after: キー / 文字列 / 数値 / boolean / null が色分けされる

## 実装

- 既存 \`utils/highlight.ts\` の \`highlightCode\` を流用 (shiki / json grammar / dark-plus テーマ / shiki-dark-plus.css は既に同梱)
- 新しい依存は追加していない
- \`:key\` に \`highlighterLoaded\` を含めて、shiki が lazy 初期化を終えた瞬間に再描画させる ([MkMfm.vue](src/components/common/MkMfm.vue#L415) と同じパターン)
- tool 結果は **文字列 / JSON 混在** なので、\`{\` / \`[\` 始まりの場合のみ JSON 扱い。時刻文字列 (\`time.now\` など) やエラーメッセージはそのまま \`<pre>\` でプレーン表示
- 内側 \`<pre class=\"shiki\">\` の余白を打ち消す CSS を追加して、\`toolEventBody\` の padding にだけ依存させる

## Test plan

- [x] \`pnpm test\` (492 passed)
- [x] \`pnpm typecheck\` / \`pnpm lint\`
- [ ] \`/notes.timeline limit=3\` の結果トグルで色付き JSON が出る
- [ ] \`/time.now\` の結果は文字列なのでプレーン表示
- [ ] \`/help\` (Markdown 文字列) はプレーン表示
- [ ] AI tool_use の input パラメタも色分けされる
- [ ] エラー結果 (\`Error (parse_error): ...\`) はプレーン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)