### PR TITLE
Release v0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.18.0"
+version = "0.19.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/capabilities/builtins/account.ts
+++ b/src/capabilities/builtins/account.ts
@@ -30,6 +30,8 @@ export const accountCurrentCapability: Command = {
         '`{ id, host, userId, username, displayName, avatarUrl, software, hasToken }`' +
         ' (アクティブなアカウントが無いときは null)',
     },
+    // store lookup のみ、API 呼び出しなし
+    cheap: true,
   },
   visible: false,
   execute: () => {
@@ -58,6 +60,8 @@ export const accountListCapability: Command = {
       type: 'array',
       description: 'Account の配列',
     },
+    // store lookup のみ、API 呼び出しなし
+    cheap: true,
   },
   visible: false,
   execute: () => {

--- a/src/capabilities/builtins/column.ts
+++ b/src/capabilities/builtins/column.ts
@@ -65,6 +65,8 @@ export const columnListCapability: Command = {
       description:
         'DeckColumn 軽量 projection の配列 (id / type / name / accountId / accountHost)',
     },
+    // deck store 照会のみ、API 呼び出しなし
+    cheap: true,
   },
   visible: false,
   execute: () => {

--- a/src/capabilities/builtins/time.ts
+++ b/src/capabilities/builtins/time.ts
@@ -22,6 +22,8 @@ export const timeNowCapability: Command = {
       type: 'string',
       description: 'ISO 8601 形式の現在時刻 (例: 2026-05-01T12:34:56.789Z)',
     },
+    // ローカル時刻計算のみ、副作用なし
+    cheap: true,
   },
   execute: () => new Date().toISOString(),
 }

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -50,6 +50,16 @@ export interface CapabilitySignature {
   params?: Record<string, ParameterDef>
   /** 戻り値の型 */
   returns?: ReturnTypeDef
+  /**
+   * HEARTBEAT Cheap Check First (#411) で「変化検知」専用に使ってよい
+   * capability か。true = ローカル / API 軽量 / 副作用なし / 結果が単純
+   * (件数や id 等)。HEARTBEAT runner は cheap=true な capability のみを
+   * skill の `cheapCheckCapabilities` 候補として受け入れる (= 重い API を
+   * tick ごとに連発するのを防ぐ)。
+   *
+   * 未指定 = false (= cheap check では使えない、AI tool としては通常通り使用可)。
+   */
+  cheap?: boolean
 }
 
 // 呼び出し元側で permissions 宣言型を参照するときの再 export

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -134,6 +134,7 @@ function createNewSkill() {
     triggers: [],
     scope: 'global',
     body: '指示文をここに記述します。\n',
+    cheapCheckCapabilities: [],
   })
   windowsStore.open('skill-edit', { skillId: skill.id })
 }

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -938,6 +938,30 @@ function handleReset() {
             </div>
           </div>
 
+          <!-- デスクトップ通知 (#411 0.19.0): 重要発見を即気付ける。
+               アプリにフォーカスがあるときは自動抑制。 -->
+          <div
+            v-if="config.heartbeat.enabled"
+            :class="$style.switchRow"
+            @click="config.heartbeat.desktopNotification = !config.heartbeat.desktopNotification"
+          >
+            <div :class="$style.switchRowLabelStack">
+              <span :class="$style.switchRowLabel">デスクトップ通知</span>
+              <span :class="$style.switchRowSubLabel">
+                重要発見 (HEARTBEAT_OK 以外) を OS 通知で表示。アプリに
+                フォーカスがあれば自動抑制
+              </span>
+            </div>
+            <button
+              class="nd-toggle-switch"
+              :class="{ on: config.heartbeat.desktopNotification }"
+              :aria-checked="config.heartbeat.desktopNotification"
+              role="switch"
+            >
+              <span class="nd-toggle-switch-knob" />
+            </button>
+          </div>
+
           <!-- Cheap Check First (#411): skill 側で cheapCheckCapabilities 宣言した
                heartbeat skill に対して、tick 開始時に「変化検知」用の軽量 capability
                を呼び、前回値と一致すれば AI 起動を skip する。

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -12,9 +12,13 @@ import {
   defaultConfig,
   deleteApiKey,
   getApiKeyStatus,
+  HEARTBEAT_DAILY_MAX_AI_RUNS_MAX,
+  HEARTBEAT_DAILY_MAX_AI_RUNS_MIN,
   HEARTBEAT_INTERVAL_DEFAULT_MINUTES,
   HEARTBEAT_INTERVAL_MAX_MINUTES,
   HEARTBEAT_INTERVAL_MIN_MINUTES,
+  HEARTBEAT_MAX_SKIP_HOURS_MAX,
+  HEARTBEAT_MAX_SKIP_HOURS_MIN,
   HIGH_RISK_PERMISSION_KEYS,
   PERMISSION_KEYS,
   type PermissionKey,
@@ -933,6 +937,88 @@ function handleReset() {
               </div>
             </div>
           </div>
+
+          <!-- Cheap Check First (#411): skill 側で cheapCheckCapabilities 宣言した
+               heartbeat skill に対して、tick 開始時に「変化検知」用の軽量 capability
+               を呼び、前回値と一致すれば AI 起動を skip する。
+               opt-out 可能 (= 常に AI を叩きたい場合は OFF にする)。 -->
+          <template v-if="config.heartbeat.enabled">
+            <div
+              :class="$style.switchRow"
+              @click="config.heartbeat.cheapCheck.enabled = !config.heartbeat.cheapCheck.enabled"
+            >
+              <div :class="$style.switchRowLabelStack">
+                <span :class="$style.switchRowLabel">Cheap Check First</span>
+                <span :class="$style.switchRowSubLabel">
+                  変化なしなら AI を起動せず HEARTBEAT_OK 扱い (skill 側で
+                  cheapCheckCapabilities の宣言が必要)
+                </span>
+              </div>
+              <button
+                class="nd-toggle-switch"
+                :class="{ on: config.heartbeat.cheapCheck.enabled }"
+                :aria-checked="config.heartbeat.cheapCheck.enabled"
+                role="switch"
+              >
+                <span class="nd-toggle-switch-knob" />
+              </button>
+            </div>
+
+            <div v-if="config.heartbeat.cheapCheck.enabled" :class="$style.field">
+              <div :class="$style.fieldHeader">
+                <span :class="$style.fieldLabel">最大連続 skip 時間</span>
+                <div :class="$style.fieldValue">
+                  <input
+                    v-model.number="config.heartbeat.cheapCheck.maxSkipHours"
+                    type="number"
+                    :min="HEARTBEAT_MAX_SKIP_HOURS_MIN"
+                    :max="HEARTBEAT_MAX_SKIP_HOURS_MAX"
+                    :class="$style.numberInput"
+                  />
+                  <span :class="$style.fieldUnit">時間</span>
+                </div>
+              </div>
+            </div>
+          </template>
+
+          <!-- 安全装置 (#411): 1 日の AI 起動上限 + 上限到達時の動作 -->
+          <template v-if="config.heartbeat.enabled">
+            <div :class="$style.field">
+              <div :class="$style.fieldHeader">
+                <span :class="$style.fieldLabel">1 日の AI 起動上限</span>
+                <div :class="$style.fieldValue">
+                  <input
+                    v-model.number="config.heartbeat.dailyMaxAiRuns"
+                    type="number"
+                    :min="HEARTBEAT_DAILY_MAX_AI_RUNS_MIN"
+                    :max="HEARTBEAT_DAILY_MAX_AI_RUNS_MAX"
+                    :class="$style.numberInput"
+                  />
+                  <span :class="$style.fieldUnit">回 / 日</span>
+                </div>
+              </div>
+            </div>
+
+            <div
+              :class="$style.switchRow"
+              @click="config.heartbeat.onDailyLimit = config.heartbeat.onDailyLimit === 'disable' ? 'warn' : 'disable'"
+            >
+              <div :class="$style.switchRowLabelStack">
+                <span :class="$style.switchRowLabel">上限到達時に自動停止</span>
+                <span :class="$style.switchRowSubLabel">
+                  OFF = 警告のみで継続 / ON = HEARTBEAT を自動 disable
+                </span>
+              </div>
+              <button
+                class="nd-toggle-switch"
+                :class="{ on: config.heartbeat.onDailyLimit === 'disable' }"
+                :aria-checked="config.heartbeat.onDailyLimit === 'disable'"
+                role="switch"
+              >
+                <span class="nd-toggle-switch-knob" />
+              </button>
+            </div>
+          </template>
 
           <!-- HEARTBEAT 用権限 (chat 用とは独立。default readonly 推奨) -->
           <template v-if="config.heartbeat.enabled">

--- a/src/composables/useAiConfig.test.ts
+++ b/src/composables/useAiConfig.test.ts
@@ -231,12 +231,17 @@ describe('mergeConfig', () => {
 })
 
 describe('heartbeat config (#411 Phase 6)', () => {
-  it('default has enabled=false, interval=30, target=auto, permissions=readonly', () => {
+  it('default has enabled=false, interval=30, target=auto, permissions=readonly + cheap-check defaults', () => {
     const cfg = defaultConfig()
     expect(cfg.heartbeat.enabled).toBe(false)
     expect(cfg.heartbeat.intervalMinutes).toBe(30)
     expect(cfg.heartbeat.target).toBe('auto')
     expect(cfg.heartbeat.permissions.preset).toBe('readonly')
+    // Cheap Check First (#411) defaults
+    expect(cfg.heartbeat.cheapCheck.enabled).toBe(true)
+    expect(cfg.heartbeat.cheapCheck.maxSkipHours).toBe(24)
+    expect(cfg.heartbeat.dailyMaxAiRuns).toBe(48)
+    expect(cfg.heartbeat.onDailyLimit).toBe('warn')
     // 旧 field が混入していないこと (accountId / denyDuringHeartbeat / skills)
     expect(
       (cfg.heartbeat as unknown as Record<string, unknown>).accountId,

--- a/src/composables/useAiConfig.test.ts
+++ b/src/composables/useAiConfig.test.ts
@@ -242,6 +242,8 @@ describe('heartbeat config (#411 Phase 6)', () => {
     expect(cfg.heartbeat.cheapCheck.maxSkipHours).toBe(24)
     expect(cfg.heartbeat.dailyMaxAiRuns).toBe(48)
     expect(cfg.heartbeat.onDailyLimit).toBe('warn')
+    // Desktop notification (#411 0.19.0)
+    expect(cfg.heartbeat.desktopNotification).toBe(true)
     // 旧 field が混入していないこと (accountId / denyDuringHeartbeat / skills)
     expect(
       (cfg.heartbeat as unknown as Record<string, unknown>).accountId,

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -158,6 +158,16 @@ export interface HeartbeatConfig {
    * - `'disable'`: toast + `heartbeat.enabled = false` で daemon 自動停止
    */
   onDailyLimit: HeartbeatDailyLimitAction
+  /**
+   * HEARTBEAT が「重要発見」と判定した内容 (= suppression を通過したテキスト) を
+   * OS デスクトップ通知として表示するか。
+   *
+   * - target='none' のとき (= silent log) は通知も出さない
+   * - アプリにフォーカスがあるとき (`document.hasFocus()`) は通知抑制
+   *   (sendDesktopNotification 内で判定)
+   * - default: true (= 重要発見があれば即気付ける = HEARTBEAT 本来の意義)
+   */
+  desktopNotification: boolean
 }
 
 /**
@@ -331,6 +341,7 @@ export function defaultConfig(): AiConfig {
       },
       dailyMaxAiRuns: defaultFileConfig.heartbeat.dailyMaxAiRuns,
       onDailyLimit: defaultFileConfig.heartbeat.onDailyLimit,
+      desktopNotification: defaultFileConfig.heartbeat.desktopNotification,
     },
   }
 }
@@ -390,6 +401,7 @@ export function normalizeHeartbeatConfig(
     cheapCheck,
     dailyMaxAiRuns,
     onDailyLimit,
+    desktopNotification: cfg.desktopNotification !== false, // default true
   }
 }
 
@@ -431,6 +443,8 @@ function mergeHeartbeat(
     },
     dailyMaxAiRuns: partial?.dailyMaxAiRuns ?? base.dailyMaxAiRuns,
     onDailyLimit: partial?.onDailyLimit ?? base.onDailyLimit,
+    desktopNotification:
+      partial?.desktopNotification ?? base.desktopNotification,
   })
 }
 

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -81,6 +81,23 @@ export const HEARTBEAT_INTERVAL_DEFAULT_MINUTES = 30
  */
 export const HEARTBEAT_ACK_MAX_CHARS = 300
 
+/** Cheap Check First (#411) のセーフティ用最小 / 最大 / デフォルト値。 */
+export const HEARTBEAT_MAX_SKIP_HOURS_MIN = 1
+export const HEARTBEAT_MAX_SKIP_HOURS_MAX = 24 * 7 // 1 週間
+export const HEARTBEAT_MAX_SKIP_HOURS_DEFAULT = 24
+
+export const HEARTBEAT_DAILY_MAX_AI_RUNS_MIN = 1
+export const HEARTBEAT_DAILY_MAX_AI_RUNS_MAX = 1000
+/**
+ * 1 日あたりの AI 起動上限のデフォルト。30 分 interval で毎回 AI を
+ * 叩いた場合の最大値 (48 = 24h / 0.5h)。Cheap Check で skip された tick
+ * はこのカウントには含めない。
+ */
+export const HEARTBEAT_DAILY_MAX_AI_RUNS_DEFAULT = 48
+
+/** 上限到達時の動作。 */
+export type HeartbeatDailyLimitAction = 'warn' | 'disable'
+
 /**
  * 出力先 AI session の routing。OpenClaw HEARTBEAT の `target` と同概念。
  * - `'auto'`: kind='heartbeat' の専用 session を auto-create + 永続使用 (default)
@@ -88,6 +105,26 @@ export const HEARTBEAT_ACK_MAX_CHARS = 300
  * - 任意の文字列 (= session id): 既存 session に明示 pin
  */
 export type HeartbeatTarget = 'auto' | 'none' | string
+
+/**
+ * Cheap Check First (#411) — tick 開始時に「変化検知」専用の軽量 capability
+ * (= cheap=true マーク済み) を呼び、前回値と一致すれば AI 起動を skip して
+ * HEARTBEAT_OK 扱いにする機構。
+ *
+ * Skill 側で `cheapCheckCapabilities: string[]` を frontmatter で宣言した
+ * skill にだけ発動する (= opt-in)。宣言なしの skill は従来通り毎回 AI を
+ * 叩く。さらに global で `enabled: false` にすれば全 skill で機構を完全停止。
+ */
+export interface CheapCheckConfig {
+  /** false で機構自体を停止 (= 全 skill で常に AI を叩く)。default: true */
+  enabled: boolean
+  /**
+   * 「変化なし」と判定し続けた場合でも、N 時間に 1 回は強制 AI 起動する
+   * セーフティ。cheap check が壊れていても定期的に AI が動くことを保証。
+   * default: 24 時間 (= 1 日 1 回は最低でも AI 起動)。
+   */
+  maxSkipHours: number
+}
 
 export interface HeartbeatConfig {
   /** false なら daemon は何もしない (default) */
@@ -108,6 +145,19 @@ export interface HeartbeatConfig {
    * `permissions[]` (required) と照合し、満たさないものを tool 一覧から除外。
    */
   permissions: PermissionsConfig
+  /** Cheap Check First の global 設定。詳細は {@link CheapCheckConfig}。 */
+  cheapCheck: CheapCheckConfig
+  /**
+   * 1 日あたりの AI 起動上限。Cheap Check で skip された tick は除外。
+   * default: 48 (= 30 分 interval で毎回叩いた場合の最大値)。
+   */
+  dailyMaxAiRuns: number
+  /**
+   * 上限到達時の動作:
+   * - `'warn'`: toast 出して **継続** (= AI を呼んで進める)
+   * - `'disable'`: toast + `heartbeat.enabled = false` で daemon 自動停止
+   */
+  onDailyLimit: HeartbeatDailyLimitAction
 }
 
 /**
@@ -275,37 +325,71 @@ export function defaultConfig(): AiConfig {
         preset: defaultFileConfig.heartbeat.permissions.preset,
         custom: { ...defaultFileConfig.heartbeat.permissions.custom },
       },
+      cheapCheck: {
+        enabled: defaultFileConfig.heartbeat.cheapCheck.enabled,
+        maxSkipHours: defaultFileConfig.heartbeat.cheapCheck.maxSkipHours,
+      },
+      dailyMaxAiRuns: defaultFileConfig.heartbeat.dailyMaxAiRuns,
+      onDailyLimit: defaultFileConfig.heartbeat.onDailyLimit,
     },
   }
 }
 
+function clampInt(
+  value: unknown,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : NaN
+  if (Number.isNaN(n)) return fallback
+  return Math.max(min, Math.min(max, Math.floor(n)))
+}
+
 /**
- * 設定値の sanity 補正。intervalMinutes を MIN〜MAX に clamp、
- * denyDuringHeartbeat は string[] として保持。
+ * 設定値の sanity 補正。
+ * - intervalMinutes / cheapCheck.maxSkipHours / dailyMaxAiRuns を MIN〜MAX に clamp
+ * - target は文字列なら何でも受け取る (空 / null は 'auto' にフォールバック)
+ * - onDailyLimit は 'warn' / 'disable' 以外なら 'warn' にフォールバック
  */
 export function normalizeHeartbeatConfig(
   cfg: HeartbeatConfig,
 ): HeartbeatConfig {
-  const interval = Number.isFinite(cfg.intervalMinutes)
-    ? Math.max(
-        HEARTBEAT_INTERVAL_MIN_MINUTES,
-        Math.min(
-          HEARTBEAT_INTERVAL_MAX_MINUTES,
-          Math.floor(cfg.intervalMinutes),
-        ),
-      )
-    : HEARTBEAT_INTERVAL_DEFAULT_MINUTES
-  // target は文字列なら何でも受け取る ('auto' / 'none' / 任意 session id)。
-  // 空文字 / null / undefined は 'auto' にフォールバック。
+  const interval = clampInt(
+    cfg.intervalMinutes,
+    HEARTBEAT_INTERVAL_MIN_MINUTES,
+    HEARTBEAT_INTERVAL_MAX_MINUTES,
+    HEARTBEAT_INTERVAL_DEFAULT_MINUTES,
+  )
   const target: HeartbeatTarget =
     typeof cfg.target === 'string' && cfg.target.length > 0
       ? cfg.target
       : 'auto'
+  const cheapCheck: CheapCheckConfig = {
+    enabled: cfg.cheapCheck?.enabled !== false, // default true
+    maxSkipHours: clampInt(
+      cfg.cheapCheck?.maxSkipHours,
+      HEARTBEAT_MAX_SKIP_HOURS_MIN,
+      HEARTBEAT_MAX_SKIP_HOURS_MAX,
+      HEARTBEAT_MAX_SKIP_HOURS_DEFAULT,
+    ),
+  }
+  const dailyMaxAiRuns = clampInt(
+    cfg.dailyMaxAiRuns,
+    HEARTBEAT_DAILY_MAX_AI_RUNS_MIN,
+    HEARTBEAT_DAILY_MAX_AI_RUNS_MAX,
+    HEARTBEAT_DAILY_MAX_AI_RUNS_DEFAULT,
+  )
+  const onDailyLimit: HeartbeatDailyLimitAction =
+    cfg.onDailyLimit === 'disable' ? 'disable' : 'warn'
   return {
     enabled: !!cfg.enabled,
     intervalMinutes: interval,
     target,
     permissions: cfg.permissions,
+    cheapCheck,
+    dailyMaxAiRuns,
+    onDailyLimit,
   }
 }
 
@@ -340,6 +424,13 @@ function mergeHeartbeat(
     intervalMinutes: partial?.intervalMinutes ?? base.intervalMinutes,
     target: partial?.target ?? base.target,
     permissions: mergePermissions(base.permissions, partial?.permissions),
+    cheapCheck: {
+      enabled: partial?.cheapCheck?.enabled ?? base.cheapCheck.enabled,
+      maxSkipHours:
+        partial?.cheapCheck?.maxSkipHours ?? base.cheapCheck.maxSkipHours,
+    },
+    dailyMaxAiRuns: partial?.dailyMaxAiRuns ?? base.dailyMaxAiRuns,
+    onDailyLimit: partial?.onDailyLimit ?? base.onDailyLimit,
   })
 }
 

--- a/src/composables/useHeartbeatDaemon.test.ts
+++ b/src/composables/useHeartbeatDaemon.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { defaultConfig } from './useAiConfig'
 import {
   _internal,
   applyHeartbeatSuppression,
+  decideCheapCheck,
   HEARTBEAT_OK_TOKEN,
 } from './useHeartbeatDaemon'
 
@@ -88,5 +90,102 @@ describe('HEARTBEAT_INSTRUCTION', () => {
   it('mentions HEARTBEAT skill (= OpenClaw style "follow strictly")', () => {
     expect(_internal.HEARTBEAT_INSTRUCTION).toContain('HEARTBEAT')
     expect(_internal.HEARTBEAT_INSTRUCTION).toContain('過去の会話')
+  })
+})
+
+describe('decideCheapCheck (#411 Cheap Check First)', () => {
+  const NOW = 1_700_000_000_000
+
+  function configWithCheapCheck(overrides?: {
+    enabled?: boolean
+    maxSkipHours?: number
+  }) {
+    const cfg = defaultConfig()
+    if (overrides?.enabled !== undefined) {
+      cfg.heartbeat.cheapCheck.enabled = overrides.enabled
+    }
+    if (overrides?.maxSkipHours !== undefined) {
+      cfg.heartbeat.cheapCheck.maxSkipHours = overrides.maxSkipHours
+    }
+    return cfg
+  }
+
+  const emptyState = { lastResultsHash: {}, lastAiRunAt: {} }
+
+  it('global disabled → 常に AI 起動 (reason: cheap-check-disabled)', () => {
+    const out = decideCheapCheck(
+      { s1: 'hash-A' },
+      { lastResultsHash: { s1: 'hash-A' }, lastAiRunAt: { s1: NOW } },
+      configWithCheapCheck({ enabled: false }),
+      NOW,
+    )
+    expect(out.shouldRunAi).toBe(true)
+    expect(out.reason).toBe('cheap-check-disabled')
+  })
+
+  it('newHashes 空 (= どの skill も宣言なし) → 常に AI 起動', () => {
+    const out = decideCheapCheck({}, emptyState, configWithCheapCheck(), NOW)
+    expect(out.shouldRunAi).toBe(true)
+    expect(out.reason).toBe('no-cheap-check-declared')
+  })
+
+  it('1 つでも hash 変化があれば AI 起動 (reason: changed:<id>)', () => {
+    const out = decideCheapCheck(
+      { s1: 'hash-A', s2: 'hash-B-NEW' },
+      {
+        lastResultsHash: { s1: 'hash-A', s2: 'hash-B' },
+        lastAiRunAt: { s1: NOW, s2: NOW },
+      },
+      configWithCheapCheck(),
+      NOW,
+    )
+    expect(out.shouldRunAi).toBe(true)
+    expect(out.reason).toMatch(/^changed:s\d$/)
+  })
+
+  it('全一致 + maxSkipHours 内 → skip (HEARTBEAT_OK 扱い)', () => {
+    const out = decideCheapCheck(
+      { s1: 'hash-A' },
+      { lastResultsHash: { s1: 'hash-A' }, lastAiRunAt: { s1: NOW } },
+      configWithCheapCheck({ maxSkipHours: 24 }),
+      NOW + 1000, // 1 秒後 (= skip window 内)
+    )
+    expect(out.shouldRunAi).toBe(false)
+    expect(out.reason).toBe('no-change-within-skip-window')
+  })
+
+  it('全一致だが maxSkipHours 経過 → 強制 AI 起動', () => {
+    const out = decideCheapCheck(
+      { s1: 'hash-A' },
+      { lastResultsHash: { s1: 'hash-A' }, lastAiRunAt: { s1: NOW } },
+      configWithCheapCheck({ maxSkipHours: 1 }),
+      NOW + 2 * 60 * 60 * 1000, // 2 時間後
+    )
+    expect(out.shouldRunAi).toBe(true)
+    expect(out.reason).toBe('max-skip-hours-elapsed')
+  })
+
+  it('lastAiRunAt が prev に存在しない (初回 tick) → 強制 AI 起動', () => {
+    // hash は一致 (= 何らかの理由で前回 hash だけ書かれて lastAiRunAt が
+    // 未記録) のとき、無限 skip を避けるため AI 起動する
+    const out = decideCheapCheck(
+      { s1: 'hash-A' },
+      { lastResultsHash: { s1: 'hash-A' }, lastAiRunAt: {} },
+      configWithCheapCheck(),
+      NOW,
+    )
+    expect(out.shouldRunAi).toBe(true)
+    expect(out.reason).toBe('max-skip-hours-elapsed')
+  })
+
+  it('newHashes をそのまま反映する (state 更新用)', () => {
+    const newHashes = { s1: 'hash-NEW' }
+    const out = decideCheapCheck(
+      newHashes,
+      emptyState,
+      configWithCheapCheck(),
+      NOW,
+    )
+    expect(out.newHashes).toEqual(newHashes)
   })
 })

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -33,6 +33,7 @@ import { type AiSession, useAiSessionsStore } from '@/stores/aiSessions'
 import { type SkillMeta, useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
+import { sendDesktopNotification } from '@/utils/desktopNotification'
 import { isTauri } from '@/utils/settingsFs'
 import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -660,6 +661,16 @@ export function useHeartbeatDaemon() {
       heartbeat: true,
     }
     sessionsStore.updateMessages(target.id, [...target.messages, message])
+
+    // OS デスクトップ通知 (#411 0.19.0): 「重要発見」を即気付ける。
+    // - cfg.desktopNotification=false なら出さない (= ユーザー opt-out)
+    // - sendDesktopNotification 内で document.hasFocus() を見て、アプリに
+    //   フォーカスあれば自動抑制 (= ユーザーが既にアプリを見ている)
+    // - 通知 body は長文をブラウザ側で切り詰められるので 200 文字 trim
+    if (cfg.desktopNotification) {
+      const body = visible.length > 200 ? `${visible.slice(0, 200)}…` : visible
+      sendDesktopNotification('HEARTBEAT', body)
+    }
 
     // 新規 session のときだけ AI でタイトル要約を試す。失敗したら
     // timestampTitle ('YYYY-MM-DD HH:mm のHEARTBEAT') がそのまま残る。

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -26,17 +26,19 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { computed, onScopeDispose, ref, watch } from 'vue'
 import { dispatchCapability } from '@/capabilities/dispatcher'
-import { listCapabilities } from '@/capabilities/registry'
+import { getCapability, listCapabilities } from '@/capabilities/registry'
 import { toAnthropicTool, toOpenAiTool } from '@/capabilities/toolSchema'
 import { useAccountsStore } from '@/stores/accounts'
 import { type AiSession, useAiSessionsStore } from '@/stores/aiSessions'
-import { useSkillsStore } from '@/stores/skills'
+import { type SkillMeta, useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
 import { isTauri } from '@/utils/settingsFs'
+import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { type ChatMessage, type ToolUseEvent, useAiChat } from './useAiChat'
 import {
+  type AiConfig,
   HEARTBEAT_ACK_MAX_CHARS,
   type HeartbeatTarget,
   type ProviderKey,
@@ -104,6 +106,178 @@ const MAX_TOOL_ROUNDS = 5
  */
 const MAX_CONSECUTIVE_FAILURES = 3
 
+/** 1 日 = 86400000 ms。epoch days への変換に使う。 */
+const MS_PER_DAY = 86_400_000
+
+// ---------------------------------------------------------------------------
+// Cheap Check First (#411) — persist state
+// ---------------------------------------------------------------------------
+
+/**
+ * skill id 単位で前回 tick の cheap check 結果と最後の AI 起動時刻を保持。
+ * - lastResultsHash: cheap capability 結果配列を JSON.stringify した文字列
+ * - lastAiRunAt: 最後に AI 推論を走らせた epoch ms (maxSkipHours の起点)
+ *
+ * localStorage に persist し、再起動跨ぎでも前回値を保持する。
+ */
+interface CheapCheckPersistedState {
+  lastResultsHash: Record<string, string>
+  lastAiRunAt: Record<string, number>
+}
+
+function loadCheapCheckState(): CheapCheckPersistedState {
+  return getStorageJson<CheapCheckPersistedState>(
+    STORAGE_KEYS.heartbeatCheapCheckState,
+    { lastResultsHash: {}, lastAiRunAt: {} },
+  )
+}
+
+function saveCheapCheckState(state: CheapCheckPersistedState): void {
+  setStorageJson(STORAGE_KEYS.heartbeatCheapCheckState, state)
+}
+
+interface DailyCounterState {
+  /** 今日の epoch days (日付境界で count を reset) */
+  date: number
+  /** 今日の AI 起動回数 (cheap check で skip された tick はカウントしない) */
+  count: number
+}
+
+function loadDailyCounter(): DailyCounterState {
+  const today = Math.floor(Date.now() / MS_PER_DAY)
+  const stored = getStorageJson<DailyCounterState>(
+    STORAGE_KEYS.heartbeatDailyCounter,
+    { date: today, count: 0 },
+  )
+  // 日付境界跨ぎ → reset
+  return stored.date === today ? stored : { date: today, count: 0 }
+}
+
+function saveDailyCounter(state: DailyCounterState): void {
+  setStorageJson(STORAGE_KEYS.heartbeatDailyCounter, state)
+}
+
+// ---------------------------------------------------------------------------
+// Cheap Check First — 純関数 helpers (テスト容易性のため module-scope)
+// ---------------------------------------------------------------------------
+
+export interface CheapCheckOutcome {
+  /** AI 起動するか (true=起動 / false=skip して HEARTBEAT_OK 扱い) */
+  shouldRunAi: boolean
+  /** 起動 / skip の理由 (debug log 用) */
+  reason: string
+  /** 今回の results hash (skill id → hash)。state 更新に使う */
+  newHashes: Record<string, string>
+}
+
+/**
+ * skill ごとに `cheapCheckCapabilities` を実行 → 結果 hash を作って返す。
+ * cheap=true & permission OK な capability のみ受け入れる。
+ *
+ * @returns skill id → 結果 hash の map (該当 skill の cheap check が成立した分のみ)
+ */
+async function collectCheapResults(
+  heartbeatSkills: SkillMeta[],
+  aiConfig: AiConfig,
+): Promise<Record<string, string>> {
+  const granted = resolvePermissions(aiConfig.heartbeat.permissions)
+  const out: Record<string, string> = {}
+
+  for (const skill of heartbeatSkills) {
+    const capIds = skill.cheapCheckCapabilities
+    if (!capIds || capIds.length === 0) continue
+
+    const results: unknown[] = []
+    let valid = false
+    for (const capId of capIds) {
+      const cap = getCapability(capId)
+      if (!cap || cap.signature?.cheap !== true) {
+        // cheap=false / 未登録 / signature なし は無視 (重い API を tick ごとに
+        // 連発するのを防ぐ)
+        continue
+      }
+      // permission チェック
+      const required = cap.permissions ?? []
+      if (!required.every((p) => granted[p])) continue
+
+      try {
+        const res = await dispatchCapability(capId, undefined, aiConfig)
+        results.push(res.ok ? res.result : { error: res.code })
+        valid = true
+      } catch (e) {
+        results.push({ error: e instanceof Error ? e.message : String(e) })
+        valid = true
+      }
+    }
+    if (valid) out[skill.id] = JSON.stringify(results)
+  }
+  return out
+}
+
+/**
+ * Cheap check の結果と前回値を比較して「AI 起動すべきか」を判定する純関数。
+ *
+ * 判定ロジック:
+ * 1. cheap check が global で disabled → 常に AI 起動
+ * 2. どの skill も cheap check 宣言なし (newHashes 空) → 常に AI 起動 (= 既存挙動)
+ * 3. 1 つでも skill の hash が変化していれば AI 起動
+ * 4. 全 skill 一致だが maxSkipHours 経過 → 強制 AI 起動 (cheap check 壊れ防止)
+ * 5. 全 skill 一致 + maxSkipHours 内 → skip (HEARTBEAT_OK 扱い)
+ */
+export function decideCheapCheck(
+  newHashes: Record<string, string>,
+  prevState: CheapCheckPersistedState,
+  aiConfig: AiConfig,
+  now: number,
+): CheapCheckOutcome {
+  if (!aiConfig.heartbeat.cheapCheck.enabled) {
+    return {
+      shouldRunAi: true,
+      reason: 'cheap-check-disabled',
+      newHashes,
+    }
+  }
+  const skillIds = Object.keys(newHashes)
+  if (skillIds.length === 0) {
+    return {
+      shouldRunAi: true,
+      reason: 'no-cheap-check-declared',
+      newHashes,
+    }
+  }
+  const changed = skillIds.find(
+    (id) => prevState.lastResultsHash[id] !== newHashes[id],
+  )
+  if (changed) {
+    return {
+      shouldRunAi: true,
+      reason: `changed:${changed}`,
+      newHashes,
+    }
+  }
+  // 全一致 — maxSkipHours 経過してたら強制起動
+  const maxSkipMs = aiConfig.heartbeat.cheapCheck.maxSkipHours * 60 * 60 * 1000
+  const oldestRunAt = skillIds.reduce<number>((min, id) => {
+    const t = prevState.lastAiRunAt[id] ?? 0
+    return t < min ? t : min
+  }, Number.POSITIVE_INFINITY)
+  if (
+    oldestRunAt === Number.POSITIVE_INFINITY ||
+    now - oldestRunAt >= maxSkipMs
+  ) {
+    return {
+      shouldRunAi: true,
+      reason: 'max-skip-hours-elapsed',
+      newHashes,
+    }
+  }
+  return {
+    shouldRunAi: false,
+    reason: 'no-change-within-skip-window',
+    newHashes,
+  }
+}
+
 /**
  * heartbeat 用の system prompt 末尾に必ず付ける指示文。
  * OpenClaw の "Read HEARTBEAT.md if it exists. Follow it strictly." と同じ意図。
@@ -170,6 +344,21 @@ export function useHeartbeatDaemon() {
    */
   let consecutiveFailures = 0
   let unlisten: UnlistenFn | null = null
+
+  /**
+   * AI 起動回数を 1 inc。日付境界を跨いでいたら reset → 1 にする。
+   * @returns inc 後の today / count
+   */
+  function tickDailyCounter(now: number): DailyCounterState {
+    const today = Math.floor(now / MS_PER_DAY)
+    const cur = loadDailyCounter()
+    const next: DailyCounterState =
+      cur.date === today
+        ? { date: today, count: cur.count + 1 }
+        : { date: today, count: 1 }
+    saveDailyCounter(next)
+    return next
+  }
 
   /**
    * AI 推論失敗時、target session に「⚠ HEARTBEAT 失敗」message として
@@ -346,6 +535,53 @@ export function useHeartbeatDaemon() {
       return
     }
 
+    // ----- Cheap Check First (#411) -----
+    // skill 側 frontmatter で `cheapCheckCapabilities: [...]` を宣言した
+    // skill のみ機構が発動する。global toggle (cheapCheck.enabled=false) で
+    // 完全停止可能。
+    const now = Date.now()
+    const newHashes = await collectCheapResults(heartbeatSkills, config.value)
+    const prevState = loadCheapCheckState()
+    const decision = decideCheapCheck(newHashes, prevState, config.value, now)
+    if (!decision.shouldRunAi) {
+      console.debug(
+        `[heartbeat] cheap-check skip AI (reason=${decision.reason}, source=${payload.source})`,
+      )
+      // skip 時も hash は最新化 (= 次 tick で「変化あり」を検知できるように)。
+      // lastAiRunAt は更新しない (= maxSkipHours は AI 起動時のみ更新)。
+      saveCheapCheckState({
+        lastResultsHash: {
+          ...prevState.lastResultsHash,
+          ...decision.newHashes,
+        },
+        lastAiRunAt: prevState.lastAiRunAt,
+      })
+      return
+    }
+
+    // ----- Daily AI runs limit (#411 安全装置) -----
+    // 上限到達時の動作:
+    //   'warn'    = toast 出して継続 (= AI 呼んで進める)
+    //   'disable' = toast + heartbeat.enabled=false で daemon 停止
+    const counter = tickDailyCounter(now)
+    if (counter.count > cfg.dailyMaxAiRuns) {
+      if (cfg.onDailyLimit === 'disable') {
+        config.value.heartbeat.enabled = false
+        toast.show(
+          `HEARTBEAT を停止しました (本日 ${cfg.dailyMaxAiRuns} 回の AI 起動上限に到達)`,
+          'warning',
+        )
+        return
+      }
+      // warn: toast を 1 日 1 回だけ出す (= count == limit+1 のときのみ)
+      if (counter.count === cfg.dailyMaxAiRuns + 1) {
+        toast.show(
+          `HEARTBEAT: 本日の AI 起動上限 (${cfg.dailyMaxAiRuns} 回) を超えました (継続中)`,
+          'warning',
+        )
+      }
+    }
+
     // AI inference (HEARTBEAT 用 permissions で capabilities を絞り込んでから渡す)
     // 失敗は silent fail にせず error message を heartbeat session に残す。
     // 連続失敗で auto-disable してユーザー通知する。
@@ -353,6 +589,18 @@ export function useHeartbeatDaemon() {
     try {
       responseText = await runAiInference(skillBodies, payload)
       consecutiveFailures = 0
+      // AI 起動成功 → cheap check state の hash + lastAiRunAt を全 skill 分更新
+      const updatedAt: Record<string, number> = { ...prevState.lastAiRunAt }
+      for (const skillId of Object.keys(decision.newHashes)) {
+        updatedAt[skillId] = now
+      }
+      saveCheapCheckState({
+        lastResultsHash: {
+          ...prevState.lastResultsHash,
+          ...decision.newHashes,
+        },
+        lastAiRunAt: updatedAt,
+      })
     } catch (e) {
       consecutiveFailures += 1
       const errMsg = e instanceof Error ? e.message : String(e)

--- a/src/defaults/ai.json5
+++ b/src/defaults/ai.json5
@@ -82,5 +82,25 @@
         'tasks.run': false,
       },
     },
+    // Cheap Check First (#411): tick 開始時に「変化検知」用の軽量
+    // capability (cheap=true) を呼び、前回値と一致すれば AI を skip
+    // して HEARTBEAT_OK 扱いにする。skill 側で
+    // `cheapCheckCapabilities: [...]` を frontmatter で宣言した skill
+    // にだけ発動する (= opt-in)。
+    // - enabled: false なら全 skill で機構を停止 (= 常に AI を叩く)
+    // - maxSkipHours: 変化なしでも N 時間に 1 回は強制 AI 起動
+    //   (cheap check が壊れていた場合のセーフティ)
+    cheapCheck: {
+      enabled: true,
+      maxSkipHours: 24,
+    },
+    // 1 日あたりの AI 起動上限。Cheap Check で skip された tick は
+    // カウントされない。デフォルト 48 = 30 分 interval で毎回叩いた
+    // 場合の最大値。
+    // onDailyLimit:
+    //   'warn'    = toast 出して継続 (= AI 呼んで進める、default)
+    //   'disable' = toast + heartbeat.enabled=false で daemon 停止
+    dailyMaxAiRuns: 48,
+    onDailyLimit: 'warn',
   },
 }

--- a/src/defaults/ai.json5
+++ b/src/defaults/ai.json5
@@ -102,5 +102,10 @@
     //   'disable' = toast + heartbeat.enabled=false で daemon 停止
     dailyMaxAiRuns: 48,
     onDailyLimit: 'warn',
+    // HEARTBEAT が「重要発見」と判定した内容を OS デスクトップ通知として
+    // 表示するか。target='none' (silent log) のときは出さない。
+    // アプリにフォーカスがあるときも自動抑制 (sendDesktopNotification 内で
+    // document.hasFocus() を判定)。
+    desktopNotification: true,
   },
 }

--- a/src/stores/misstore.ts
+++ b/src/stores/misstore.ts
@@ -343,6 +343,9 @@ export const useMisStoreStore = defineStore('misstore', () => {
         updatedAt: now,
         builtIn: false,
         iconUrl: (meta.iconUrl as string | undefined) || entry.iconUrl,
+        cheapCheckCapabilities: Array.isArray(meta.cheapCheckCapabilities)
+          ? (meta.cheapCheckCapabilities as string[])
+          : [],
       }
 
       if (existing) {

--- a/src/stores/skills.ts
+++ b/src/stores/skills.ts
@@ -35,6 +35,19 @@ export interface SkillMeta {
   builtIn?: boolean
   /** スキル個別アイコン URL (MisStore registry の iconUrl 互換) */
   iconUrl?: string
+  /**
+   * HEARTBEAT Cheap Check First (#411): tick 開始時に呼んで「変化検知」
+   * に使う capability id 配列。指定された capability は cheap=true な
+   * もののみ受け入れられる (重い API は無視)。
+   *
+   * - 空配列 (default) = cheap check 機構を発動しない (= 毎回 AI を叩く)
+   * - 1 個以上指定 = それらの結果を JSON.stringify で前回値と比較し、
+   *   変化なしなら AI を skip して HEARTBEAT_OK 扱い
+   *
+   * mode='heartbeat' な skill にのみ意味がある。
+   * 型は常に `string[]` (空配列含む) — `triggers` と同じパターン。
+   */
+  cheapCheckCapabilities: string[]
 }
 
 export function generateSkillId(name: string): string {
@@ -62,6 +75,7 @@ interface SkillFrontmatter {
   createdAt?: number
   updatedAt?: number
   iconUrl?: string
+  cheapCheckCapabilities?: string[]
 }
 
 function asArray(v: unknown): string[] {
@@ -89,6 +103,9 @@ function frontmatterFromMeta(skill: SkillMeta): Record<string, unknown> {
   if (skill.storeId) out.storeId = skill.storeId
   if (skill.builtIn) out.builtIn = true
   if (skill.iconUrl) out.iconUrl = skill.iconUrl
+  if (skill.cheapCheckCapabilities && skill.cheapCheckCapabilities.length > 0) {
+    out.cheapCheckCapabilities = skill.cheapCheckCapabilities
+  }
   return out
 }
 
@@ -125,6 +142,7 @@ function metaFromFrontmatter(
     updatedAt: fm.updatedAt ?? now,
     builtIn: !!fm.builtIn,
     iconUrl: fm.iconUrl,
+    cheapCheckCapabilities: asArray(fm.cheapCheckCapabilities),
   }
 }
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -93,6 +93,12 @@ export const STORAGE_KEYS = {
   // AI settings
   aiSettings: 'nd-ai-settings',
   skillsActive: 'nd-skills-active',
+  // HEARTBEAT (#411) Cheap Check First の transient state:
+  // skill id ごとの { lastResultsHash, lastAiRunAt } を 1 つの map に格納
+  heartbeatCheapCheckState: 'nd-heartbeat-cheap-check-state',
+  // 1 日の AI 起動カウンター (再起動跨ぎでカウント維持):
+  // { dateEpochDays, count }
+  heartbeatDailyCounter: 'nd-heartbeat-daily-counter',
 
   // Custom timelines (per-host / per-account)
   customTimeline: (host: string) => `nd:custom_tl:${host}`,


### PR DESCRIPTION
## Summary

v0.19.0 リリース。テーマは **HEARTBEAT 実用化回**。
v0.18.0 で出した HEARTBEAT daemon を「安心して常時 ON にできる」状態に
仕上げ、ambient assistant 体験として完成させた。

## Highlights

### 🛡️ Cheap Check First (#411)
無人時間でも 30 分ごとに AI を毎回叩く現状 = **API コスト爆発リスク**を塞ぐ。
OpenClaw 設計書の中核原則を実装。

- skill 側 frontmatter で `cheapCheckCapabilities: [...]` を宣言した
  heartbeat skill にのみ発動する **opt-in モデル**
- tick 開始時に cheap=true な capability で「変化検知」 → 前回値と一致なら
  AI を skip して HEARTBEAT_OK 扱い
- `maxSkipHours` (default 24) で「何時間に 1 回は強制起動」のセーフティ
- global toggle (`cheapCheck.enabled`) で機構自体を完全停止可
- 既存 capability 4 個に `cheap=true` マーキング (time / account / column)

### 🚨 Daily AI runs counter (安全装置)
想定外の API 課金を防ぐサーキットブレーカー。

- 1 日の AI 起動上限 (default 48 = 30 分 interval で毎回叩いた最大値)
- 上限到達時の動作を選択: `warn` (toast 出して継続) or `disable` (自動停止)
- localStorage で永続化、日付境界で自動 reset

### 🔔 OS デスクトップ通知統合
HEARTBEAT が「重要発見」と判定した内容を OS 通知で表示。

- アプリにフォーカスがあるときは自動抑制 (= 既に見ている)
- target='none' (silent log) のときは通知も出ない
- `desktopNotification` toggle で opt-out 可

### ✨ AI Task kind 結線 (前 PR #449 の続き)
タスクカラムから AI セッション経由で TaskDefinition を 1-shot 実行可能に。

- 新規 capability `tasks.run`
- TaskRunner UI に 🧠 trigger ボタン
- session 一覧アイコンを ▷ に統一

### Misc
- カラム表示名「AIチャット」→「AI」(主流命名に合わせて短縮)
- TaskRunner defaultBar アイコンを default task 自身の icon に追従
- README image 更新

## Test plan

- [x] `pnpm typecheck` (vue-tsc) green
- [x] `pnpm lint` (biome) green
- [x] `pnpm test` (556 / 556 pass)
- [x] `pnpm tauri:dev` で AI 設定 UI / Cheap Check / daily counter 動作確認
- [ ] CI (lint / typecheck / test) green を待つ
- [ ] WSL2 環境で desktop 通知は実機検証不可、リリース後ユーザー報告で確認

## リリース後 (別 PR)

- HEARTBEAT 6 プリセット UI
- `notifications.peek` 等の cheap 専用 capability
- `'command'` kind dead 型 cleanup
- winget / aur ジョブの修理 (3 連続 failure 中)