### PR TITLE
Release v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.15.10",
+  "version": "0.16.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.15.10"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.15.10"
+version = "0.16.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.15.10",
+  "version": "0.16.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary
- Capability Registry / Dispatcher 基盤を導入し、AI チャットからツール呼び出しが end-to-end で動作 (Phase 2 A-1〜A-7)
- 読取系 / UI 系 capability を多数追加 (notes.search / timeline / user / lookup / notifications.list / drive.list / notes.show / notes.children 等)
- AI チャットに `<notedeck-context>` を注入し、可視ノート・直近会話・カラム種別ごとのコンテキストを供給
- AI チャットカラムで `/` (slash) によるコマンド直接実行、tool_use / tool_result の可視化、tool 入出力 JSON を shiki でハイライト
- AI 設定に permissions / dataSources を追加 (`ai.json5` schema 拡張 + UI)
- `SKILLS.md` を追加 (AI skill 技術リファレンス)

## Changelog (v0.15.10 → v0.16.0)
- feat: AI チャットの tool 入出力 JSON を shiki で syntax highlight
- feat: read 系 capability を 5 個追加 (user.lookup / notifications.list / drive.list / notes.show / notes.children)
- feat: AI チャットカラムで /(slash) コマンドによる capability 直接実行
- feat: notes capability の上限を 100 件に拡張 + untilId pagination
- feat(capabilities): add notes.search / timeline / user (Phase 2 A-7)
- docs: add SKILLS.md (AI skill technical reference)
- feat(capabilities): add 6 read-only / UI builtin capabilities (Phase 2 A-5)
- feat(commands): mirror AI-capable commands to capability registry (Phase 2 A-4)
- feat(ai-chat): visualize tool_use / tool_result in chat UI (Phase 2 A-3.3c)
- fix(capabilities): sanitize dotted capability id for AI tool name
- feat(ai-chat): wire AI tool calling end-to-end (Phase 2 A-3.3b)
- feat(ai-chat): wire format for tool_use / tool_result messages (Phase 2 A-3.3a)
- feat(ai-chat): forward tools to AI and stream tool_use events (Phase 2 A-3.2)
- feat(capabilities): add registry / dispatcher / tool schema (Phase 2 A-3.1)
- feat(capabilities): introduce Capability Registry types (Phase 2 A-1)
- feat(ai): split visible context block by column kind
- feat(ai): generalize visible items pipeline to non-note columns
- test(ai): add credential leak / preset coverage guards
- fix(ai): fall back to first timeline column when none is focused
- feat(ai): include recent conversation in <notedeck-context>
- feat(ai): pipe visible notes from timeline / list columns to AI
- feat(ai): inject <notedeck-context> into AI system prompt
- feat(ai): permissions / dataSources UI in AiSettingsContent
- feat(ai): add permissions / dataSources schema to ai.json5

## Test plan
- [ ] CI (lint, typecheck, test) green
- [ ] AI チャットで `/` コマンド実行 → tool_use / tool_result が可視化され JSON がシンタックスハイライトされる
- [ ] AI が `<notedeck-context>` 経由で可視ノート・直近会話を参照できる
- [ ] permissions / dataSources の設定 UI が動作 (`ai.json5` に永続化)
- [ ] notes / user / notifications / drive 系 capability が AI から呼び出せる