### PR TITLE
Release v0.19.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.19.5",
+  "version": "0.19.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.19.5"
+version = "0.19.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.19.5"
+version = "0.19.6"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -19,9 +19,11 @@ import { useAiConversation } from '@/composables/useAiConversation'
 import {
   buildAiContextBlock,
   joinSystemPrompt,
+  projectMemos,
   projectRecentConversation,
   projectVisibleItems,
 } from '@/composables/useAiSystemContext'
+import { ensureMemosLoaded, loadAllMemos } from '@/composables/useMemos'
 import { isSlashCommand, runSlashCommand } from '@/composables/useSlashCommand'
 import { useAccountsStore } from '@/stores/accounts'
 import { type AiSessionMeta, useAiSessionsStore } from '@/stores/aiSessions'
@@ -61,6 +63,10 @@ const deckStore = useDeckStore()
 const accountsStore = useAccountsStore()
 
 void sessionsStore.loadAllMeta()
+// メモは <memos> データソースとして AI context に注入し得るので、
+// AI カラムが mount された時点で in-memory cache をウォームアップしておく
+// (sendMessage は同期 cache 取得しか行わないため)。
+void ensureMemosLoaded()
 
 const { config: aiConfig } = useAiConfig()
 const aiChat = useAiChat()
@@ -510,11 +516,20 @@ async function sendMessage() {
           !m.heartbeat,
       )
 
+      // memos は active account のものだけを context に含める。AI カラム自体は
+      // cross-account だが、メモは per-account 設計なので「いま操作中の account
+      // の draft / Zettelkasten」が一番文脈として明確。
+      const activeAccountId = accountsStore.activeAccount?.id ?? null
+      const memoEntries = activeAccountId
+        ? Object.entries(loadAllMemos(activeAccountId))
+        : []
+
       const contextBlock = buildAiContextBlock(aiConfig.value, {
         activeAccount: accountsStore.activeAccount,
         currentColumn: focusedColumn ?? props.column,
         visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
         recentConversation: projectRecentConversation(history),
+        memos: projectMemos(memoEntries),
         accounts: accountsStore.accounts,
       })
       const system = joinSystemPrompt(skillsPrompt, contextBlock)

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -236,6 +236,12 @@ const DATA_SOURCE_LABELS: Record<DataSourceKey, DataSourceLabel> = {
     icon: 'ti-messages',
     description: '直近の会話を context に含める',
   },
+  memos: {
+    label: 'ローカルメモ (上限 20 件)',
+    icon: 'ti-notes',
+    description:
+      'Zettelkasten 形式のローカルメモを context に含める (現在のアカウントのみ)',
+  },
 }
 
 const HIGH_RISK_SET = new Set<PermissionKey>(HIGH_RISK_PERMISSION_KEYS)

--- a/src/composables/useAiConfig.test.ts
+++ b/src/composables/useAiConfig.test.ts
@@ -36,12 +36,13 @@ describe('defaultConfig', () => {
     expect(resolved['network.external']).toBe(false)
   })
 
-  it('default dataSources include account/column but not visibleNotes/recentConversation', () => {
+  it('default dataSources include account/column but not visibleNotes/recentConversation/memos', () => {
     const resolved = resolveDataSources(defaultConfig().dataSources)
     expect(resolved.currentAccount).toBe(true)
     expect(resolved.currentColumn).toBe(true)
     expect(resolved.visibleNotes).toBe(false)
     expect(resolved.recentConversation).toBe(false)
+    expect(resolved.memos).toBe(false)
   })
 })
 
@@ -119,6 +120,13 @@ describe('setPermissionPreset / setDataSourcePreset', () => {
     expect(next.preset).toBe('full')
     expect(next.custom.visibleNotes).toBe(true)
     expect(next.custom.recentConversation).toBe(true)
+    expect(next.custom.memos).toBe(true)
+  })
+
+  it('safe preset enables memos (PKM 用 markdown はユーザー自身の note として送って良い)', () => {
+    const next = setDataSourcePreset(defaultConfig().dataSources, 'safe')
+    expect(next.preset).toBe('safe')
+    expect(next.custom.memos).toBe(true)
   })
 })
 

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -54,6 +54,7 @@ export const DATA_SOURCE_KEYS = [
   'currentColumn',
   'visibleNotes',
   'recentConversation',
+  'memos',
 ] as const
 export type DataSourceKey = (typeof DATA_SOURCE_KEYS)[number]
 
@@ -251,18 +252,21 @@ const DATA_SOURCE_PRESETS: Record<
     currentColumn: true,
     visibleNotes: false,
     recentConversation: false,
+    memos: false,
   },
   safe: {
     currentAccount: true,
     currentColumn: true,
     visibleNotes: true,
     recentConversation: true,
+    memos: true,
   },
   full: {
     currentAccount: true,
     currentColumn: true,
     visibleNotes: true,
     recentConversation: true,
+    memos: true,
   },
 }
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -11,14 +11,18 @@ import {
   buildHeartbeatContextBlock,
   composeHeartbeatSystemPrompt,
   joinSystemPrompt,
+  MAX_MEMOS,
   MAX_RECENT_TURNS,
   MAX_VISIBLE_NOTES,
+  type MemoEntry,
   pickVisibleBlockTag,
+  projectMemos,
   projectRecentConversation,
   projectVisibleItems,
   projectVisibleNotes,
   stripCredentials,
 } from './useAiSystemContext'
+import type { StoredMemo } from './useMemos'
 
 const SAMPLE_ACCOUNT: Account = {
   id: 'acc-1',
@@ -126,6 +130,7 @@ describe('buildAiContextBlock', () => {
         currentColumn: false,
         visibleNotes: false,
         recentConversation: false,
+        memos: false,
       },
     }
     const block = buildAiContextBlock(cfg, {
@@ -604,6 +609,139 @@ describe('projectRecentConversation', () => {
       },
     ])
     expect(out).toEqual([{ role: 'user', content: '' }])
+  })
+})
+
+describe('projectMemos', () => {
+  function makeMemo(text: string, updatedAt: string): StoredMemo {
+    return {
+      updatedAt,
+      data: {
+        text,
+        cw: 'secret-cw',
+        showCw: true,
+        visibility: 'followers',
+        localOnly: true,
+        fileIds: ['file-1'],
+        pollChoices: ['a', 'b'],
+        pollMultiple: true,
+        showPoll: true,
+        scheduledAt: '2026-01-01T00:00:00Z',
+      },
+    }
+  }
+
+  it('returns empty array for empty / undefined input', () => {
+    expect(projectMemos(undefined)).toEqual([])
+    expect(projectMemos([])).toEqual([])
+  })
+
+  it('keeps only id / text / updatedAt and drops draft-only fields', () => {
+    const entries: MemoEntry[] = [
+      ['20260101010101', makeMemo('first body', '2026-01-01T01:01:01Z')],
+    ]
+    const out = projectMemos(entries)
+    expect(out).toEqual([
+      {
+        id: '20260101010101',
+        text: 'first body',
+        updatedAt: '2026-01-01T01:01:01Z',
+      },
+    ])
+    // draft 専用フィールドが落ちていることを明示確認
+    const memo = out[0] as unknown as Record<string, unknown>
+    expect(memo).not.toHaveProperty('cw')
+    expect(memo).not.toHaveProperty('visibility')
+    expect(memo).not.toHaveProperty('fileIds')
+    expect(memo).not.toHaveProperty('pollChoices')
+    expect(memo).not.toHaveProperty('scheduledAt')
+    expect(memo).not.toHaveProperty('localOnly')
+  })
+
+  it('sorts by updatedAt descending (newest first)', () => {
+    const entries: MemoEntry[] = [
+      ['20260101000000', makeMemo('older', '2026-01-01T00:00:00Z')],
+      ['20260201000000', makeMemo('newest', '2026-02-01T00:00:00Z')],
+      ['20260115000000', makeMemo('middle', '2026-01-15T00:00:00Z')],
+    ]
+    const out = projectMemos(entries)
+    expect(out.map((m) => m.text)).toEqual(['newest', 'middle', 'older'])
+  })
+
+  it('caps the result at MAX_MEMOS (20) by default', () => {
+    const entries: MemoEntry[] = Array.from({ length: 30 }, (_, i) => {
+      // i が大きいほど updatedAt が新しい
+      const day = String(i + 1).padStart(2, '0')
+      return [
+        `2026010100000${i}`,
+        makeMemo(`memo-${i}`, `2026-01-${day}T00:00:00Z`),
+      ] as MemoEntry
+    })
+    const out = projectMemos(entries)
+    expect(out).toHaveLength(MAX_MEMOS)
+    // 一番新しい (= i=29) が先頭
+    expect(out[0]?.text).toBe('memo-29')
+  })
+
+  it('respects custom limit', () => {
+    const entries: MemoEntry[] = Array.from(
+      { length: 5 },
+      (_, i) =>
+        [
+          `2026010100000${i}`,
+          makeMemo(`m${i}`, `2026-01-0${i + 1}T00:00:00Z`),
+        ] as MemoEntry,
+    )
+    expect(projectMemos(entries, 2)).toHaveLength(2)
+  })
+})
+
+describe('buildAiContextBlock — memos', () => {
+  const SAMPLE_MEMO = {
+    id: '20260101010101',
+    text: 'todo: write release notes',
+    updatedAt: '2026-01-01T01:01:01Z',
+  }
+
+  it('emits <memos> when ds.memos is on and memos array is non-empty', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      memos: [SAMPLE_MEMO],
+    })
+    expect(block).toContain('<memos>')
+    expect(block).toContain('"id": "20260101010101"')
+    expect(block).toContain('"text": "todo: write release notes"')
+  })
+
+  it('omits <memos> when ds.memos is off (readonly preset)', () => {
+    const cfg = configWithDataSources('readonly')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      memos: [SAMPLE_MEMO],
+    })
+    expect(block).not.toContain('<memos>')
+  })
+
+  it('omits <memos> when memos array is empty even if enabled', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      memos: [],
+    })
+    expect(block).not.toContain('<memos>')
+  })
+
+  it('omits <memos> when memos is undefined even if enabled', () => {
+    const cfg = configWithDataSources('safe')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+    })
+    expect(block).not.toContain('<memos>')
   })
 })
 

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -12,6 +12,7 @@
 import type { Account } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import { type AiConfig, resolveDataSources } from './useAiConfig'
+import type { StoredMemo } from './useMemos'
 
 /**
  * AI に送ってはいけないフィールド名 (credential / 機密データ)。
@@ -52,6 +53,11 @@ export interface AiContextInput {
   /** Phase 1 C5 で接続予定。未指定なら出力しない。 */
   recentConversation?: unknown[]
   /**
+   * 既に projection 済みのローカルメモ (Zettelkasten 形式 markdown)。
+   * 空配列 / undefined なら出力しない。
+   */
+  memos?: ProjectedMemo[]
+  /**
    * accountId → host 引きのための accounts 一覧 (任意)。指定すると
    * `<currentColumn>` 内に `accountHost` を補強し、AI が「このカラムは
    * どのサーバーか」を即把握できる。
@@ -64,6 +70,9 @@ export const MAX_VISIBLE_NOTES = 10
 
 /** AI 送信時に context に含める直近会話の上限ターン数 (= 直近 N メッセージ)。 */
 export const MAX_RECENT_TURNS = 20
+
+/** AI 送信時に context に含めるローカルメモの上限件数 (updatedAt 降順 + 先頭切り出し)。 */
+export const MAX_MEMOS = 20
 
 /**
  * AI 送信用に可視 item を軽量化する projection。
@@ -174,6 +183,44 @@ export function projectRecentConversation(
     })
   }
   return out
+}
+
+/**
+ * ローカルメモを <memos> ブロックに渡せる形へ投影する。
+ *
+ * メモは Zettelkasten 形式の永続 markdown ファイルで、PKM 用途。本文 (`text`) と
+ * id / 更新時刻だけ抜き、draft 専用フィールド (cw / visibility / fileIds /
+ * pollChoices / scheduledAt 等) は AI に渡さない (AI 側で本質的に不要 + 機密性も
+ * 低減)。createdAt は memoKey 自体が `YYYYMMDDHHmmss` 形式の Zettelkasten id =
+ * 作成時刻なので、AI は id から推測できる (= 別フィールドとして渡す必要なし)。
+ *
+ * - updatedAt 降順ソート (新しいメモが上)
+ * - limit (default {@link MAX_MEMOS}) で先頭切り出し
+ *
+ * 入力は `useMemos.ts` の `loadAllMemos(accountId)` の戻り値 `StoredMemos`
+ * (= Record<memoKey, StoredMemo>) を `Object.entries` で展開した形。
+ */
+export interface ProjectedMemo {
+  id: string
+  text: string
+  updatedAt: string
+}
+
+export type MemoEntry = readonly [memoKey: string, memo: StoredMemo]
+
+export function projectMemos(
+  entries: readonly MemoEntry[] | undefined,
+  limit = MAX_MEMOS,
+): ProjectedMemo[] {
+  if (!entries || entries.length === 0) return []
+  const sorted = [...entries].sort(([, a], [, b]) =>
+    a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0,
+  )
+  return sorted.slice(0, limit).map(([memoKey, memo]) => ({
+    id: memoKey,
+    text: memo.data.text,
+    updatedAt: memo.updatedAt,
+  }))
 }
 
 function projectOneNote(n: unknown): ProjectedNote {
@@ -295,6 +342,9 @@ export function buildAiContextBlock(
     parts.push(
       `  <recentConversation>\n${jsonBlock(ctx.recentConversation)}\n  </recentConversation>`,
     )
+  }
+  if (ds.memos && ctx.memos && ctx.memos.length > 0) {
+    parts.push(`  <memos>\n${jsonBlock(ctx.memos)}\n  </memos>`)
   }
 
   if (parts.length === 0) return ''

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -49,7 +49,9 @@ import {
 import {
   buildAiContextBlock,
   composeHeartbeatSystemPrompt,
+  projectMemos,
 } from './useAiSystemContext'
+import { ensureMemosLoaded, loadAllMemos } from './useMemos'
 
 /**
  * Rust scheduler (`commands/heartbeat.rs`) が `nd:ai-heartbeat-tick` event で
@@ -719,9 +721,19 @@ export function useHeartbeatDaemon() {
           ? eligibleCaps.map(toAnthropicTool)
           : eligibleCaps.map(toOpenAiTool)
 
+    // memos は active account のものだけを context に含める (#464)。
+    // heartbeat は currentColumn=null だが memos は column 非依存なので
+    // ds.memos が ON なら自律 tick からも参照される。
+    await ensureMemosLoaded()
+    const heartbeatActiveAccountId = accountsStore.activeAccount?.id ?? null
+    const heartbeatMemoEntries = heartbeatActiveAccountId
+      ? Object.entries(loadAllMemos(heartbeatActiveAccountId))
+      : []
+
     const notedeckContext = buildAiContextBlock(config.value, {
       activeAccount: accountsStore.activeAccount,
       currentColumn: null,
+      memos: projectMemos(heartbeatMemoEntries),
       accounts: accountsStore.accounts,
     })
     const heartbeatContext = `<heartbeat-skills>\n${skillBodies.join('\n\n---\n\n')}\n</heartbeat-skills>`

--- a/src/composables/useMemos.ts
+++ b/src/composables/useMemos.ts
@@ -165,11 +165,10 @@ function toFrontmatterSource(
   if (author) frontmatter.author = author
   frontmatter.createdAt = createdAt
   frontmatter.updatedAt = stored.updatedAt
-  frontmatter.format = 'mfm'
-  frontmatter.visibility = d.visibility
 
   // Optional fields — only emit when non-default to keep the frontmatter
   // readable in Obsidian/LLM contexts.
+  if (d.visibility !== 'public') frontmatter.visibility = d.visibility
   if (d.cw.trim()) {
     frontmatter.cw = d.cw
     if (d.showCw) frontmatter.showCw = true

--- a/src/defaults/ai.json5
+++ b/src/defaults/ai.json5
@@ -37,6 +37,8 @@
 
   // データソース: AI に送る system prompt に含める情報
   // permissions と違い、Phase 1 から即動作する (system prompt 末尾に <notedeck-context> として注入)
+  // - memos: ローカル Zettelkasten 形式の markdown メモを <memos> ブロックとして
+  //   注入。active account のみ、updatedAt 降順で上限 20 件。
   dataSources: {
     preset: 'readonly',
     custom: {
@@ -44,6 +46,7 @@
       'currentColumn': true,
       'visibleNotes': false,
       'recentConversation': false,
+      'memos': false,
     },
   },
 


### PR DESCRIPTION
## Summary

- feat(ai): AI カラムの情報源としてローカルメモを含められるように (#464)
- refactor(memo): frontmatter から format と visibility default を省略

## Test plan

- [ ] `pnpm lint` / `pnpm typecheck` / `pnpm test` が通ること
- [ ] `pnpm tauri:dev` で起動確認
- [ ] AI カラムでローカルメモを情報源として参照できること
- [ ] 既存メモの読み書きが互換のまま動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)