### PR TITLE
feat(chat): 起動時の即時 hydrate (#460 Phase B-2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1284,7 +1284,7 @@ DB::open_with_eviction(path, notes_cfg, chat_cfg)
 |-------|------|---------|---|
 | **A** | notecli `chat_messages_cache` テーブル + WS 全 event (`message`/`deleted`/`react`/`unreact`) を notecli 内で DB 反映 + REST 受信時の透過 upsert + `chat.cacheEnabled` opt-out + frontend `chatMessageStore` (Pinia 正規化ストア) 新設 + adapter 層の `cache` 引数と cached-getter wrapper | UI 影響なし (既存 `DeckChatColumn` はそのまま動作) | ✅ 実装済 |
 | **B-1** | (a) `DeckChatColumn` の `connect` / `openConversation` / `loadOlder` でログアウト中・API エラー時にキャッシュ fallback (b) chat カラムを `guestAllowed: true` (timeline と統一)、ログアウト中アカウントでも追加可能 (c) auth 必須操作 (送信・リアクションピッカー・添付) はボタン押下時点で `showLoginPrompt()` で先行誘導 (d) 「ログアウト中」バナーは DeckColumn 既存仕組みに任せる | **ログアウト後でも履歴閲覧できる**。トークン失効・サーバ BAN・オフライン時もキャッシュで救済。auth 必須操作は TL カラムと同じ「再ログインすると操作できます」トーストで誘導 | ✅ 実装済 |
-| **B-2** | 起動時の即時 hydrate (DB → render → 並行で API fetch して reconcile) | 体感速度向上。起動直後のチャット履歴が瞬時に出る | 未着手 |
+| **B-2** | `connectPerAccount` / `connectCrossAccount` / `openConversation` で **キャッシュから先に hydrate して即時 render → 並行で API fetch して reconcile** (server is source of truth で完全置換)。cross-account history view の entry build を `buildCrossAccountHistoryEntries` に抽出して両 phase で再利用 | カラム作成・タブ切替・thread を開く操作が**瞬時に表示**される。ネット遅延の影響は API reconcile 中だけ | ✅ 実装済 |
 | **B-3** | WS `react` / `unreact` イベントを `chatMessageStore.applyUpdate()` で UI 反映 | 他クライアントの reaction がリアルタイムに見える (現状は楽観的更新のみ) | 未着手 |
 | **B-4** | 起動 / WS 再接続時の sinceId gap reconcile | WS 切断中に届いたメッセージを起動時に取り戻す | 未着手 |
 | **B-5** | `DeckChatColumn.vue` を ID 参照ベースに refactor して `chatMessageStore` を唯一の実体に統合 + SnapshotStore のタブ切替復元 | アーキ整合 (`noteStore` パターンに揃う) | 未着手 |

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -171,22 +171,86 @@ async function loadCachedHistory(accountId: string): Promise<ChatMessage[]> {
   }
 }
 
+/**
+ * cross-account history view の entry 構築 (#460)。
+ * 全アカウントから集めた message を thread (room/DM) 単位の最新 1 件に dedup する。
+ * cache hydrate phase / API reconcile phase の両方から呼ぶ。
+ */
+function buildCrossAccountHistoryEntries(
+  allMessages: { msg: ChatMessage; accountId: string; host: string }[],
+): HistoryEntry[] {
+  const entries: HistoryEntry[] = []
+  const seen = new Set<string>()
+  const sorted = [...allMessages].sort(
+    (a, b) =>
+      new Date(b.msg.createdAt).getTime() - new Date(a.msg.createdAt).getTime(),
+  )
+
+  for (const { msg, accountId, host } of sorted) {
+    const uid = accountsStore.accounts.find((a) => a.id === accountId)?.userId
+    if (msg.toRoomId) {
+      const key = `${accountId}:room:${msg.toRoomId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      entries.push({
+        key,
+        accountId,
+        serverHost: host,
+        message: msg,
+        isRoom: true,
+        name: msg.toRoom?.name || 'Room',
+        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
+        avatarDecorations: msg.fromUser?.avatarDecorations,
+        roomId: msg.toRoomId,
+      })
+    } else {
+      const otherId = msg.fromUserId === uid ? msg.toUserId : msg.fromUserId
+      if (!otherId) continue
+      const key = `${accountId}:user:${otherId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      const other = msg.fromUserId === uid ? msg.toUser : msg.fromUser
+      entries.push({
+        key,
+        accountId,
+        serverHost: host,
+        message: msg,
+        isRoom: false,
+        name: other?.name || other?.username || otherId,
+        avatarUrl: other?.avatarUrl ?? undefined,
+        avatarDecorations: other?.avatarDecorations,
+        otherId,
+      })
+    }
+  }
+
+  return entries
+}
+
 async function connectPerAccount() {
   if (!account.value) {
     isLoading.value = false
     return
   }
 
-  // ログアウト中はキャッシュから読むだけ。API は呼ばない。
-  // 「ログアウト中」バナーは DeckColumn が自動で表示する。
-  if (!account.value.hasToken) {
-    if (props.column.accountId) {
-      chatHistory.value = await loadCachedHistory(props.column.accountId)
+  // 1. キャッシュから先に読み込んで即時 render (B-2 hydrate)。これにより
+  //    「起動直後/タブ切替直後にチャット履歴が瞬時に出る」体感を実現する。
+  if (props.column.accountId) {
+    const cached = await loadCachedHistory(props.column.accountId)
+    if (cached.length > 0) {
+      chatHistory.value = cached
+      isLoading.value = false
     }
+  }
+
+  // ログアウト中はキャッシュだけで終わり (B-1)。「ログアウト中」バナーは
+  // DeckColumn が自動表示する。
+  if (!account.value.hasToken) {
     isLoading.value = false
     return
   }
 
+  // 2. 並行で API fetch して reconcile (server is source of truth で完全置換)
   try {
     const adapter = await initAdapter()
     if (!adapter) return
@@ -210,16 +274,9 @@ async function connectPerAccount() {
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
     )
   } catch (e) {
-    // API エラー (token 失効 / サーバ BAN / オフライン等) → キャッシュ fallback
-    // 「オフライン」状態は offlineModeStore 経由で DeckColumn の offlineBanner が表す。
-    if (props.column.accountId) {
-      const cached = await loadCachedHistory(props.column.accountId)
-      if (cached.length > 0) {
-        chatHistory.value = cached
-      } else {
-        error.value = AppError.from(e)
-      }
-    } else {
+    // キャッシュで既に hydrate 済みならエラー表示しない (B-1 fallback と同じ判断)。
+    // 「オフライン」表示は DeckColumn の offlineBanner に任せる。
+    if (chatHistory.value.length === 0) {
       error.value = AppError.from(e)
     }
   } finally {
@@ -240,10 +297,28 @@ async function connectCrossAccount() {
     done: false,
   }))
 
+  // 1. 全アカウントのキャッシュを並列取得して即時 render (B-2 hydrate)
+  const cachedResults = await Promise.all(
+    accounts.map(async (acc) => {
+      const cached = await loadCachedHistory(acc.id)
+      return cached.map((msg) => ({
+        msg,
+        accountId: acc.id,
+        host: acc.host,
+      }))
+    }),
+  )
+  const cachedAll = cachedResults.flat()
+  if (cachedAll.length > 0) {
+    historyEntries.value = buildCrossAccountHistoryEntries(cachedAll)
+    isLoading.value = false
+  }
+
+  // 2. 並行で API fetch して reconcile。ログイン中アカウントは fresh、
+  //    ログアウト中は引き続き cache (上の hydrate と同じ結果)、API エラー時は cache fallback。
   const results = await Promise.allSettled(
     accounts.map(async (acc, i) => {
       try {
-        // ログアウト中はキャッシュから直接
         if (!acc.hasToken) {
           const cached = await loadCachedHistory(acc.id)
           return cached.map((msg) => ({
@@ -287,58 +362,12 @@ async function connectCrossAccount() {
     }),
   )
 
-  const entries: HistoryEntry[] = []
-  const seen = new Set<string>()
-
   const allMessages: { msg: ChatMessage; accountId: string; host: string }[] =
     []
   for (const r of results) {
     if (r.status === 'fulfilled') allMessages.push(...r.value)
   }
-  allMessages.sort(
-    (a, b) =>
-      new Date(b.msg.createdAt).getTime() - new Date(a.msg.createdAt).getTime(),
-  )
-
-  for (const { msg, accountId, host } of allMessages) {
-    const uid = accountsStore.accounts.find((a) => a.id === accountId)?.userId
-    if (msg.toRoomId) {
-      const key = `${accountId}:room:${msg.toRoomId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      entries.push({
-        key,
-        accountId,
-        serverHost: host,
-        message: msg,
-        isRoom: true,
-        name: msg.toRoom?.name || 'Room',
-        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
-        avatarDecorations: msg.fromUser?.avatarDecorations,
-        roomId: msg.toRoomId,
-      })
-    } else {
-      const otherId = msg.fromUserId === uid ? msg.toUserId : msg.fromUserId
-      if (!otherId) continue
-      const key = `${accountId}:user:${otherId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      const other = msg.fromUserId === uid ? msg.toUser : msg.fromUser
-      entries.push({
-        key,
-        accountId,
-        serverHost: host,
-        message: msg,
-        isRoom: false,
-        name: other?.name || other?.username || otherId,
-        avatarUrl: other?.avatarUrl ?? undefined,
-        avatarDecorations: other?.avatarDecorations,
-        otherId,
-      })
-    }
-  }
-
-  historyEntries.value = entries
+  historyEntries.value = buildCrossAccountHistoryEntries(allMessages)
   isLoading.value = false
   loadProgress.value = []
 }
@@ -452,16 +481,29 @@ async function openConversation(
         'roomId' in entry ? entry.roomId : (entry.message.toRoomId ?? '')
       currentRoomId.value = roomId ?? ''
       currentOtherId.value = null
+      const threadId = `r:${currentRoomId.value}`
+
+      // 1. Cache hydrate (B-2): 即時に thread を表示する。
+      const cached = await loadCachedThread(threadId)
+      if (cached.length > 0) {
+        messages.value = cached
+        viewMode.value = 'conversation'
+        isLoading.value = false
+        scrollToBottom()
+      }
+
       if (isLoggedOut || !adapter) {
-        messages.value = await loadCachedThread(`r:${currentRoomId.value}`)
+        if (cached.length === 0) messages.value = []
       } else {
+        // 2. 並行で API fetch して reconcile
         try {
           const msgs = await adapter.api.getChatRoomMessages(
             currentRoomId.value,
           )
           messages.value = msgs.slice().reverse()
         } catch {
-          messages.value = await loadCachedThread(`r:${currentRoomId.value}`)
+          // cache hydrate 済みならそのまま、空ならそのまま空 (error は最終 catch で吸収)
+          if (cached.length === 0) messages.value = []
         }
         if (isCrossAccount.value) adapter.stream.connect()
         chatSub = createQuerySubscription({
@@ -485,14 +527,26 @@ async function openConversation(
             : entry.message.fromUserId
       currentOtherId.value = otherId
       currentRoomId.value = null
+      const threadId = `u:${otherId}`
+
+      // 1. Cache hydrate (B-2)
+      const cached = await loadCachedThread(threadId)
+      if (cached.length > 0) {
+        messages.value = cached
+        viewMode.value = 'conversation'
+        isLoading.value = false
+        scrollToBottom()
+      }
+
       if (isLoggedOut || !adapter) {
-        messages.value = await loadCachedThread(`u:${otherId}`)
+        if (cached.length === 0) messages.value = []
       } else {
+        // 2. 並行で API fetch して reconcile
         try {
           const msgs = await adapter.api.getChatUserMessages(otherId)
           messages.value = msgs.slice().reverse()
         } catch {
-          messages.value = await loadCachedThread(`u:${otherId}`)
+          if (cached.length === 0) messages.value = []
         }
         if (isCrossAccount.value) adapter.stream.connect()
         chatSub = createQuerySubscription({


### PR DESCRIPTION
## Summary

- #460 の Phase B-2 を実装。B-1 で仕込んだ cache fallback を「**常に先に DB から読んで即時 render → 並行で API fetch して reconcile**」する offline-first 標準パターンに格上げする
- カラム作成・タブ切替・thread を開く操作が「ネット待ちの空白」から「ローカル cache 即時表示 → 数百ms 後に server 値で上書き」になり、体感速度が劇的に改善する
- 体感価値はノートの SnapshotStore + 3 段層構造に近づく流れ。Phase B-3〜B-5 で `chatMessageStore` を本格使用する地ならし

## 含まれるコミット

| sha | 内容 |
|---|---|
| `eeb31e2b` | feat(chat): 起動時の即時 hydrate (#460 Phase B-2) |

## 実装

`DeckChatColumn.vue` の 3 つの connect/open 関数を hydrate→reconcile に書き換え:

| 関数 | 変更内容 |
|---|---|
| `connectPerAccount` | 先に `loadCachedHistory` → 即時 `chatHistory` に流して `isLoading` 解除 → 並行で adapter API fetch して上書き。失敗時 cached が hydrate 済みなら error 表示しない |
| `connectCrossAccount` | 全アカウント分の cache を `Promise.all` で並列取得 → `buildCrossAccountHistoryEntries` で entry 構築 → 即時 `historyEntries` 表示 → 並行で各アカウント API fetch (B-1 で書いたロジックそのまま流用) |
| `openConversation` | thread を開く時点で先に `loadCachedThread` → `messages` に流し `viewMode = 'conversation'` に即切替 → 並行で API fetch して上書き |

ヘルパ抽出:
- `buildCrossAccountHistoryEntries(allMessages)` — cross-account の room/DM dedup + 時系列 sort を関数化。cache phase / API phase 双方で再利用

ARCHITECTURE.md「チャットキャッシュ・アーキテクチャ」の Phase 表を B-2 完了で同期。

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 566 件 pass
- [ ] **動作確認 (要 reviewer 実機)**:
  - [ ] アプリ起動 → chat カラム自動 mount で history が**ネット待ちなし**で即出る
  - [ ] history view から thread をタップ → conversation view が**即出る** (ネット fetch は背後で reconcile)
  - [ ] cross-account chat カラムでも同様 (全アカウント cache 即表示 → 各 API fetch で順次 reconcile)
  - [ ] ネットワーク遮断 → 起動 → cache のみで表示。API は background で失敗するが UI に error 表示は出ない
  - [ ] 復旧 → 次回 mount 時に新着が反映される

## NOTE

- Phase B-1 でログアウト/エラー fallback は既に動いているので、B-2 はその上に「成功時も先に cache を見せる」レイヤーを足しただけ。**ログアウト中** / **オフライン** のシナリオは B-1 と完全に同等の挙動を維持
- B-3 (WS reactions UI 反映) と B-5 (ID 参照 refactor) で `chatMessageStore` を本格使用する流れで、その時点でこの hydrate→reconcile も noteStore.put + ID 参照に書き換える方向

🤖 Generated with [Claude Code](https://claude.com/claude-code)