### PR TITLE
fix(chat): legacy messaging/unread API を新 chat API に置換 (#469)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=091b5e75bd840e9399400c7c0804549b8b0c2913#091b5e75bd840e9399400c7c0804549b8b0c2913"
+source = "git+https://github.com/hitalin/notecli?rev=1489d3ecd5df56335d58491a3a238a9d0121a87d#1489d3ecd5df56335d58491a3a238a9d0121a87d"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "091b5e75bd840e9399400c7c0804549b8b0c2913", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "1489d3ecd5df56335d58491a3a238a9d0121a87d", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -104,7 +104,13 @@ pub async fn api_get_unread_chat(
 ) -> Result<bool> {
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials(&db, &account_id)?;
-    client.get_unread_chat(&host, &token).await
+    // notecli #9 (#469) で `messaging/unread` 廃止に伴い `chat/history` の
+    // isRead 集計に切り替わったため、自分送信メッセージ除外用に user_id を渡す。
+    let me_user_id = match db.get_account(&account_id) {
+        Ok(Some(account)) => account.user_id.clone(),
+        _ => return Ok(false),
+    };
+    client.get_unread_chat(&host, &token, &me_user_id).await
 }
 
 // --- Chat ---


### PR DESCRIPTION
## Summary

#469: Misskey 新 Chat API ([#15686](https://github.com/misskey-dev/misskey/pull/15686), v2025) で legacy \`messaging/unread\` エンドポイントが完全廃止されたため、\`chat/history\` の \`isRead\` 集計に置き換える。

[notecli#9](https://github.com/hitalin/notecli/pull/9) (merged) と組み合わせて完結する PR。

## Why

\`packages/backend/src/server/api/endpoints/messaging/\` ディレクトリ自体が Misskey develop に存在せず、最新サーバに対しては既存実装が API エラー (= UI チャット未読バッジが常に 0) になっていた。

本 PR + notecli#9 の組み合わせで、\`useUnreadChat\` ベースのバッジが最新 Misskey サーバでも正しく動作するようになる。

## Changes

### [\`src-tauri/Cargo.toml\`](src-tauri/Cargo.toml)

notecli rev を \`091b5e7\` → \`1489d3e\` に更新 ([notecli#9](https://github.com/hitalin/notecli/pull/9) 取り込み)。

### [\`src-tauri/src/commands/messaging.rs\`](src-tauri/src/commands/messaging.rs) \`api_get_unread_chat\`

notecli \`get_unread_chat\` のシグネチャ拡張 (\`me_user_id\` 引数追加) に追従:

```rust
let me_user_id = match db.get_account(&account_id) {
    Ok(Some(account)) => account.user_id.clone(),
    _ => return Ok(false),
};
client.get_unread_chat(&host, &token, &me_user_id).await
```

\`me_user_id\` を渡す理由は **自分送信メッセージを除外** するため。Misskey の \`isRead\` は DM の場合 "相手が読んだか" を意味するので、自分送信で \`isRead=false\` でも自分の未読扱いにしない。

frontend 側 (\`useUnreadChat\` / \`useColumnBadge\`) は \`api_get_unread_chat\` を呼び続けるだけで変更なし。signature は specta が再生成して bindings.ts に反映される。

## Test plan

- [x] \`pnpm typecheck\` (specta bindings 再生成 + 型整合)
- [x] \`pnpm lint\`
- [x] \`pnpm test\` (566 passed)
- [x] \`cargo check\` in src-tauri (notecli 1489d3e 取り込み成功)
- [ ] 手動: 最新 Misskey サーバに接続 → 未読 DM/room がある状態でアプリ起動 → ナビバー/チャットカラムのバッジに数字が出る
- [ ] 手動: 未読を読み終わった → 次回 polling (chatPollInterval) でバッジが消える
- [ ] 手動: 自分送信のみで相手未読の DM がある状態 → バッジが出ない (= 自分の未読扱いされない)

## Related

- Issue: #469
- 前提 PR: [hitalin/notecli#9](https://github.com/hitalin/notecli/pull/9) (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)