### PR TITLE
Release v0.19.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.19.4",
+  "version": "0.19.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.19.4"
+version = "0.19.5"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/api.ts
+++ b/src/aiscript/api.ts
@@ -92,7 +92,13 @@ export function createAiScriptEnv(
         await options.onDialog(title, text, type)
       } else {
         const { confirm } = useConfirm()
-        await confirm({ title, message: text, okLabel: 'OK', hideCancel: true })
+        await confirm({
+          title,
+          message: text,
+          okLabel: 'OK',
+          hideCancel: true,
+          type,
+        })
       }
       return values.NULL
     },
@@ -107,7 +113,7 @@ export function createAiScriptEnv(
       return values.BOOL(result)
     }
     const { confirm } = useConfirm()
-    const result = await confirm({ title, message: text })
+    const result = await confirm({ title, message: text, type: 'question' })
     return values.BOOL(result)
   })
 

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -175,6 +175,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
     label: 'タイムライン',
     icon: 'home',
     group: 'account',
+    guestAllowed: true,
     defaultProps: { tl: 'home', name: null },
     component: () => import('@/components/deck/DeckTimelineColumn.vue'),
   },

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -1,11 +1,34 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
+import SystemIcon from '@/components/common/SystemIcon.vue'
 import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useVaporTransition } from '@/composables/useVaporTransition'
-import { useConfirm } from '@/stores/confirm'
+import { type ConfirmIcon, useConfirm } from '@/stores/confirm'
 
 const { visible: show, options, resolve } = useConfirm()
+
+const iconType = computed<Exclude<ConfirmIcon, 'none'> | null>(() => {
+  if (options.value.icon === 'none') return null
+  if (options.value.icon) return options.value.icon
+  switch (options.value.type) {
+    case 'danger':
+    case 'warning':
+      return 'warn'
+    case 'info':
+      return 'info'
+    case 'success':
+      return 'success'
+    case 'error':
+      return 'error'
+    case 'question':
+      return 'question'
+    case 'waiting':
+      return 'waiting'
+    default:
+      return null
+  }
+})
 
 const { visible, entering, leaving } = useVaporTransition(show, {
   enterDuration: 200,
@@ -37,6 +60,9 @@ useNativeDialog(dialogRef, visible, {
         :class="[entering && $style.contentEnter, leaving && $style.contentLeave]"
       >
         <div :class="$style.header">
+          <div v-if="iconType" :class="$style.icon">
+            <SystemIcon :type="iconType" />
+          </div>
           <div :class="$style.title">{{ options.title }}</div>
         </div>
         <div :class="$style.body">
@@ -63,8 +89,19 @@ useNativeDialog(dialogRef, visible, {
 @use '@/styles/popup';
 
 .header {
-  padding: 16px 20px 4px;
+  padding: 20px 20px 4px;
   text-align: center;
+}
+
+.icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 8px;
+
+  svg {
+    width: 40px;
+    height: 40px;
+  }
 }
 
 .title {

--- a/src/components/common/SystemIcon.vue
+++ b/src/components/common/SystemIcon.vue
@@ -4,12 +4,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 Adapted from Misskey's MkSystemIcon.vue:
 https://github.com/misskey-dev/misskey/blob/develop/packages/frontend/src/components/global/MkSystemIcon.vue
-NoteDeck テーマ変数に合わせて色を置換。info / question / error の 3 種のみ移植。
+NoteDeck テーマ変数に合わせて色を置換。
 -->
 
 <script setup lang="ts">
 defineProps<{
-  type: 'info' | 'question' | 'error'
+  type: 'info' | 'question' | 'success' | 'warn' | 'error' | 'waiting'
 }>()
 </script>
 
@@ -53,6 +53,41 @@ defineProps<{
     />
   </svg>
   <svg
+    v-else-if="type === 'success'"
+    :class="[$style.icon, $style.success]"
+    viewBox="0 0 160 160"
+  >
+    <path
+      d="M62,80L74,92L98,68"
+      pathLength="1"
+      :class="[$style.line, $style.animLine]"
+    />
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      pathLength="1"
+      :class="[$style.line, $style.animCircle]"
+    />
+  </svg>
+  <svg
+    v-else-if="type === 'warn'"
+    :class="[$style.icon, $style.warn]"
+    viewBox="0 0 160 160"
+  >
+    <path
+      d="M80,64L80,88"
+      pathLength="1"
+      :class="[$style.line, $style.animLine]"
+    />
+    <path d="M80,108L80,108" :class="[$style.line, $style.animFade]" />
+    <path
+      d="M92,28L144,116C148.709,124.65 144.083,135.82 136,136L24,136C15.917,135.82 11.291,124.65 16,116L68,28C73.498,19.945 86.771,19.945 92,28Z"
+      pathLength="1"
+      :class="[$style.line, $style.animLine]"
+    />
+  </svg>
+  <svg
     v-else-if="type === 'error'"
     :class="[$style.icon, $style.error]"
     viewBox="0 0 160 160"
@@ -77,6 +112,26 @@ defineProps<{
       :class="[$style.line, $style.animCircle]"
     />
   </svg>
+  <svg
+    v-else-if="type === 'waiting'"
+    :class="[$style.icon, $style.waiting]"
+    viewBox="0 0 160 160"
+  >
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      pathLength="1"
+      :class="[$style.line, $style.animCircleWaiting]"
+    />
+    <circle
+      cx="80"
+      cy="80"
+      r="56"
+      style="opacity: 0.25"
+      :class="[$style.line]"
+    />
+  </svg>
 </template>
 
 <style lang="scss" module>
@@ -92,8 +147,20 @@ defineProps<{
     color: var(--nd-fg);
   }
 
+  &.success {
+    color: var(--nd-success);
+  }
+
+  &.warn {
+    color: var(--nd-warn);
+  }
+
   &.error {
     color: var(--nd-error);
+  }
+
+  &.waiting {
+    color: var(--nd-accent);
   }
 }
 
@@ -120,10 +187,16 @@ defineProps<{
   transform: rotate(-90deg);
 }
 
+.animCircleWaiting {
+  stroke-dasharray: 1;
+  stroke-dashoffset: calc(1 / 1.5);
+  animation: waiting 0.75s linear infinite;
+  transform-origin: center;
+}
+
 .animFade {
   opacity: 0;
-  animation: fade-in var(--duration, 0.5s) cubic-bezier(0, 0, 0.25, 1) 1 forwards
-    ;
+  animation: fade-in var(--duration, 0.5s) cubic-bezier(0, 0, 0.25, 1) 1 forwards;
   animation-delay: var(--delay, 0s);
 }
 
@@ -135,6 +208,15 @@ defineProps<{
   100% {
     stroke-dashoffset: 0;
     opacity: 1;
+  }
+}
+
+@keyframes waiting {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
   }
 }
 

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -85,6 +85,7 @@ async function toggleOfflineMode() {
       : 'すべての通信を停止し、キャッシュ済みデータのみ表示します。',
     okLabel: isOn ? '解除' : '切替',
     cancelLabel: 'キャンセル',
+    type: 'question',
   })
   if (ok) await offlineModeStore.toggle()
 }
@@ -98,6 +99,7 @@ async function toggleRealtimeMode() {
       : 'リアルタイム更新に切り替えます。',
     okLabel: '切替',
     cancelLabel: 'キャンセル',
+    type: 'question',
   })
   if (ok) realtimeModeStore.toggle()
 }

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -39,11 +39,16 @@ const props = defineProps<{
 const deckStore = useDeckStore()
 const accountsStore = useAccountsStore()
 
-// Guest accounts can only access public timelines (local/global), not home
+// Guest accounts can only access public timelines (local/global), not home/social
 const accountData = accountsStore.accountMap.get(props.column.accountId ?? '')
-const defaultTl: TimelineType =
-  accountData?.hasToken === false ? 'local' : 'home'
-const tlType = ref<TimelineType>(props.column.tl || defaultTl)
+const isGuestAccountForTl = accountData?.hasToken === false
+const defaultTl: TimelineType = isGuestAccountForTl ? 'local' : 'home'
+const savedTl = props.column.tl
+const initialTl: TimelineType =
+  isGuestAccountForTl && (savedTl === 'home' || savedTl === 'social')
+    ? defaultTl
+    : savedTl || defaultTl
+const tlType = ref<TimelineType>(initialTl)
 
 // --- Filter ---
 const columnFilters = computed<TimelineFilter>(() => props.column.filters ?? {})
@@ -71,17 +76,38 @@ const noteColumnConfig: NoteColumnConfig = {
         ...buildTimelineOptions(),
       })
     } catch (e) {
-      // Handle "disabled" timeline errors: remove related TL tabs and switch
-      if (String(e).includes('disabled')) {
+      // Promote server errors that mean "this tab is unreachable" into
+      // runtime-denied state. Both code-form (LTL_DISABLED, GTL_DISABLED,
+      // CREDENTIAL_REQUIRED) and the legacy "disabled" substring are honored.
+      const errStr = String(e)
+      const explicitTarget: TimelineType | null = errStr.includes(
+        'LTL_DISABLED',
+      )
+        ? 'local'
+        : errStr.includes('GTL_DISABLED')
+          ? 'global'
+          : null
+      const isUnreachable =
+        explicitTarget !== null ||
+        errStr.includes('disabled') ||
+        errStr.includes('CREDENTIAL_REQUIRED')
+      if (isUnreachable) {
+        const target = explicitTarget ?? tlType.value
         const aid = props.column.accountId
-        const related = new Set(getRelatedTimelineTypes(tlType.value))
+        // CREDENTIAL_REQUIRED only kills the failing tab; *_DISABLED takes the
+        // whole policy group (e.g. local + social share ltlAvailable).
+        const related = errStr.includes('CREDENTIAL_REQUIRED')
+          ? new Set<string>([target])
+          : new Set(getRelatedTimelineTypes(target))
         if (aid) {
           for (const t of related) markTimelineDenied(aid, t)
         }
         availableStandardTl.value = availableStandardTl.value.filter(
           (t) => !related.has(t),
         )
-        switchTl(availableStandardTl.value[0] ?? 'home')
+        if (related.has(tlType.value)) {
+          switchTl(availableStandardTl.value[0] ?? 'home')
+        }
         return []
       }
       throw e
@@ -186,7 +212,10 @@ const allTlTypes = computed(() => {
   if (!policyLoaded.value) return TL_TYPES.map((t) => t) // No account — show all
   const allowed = availableStandardTl.value
   if (allowed.length === 0) {
-    // Policies loaded but nothing available — show home only as safe fallback
+    // Policies loaded but nothing available. Guests have no home/social, so
+    // returning empty is the only honest answer; authenticated users fall
+    // back to home as a last resort.
+    if (isGuestAccountForTl) return []
     return TL_TYPES.filter((t) => t.value === 'home')
   }
   const allowedSet = new Set(allowed)
@@ -376,6 +405,11 @@ onMounted(async () => {
   try {
     if (host && accountId) {
       await Promise.all([applyPolicies(accountId, host), refreshFilterKeys()])
+      if (availableStandardTl.value.length === 0) {
+        // Nothing reachable for this account (e.g. guest on a closed server).
+        // Leave connectReady=false so useNoteColumn doesn't fire a doomed fetch.
+        return
+      }
       if (!availableStandardTl.value.includes(tlType.value)) {
         // Only update tlType synchronously here — full reconnect will happen
         // via connectReady watcher in useNoteColumn, avoiding a double-connect race.

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -663,6 +663,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
       streamingBatch.setPaused(true)
       resubscribe(adapter)
       setNotes([])
+      error.value = null
       isLoading.value = true
       try {
         // Load cache if requested
@@ -707,6 +708,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     // Swap subscription (stream/WebSocket stays connected)
     resubscribe(adapter)
     setNotes(snapshotNotes)
+    error.value = null
     await nextTick()
     if (scroller.value) scroller.value.scrollTop = scrollTop
 

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -1,11 +1,30 @@
 import { ref } from 'vue'
 
+export type ConfirmType =
+  | 'normal'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'success'
+  | 'error'
+  | 'question'
+  | 'waiting'
+export type ConfirmIcon =
+  | 'info'
+  | 'question'
+  | 'success'
+  | 'warn'
+  | 'error'
+  | 'waiting'
+  | 'none'
+
 export interface ConfirmOptions {
   title: string
   message: string
   okLabel?: string
   cancelLabel?: string
-  type?: 'normal' | 'danger'
+  type?: ConfirmType
+  icon?: ConfirmIcon
   hideCancel?: boolean
 }
 

--- a/src/utils/customTimelines.ts
+++ b/src/utils/customTimelines.ts
@@ -180,6 +180,40 @@ export function markTimelineDenied(accountId: string, tlType: string): void {
     runtimeDenied.set(accountId, set)
   }
   set.add(tlType)
+  // Drop memory cache so the next detect() rebuilds with the new denied applied.
+  // Without this, a stale memory hit would re-expose a tab we just learned is dead.
+  availableTlCache.delete(accountId)
+}
+
+/** Apply runtime-denied set to a result in-place. */
+function applyRuntimeDenied(
+  accountId: string,
+  result: TimelineAvailability,
+): void {
+  const rtDenied = getRuntimeDenied(accountId)
+  for (const d of rtDenied) {
+    result.denied.add(d)
+    const idx = result.available.indexOf(d as TimelineType)
+    if (idx >= 0) result.available.splice(idx, 1)
+  }
+}
+
+/**
+ * Strip TL types unreachable for the account in-place.
+ * Currently only guests, who lack auth for `home` and `social` (= hybrid).
+ * Applied even on cache hits so stale entries from older builds get cleaned up.
+ */
+function applyAccountExclusions(
+  accountId: string,
+  result: TimelineAvailability,
+): void {
+  const account = useAccountsStore().accountMap.get(accountId)
+  if (account?.hasToken !== false) return
+  for (const t of ['home', 'social'] as const) {
+    const idx = result.available.indexOf(t)
+    if (idx >= 0) result.available.splice(idx, 1)
+    result.denied.add(t)
+  }
 }
 
 export function getRuntimeDenied(accountId: string): Set<string> {
@@ -190,7 +224,41 @@ export function clearRuntimeDenied(accountId: string): void {
   runtimeDenied.delete(accountId)
 }
 
-/** Core network fetch logic for policies. Caches result in memory + localStorage. */
+/**
+ * Translate a flat policies object into TL availability/denial sets.
+ * Shared by authenticated (i/get-policies) and unauthenticated (meta.policies) paths.
+ */
+function applyPoliciesToAvailability(
+  policies: Record<string, boolean>,
+  available: TimelineType[],
+  denied: Set<string>,
+): void {
+  const hasPolicySupport = Object.keys(policies).length > 0
+  for (const [policyKey, tlTypes] of Object.entries(POLICY_TIMELINE_MAP)) {
+    if (hasPolicySupport) {
+      if (policies[policyKey] === true) {
+        available.push(...tlTypes)
+      } else {
+        for (const t of tlTypes) denied.add(t)
+      }
+    } else {
+      available.push(...tlTypes)
+    }
+  }
+  for (const [key, value] of Object.entries(policies)) {
+    if (POLICY_HANDLED_KEYS.has(key)) continue
+    const match = key.match(TL_AVAILABLE_RE)
+    if (!match) continue
+    const type = match[1] as string
+    if (value === true) {
+      available.push(type)
+    } else {
+      denied.add(type)
+    }
+  }
+}
+
+/** Core network fetch logic for authenticated policies. */
 async function fetchPoliciesFromNetwork(
   accountId: string,
 ): Promise<TimelineAvailability> {
@@ -203,7 +271,6 @@ async function fetchPoliciesFromNetwork(
     boolean
   >
 
-  // Separate mode flags from policies
   const policies: Record<string, boolean> = {}
   for (const [key, value] of Object.entries(data)) {
     if (key.startsWith('isIn') && key.endsWith('Mode')) {
@@ -213,46 +280,41 @@ async function fetchPoliciesFromNetwork(
     }
   }
 
-  // Determine if server supports the policy system.
-  const hasPolicySupport =
-    Object.keys(policies).length > 0 || Object.keys(modes).length > 0
+  applyPoliciesToAvailability(policies, available, denied)
 
-  // Standard TLs
-  const handledKeys = POLICY_HANDLED_KEYS
-  for (const [policyKey, tlTypes] of Object.entries(POLICY_TIMELINE_MAP)) {
-    if (hasPolicySupport) {
-      if (policies[policyKey] === true) {
-        available.push(...tlTypes)
-      } else {
-        for (const t of tlTypes) denied.add(t)
-      }
-    } else {
-      available.push(...tlTypes)
-    }
+  const result: TimelineAvailability = { available, denied, modes }
+  applyAccountExclusions(accountId, result)
+  applyRuntimeDenied(accountId, result)
+  availableTlCache.set(accountId, result)
+  writeCache(STORAGE_KEYS.policies(accountId), serializeAvailability(result))
+  return result
+}
+
+/**
+ * Public fallback for unauthenticated accounts: read default policies from
+ * the server's `meta` endpoint (no auth required). Tabs that the server has
+ * disabled at policy level (e.g. ltlAvailable=false) are filtered out before
+ * any TL fetch is attempted.
+ */
+async function fetchPoliciesFromMeta(
+  accountId: string,
+): Promise<TimelineAvailability> {
+  const denied = new Set<string>()
+  const available: TimelineType[] = []
+
+  const meta = (unwrap(await commands.apiGetMetaDetail(accountId)) ??
+    {}) as Record<string, unknown>
+  const rawPolicies = (meta.policies ?? {}) as Record<string, unknown>
+  const policies: Record<string, boolean> = {}
+  for (const [k, v] of Object.entries(rawPolicies)) {
+    if (typeof v === 'boolean') policies[k] = v
   }
 
-  // Fork-specific: scan *TlAvailable patterns dynamically
-  for (const [key, value] of Object.entries(policies)) {
-    if (handledKeys.has(key)) continue
-    const match = key.match(TL_AVAILABLE_RE)
-    if (!match) continue
-    const type = match[1] as string
-    if (value === true) {
-      available.push(type)
-    } else {
-      denied.add(type)
-    }
-  }
+  applyPoliciesToAvailability(policies, available, denied)
 
-  // Apply runtime-denied types (from previous "disabled" API errors)
-  const rtDenied = getRuntimeDenied(accountId)
-  for (const d of rtDenied) {
-    denied.add(d)
-    const idx = available.indexOf(d as TimelineType)
-    if (idx >= 0) available.splice(idx, 1)
-  }
-
-  const result = { available, denied, modes }
+  const result: TimelineAvailability = { available, denied, modes: {} }
+  applyAccountExclusions(accountId, result)
+  applyRuntimeDenied(accountId, result)
   availableTlCache.set(accountId, result)
   writeCache(STORAGE_KEYS.policies(accountId), serializeAvailability(result))
   return result
@@ -267,44 +329,20 @@ async function fetchPoliciesFromNetwork(
 export async function detectAvailableTimelines(
   accountId: string,
 ): Promise<TimelineAvailability> {
-  // 1. Memory cache
+  // 1. Memory cache (markTimelineDenied invalidates this so fresh denials surface)
   const cached = availableTlCache.get(accountId)
   if (cached) return cached
 
-  // Logged-out: use cached policies from authenticated session (preserves tabs)
-  const account = useAccountsStore().accountMap.get(accountId)
-  if (account && !account.hasToken) {
-    const stored = readCache<SerializedAvailability>(
-      STORAGE_KEYS.policies(accountId),
-    )
-    if (stored) {
-      const result = deserializeAvailability(stored.data)
-      availableTlCache.set(accountId, result)
-      return result
-    }
-    // No cache (guest account): conservative fallback
-    const result: TimelineAvailability = {
-      available: ['local', 'global'],
-      denied: new Set(),
-      modes: {},
-    }
-    availableTlCache.set(accountId, result)
-    return result
-  }
-
-  // 2. localStorage cache (SWR)
+  // 2. localStorage cache (SWR) — shared by both authenticated and logged-out.
+  //    applyAccountExclusions cleans up entries from older builds that may
+  //    have stored guest-unreachable types like 'home' or 'social'.
   const stored = readCache<SerializedAvailability>(
     STORAGE_KEYS.policies(accountId),
   )
   if (stored) {
     const result = deserializeAvailability(stored.data)
-    // Apply runtime-denied on top of cached data
-    const rtDenied = getRuntimeDenied(accountId)
-    for (const d of rtDenied) {
-      result.denied.add(d)
-      const idx = result.available.indexOf(d as TimelineType)
-      if (idx >= 0) result.available.splice(idx, 1)
-    }
+    applyAccountExclusions(accountId, result)
+    applyRuntimeDenied(accountId, result)
     availableTlCache.set(accountId, result)
     if (Date.now() - stored.updatedAt >= POLICY_CACHE_TTL_MS) {
       fetchPoliciesFromNetwork(accountId).catch(() => {
@@ -314,20 +352,38 @@ export async function detectAvailableTimelines(
     return result
   }
 
-  // 3. No cache — network required
-  try {
-    return await fetchPoliciesFromNetwork(accountId)
-  } catch (e) {
-    console.warn('[availableTimelines] failed to detect policies:', e)
-    // Conservative fallback: keep only 'home'
-    const result: TimelineAvailability = {
-      available: ['home'],
-      denied: new Set(),
-      modes: {},
+  // 3. No cache — try network.
+  //    - Authenticated: i/get-policies (per-user role-aggregated).
+  //    - Guest: meta.policies (server defaults, no auth).
+  const account = useAccountsStore().accountMap.get(accountId)
+  if (account?.hasToken) {
+    try {
+      return await fetchPoliciesFromNetwork(accountId)
+    } catch (e) {
+      console.warn('[availableTimelines] failed to detect policies (auth):', e)
     }
-    availableTlCache.set(accountId, result)
-    return result
+  } else if (account) {
+    try {
+      return await fetchPoliciesFromMeta(accountId)
+    } catch (e) {
+      console.warn('[availableTimelines] failed to detect policies (meta):', e)
+    }
   }
+
+  // 4. Final fallback: token state determines safe defaults; runtime-denied
+  //    applied so tabs we already learned are dead stay hidden.
+  const fallbackAvailable: TimelineType[] = account?.hasToken
+    ? ['home']
+    : ['local', 'global']
+  const result: TimelineAvailability = {
+    available: fallbackAvailable,
+    denied: new Set(),
+    modes: {},
+  }
+  applyAccountExclusions(accountId, result)
+  applyRuntimeDenied(accountId, result)
+  availableTlCache.set(accountId, result)
+  return result
 }
 
 /** Invalidate the cached availability for an account (e.g., after mode toggle). */


### PR DESCRIPTION
## Summary

- `feat(confirm)`: 確認ダイアログに本家風 SVG アイコンを追加
- `fix(timeline)`: ゲストアカウントの TL タブ可視性を修正
- `chore`: bump version to 0.19.5

## Test plan

- [ ] CI: lint / typecheck / test 通過
- [ ] 確認ダイアログのアイコン表示を確認
- [ ] ゲストアカウントで TL タブが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)