### PR TITLE
feat(site): スマホアプリのストア配布に向けたテスターと寄付の導線を追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -393,6 +393,32 @@
     </div>
   </section>
 
+  <!-- Mobile Store Distribution -->
+  <section class="section-default" id="mobile-store">
+    <div class="section-inner section-narrow">
+      <h2 class="section-title fade-in" data-direction="up">スマホ版を、ストアで届けるために</h2>
+      <p class="section-sub fade-in" data-direction="up">Google Play / App Store への正式配布には、開発者アカウントの登録費とクローズドテストの参加者が必要です。需要があれば、コミュニティの皆さんと一緒に進めたいと思っています。</p>
+      <div class="store-cta-grid">
+        <div class="store-cta glass fade-in" data-direction="up">
+          <div class="store-cta-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
+          </div>
+          <h3>ベータテスター募集</h3>
+          <p>Google Play では配布前に最低 12 名・14 日間のクローズドテストが必要です。実機での動作確認やフィードバックにご協力いただける方を募集しています。</p>
+          <a href="https://github.com/hitalin/notedeck/issues/new?title=%5BBeta%5D+%E3%82%B9%E3%83%88%E3%82%A2%E9%85%8D%E5%B8%83%E3%83%99%E3%83%BC%E3%82%BF%E3%83%86%E3%82%B9%E3%83%88%E5%BF%9C%E5%8B%9F" class="btn btn-secondary">テスターに応募</a>
+        </div>
+        <div class="store-cta glass fade-in" data-direction="up">
+          <div class="store-cta-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
+          </div>
+          <h3>開発を支援する</h3>
+          <p>Google Play（登録費 $25）/ Apple Developer Program（$99/年）のアカウント費用、テスト機材の調達、継続的な配布作業の維持にあてさせていただきます。</p>
+          <a href="https://github.com/sponsors/hitalin" class="btn btn-primary">GitHub Sponsor</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Footer -->
   <footer>
     <div class="footer-links">

--- a/site/style.css
+++ b/site/style.css
@@ -191,6 +191,15 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .guest-cta .btn{flex-shrink:0;white-space:nowrap}
 @media(max-width:640px){.guest-cta{flex-direction:column;text-align:center}.guest-cta .btn{align-self:center}}
 
+/* ===== Store CTA (mobile distribution) ===== */
+.store-cta-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1.5rem;margin-top:1.5rem}
+@media(max-width:800px){.store-cta-grid{grid-template-columns:1fr}}
+.store-cta{padding:2rem 1.75rem;text-align:center;display:flex;flex-direction:column;align-items:center}
+.store-cta:hover{transform:translateY(-5px)}
+.store-cta-icon{display:inline-flex;align-items:center;justify-content:center;width:60px;height:60px;border-radius:16px;background:linear-gradient(135deg,rgba(134,179,0,0.15),rgba(74,179,0,0.1));color:var(--accent);margin-bottom:1rem}
+.store-cta h3{font-size:1.2rem;font-weight:800;margin-bottom:.5rem}
+.store-cta p{color:var(--text-muted);font-size:.9rem;line-height:1.7;margin-bottom:1.25rem;flex:1}
+
 /* ===== Highlight rows (alternating left/right) ===== */
 .highlight-row{margin-bottom:2rem}
 .highlight-row:last-child{margin-bottom:0}


### PR DESCRIPTION
## Summary

- ランディングページ (`site/index.html`) の下部にスマホアプリストア配布に向けた CTA セクションを追加
- ベータテスター募集（GitHub Issue 起票へ誘導）と GitHub Sponsor の 2 導線を 2 カラムカードで配置
- ダウンロードセクション (`section-alt`) とフッターの間に `section-default` で挿入し、交互背景のリズムを維持
- スタイルは既存の `pillar` / `guest-cta` の調子に合わせた `store-cta-grid` / `store-cta` を新設（800px 以下で 1 カラム）

## Why

Google Play / App Store への正式配布には、開発者アカウントの登録費（Google Play \$25, Apple Developer Program \$99/年）と、Google Play の場合は最低 12 名・14 日間のクローズドテストが必要。需要があればコミュニティと一緒に進めたい、という方針をランディングページから可視化する。

## Test plan

- [ ] Cloudflare Pages のプレビュー (PR デプロイ) で見た目を確認
- [ ] デスクトップ幅で 2 カラム、モバイル幅 (≤800px) で 1 カラムになるか
- [ ] 「テスターに応募」リンクから新規 Issue 作成画面にタイトル prefilled で遷移するか
- [ ] 「GitHub Sponsor」リンクが https://github.com/sponsors/hitalin に遷移するか
- [ ] ダーク/ライト両方で視認性 OK

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)