### PR TITLE
Release v0.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.19.2",
+  "version": "0.19.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.19.2"
+version = "0.19.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -902,7 +902,7 @@ defineExpose({
 }
 
 .instanceIcon {
-  width: 20px;
+  width: 30px;
   aspect-ratio: 1;
   border-radius: 4px;
   user-select: none;
@@ -1358,7 +1358,7 @@ defineExpose({
   }
 
   .instanceIcon {
-    width: 20px;
+    width: 30px;
     border-radius: 4px;
   }
 

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -1,11 +1,21 @@
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, ref, useCssModule, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onUnmounted,
+  ref,
+  toRef,
+  useCssModule,
+  watch,
+} from 'vue'
 import { useCommandStore } from '@/commands/registry'
 import ColumnBadges from '@/components/common/ColumnBadges.vue'
 import { useAccountActions } from '@/composables/useAccountActions'
 import { useColumnBadge } from '@/composables/useColumnBadge'
 import { COLUMN_ICONS, COLUMN_LABELS } from '@/composables/useColumnTabs'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNavigation } from '@/composables/useNavigation'
+import { useVaporTransition } from '@/composables/useVaporTransition'
 import {
   type Account,
   getAccountLabel,
@@ -210,9 +220,55 @@ function openLaunchPad(e: MouseEvent) {
   })
 }
 
+function toggleProfileMenu() {
+  if (props.showProfileMenu) {
+    emit('update:showProfileMenu', false)
+  } else {
+    closeDrawerAndDo(() => emit('update:showProfileMenu', true))
+  }
+}
+
+function toggleSettingsMenu() {
+  if (props.showSettingsMenu) {
+    emit('update:showSettingsMenu', false)
+  } else {
+    closeDrawerAndDo(() => emit('update:showSettingsMenu', true))
+  }
+}
+
 // Account menu
 const accountMenuId = ref<string | null>(null)
 const showAccountPopup = ref(false)
+const accountDialogRef = ref<HTMLDialogElement | null>(null)
+const { visible: accountPopupVisible, leaving: accountPopupLeaving } =
+  useVaporTransition(toRef(showAccountPopup), {
+    enterDuration: 200,
+    leaveDuration: 200,
+  })
+
+useNativeDialog(
+  accountDialogRef,
+  computed(() => accountPopupVisible.value && isCompact.value),
+  {
+    onCancel: () => {
+      showAccountPopup.value = false
+      accountMenuId.value = null
+    },
+    leaveDuration: 200,
+  },
+)
+
+function toggleAccountPopup() {
+  if (showAccountPopup.value) {
+    showAccountPopup.value = false
+    accountMenuId.value = null
+  } else {
+    closeDrawerAndDo(() => {
+      showAccountPopup.value = true
+      accountMenuId.value = null
+    })
+  }
+}
 const accountMenuStyle = ref<Record<string, string>>({})
 const selectedAccount = computed(() =>
   accountsStore.accounts.find((a) => a.id === accountMenuId.value),
@@ -506,7 +562,7 @@ defineExpose({
                 :class="$style.item"
                 title="プロファイル"
                 @pointerdown.stop
-                @click.stop="emit('update:showProfileMenu', !props.showProfileMenu)"
+                @click.stop="toggleProfileMenu()"
               >
                 <i class="ti ti-layout" />
                 <span :class="$style.label">プロファイル</span>
@@ -520,7 +576,7 @@ defineExpose({
                 :class="$style.item"
                 title="設定"
                 @pointerdown.stop
-                @click.stop="emit('update:showSettingsMenu', !props.showSettingsMenu)"
+                @click.stop="toggleSettingsMenu()"
               >
                 <i class="ti ti-settings" />
                 <span :class="$style.label">設定</span>
@@ -575,7 +631,7 @@ defineExpose({
               :class="$style.item"
               title="アカウント"
               @pointerdown.stop
-              @click.stop="isCompact ? (showAccountPopup = !showAccountPopup, accountMenuId = null) : commandStore.execute('account-menu')"
+              @click.stop="isCompact ? toggleAccountPopup() : commandStore.execute('account-menu')"
             >
               <div :class="$style.iconWrap">
                 <i class="ti ti-user" />
@@ -583,8 +639,9 @@ defineExpose({
               </div>
               <span :class="$style.label">アカウント</span>
             </button>
+            <!-- Desktop: anchored popup above the button -->
             <div
-              v-if="showAccountPopup"
+              v-if="!isCompact && showAccountPopup"
               :class="$style.accountPopup"
               @click.stop="accountMenuId = null"
             >
@@ -642,6 +699,74 @@ defineExpose({
                 <span>アカウント管理</span>
               </button>
             </div>
+
+            <!-- Mobile: bottom sheet via native <dialog> -->
+            <dialog
+              v-if="isCompact && accountPopupVisible"
+              ref="accountDialogRef"
+              class="_nativeDialog"
+              :class="[$style.mobileBackdrop, accountPopupLeaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+            >
+              <div
+                autofocus
+                tabindex="-1"
+                :class="[$style.accountPopup, $style.accountPopupMobile, accountPopupLeaving ? $style.sheetContentLeave : $style.sheetContentEnter]"
+                @click.stop="accountMenuId = null"
+              >
+                <div
+                  v-for="acc in accountsStore.accounts"
+                  :key="acc.id"
+                  :class="$style.accountPopupItem"
+                  @click.stop="toggleAccountMenu(acc.id, $event)"
+                >
+                  <div
+                    :class="[$style.accountPopupBtn, { [$style.accountPopupBtnActive]: accountMenuId === acc.id }]"
+                    :title="getAccountLabel(acc)"
+                  >
+                    <div :class="$style.avatarWrap">
+                      <img
+                        v-if="isGuestAccount(acc)"
+                        src="/avatar-guest.svg"
+                        :class="$style.avatar"
+                      />
+                      <img
+                        v-else-if="acc.avatarUrl"
+                        :src="proxyThumbUrl(acc.avatarUrl, 56)"
+                        :class="$style.avatar"
+                      />
+                      <div v-else :class="[$style.avatar, $style.avatarPlaceholder]" />
+                      <img
+                        :src="getServerIconUrl(acc.host)"
+                        :class="$style.serverBadge"
+                        :title="acc.host"
+                      />
+                      <span
+                        :class="[$style.onlineIndicator, onlineStatusClass(acc.id)]"
+                      />
+                    </div>
+                    <span :class="$style.accountPopupName">{{ getAccountLabel(acc) }}</span>
+                    <i class="ti ti-chevron-right" :class="$style.accountPopupChevron" />
+                  </div>
+                </div>
+                <div :class="$style.accountPopupDivider" />
+                <button
+                  class="_button"
+                  :class="$style.accountPopupBtn"
+                  @click="showAccountPopup = false; closeDrawerAndDo(navigateToLogin)"
+                >
+                  <div :class="$style.accountPopupIcon"><i class="ti ti-plus" /></div>
+                  <span>アカウント追加</span>
+                </button>
+                <button
+                  class="_button"
+                  :class="$style.accountPopupBtn"
+                  @click="showAccountPopup = false; closeDrawerAndDo(() => windowsStore.open('account-manager'))"
+                >
+                  <div :class="$style.accountPopupIcon"><i class="ti ti-settings" /></div>
+                  <span>アカウント管理</span>
+                </button>
+              </div>
+            </dialog>
             <!-- NavAccountMenu: position:fixed で右横に配置（overflow制約を回避） -->
             <NavAccountMenu
               v-if="showAccountPopup && selectedAccount"
@@ -725,6 +850,7 @@ defineExpose({
 
 <style lang="scss" module>
 @use '@/styles/buttons' as *;
+@use '@/styles/navMenu';
 
 .wrapper {
   display: contents;
@@ -927,6 +1053,33 @@ defineExpose({
   background: var(--nd-navBg);
   border-radius: var(--nd-radius-md);
   box-shadow: var(--nd-shadow-m);
+}
+
+// Mobile bottom sheet — used inside <dialog class="_nativeDialog">
+.accountPopupMobile {
+  position: static;
+  bottom: auto;
+  left: auto;
+  right: auto;
+  width: 100%;
+  margin: 0;
+  border-radius: 16px 16px 0 0;
+  background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 8px 0 calc(8px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+
+  .accountPopupBtn {
+    padding: 10px 16px;
+    min-height: 44px;
+    font-size: 0.9em;
+  }
 }
 
 .accountPopupItem {

--- a/src/components/deck/DeckProfileMenu.vue
+++ b/src/components/deck/DeckProfileMenu.vue
@@ -5,6 +5,7 @@ import { computed, nextTick, ref, toRef, useTemplateRef, watch } from 'vue'
 import { refreshProfileCommands } from '@/commands/definitions'
 import { switchProfileWithWindows } from '@/composables/useDeckWindow'
 import { useMenuKeyboard } from '@/composables/useMenuKeyboard'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { usePointerReorder } from '@/composables/usePointerReorder'
 import { usePortal } from '@/composables/usePortal'
 import { useVaporTransition } from '@/composables/useVaporTransition'
@@ -36,6 +37,16 @@ const { visible: menuVisible, leaving: menuLeaving } = useVaporTransition(
 const profiles = computed(() => profileStore.getProfiles())
 const menuEl = ref<HTMLElement | null>(null)
 const fixedStyle = ref<CSSProperties | undefined>()
+const dialogRef = ref<HTMLDialogElement | null>(null)
+
+useNativeDialog(
+  dialogRef,
+  computed(() => menuVisible.value && isCompact.value),
+  {
+    onCancel: () => emit('close'),
+    leaveDuration: 180,
+  },
+)
 
 const { activate: activateKeyboard, deactivate: deactivateKeyboard } =
   useMenuKeyboard({
@@ -48,7 +59,7 @@ watch(
   () => props.show,
   (val) => {
     if (val) {
-      if (props.anchor) {
+      if (props.anchor && !isCompact.value) {
         const rect = props.anchor.getBoundingClientRect()
         fixedStyle.value = {
           position: 'fixed',
@@ -58,7 +69,7 @@ watch(
       } else {
         fixedStyle.value = undefined
       }
-      nextTick(activateKeyboard)
+      if (!isCompact.value) nextTick(activateKeyboard)
     } else {
       deactivateKeyboard()
     }
@@ -116,9 +127,10 @@ const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
 </script>
 
 <template>
-  <div v-if="show || menuVisible" ref="profileMenuPortalRef">
+  <!-- Desktop: portal-rendered popup -->
+  <div v-if="!isCompact && (show || menuVisible)" ref="profileMenuPortalRef">
     <div v-if="show" :class="$style.menuBackdrop" @pointerdown="emit('close')" />
-    <div v-if="menuVisible" ref="menuEl" :class="[$style.profileMenu, { [$style.mobile]: isCompact }, menuLeaving ? $style.menuLeave : $style.menuEnter]" :style="fixedStyle" class="_popupMenu" @pointerdown.stop>
+    <div v-if="menuVisible" ref="menuEl" :class="[$style.profileMenu, menuLeaving ? $style.menuLeave : $style.menuEnter]" :style="fixedStyle" class="_popupMenu" @pointerdown.stop>
       <div :class="$style.list">
         <div
           v-for="(p, i) in profiles"
@@ -163,6 +175,58 @@ const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
 
     </div>
   </div>
+
+  <!-- Mobile: bottom sheet via native <dialog> -->
+  <dialog
+    v-if="isCompact && menuVisible"
+    ref="dialogRef"
+    class="_nativeDialog"
+    :class="[$style.mobileBackdrop, menuLeaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+  >
+    <div autofocus tabindex="-1" ref="menuEl" :class="[$style.profileMenu, $style.mobile, menuLeaving ? $style.sheetContentLeave : $style.sheetContentEnter]" class="_popupMenu" @pointerdown.stop>
+      <div :class="$style.list">
+        <div
+          v-for="(p, i) in profiles"
+          :key="p.id"
+          :data-profile-idx="i"
+          :class="[$style.item, { [$style.active]: p.id === deckStore.windowProfileId, [$style.dragging]: dragFromIndex === i, [$style.dragOver]: dragOverIndex === i }]"
+          tabindex="0"
+          @click="apply(p.id)"
+          @keydown.enter="apply(p.id)"
+        >
+          <i class="ti ti-grip-vertical" :class="$style.grip" @pointerdown="startDrag(i, $event)" />
+          <span :class="$style.name">{{ p.name }}</span>
+          <button
+            class="_button"
+            :class="$style.action"
+            title="エディタで開く"
+            @click.stop="openEditor(p.id)"
+          >
+            <i class="ti ti-pencil" />
+          </button>
+          <button
+            class="_button"
+            :class="[$style.action, $style.deleteAction]"
+            title="削除"
+            @click.stop="remove(p.id)"
+          >
+            <i class="ti ti-trash" />
+          </button>
+        </div>
+      </div>
+
+      <div v-if="profiles.length === 0" :class="$style.empty">
+        保存されたプロファイルはありません
+      </div>
+
+      <div :class="$style.divider" />
+
+      <div :class="[$style.item, $style.newItem]" tabindex="0" @click="createProfile" @keydown.enter="createProfile">
+        <i class="ti ti-plus" />
+        <span>新規プロファイル</span>
+      </div>
+    </div>
+  </dialog>
 </template>
 
 <style lang="scss" module>
@@ -301,16 +365,23 @@ const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
   }
 }
 
-/* Mobile overrides */
+/* Mobile overrides — bottom sheet inside <dialog class="_nativeDialog"> */
 .mobile {
   &.profileMenu {
-    width: 234px;
+    position: static;
+    width: 100%;
     max-width: none;
     min-width: 0;
-    border-radius: 12px;
-    background: color-mix(in srgb, var(--nd-navBg) 92%, transparent);
+    margin: 0;
+    border-radius: 16px 16px 0 0;
+    background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
     box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
-    padding: 4px 0;
+    padding: 4px 0 calc(4px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
   }
 
   .item {

--- a/src/components/deck/DeckSettingsMenu.vue
+++ b/src/components/deck/DeckSettingsMenu.vue
@@ -12,6 +12,7 @@ import {
 } from 'vue'
 
 import { useMenuKeyboard } from '@/composables/useMenuKeyboard'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { usePortal } from '@/composables/usePortal'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { type ConfirmOptions, useConfirm } from '@/stores/confirm'
@@ -56,6 +57,16 @@ function toggleSection(key: string) {
 
 const menuEl = ref<HTMLElement | null>(null)
 const fixedStyle = ref<CSSProperties | undefined>()
+const dialogRef = ref<HTMLDialogElement | null>(null)
+
+useNativeDialog(
+  dialogRef,
+  computed(() => menuVisible.value && isCompact.value),
+  {
+    onCancel: () => emit('close'),
+    leaveDuration: 180,
+  },
+)
 
 const { activate: activateKeyboard, deactivate: deactivateKeyboard } =
   useMenuKeyboard({
@@ -68,7 +79,7 @@ watch(
   () => props.show,
   (val) => {
     if (val) {
-      if (props.anchor) {
+      if (props.anchor && !isCompact.value) {
         const rect = props.anchor.getBoundingClientRect()
         fixedStyle.value = {
           position: 'fixed',
@@ -78,7 +89,7 @@ watch(
       } else {
         fixedStyle.value = undefined
       }
-      nextTick(activateKeyboard)
+      if (!isCompact.value) nextTick(activateKeyboard)
     } else {
       deactivateKeyboard()
     }
@@ -245,9 +256,10 @@ usePortal(settingsMenuPortalRef)
 </script>
 
 <template>
-  <div v-if="show || menuVisible" ref="settingsMenuPortalRef">
+  <!-- Desktop: portal-rendered popup -->
+  <div v-if="!isCompact && (show || menuVisible)" ref="settingsMenuPortalRef">
   <div v-if="show" :class="$style.menuBackdrop" @pointerdown="emit('close')" />
-    <div v-if="menuVisible" ref="menuEl" :class="[$style.settingsMenu, { [$style.mobile]: isCompact }, menuLeaving ? $style.menuLeave : $style.menuEnter]" :style="fixedStyle" class="_popupMenu" @pointerdown.stop>
+    <div v-if="menuVisible" ref="menuEl" :class="[$style.settingsMenu, menuLeaving ? $style.menuLeave : $style.menuEnter]" :style="fixedStyle" class="_popupMenu" @pointerdown.stop>
       <div :class="$style.menuBody">
       <!-- アピアランス -->
       <div :class="$style.categorySection">
@@ -445,6 +457,83 @@ usePortal(settingsMenuPortalRef)
       </div>
     </div>
   </div>
+
+  <!-- Mobile: bottom sheet via native <dialog> -->
+  <dialog
+    v-if="isCompact && menuVisible"
+    ref="dialogRef"
+    class="_nativeDialog"
+    :class="[$style.mobileBackdrop, menuLeaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+  >
+    <div autofocus tabindex="-1" ref="menuEl" :class="[$style.settingsMenu, $style.mobile, menuLeaving ? $style.sheetContentLeave : $style.sheetContentEnter]" class="_popupMenu" @pointerdown.stop>
+      <div :class="$style.menuBody">
+      <!-- アピアランス -->
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('appearanceEditor')">
+          <i class="ti ti-brush" />
+          <span>アピアランス</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+
+      <!-- 環境設定 (フラットに展開) -->
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('aiSettings')">
+          <i class="ti ti-robot" />
+          <span>AI</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('performanceEditor')">
+          <i class="ti ti-gauge" />
+          <span>パフォーマンス</span>
+          <span v-if="Object.keys(perfStore.overrides).length > 0" :class="$style.activeDot" />
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('cssEditor')">
+          <i class="ti ti-code" />
+          <span>カスタムCSS</span>
+          <span v-if="themeStore.customCss" :class="$style.activeDot" />
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('tasksEditor')">
+          <i class="ti ti-player-play" />
+          <span>タスク</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('snippetsEditor')">
+          <i class="ti ti-code-plus" />
+          <span>スニペット</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+
+      <!-- データ -->
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('backup')">
+          <i class="ti ti-database" />
+          <span>バックアップ</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+      <div :class="$style.categorySection">
+        <button :class="$style.categoryHeader" @click="openToolWindow('cacheEditor')">
+          <i class="ti ti-eraser" />
+          <span>キャッシュ</span>
+          <i class="ti ti-chevron-right" :class="$style.chevronNav" />
+        </button>
+      </div>
+
+      </div>
+    </div>
+  </dialog>
 </template>
 
 <style lang="scss" module>
@@ -640,14 +729,27 @@ usePortal(settingsMenuPortalRef)
   position: relative;
 }
 
+/* Mobile bottom sheet — used inside <dialog class="_nativeDialog"> */
 .mobile {
-  width: 234px;
-  max-width: calc(100vw - 16px);
-  min-width: 0;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--nd-navBg) 92%, transparent);
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
-  max-height: 70vh;
+  &.settingsMenu {
+    position: static;
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    margin: 0;
+    bottom: auto;
+    right: auto;
+    border-radius: 16px 16px 0 0;
+    background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+    max-height: 80vh;
+    padding-bottom: var(--nd-safe-area-bottom, env(safe-area-inset-bottom));
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+  }
 
   .settingsMenuItem {
     padding: 8px 12px;
@@ -657,6 +759,10 @@ usePortal(settingsMenuPortalRef)
   .categoryHeader {
     padding: 8px 12px;
     min-height: 44px;
+  }
+
+  .categorySection:last-child {
+    border-bottom: none;
   }
 }
 

--- a/src/components/deck/NavAccountMenu.vue
+++ b/src/components/deck/NavAccountMenu.vue
@@ -2,6 +2,7 @@
 import { computed, nextTick, ref, toRef, watch } from 'vue'
 import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useMenuKeyboard } from '@/composables/useMenuKeyboard'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNavigation } from '@/composables/useNavigation'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { type Account, isGuestAccount } from '@/stores/accounts'
@@ -40,7 +41,17 @@ const emit = defineEmits<{
 
 const { navigateToUser } = useNavigation()
 const menuRef = ref<HTMLElement | null>(null)
+const dialogRef = ref<HTMLDialogElement | null>(null)
 const fixedStyle = ref<Record<string, string>>({})
+
+useNativeDialog(
+  dialogRef,
+  computed(() => menuVisible.value && isCompact.value),
+  {
+    onCancel: () => emit('close'),
+    leaveDuration: 180,
+  },
+)
 const { activate: activateKeyboard, deactivate: deactivateKeyboard } =
   useMenuKeyboard({
     containerRef: menuRef,
@@ -98,18 +109,19 @@ function modeIcon(key: string, active: boolean): string {
 </script>
 
 <template>
+    <!-- Desktop: anchored popup -->
     <div
-      v-if="menuVisible"
+      v-if="!isCompact && menuVisible"
       ref="menuRef"
       class="_popupMenu"
       :class="[
         $style.navAccountMenu,
-        { [$style.menuRight]: navCollapsed && !fixedStyle.position, [$style.mobile]: isCompact },
+        { [$style.menuRight]: navCollapsed && !fixedStyle.position },
         menuLeaving
           ? (navCollapsed ? $style.menuLeaveRight : $style.menuLeave)
           : (navCollapsed ? $style.menuEnterRight : $style.menuEnter),
       ]"
-      :style="navCollapsed && !isCompact ? fixedStyle : undefined"
+      :style="navCollapsed ? fixedStyle : undefined"
       @click.stop
     >
       <!-- Mode toggles (auth required) -->
@@ -175,6 +187,87 @@ function modeIcon(key: string, active: boolean): string {
         </button>
       </template>
     </div>
+
+    <!-- Mobile: bottom sheet via native <dialog> -->
+    <dialog
+      v-if="isCompact && menuVisible"
+      ref="dialogRef"
+      class="_nativeDialog"
+      :class="[$style.mobileBackdrop, menuLeaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+    >
+      <div
+        autofocus
+        tabindex="-1"
+        ref="menuRef"
+        class="_popupMenu"
+        :class="[
+          $style.navAccountMenu,
+          $style.mobile,
+          menuLeaving ? $style.sheetContentLeave : $style.sheetContentEnter,
+        ]"
+        @click.stop
+      >
+        <template v-if="account.hasToken && Object.keys(modes).length > 0">
+          <button
+            v-for="(val, key) in modes"
+            :key="key"
+            class="_button"
+            :class="[$style.navAccountMenuItem, { [$style.modeActive]: val }]"
+            :disabled="togglingMode"
+            @click="hapticSelection(); emit('toggle-mode', key as string)"
+            @keydown.enter="emit('toggle-mode', key as string)"
+          >
+            <span :class="$style.navAccountMenuLabel">{{ modeLabel(key as string) }}</span>
+            <i :class="['ti', modeIcon(key as string, val)]" />
+          </button>
+        </template>
+        <div v-if="modeError" :class="$style.navAccountMenuError">{{ modeError }}</div>
+        <template v-if="!isGuestAccount(account)">
+          <div v-if="account.hasToken && Object.keys(modes).length > 0" :class="$style.navAccountMenuDivider" />
+          <button class="_button" :class="$style.navAccountMenuItem" @click="navigateToUser(account.id, account.userId)">
+            <span>プロフィール</span>
+            <i class="ti ti-user" />
+          </button>
+          <div :class="$style.navAccountMenuDivider" />
+          <button class="_button" :class="$style.navAccountMenuItem" @click="account.hasToken ? openUrl(`https://${account.host}/settings`) : showLoginPrompt()">
+            <span>設定</span>
+            <i class="ti ti-external-link" />
+          </button>
+        </template>
+        <button v-if="isAdmin" class="_button" :class="$style.navAccountMenuItem" @click="openUrl(`https://${account.host}/admin`)">
+          <span>コントロールパネル</span>
+          <i class="ti ti-external-link" />
+        </button>
+
+        <div v-if="hasUpperSection" :class="$style.navAccountMenuDivider" />
+        <button class="_button" :class="$style.navAccountMenuItem" @click="emit('clear-cache')">
+          <span>キャッシュ削除</span>
+          <i class="ti ti-eraser" />
+        </button>
+        <template v-if="account.hasToken">
+          <button class="_button" :class="[$style.navAccountMenuItem, $style.navAccountLogout]" @click="emit('logout')">
+            <span>ログアウト</span>
+            <i class="ti ti-logout" />
+          </button>
+        </template>
+        <template v-else-if="isGuestAccount(account)">
+          <button class="_button" :class="[$style.navAccountMenuItem, $style.navAccountLogout]" @click="emit('logout')">
+            <span>データを削除</span>
+            <i class="ti ti-trash" />
+          </button>
+        </template>
+        <template v-else>
+          <button class="_button" :class="[$style.navAccountMenuItem, $style.navAccountRelogin]" @click="emit('relogin', account.host)">
+            <span>再ログイン</span>
+            <i class="ti ti-login" />
+          </button>
+          <button class="_button" :class="[$style.navAccountMenuItem, $style.navAccountLogout]" @click="emit('logout')">
+            <span>データを削除</span>
+            <i class="ti ti-trash" />
+          </button>
+        </template>
+      </div>
+    </dialog>
 </template>
 
 <style lang="scss" module>
@@ -244,13 +337,35 @@ function modeIcon(key: string, active: boolean): string {
   word-break: break-word;
 }
 
+/* Mobile bottom sheet — used inside <dialog class="_nativeDialog"> */
 .mobile {
-  position: fixed;
-  bottom: calc(50px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
-  left: 8px;
-  right: 8px;
-  top: auto;
-  margin: 0;
+  &.navAccountMenu {
+    position: static;
+    width: 100%;
+    margin: 0;
+    bottom: auto;
+    left: auto;
+    right: auto;
+    top: auto;
+    min-width: 0;
+    border-radius: 16px 16px 0 0;
+    background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
+    box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 8px 0 calc(8px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
+
+    &:focus,
+    &:focus-visible {
+      outline: none;
+    }
+  }
+
+  .navAccountMenuItem {
+    padding: 10px 16px;
+    min-height: 44px;
+    font-size: 0.9em;
+  }
 }
 
 .navAccountLogout {

--- a/src/styles/_navMenu.scss
+++ b/src/styles/_navMenu.scss
@@ -25,3 +25,29 @@
     to { opacity: 0; transform: translateY(8px); }
   }
 }
+
+// Mobile bottom-sheet — used together with a `<dialog class="_nativeDialog">`
+// host. The `mobileBackdrop` class anchors the sheet to the viewport bottom;
+// `sheetContentEnter` / `sheetContentLeave` slide the inner content up/down.
+:global(dialog._nativeDialog[open]).mobileBackdrop {
+  align-items: flex-end;
+  justify-content: stretch;
+}
+
+.sheetBackdropEnter {
+  animation: sheetBdIn var(--nd-duration-base, 0.18s) var(--nd-ease-decel, ease);
+}
+.sheetBackdropLeave {
+  animation: sheetBdOut var(--nd-duration-base, 0.18s) ease-out forwards;
+}
+@keyframes sheetBdIn { from { opacity: 0; } }
+@keyframes sheetBdOut { to { opacity: 0; } }
+
+.sheetContentEnter {
+  animation: sheetIn 0.25s var(--nd-ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+.sheetContentLeave {
+  animation: sheetOut 0.2s var(--nd-ease-decel, ease) forwards;
+}
+@keyframes sheetIn { from { transform: translateY(100%); } }
+@keyframes sheetOut { to { transform: translateY(100%); } }


### PR DESCRIPTION
## Summary

- `feat(deck-navbar)`: モバイル時のメニューをボトムシート化
- `feat(deck-navbar)`: アプリアイコンを 1.5 倍に拡大
- `chore`: bump version to 0.19.3

## Test plan

- [ ] CI: lint / typecheck / test 通過
- [ ] デスクトップ: ナビバーアプリアイコンの拡大表示を確認
- [ ] モバイル: ナビバーメニューがボトムシートで開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)