### PR TITLE
Release v0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.16.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.16.0"
+version = "0.16.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/capabilities/builtins/column.test.ts
+++ b/src/capabilities/builtins/column.test.ts
@@ -20,6 +20,15 @@ describe('column.list capability', () => {
   it('uses dot-notation id', () => {
     expect(columnListCapability.id).toBe('column.list')
   })
+
+  it('advertises accountHost in signature description and returns', () => {
+    // <currentColumn> 補強と対をなす多サーバー対応:
+    // AI が account.list を呼ばずに「どれが misskey.io カラムか」判定できる
+    expect(columnListCapability.signature?.description).toContain('accountHost')
+    expect(columnListCapability.signature?.returns?.description).toContain(
+      'accountHost',
+    )
+  })
 })
 
 describe('column.add capability', () => {

--- a/src/capabilities/builtins/column.ts
+++ b/src/capabilities/builtins/column.ts
@@ -1,4 +1,5 @@
 import type { Command } from '@/commands/registry'
+import { useAccountsStore } from '@/stores/accounts'
 import type { ColumnType } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 
@@ -54,21 +55,31 @@ export const columnListCapability: Command = {
   permissions: [],
   signature: {
     description:
-      '現在開かれているカラムを配列で返す。各要素は { id, type, name, accountId } 等を含む。',
+      '現在開かれているカラムを配列で返す。各要素は' +
+      ' `{ id, type, name, accountId, accountHost }` を含む。' +
+      ' accountHost を見れば「どれが misskey.io のカラムか」を' +
+      ' account.list を呼ばずに判定できる。',
     params: {},
     returns: {
       type: 'array',
-      description: 'DeckColumn の配列',
+      description:
+        'DeckColumn 軽量 projection の配列 (id / type / name / accountId / accountHost)',
     },
   },
   visible: false,
   execute: () => {
-    return useDeckStore().columns.map((c) => ({
-      id: c.id,
-      type: c.type,
-      name: c.name,
-      accountId: c.accountId,
-    }))
+    const accounts = useAccountsStore().accounts
+    const hostById = new Map(accounts.map((a) => [a.id, a.host]))
+    return useDeckStore().columns.map((c) => {
+      const host = c.accountId ? hostById.get(c.accountId) : undefined
+      return {
+        id: c.id,
+        type: c.type,
+        name: c.name,
+        accountId: c.accountId,
+        ...(host ? { accountHost: host } : {}),
+      }
+    })
   },
 }
 

--- a/src/capabilities/builtins/drive.ts
+++ b/src/capabilities/builtins/drive.ts
@@ -36,9 +36,10 @@ export const driveListCapability: Command = {
   permissions: ['drive.read'],
   signature: {
     description:
-      '現在 active なアカウントの Misskey ドライブのファイル一覧を取得する。' +
+      '指定アカウント (未指定なら active) の Misskey ドライブのファイル一覧を取得する。' +
       ' folderId 省略でルート、fileType 指定 (例: `image/`) で MIME prefix' +
-      ' フィルタ。返り値は raw な配列 (id / name / type / size / url 等)。',
+      ' フィルタ。返り値は raw な配列 (id / name / type / size / url 等)。' +
+      ' 別サーバーのドライブを読むときは `<currentColumn>.accountId` を渡す。',
     params: {
       folderId: {
         type: 'string',
@@ -56,6 +57,13 @@ export const driveListCapability: Command = {
           'MIME prefix フィルタ (例: `image/` / `video/` / `application/pdf`)',
         optional: true,
       },
+      accountId: {
+        type: 'string',
+        description:
+          'どのアカウントのドライブを叩くか。未指定なら active アカウント。' +
+          ' 別サーバーのカラムを読むときは `<currentColumn>.accountId` を渡す。',
+        optional: true,
+      },
     },
     returns: {
       type: 'array',
@@ -64,7 +72,12 @@ export const driveListCapability: Command = {
   },
   visible: false,
   execute: async (params) => {
-    const accountId = useAccountsStore().activeAccountId
+    const explicitAccountId =
+      typeof params?.accountId === 'string' &&
+      params.accountId.trim().length > 0
+        ? params.accountId.trim()
+        : null
+    const accountId = explicitAccountId ?? useAccountsStore().activeAccountId
     if (!accountId) throw new Error('No active account')
     const folderId = pickStringOrNull(params?.folderId)
     const fileType = pickStringOrNull(params?.fileType)

--- a/src/capabilities/builtins/notes.ts
+++ b/src/capabilities/builtins/notes.ts
@@ -48,6 +48,25 @@ function pickUntilId(input: unknown): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined
 }
 
+function pickAccountId(input: unknown): string | undefined {
+  if (typeof input !== 'string') return undefined
+  const trimmed = input.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+/**
+ * AI tool description に共通で追記する `accountId` パラメタの説明文。
+ * AI が `<currentAccount>` と `<currentColumn>` の差を見て、別サーバーの
+ * カラムを読みたいときは `<currentColumn>.accountId` を渡せるよう示唆する。
+ */
+const ACCOUNT_ID_HINT =
+  '`accountId` 未指定なら active アカウントを使う。' +
+  ' active と異なるサーバーのカラムを読みたいときは `<currentColumn>.accountId` を渡す。'
+
+const ACCOUNT_ID_PARAM_DESC =
+  'どのアカウントの adapter で叩くか。未指定なら active アカウント。' +
+  ' 別サーバーのカラムを読むときは `<currentColumn>.accountId` を渡す。'
+
 /** `notes.search` — Misskey の /notes/search 経由でキーワード検索 */
 export const notesSearchCapability: Command = {
   id: 'notes.search',
@@ -61,7 +80,8 @@ export const notesSearchCapability: Command = {
     description:
       'キーワードでノートを全文検索する。Misskey の /notes/search を使う。' +
       ' 結果は note projection (id / userId / username / text / createdAt) で返す。' +
-      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。',
+      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。' +
+      ` ${ACCOUNT_ID_HINT}`,
     params: {
       query: {
         type: 'string',
@@ -78,6 +98,11 @@ export const notesSearchCapability: Command = {
           'この ID より前のノートを取得 (ページング用)。前回呼び出しの最後のノートの id を渡す。',
         optional: true,
       },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
     },
     returns: {
       type: 'array',
@@ -90,7 +115,8 @@ export const notesSearchCapability: Command = {
     if (!query) throw new Error('notes.search: query is required')
     const limit = clampLimit(params?.limit)
     const untilId = pickUntilId(params?.untilId)
-    const api = await getApiAdapter(undefined)
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const notes = await api.searchNotes(query, { limit, untilId })
     return projectVisibleItems(notes, 'search', limit)
   },
@@ -110,7 +136,8 @@ export const notesTimelineCapability: Command = {
       'タイムラインを取得する。home はログイン中のフォロー含むホーム、' +
       ' local はサーバー内ローカル、social はホーム+ローカル混合、' +
       ' global は連合宇宙全体。' +
-      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。',
+      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。' +
+      ` ${ACCOUNT_ID_HINT}`,
     params: {
       type: {
         type: 'string',
@@ -126,6 +153,11 @@ export const notesTimelineCapability: Command = {
         type: 'string',
         description:
           'この ID より前のノートを取得 (ページング用)。前回呼び出しの最後のノートの id を渡す。',
+        optional: true,
+      },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
         optional: true,
       },
     },
@@ -144,7 +176,8 @@ export const notesTimelineCapability: Command = {
     }
     const limit = clampLimit(params?.limit)
     const untilId = pickUntilId(params?.untilId)
-    const api = await getApiAdapter(undefined)
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const notes = await api.getTimeline(type as TimelineType, {
       limit,
       untilId,
@@ -166,7 +199,8 @@ export const notesUserCapability: Command = {
     description:
       '特定ユーザーの最近のノートを取得する。userId は Misskey の内部 ID' +
       ' (username ではなく)。' +
-      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。',
+      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。' +
+      ` ${ACCOUNT_ID_HINT}`,
     params: {
       userId: {
         type: 'string',
@@ -183,6 +217,11 @@ export const notesUserCapability: Command = {
           'この ID より前のノートを取得 (ページング用)。前回呼び出しの最後のノートの id を渡す。',
         optional: true,
       },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
     },
     returns: {
       type: 'array',
@@ -196,7 +235,8 @@ export const notesUserCapability: Command = {
     if (!userId) throw new Error('notes.user: userId is required')
     const limit = clampLimit(params?.limit)
     const untilId = pickUntilId(params?.untilId)
-    const api = await getApiAdapter(undefined)
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const notes = await api.getUserNotes(userId, { limit, untilId })
     return projectVisibleItems(notes, 'user', limit)
   },
@@ -214,11 +254,17 @@ export const notesShowCapability: Command = {
   signature: {
     description:
       'noteId で 1 件のノートを取得する。リプライ先や引用元の本文を見たい' +
-      ' ときに使う。戻り値は単一の note projection (配列ではない)。',
+      ' ときに使う。戻り値は単一の note projection (配列ではない)。' +
+      ` ${ACCOUNT_ID_HINT}`,
     params: {
       noteId: {
         type: 'string',
         description: 'Misskey 内部の note ID',
+      },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
       },
     },
     returns: {
@@ -232,7 +278,8 @@ export const notesShowCapability: Command = {
     const noteId =
       typeof params?.noteId === 'string' ? params.noteId.trim() : ''
     if (!noteId) throw new Error('notes.show: noteId is required')
-    const api = await getApiAdapter(undefined)
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const note = await api.getNote(noteId)
     // 配列を経由するが結果は 1 件目を返す (projection を再利用するため)
     return projectVisibleItems([note], 'search', 1)[0] ?? null
@@ -252,7 +299,8 @@ export const notesChildrenCapability: Command = {
     description:
       '指定ノートへの直接リプライ (= 子ノート) を取得する。会話のスレッドを' +
       ' 辿りたいときに使う。' +
-      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。',
+      ' 100 件を超えて取得したい場合は、最後のノートの id を untilId に渡して再呼び出し。' +
+      ` ${ACCOUNT_ID_HINT}`,
     params: {
       noteId: {
         type: 'string',
@@ -269,6 +317,11 @@ export const notesChildrenCapability: Command = {
           'この ID より前のリプライを取得 (ページング用)。前回呼び出しの最後のノートの id を渡す。',
         optional: true,
       },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
     },
     returns: {
       type: 'array',
@@ -282,7 +335,8 @@ export const notesChildrenCapability: Command = {
     if (!noteId) throw new Error('notes.children: noteId is required')
     const limit = clampLimit(params?.limit)
     const untilId = pickUntilId(params?.untilId)
-    const api = await getApiAdapter(undefined)
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const notes = await api.getNoteChildren(noteId, { limit, untilId })
     return projectVisibleItems(notes, 'search', limit)
   },

--- a/src/capabilities/builtins/notifications.ts
+++ b/src/capabilities/builtins/notifications.ts
@@ -11,9 +11,11 @@ import { useAccountsStore } from '@/stores/accounts'
 const MAX_NOTIFICATIONS_PER_CALL = 100
 const DEFAULT_LIMIT = 10
 
-async function getApiAdapter(): Promise<ApiAdapter> {
+async function getApiAdapter(
+  accountId: string | undefined,
+): Promise<ApiAdapter> {
   const store = useAccountsStore()
-  const id = store.activeAccountId
+  const id = accountId ?? store.activeAccountId
   if (!id) throw new Error('No active account')
   const acc = store.accounts.find((a) => a.id === id)
   if (!acc) throw new Error(`Account "${id}" not found`)
@@ -27,6 +29,12 @@ function clampLimit(input: unknown, fallback = DEFAULT_LIMIT): number {
 }
 
 function pickUntilId(input: unknown): string | undefined {
+  if (typeof input !== 'string') return undefined
+  const trimmed = input.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function pickAccountId(input: unknown): string | undefined {
   if (typeof input !== 'string') return undefined
   const trimmed = input.trim()
   return trimmed.length > 0 ? trimmed : undefined
@@ -47,9 +55,10 @@ export const notificationsListCapability: Command = {
   permissions: ['notifications'],
   signature: {
     description:
-      '現在 active なアカウントの通知一覧を取得する。type / userId / noteId /' +
-      ' reaction / createdAt 等の projection が返る。' +
-      ' 100 件を超えて取得したい場合は、最後の通知の id を untilId に渡して再呼び出し。',
+      '指定アカウント (未指定なら active) の通知一覧を取得する。' +
+      ' type / userId / noteId / reaction / createdAt 等の projection が返る。' +
+      ' 100 件を超えて取得したい場合は、最後の通知の id を untilId に渡して再呼び出し。' +
+      ' 別サーバーの通知を読むときは `<currentColumn>.accountId` を渡す。',
     params: {
       limit: {
         type: 'number',
@@ -62,6 +71,13 @@ export const notificationsListCapability: Command = {
           'この ID より前の通知を取得 (ページング用)。前回呼び出しの最後の通知の id を渡す。',
         optional: true,
       },
+      accountId: {
+        type: 'string',
+        description:
+          'どのアカウントの通知を取るか。未指定なら active アカウント。' +
+          ' 別サーバーのカラムを読むときは `<currentColumn>.accountId` を渡す。',
+        optional: true,
+      },
     },
     returns: {
       type: 'array',
@@ -72,7 +88,8 @@ export const notificationsListCapability: Command = {
   execute: async (params) => {
     const limit = clampLimit(params?.limit)
     const untilId = pickUntilId(params?.untilId)
-    const api = await getApiAdapter()
+    const accountId = pickAccountId(params?.accountId)
+    const api = await getApiAdapter(accountId)
     const notifications = await api.getNotifications({ limit, untilId })
     return projectVisibleItems(notifications, 'notifications', limit)
   },

--- a/src/capabilities/builtins/user.ts
+++ b/src/capabilities/builtins/user.ts
@@ -13,9 +13,11 @@ import { useAccountsStore } from '@/stores/accounts'
  * Misskey の `users/show` を使う。host は `@hitalin@yami.ski` の `yami.ski` 部分
  * (ローカル / 自インスタンスのときは省略可)。
  */
-async function getApiAdapter(): Promise<ApiAdapter> {
+async function getApiAdapter(
+  accountId: string | undefined,
+): Promise<ApiAdapter> {
   const store = useAccountsStore()
-  const id = store.activeAccountId
+  const id = accountId ?? store.activeAccountId
   if (!id) throw new Error('No active account')
   const acc = store.accounts.find((a) => a.id === id)
   if (!acc) throw new Error(`Account "${id}" not found`)
@@ -35,7 +37,8 @@ export const userLookupCapability: Command = {
     description:
       'username (+ 任意で host) から Misskey ユーザー情報を取得する。' +
       ' `@user@example.com` 形式から userId を引いて notes.user に渡す動線で使う。' +
-      ' 戻り値の id が Misskey 内部の user ID。',
+      ' 戻り値の id が Misskey 内部の user ID。' +
+      ' 別サーバー視点で lookup したいときは `<currentColumn>.accountId` を渡す。',
     params: {
       username: {
         type: 'string',
@@ -45,6 +48,13 @@ export const userLookupCapability: Command = {
         type: 'string',
         description:
           'リモートホスト (例: `yami.ski`)。同インスタンス内ユーザーなら省略。',
+        optional: true,
+      },
+      accountId: {
+        type: 'string',
+        description:
+          'どのアカウントの adapter で lookup するか。未指定なら active アカウント。' +
+          ' 別サーバーのカラムを操作中なら `<currentColumn>.accountId` を渡す。',
         optional: true,
       },
     },
@@ -67,7 +77,12 @@ export const userLookupCapability: Command = {
       typeof params?.host === 'string' && params.host.trim().length > 0
         ? params.host.trim()
         : null
-    const api = await getApiAdapter()
+    const accountId =
+      typeof params?.accountId === 'string' &&
+      params.accountId.trim().length > 0
+        ? params.accountId.trim()
+        : undefined
+    const api = await getApiAdapter(accountId)
     const user = await api.lookupUser(username, host)
     return stripCredentials(user)
   },

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -483,6 +483,7 @@ async function sendMessage() {
         currentColumn: focusedColumn ?? props.column,
         visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
         recentConversation: projectRecentConversation(history),
+        accounts: accountsStore.accounts,
       })
       const system = joinSystemPrompt(skillsPrompt, contextBlock)
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -248,6 +248,68 @@ describe('buildAiContextBlock', () => {
     expect(block).toContain('<currentColumn>')
     expect(block).toContain('"id": "col-1"')
   })
+
+  it('enriches currentColumn with accountHost when accounts is provided', () => {
+    const cfg = configWithDataSources('safe')
+    const column = {
+      id: 'col-misskey-io',
+      type: 'timeline',
+      name: 'misskey.io LTL',
+      accountId: 'acc-2',
+    } as unknown as DeckColumn
+    const accounts: Account[] = [
+      SAMPLE_ACCOUNT,
+      {
+        id: 'acc-2',
+        host: 'misskey.io',
+        userId: 'u2',
+        username: 'sub',
+        displayName: 'Sub',
+        avatarUrl: null,
+        software: 'misskey-dev/misskey',
+        hasToken: true,
+      },
+    ]
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: column,
+      accounts,
+    })
+    // <currentColumn> 内に accountHost が出る
+    expect(block).toContain('"accountHost": "misskey.io"')
+    expect(block).toContain('"accountId": "acc-2"')
+  })
+
+  it('does not add accountHost when column.accountId is null', () => {
+    const cfg = configWithDataSources('safe')
+    const column = {
+      id: 'col-noacc',
+      type: 'timeline',
+      name: 'TL',
+      accountId: null,
+    } as unknown as DeckColumn
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: column,
+      accounts: [SAMPLE_ACCOUNT],
+    })
+    expect(block).not.toContain('accountHost')
+  })
+
+  it('does not add accountHost when accounts list is omitted (back-compat)', () => {
+    const cfg = configWithDataSources('safe')
+    const column = {
+      id: 'col-x',
+      type: 'timeline',
+      name: 'TL',
+      accountId: 'acc-1',
+    } as unknown as DeckColumn
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: SAMPLE_ACCOUNT,
+      currentColumn: column,
+    })
+    expect(block).not.toContain('accountHost')
+  })
 })
 
 describe('projectVisibleNotes', () => {

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -51,6 +51,12 @@ export interface AiContextInput {
   visibleNotes?: unknown[]
   /** Phase 1 C5 で接続予定。未指定なら出力しない。 */
   recentConversation?: unknown[]
+  /**
+   * accountId → host 引きのための accounts 一覧 (任意)。指定すると
+   * `<currentColumn>` 内に `accountHost` を補強し、AI が「このカラムは
+   * どのサーバーか」を即把握できる。
+   */
+  accounts?: readonly Account[]
 }
 
 /** AI に渡す可視ノートの上限件数。 */
@@ -243,6 +249,21 @@ function jsonBlock(obj: unknown): string {
 }
 
 /**
+ * column.accountId が accounts のどれか一致したら `accountHost` を加えて返す。
+ * AI が `<currentColumn>` を見るだけで「これは misskey.io のカラム」と即理解
+ * できるようにするための補強。
+ */
+function enrichColumnWithHost(
+  column: DeckColumn,
+  accounts: readonly Account[] | undefined,
+): DeckColumn & { accountHost?: string } {
+  if (!accounts || !column.accountId) return column
+  const acc = accounts.find((a) => a.id === column.accountId)
+  if (!acc) return column
+  return { ...column, accountHost: acc.host }
+}
+
+/**
  * dataSources 設定と context 入力から `<notedeck-context>` XML ブロックを組む。
  * 何も入らない場合は空文字列を返す (skills prompt との結合で no-op になる)。
  */
@@ -259,9 +280,8 @@ export function buildAiContextBlock(
     )
   }
   if (ds.currentColumn && ctx.currentColumn) {
-    parts.push(
-      `  <currentColumn>\n${jsonBlock(ctx.currentColumn)}\n  </currentColumn>`,
-    )
+    const enriched = enrichColumnWithHost(ctx.currentColumn, ctx.accounts)
+    parts.push(`  <currentColumn>\n${jsonBlock(enriched)}\n  </currentColumn>`)
   }
   if (ds.visibleNotes && ctx.visibleNotes && ctx.visibleNotes.length > 0) {
     const tag = pickVisibleBlockTag(ctx.currentColumn?.type)


### PR DESCRIPTION
## Summary

v0.16.0 以降のパッチリリース。AI capability のマルチサーバー対応 fix とサイト導線追加。

## Changes since v0.16.0

- fix(ai): capability に accountId param を追加してマルチサーバー対応
- fix(ai): column.list にも accountHost を追加 (前コミットと対をなす)
- feat(site): スマホアプリのストア配布に向けたテスターと寄付の導線を追加
- chore: bump version to 0.16.1

## Test plan

- [x] pre-commit hook (biome + vue-tsc) パス
- [x] cargo check パス (Cargo.lock 同期)
- [ ] CI (lint / typecheck / test) パス確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)