### PR TITLE
feat(chat): UI 改善 (バッジ / カスタム絵文字 / Drive Picker)

### DIFF
--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -40,11 +40,13 @@ const displayUser = computed(() => {
   if (!u) return null
   return {
     name: u.name || u.username,
+    hasName: !!u.name,
     avatarUrl: u.avatarUrl ?? null,
     avatarDecorations: u.avatarDecorations ?? [],
     username: u.username,
     host: u.host ?? null,
     isCat: u.isCat,
+    emojis: u.emojis ?? {},
   }
 })
 
@@ -185,7 +187,14 @@ usePortal(lightboxPortalRef)
     <div :class="$style.chatBubbleWrapper">
       <div :class="$style.chatBubble">
         <div v-if="!isMine && displayUser" :class="$style.chatSender">
-          {{ displayUser.name }}
+          <MkMfm
+            v-if="displayUser.hasName"
+            :text="displayUser.name"
+            :emojis="displayUser.emojis"
+            :server-host="serverHost"
+            plain
+          />
+          <template v-else>{{ displayUser.username }}</template>
         </div>
         <div v-if="message.text" :class="$style.chatText">
           <MkMfm :text="message.text" :server-host="serverHost" @mention-hover="onMentionHover" @mention-leave="onMentionLeave" />

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -20,6 +20,7 @@ import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
 import MkChatMessage from '@/components/common/MkChatMessage.vue'
+import MkDrivePicker from '@/components/common/MkDrivePicker.vue'
 import MkReactionPicker from '@/components/common/MkReactionPicker.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
 import {
@@ -144,9 +145,8 @@ const conversationServerHost = ref<string | null>(null)
 const messageText = ref('')
 const isSending = ref(false)
 const showEmojiPicker = ref(false)
+const showDrivePicker = ref(false)
 const attachedFile = ref<NormalizedDriveFile | null>(null)
-const isUploading = ref(false)
-const fileInput = ref<HTMLInputElement | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
 let chatSub: ChannelSubscription | null = null
@@ -746,7 +746,7 @@ function goBack() {
 }
 
 const canSend = computed(() => {
-  if (isSending.value || isUploading.value) return false
+  if (isSending.value) return false
   return messageText.value.trim().length > 0 || attachedFile.value !== null
 })
 
@@ -808,45 +808,19 @@ function pickEmoji(reaction: string) {
   showEmojiPicker.value = false
 }
 
-function openFilePicker() {
-  fileInput.value?.click()
+/**
+ * 通常ノートの投稿フォーム ([MkPostForm.vue]) と同じ MkDrivePicker フローに統一する。
+ * Drive 上の既存ファイルを選ぶ操作と新規アップロードの両方が picker 内で完結する。
+ */
+function toggleDrivePicker() {
+  if (!ensureActiveAccountAuth()) return
+  showDrivePicker.value = !showDrivePicker.value
 }
 
-async function onFileSelected(e: Event) {
-  const input = e.target as HTMLInputElement
-  const files = input.files
-  if (!files || !files[0]) return
-
-  if (!ensureActiveAccountAuth()) {
-    input.value = ''
-    return
-  }
-
-  const accId = activeAccountId.value
-  // For cross-account, get adapter via multiAdapters; for per-account, use getAdapter()
-  const adapter = isCrossAccount.value
-    ? accId
-      ? await multiAdapters.getOrCreate(accId)
-      : null
-    : getAdapter()
-  if (!adapter) return
-
-  isUploading.value = true
-  try {
-    const file = files[0]
-    const buffer = await file.arrayBuffer()
-    const data = Array.from(new Uint8Array(buffer))
-    attachedFile.value = await adapter.api.uploadFile(
-      file.name,
-      data,
-      file.type || 'application/octet-stream',
-    )
-  } catch (e) {
-    handleActionError(e)
-  } finally {
-    isUploading.value = false
-    input.value = ''
-  }
+function onDrivePicked(files: NormalizedDriveFile[]) {
+  // Misskey の chat/messages/create は fileId を 1 つしか受け付けないので先頭のみ採用する。
+  if (files.length > 0 && files[0]) attachedFile.value = files[0]
+  showDrivePicker.value = false
 }
 
 function removeAttachment() {
@@ -1293,12 +1267,13 @@ onBeforeUnmount(() => {
             <i class="ti ti-x" />
           </button>
         </div>
-        <div v-if="isUploading" :class="$style.chatUploading">
-          <i class="ti ti-loader-2 nd-spin" /> アップロード中...
-        </div>
         <div :class="$style.chatInputRow">
           <div :class="$style.chatInputActions">
-            <button :class="$style.chatActionBtn" title="ファイル" @click="openFilePicker">
+            <button
+              :class="[$style.chatActionBtn, { [$style.active]: showDrivePicker }]"
+              title="ドライブ"
+              @click.stop="toggleDrivePicker"
+            >
               <i class="ti ti-photo" />
             </button>
             <button :class="$style.chatActionBtn" title="絵文字" @click.stop="showEmojiPicker = !showEmojiPicker">
@@ -1329,13 +1304,14 @@ onBeforeUnmount(() => {
             @pick="pickEmoji"
           />
         </div>
-        <input
-          ref="fileInput"
-          type="file"
-          style="display: none"
-          accept="image/*,video/*,audio/*"
-          @change="onFileSelected"
-        />
+        <!-- Drive picker (below input row) -->
+        <div v-if="showDrivePicker && activeAccountId" :class="$style.chatDrivePopup" @click.stop>
+          <MkDrivePicker
+            :account-id="activeAccountId"
+            @pick="onDrivePicked"
+            @close="showDrivePicker = false"
+          />
+        </div>
       </div>
     </div>
   </DeckColumn>
@@ -1549,13 +1525,6 @@ onBeforeUnmount(() => {
   }
 }
 
-.chatUploading {
-  font-size: 0.8em;
-  opacity: 0.5;
-  padding: 2px 8px 4px;
-}
-
-
 .chatInputRow {
   display: flex;
   align-items: flex-end;
@@ -1585,6 +1554,12 @@ onBeforeUnmount(() => {
   &:hover {
     opacity: 0.8;
     background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.05));
+  }
+
+  &.active {
+    opacity: 1;
+    color: var(--nd-accent);
+    background: var(--nd-accentedBg, rgba(134, 179, 0, 0.15));
   }
 }
 
@@ -1641,6 +1616,17 @@ onBeforeUnmount(() => {
   right: 0;
   max-height: 320px;
   overflow: auto;
+  background: var(--nd-popup);
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+  z-index: var(--nd-z-menu);
+}
+
+.chatDrivePopup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
   background: var(--nd-popup);
   border-radius: 12px 12px 0 0;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -34,6 +34,7 @@ import { useNoteSound } from '@/composables/useNoteSound'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useChatMessageStore } from '@/stores/chatMessageStore'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -74,7 +75,26 @@ const {
 const accountsStore = useAccountsStore()
 const multiAdapters = useMultiAccountAdapters()
 const chatMessageStore = useChatMessageStore()
+const serversStore = useServersStore()
 const { prefetch: prefetchThreads } = useChatThreadPrefetch()
+
+/** cross-account history entry のサーバー favicon URL を解決する。 */
+function resolveEntryServerIcon(host: string): string {
+  return (
+    serversStore.servers.get(host)?.iconUrl || `https://${host}/favicon.ico`
+  )
+}
+
+/** 2 アカウント以上ログイン中の cross-account view でのみサーバーバッジを出す。 */
+const showServerBadge = computed(
+  () => isCrossAccount.value && accountsStore.accounts.length >= 2,
+)
+
+function entryBadgeTitle(entry: HistoryEntry): string {
+  const acc = accountsStore.accounts.find((a) => a.id === entry.accountId)
+  if (!acc) return entry.serverHost
+  return `@${acc.username}@${acc.host}`
+}
 
 /**
  * 操作対象アカウントが投稿可能 (token 保持) かをチェックする (#460)。
@@ -1165,21 +1185,29 @@ onBeforeUnmount(() => {
           :class="$style.historyItem"
           @click="openConversation(entry)"
         >
-          <MkAvatar
-            v-if="entry.avatarUrl"
-            :avatar-url="entry.avatarUrl"
-            :decorations="entry.avatarDecorations ?? []"
-            :size="36"
-          />
-          <div v-else :class="$style.historyAvatarPlaceholder">
-            <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
+          <div :class="$style.historyAvatarWrap">
+            <MkAvatar
+              v-if="entry.avatarUrl"
+              :avatar-url="entry.avatarUrl"
+              :decorations="entry.avatarDecorations ?? []"
+              :size="36"
+            />
+            <div v-else :class="$style.historyAvatarPlaceholder">
+              <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
+            </div>
+            <img
+              v-if="showServerBadge"
+              :src="resolveEntryServerIcon(entry.serverHost)"
+              :class="$style.historyServerBadge"
+              :title="entryBadgeTitle(entry)"
+              @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
+            />
           </div>
           <div :class="$style.historyInfo">
             <div :class="$style.historyName">{{ entry.name }}</div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
           <div :class="$style.historyMeta">
-            <span :class="$style.historyHost">{{ entry.serverHost }}</span>
             <span :class="$style.historyTime">{{ formatTime(entry.message.createdAt) }}</span>
           </div>
         </button>
@@ -1388,6 +1416,13 @@ onBeforeUnmount(() => {
   }
 }
 
+.historyAvatarWrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+}
+
 .historyAvatarPlaceholder {
   width: 36px;
   height: 36px;
@@ -1396,8 +1431,21 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
   opacity: 0.5;
+}
+
+.historyServerBadge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--nd-panel);
+  box-shadow: 0 0 0 2px var(--nd-panel);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .historyInfo {
@@ -1428,15 +1476,6 @@ onBeforeUnmount(() => {
   align-items: flex-end;
   gap: 2px;
   flex-shrink: 0;
-}
-
-.historyHost {
-  font-size: 0.7em;
-  opacity: 0.35;
-  max-width: 80px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .historyTime {

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -21,6 +21,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
 import MkChatMessage from '@/components/common/MkChatMessage.vue'
 import MkDrivePicker from '@/components/common/MkDrivePicker.vue'
+import MkMfm from '@/components/common/MkMfm.vue'
 import MkReactionPicker from '@/components/common/MkReactionPicker.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
 import {
@@ -159,6 +160,10 @@ interface HistoryEntry {
   message: ChatMessage
   isRoom: boolean
   name: string
+  /** 表示名 (`name`) が user-defined か (false なら fallback の username/roomId を使用)。 */
+  hasName: boolean
+  /** name に含まれる `:shortcode:` を画像に解決するための辞書。 */
+  emojis?: Record<string, string>
   avatarUrl?: string
   avatarDecorations?: AvatarDecoration[]
   otherId?: string
@@ -248,6 +253,10 @@ function buildCrossAccountHistoryEntries(
         message: msg,
         isRoom: true,
         name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        // ChatRoom には emojis 辞書が無いので、最新メッセージ送信者の辞書で代替する
+        // (同一サーバー上の shortcode は同じ辞書で解決できる)
+        emojis: msg.fromUser?.emojis ?? undefined,
         avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
         avatarDecorations: msg.fromUser?.avatarDecorations,
         roomId: msg.toRoomId,
@@ -266,6 +275,8 @@ function buildCrossAccountHistoryEntries(
         message: msg,
         isRoom: false,
         name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
         avatarUrl: other?.avatarUrl ?? undefined,
         avatarDecorations: other?.avatarDecorations,
         otherId,
@@ -535,6 +546,8 @@ function getHistoryEntries() {
     message: ChatMessage
     isRoom: boolean
     name: string
+    hasName: boolean
+    emojis?: Record<string, string>
     avatarUrl?: string
     avatarDecorations?: AvatarDecoration[]
   }[] = []
@@ -548,6 +561,8 @@ function getHistoryEntries() {
         message: msg,
         isRoom: true,
         name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        emojis: msg.fromUser?.emojis ?? undefined,
         avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
         avatarDecorations: msg.fromUser?.avatarDecorations,
       })
@@ -563,6 +578,8 @@ function getHistoryEntries() {
         message: msg,
         isRoom: false,
         name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
         avatarUrl: other?.avatarUrl ?? undefined,
         avatarDecorations: other?.avatarDecorations,
       })
@@ -1178,7 +1195,16 @@ onBeforeUnmount(() => {
             />
           </div>
           <div :class="$style.historyInfo">
-            <div :class="$style.historyName">{{ entry.name }}</div>
+            <div :class="$style.historyName">
+              <MkMfm
+                v-if="entry.hasName"
+                :text="entry.name"
+                :emojis="entry.emojis"
+                :server-host="entry.serverHost"
+                plain
+              />
+              <template v-else>{{ entry.name }}</template>
+            </div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
           <div :class="$style.historyMeta">
@@ -1209,7 +1235,16 @@ onBeforeUnmount(() => {
             <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
           </div>
           <div :class="$style.historyInfo">
-            <div :class="$style.historyName">{{ entry.name }}</div>
+            <div :class="$style.historyName">
+              <MkMfm
+                v-if="entry.hasName"
+                :text="entry.name"
+                :emojis="entry.emojis"
+                :server-host="account?.host"
+                plain
+              />
+              <template v-else>{{ entry.name }}</template>
+            </div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
         </button>


### PR DESCRIPTION
## Summary

チャットカラムまわりの UX 改善 3 件を 1 PR に。

- **#1 cross-account 履歴のサーバーバッジ化** — 右側の host テキスト (`historyHost`) を撤去し、通知カラムと同じパターンでアバター右上にサーバー favicon を重ねる。識別は tooltip (`@username@host`)。
- **#2 カスタム絵文字描画** — `:hoge:` を含むユーザー名 / ルーム名を bubble の sender, history list の両方で MkMfm レンダリング。`ChatUser.emojis` 辞書をそのまま使用 (Room は ChatRoom に辞書が無いので最新メッセージ送信者の辞書で代替)。
- **#3 ファイル添付を Drive Picker 経由に統一** — `<input type="file">` 直叩きを撤去し、通常ノート投稿フォーム ([MkPostForm.vue](src/components/common/MkPostForm.vue)) と同じ MkDrivePicker フローに合流。既存ファイル選択と新規アップロードの両方が picker 内で完結。`chat/messages/create` は fileId を 1 つしか受け取らないので picker 側で複数選ばれても先頭のみ採用。

## Commit-by-commit

1. `feat(chat): メッセージ送信者名にカスタム絵文字を描画` — MkChatMessage.vue (#2 メイン)
2. `feat(chat): cross-account 履歴で host テキストをサーバーアイコンバッジに置換` — DeckChatColumn.vue (#1)
3. `feat(chat): ファイル添付を Drive Picker 経由に統一` — DeckChatColumn.vue (#3)
4. `feat(chat): 履歴一覧の相手名 / ルーム名にもカスタム絵文字を描画` — DeckChatColumn.vue (#2 history list 追加)

## Test plan

- [x] `pnpm typecheck` 通過 (vue-tsc)
- [x] `pnpm lint` 通過 (biome)
- [x] `pnpm test` 通過 (566 tests)
- [ ] **ブラウザ確認 (未実施)** — 以下の golden path を実機で見たい:
  - cross-account チャット履歴の右上にサーバーアイコン (favicon 取得失敗時 `/server-icon-error.svg` fallback)
  - カスタム絵文字を name に持つユーザーの bubble・history list 両方で `:emoji:` が画像化される
  - Drive ボタン押下で picker が textarea 上にポップアップ → ファイル選択 → 添付プレビュー反映
  - picker 内アップロードセルで新規 upload → 添付に反映
  - picker キャンセル時に attachedFile が変わらない

## 関連スコープ外

- 会話を開いた際の DeckColumn ヘッダー (`conversationTitle`) は string prop のため `:emoji:` が plain で残る。これは別 PR で対応 (DeckColumn の title slot 化が必要)。