### PR TITLE
fix(chat): メッセージ右クリックで「内容をコピー」「削除」 (#468)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=1489d3ecd5df56335d58491a3a238a9d0121a87d#1489d3ecd5df56335d58491a3a238a9d0121a87d"
+source = "git+https://github.com/hitalin/notecli?rev=b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6#b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "1489d3ecd5df56335d58491a3a238a9d0121a87d", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -294,6 +294,29 @@ pub async fn api_unreact_chat_message(
         .await
 }
 
+// --- Chat delete ---
+
+/// Misskey 新 Chat API の `chat/messages/delete` をラップする (#468)。
+/// Misskey はハード削除のみで、削除成功後 WS `chat:deleted` event が
+/// 配信される。notecli 側の streaming.rs がそれを受けて
+/// `chat_messages_cache` から自動削除し、フロントには
+/// `stream-chat-message-deleted` event が emit される。フロントの
+/// QuerySubscription はその event を受けて UI からも消すため、
+/// この command の呼び出し側で楽観更新は不要。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_delete_chat_message(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    message_id: String,
+) -> Result<()> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client
+        .delete_chat_message(&host, &token, &message_id)
+        .await
+}
+
 // --- Legacy messaging ---
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::api_read_announcement,
             commands::api_react_chat_message,
             commands::api_unreact_chat_message,
+            commands::api_delete_chat_message,
             commands::api_create_messaging_message,
             commands::api_search_users_by_query,
             commands::api_search_hashtags,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -851,6 +851,23 @@ async apiUnreactChatMessage(accountId: string, messageId: string, reaction: stri
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Misskey 新 Chat API の `chat/messages/delete` をラップする (#468)。
+ * Misskey はハード削除のみで、削除成功後 WS `chat:deleted` event が
+ * 配信される。notecli 側の streaming.rs がそれを受けて
+ * `chat_messages_cache` から自動削除し、フロントには
+ * `stream-chat-message-deleted` event が emit される。フロントの
+ * QuerySubscription はその event を受けて UI からも消すため、
+ * この command の呼び出し側で楽観更新は不要。
+ */
+async apiDeleteChatMessage(accountId: string, messageId: string) : Promise<Result<null, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_delete_chat_message", { accountId, messageId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async apiCreateMessagingMessage(accountId: string, params: JsonValue) : Promise<Result<ChatMessage, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_create_messaging_message", { accountId, params }) };

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -2,6 +2,7 @@
 import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue'
 import type { ChatMessage, NormalizedUser } from '@/adapters/types'
 import MkAvatar from '@/components/common/MkAvatar.vue'
+import MkChatMessageMoreMenu from '@/components/common/MkChatMessageMoreMenu.vue'
 import MkMfm from '@/components/common/MkMfm.vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useHoverPopup } from '@/composables/useHoverPopup'
@@ -25,7 +26,10 @@ if (props.accountId) provideNoteAccountId(props.accountId)
 const emit = defineEmits<{
   react: [messageId: string, reaction: string]
   unreact: [messageId: string, reaction: string]
+  delete: [messageId: string]
 }>()
+
+const moreMenuRef = ref<InstanceType<typeof MkChatMessageMoreMenu> | null>(null)
 
 const { reactionUrl } = useEmojiResolver()
 
@@ -185,7 +189,10 @@ usePortal(lightboxPortalRef)
       :is-cat="displayUser.isCat"
     />
     <div :class="$style.chatBubbleWrapper">
-      <div :class="$style.chatBubble">
+      <div
+        :class="$style.chatBubble"
+        @contextmenu.prevent.stop="moreMenuRef?.open($event)"
+      >
         <div v-if="!isMine && displayUser" :class="$style.chatSender">
           <MkMfm
             v-if="displayUser.hasName"
@@ -262,6 +269,13 @@ usePortal(lightboxPortalRef)
       </button>
     </div>
   </div>
+
+  <MkChatMessageMoreMenu
+    ref="moreMenuRef"
+    :message="message"
+    :is-mine="!!isMine"
+    @delete="emit('delete', $event)"
+  />
 
   <div v-if="mentionPopup.isVisible.value && mentionUserId" ref="mentionPortalRef">
     <MkUserPopup

--- a/src/components/common/MkChatMessageMoreMenu.vue
+++ b/src/components/common/MkChatMessageMoreMenu.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ChatMessage } from '@/adapters/types'
+import PopupMenu from './PopupMenu.vue'
+
+const props = defineProps<{
+  message: ChatMessage
+  isMine: boolean
+}>()
+
+const emit = defineEmits<{
+  delete: [messageId: string]
+}>()
+
+const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
+const showDeleteConfirm = ref(false)
+
+function open(e: MouseEvent) {
+  popupMenuRef.value?.open(e)
+}
+
+function close() {
+  popupMenuRef.value?.close()
+}
+
+function resetSubViews() {
+  showDeleteConfirm.value = false
+}
+
+async function copyAndClose(text: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.style.cssText = 'position:fixed;opacity:0'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    document.body.removeChild(ta)
+  }
+  close()
+}
+
+function confirmDelete() {
+  emit('delete', props.message.id)
+  close()
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <PopupMenu ref="popupMenuRef" @close="resetSubViews">
+    <!-- Delete confirm -->
+    <template v-if="showDeleteConfirm">
+      <div class="_popupConfirmText">このメッセージを削除しますか？</div>
+      <button class="_popupItem _popupItemDanger" @click="confirmDelete">
+        <i class="ti ti-trash" />
+        削除
+      </button>
+      <button class="_popupItem" @click="showDeleteConfirm = false">
+        <i class="ti ti-x" />
+        キャンセル
+      </button>
+    </template>
+
+    <!-- Main menu -->
+    <template v-else>
+      <button v-if="message.text" class="_popupItem" @click="copyAndClose(message.text!)">
+        <i class="ti ti-copy" />
+        内容をコピー
+      </button>
+      <template v-if="isMine">
+        <div v-if="message.text" class="_popupDivider" />
+        <button class="_popupItem _popupItemDanger" @click="showDeleteConfirm = true">
+          <i class="ti ti-trash" />
+          削除
+        </button>
+      </template>
+    </template>
+  </PopupMenu>
+</template>

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -883,6 +883,24 @@ async function handleUnreact(messageId: string, reaction: string) {
   }
 }
 
+/**
+ * チャットメッセージを Misskey 側から削除する (#468)。
+ * 削除成功後 WS `chat:deleted` event が配信され、QuerySubscription の
+ * `onDelete` 経由で UI から自動的に消える。先回りで `removeMessage()`
+ * しても dedup window で吸収されるが、楽観更新は不要なのでここでは行わない。
+ */
+async function handleDelete(messageId: string) {
+  const accId = activeAccountId.value
+  if (!accId) return
+  if (!ensureActiveAccountAuth()) return
+
+  try {
+    unwrap(await commands.apiDeleteChatMessage(accId, messageId))
+  } catch (e) {
+    handleActionError(e)
+  }
+}
+
 function pickReaction(reaction: string) {
   if (reactionTargetId.value) {
     handleReact(reactionTargetId.value, reaction)
@@ -1273,6 +1291,7 @@ onBeforeUnmount(() => {
               :other-avatar-url="currentRoomId ? undefined : conversationOtherAvatarUrl ?? undefined"
               @react="handleReact"
               @unreact="handleUnreact"
+              @delete="handleDelete"
             />
           </div>
         </template>


### PR DESCRIPTION
Fixes #468

## Summary

チャットメッセージのバブルを右クリックすると、ノートと同じ PopupMenu パターンでコンテキストメニューが開く。表示項目は最小限の 2 つ:

- **内容をコピー** (本文がある時のみ)
- **削除** (自分のメッセージのみ。サブビューで確認後に削除)

`chat/messages/delete` バインディングは notecli/notedeck の両方に無かったので併せて追加。

- 上流: [hitalin/notecli#10](https://github.com/hitalin/notecli/pull/10) (マージ済み, rev `b4786e1a`)
- 削除後は WS `chat:deleted` event → `chat_messages_cache` 削除 + `stream-chat-message-deleted` emit → QuerySubscription `onDelete` 経由で UI 反映、なので楽観更新は不要

## Commit-by-commit

1. `chore(deps): bump notecli to add chat/messages/delete API`
2. `feat(chat): api_delete_chat_message Tauri command を追加` (messaging.rs + lib.rs collect_commands + bindings.ts)
3. `feat(chat): メッセージ右クリックメニューで「内容をコピー」「削除」 (#468)` (MkChatMessageMoreMenu 新設 + MkChatMessage 配線 + DeckChatColumn handler)

## Test plan

- [x] `cargo check` 通過 (Cargo.lock 更新)
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過 (566 tests)
- [ ] **ブラウザ確認 (未実施)** — 動作確認したいケース:
  - 自分のメッセージを右クリック → 「内容をコピー」「削除」が出る
  - 相手のメッセージを右クリック → 「内容をコピー」のみ (text なしの場合は何も出ない)
  - 削除サブビューで「削除」押下後、WS 経由で UI から消える
  - 削除サブビューで「キャンセル」押下時に main view に戻る
  - クリップボードに本文がコピーされる

## 関連

`feat(chat): UI polish (#478)` の後続。同じファイル群を触るが、独立した別機能なので 1 PR = 1 課題で分けた。