### PR TITLE
fix(chat): メッセージ送信を新 API (chat/messages/create-to-{user,room}) に統一

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6#b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6"
+source = "git+https://github.com/hitalin/notecli?rev=4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad#4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad#4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad"
+source = "git+https://github.com/hitalin/notecli?rev=5f80dbe2e5c083a61af81c5befd1e6736c12e02a#5f80dbe2e5c083a61af81c5befd1e6736c12e02a"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "5f80dbe2e5c083a61af81c5befd1e6736c12e02a", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -187,6 +187,10 @@ pub async fn api_get_chat_room_messages(
     Ok(msgs)
 }
 
+/// Misskey 新 Chat API の `chat/messages/create-to-{user,room}` をラップする。
+/// `text` / `file_id` は両方 Option で、どちらか一方は必須 (Misskey 側で
+/// バリデーション)。`user_id` / `room_id` も両方 Option で、どちらか一方は必須
+/// (こちらは本関数で先回り検証)。
 #[tauri::command]
 #[specta::specta]
 pub async fn api_create_chat_message(
@@ -194,19 +198,22 @@ pub async fn api_create_chat_message(
     account_id: String,
     user_id: Option<String>,
     room_id: Option<String>,
-    text: String,
+    text: Option<String>,
+    file_id: Option<String>,
 ) -> Result<ChatMessage> {
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials(&db, &account_id)?;
+    let text_ref = text.as_deref();
+    let file_id_ref = file_id.as_deref();
     let msg = match (user_id, room_id) {
         (Some(uid), _) => {
             client
-                .create_chat_message_to_user(&host, &token, &uid, &text)
+                .create_chat_message_to_user(&host, &token, &uid, text_ref, file_id_ref)
                 .await?
         }
         (_, Some(rid)) => {
             client
-                .create_chat_message_to_room(&host, &token, &rid, &text)
+                .create_chat_message_to_room(&host, &token, &rid, text_ref, file_id_ref)
                 .await?
         }
         _ => {

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -324,16 +324,3 @@ pub async fn api_delete_chat_message(
         .await
 }
 
-// --- Legacy messaging ---
-
-#[tauri::command]
-#[specta::specta]
-pub async fn api_create_messaging_message(
-    app_state: State<'_, AppState>,
-    account_id: String,
-    params: serde_json::Value,
-) -> Result<ChatMessage> {
-    let (db, client) = app_state.ready().await;
-    let (host, token) = get_credentials(&db, &account_id)?;
-    client.create_messaging_message(&host, &token, params).await
-}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,7 +180,6 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::api_react_chat_message,
             commands::api_unreact_chat_message,
             commands::api_delete_chat_message,
-            commands::api_create_messaging_message,
             commands::api_search_users_by_query,
             commands::api_search_hashtags,
             commands::api_ap_show,

--- a/src/adapters/misskey/api.ts
+++ b/src/adapters/misskey/api.ts
@@ -690,7 +690,8 @@ export class MisskeyApi implements ApiAdapter {
   async createChatMessage(params: {
     userId?: string
     roomId?: string
-    text: string
+    text?: string
+    fileId?: string
   }): Promise<ChatMessage> {
     this.requireAuth()
     return unwrapAny(
@@ -698,7 +699,8 @@ export class MisskeyApi implements ApiAdapter {
         this.accountId,
         params.userId ?? null,
         params.roomId ?? null,
-        params.text,
+        params.text ?? null,
+        params.fileId ?? null,
       ),
     )
   }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1394,9 +1394,15 @@ async apiGetChatRoomMessages(accountId: string, roomId: string, limit: number | 
     else return { status: "error", error: e  as any };
 }
 },
-async apiCreateChatMessage(accountId: string, userId: string | null, roomId: string | null, text: string) : Promise<Result<ChatMessage, { code: string; message: string }>> {
+/**
+ * Misskey 新 Chat API の `chat/messages/create-to-{user,room}` をラップする。
+ * `text` / `file_id` は両方 Option で、どちらか一方は必須 (Misskey 側で
+ * バリデーション)。`user_id` / `room_id` も両方 Option で、どちらか一方は必須
+ * (こちらは本関数で先回り検証)。
+ */
+async apiCreateChatMessage(accountId: string, userId: string | null, roomId: string | null, text: string | null, fileId: string | null) : Promise<Result<ChatMessage, { code: string; message: string }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("api_create_chat_message", { accountId, userId, roomId, text }) };
+    return { status: "ok", data: await TAURI_INVOKE("api_create_chat_message", { accountId, userId, roomId, text, fileId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -868,14 +868,6 @@ async apiDeleteChatMessage(accountId: string, messageId: string) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
-async apiCreateMessagingMessage(accountId: string, params: JsonValue) : Promise<Result<ChatMessage, { code: string; message: string }>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("api_create_messaging_message", { accountId, params }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
 async apiSearchUsersByQuery(accountId: string, query: string, limit: number | null) : Promise<Result<JsonValue, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_search_users_by_query", { accountId, query, limit }) };

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -15,7 +15,7 @@ import type {
   ChatMessage,
   NormalizedDriveFile,
 } from '@/adapters/types'
-import type { ChatReactionUser, JsonValue } from '@/bindings'
+import type { ChatReactionUser } from '@/bindings'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
@@ -773,17 +773,21 @@ async function sendMessage() {
   if (!accId) return
   if (!ensureActiveAccountAuth()) return
 
+  // Misskey v2025 で legacy `messaging/messages/create` (`apiCreateMessagingMessage`) は
+  // 削除済みなので、新 Chat API #15686 の `chat/messages/create-to-{user,room}`
+  // (`apiCreateChatMessage`) に統一する。text / fileId のいずれか一方でも送信可能。
   isSending.value = true
   try {
-    const params: Record<string, unknown> = {
-      text: messageText.value.trim() || undefined,
-    }
-    if (currentOtherId.value) params.userId = currentOtherId.value
-    if (currentRoomId.value) params.roomId = currentRoomId.value
-    if (attachedFile.value) params.fileId = attachedFile.value.id
-
+    const text = messageText.value.trim() || null
+    const fileId = attachedFile.value?.id ?? null
     const sent = unwrap(
-      await commands.apiCreateMessagingMessage(accId, params as JsonValue),
+      await commands.apiCreateChatMessage(
+        accId,
+        currentOtherId.value,
+        currentRoomId.value,
+        text,
+        fileId,
+      ),
     ) as unknown as ChatMessage
     messageText.value = ''
     attachedFile.value = null


### PR DESCRIPTION
## Summary

新規チャット送信時に **`messaging/messages/create` (404)** が出ていたバグの修正。Misskey v2025 (#15686) で legacy messaging API が完全削除されているため、`apiCreateMessagingMessage` 経由では送信不能だった。

新 Chat API の `chat/messages/create-to-{user,room}` を呼ぶ `apiCreateChatMessage` (notedeck#479 で追加済み) に統一する。あわせてシグネチャを `text` / `fileId` ともに optional に拡張し、ファイル単独送信にも対応する (Misskey 側で「テキスト or ファイル」必須を検証)。

## 上流 PR (両方マージ済み・取り込み済み)

- [hitalin/notecli#11](https://github.com/hitalin/notecli/pull/11) — `create_chat_message_to_{user,room}` の text/fileId optional 化 + 旧コードの `userId`/`roomId` パラメータ名を Misskey schema 準拠の `toUserId`/`toRoomId` に修正
- [hitalin/notecli#12](https://github.com/hitalin/notecli/pull/12) — dead code 化していた `create_messaging_message` 関数を撤去

最終 rev: `5f80dbe2`

## Commit-by-commit

1. `chore(deps): bump notecli で text/fileId optional 化に追従` (notecli#11 取り込み)
2. `fix(chat): 新規メッセージ送信を chat/messages/create-to-{user,room} に切替`
3. `refactor(chat): legacy api_create_messaging_message Tauri command を撤去`
4. `chore(deps): bump notecli で legacy create_messaging_message 関数撤去に追従` (notecli#12 取り込み)

## Test plan

- [x] `cargo check` 通過
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 通過 (566 tests)
- [ ] **ブラウザ確認 (未実施)** — 動作確認したいケース:
  - DM スレッドで「テキストのみ」送信 → 成功 + UI に反映 + WS で相手にも届く
  - DM スレッドで「ファイルのみ (Drive Picker から)」送信 → 成功 + UI 反映
  - Room スレッドで「テキスト + ファイル」送信 → 成功 + UI 反映
  - 空文字 + 添付なしの状態で送信ボタンが押下不可 (canSend computed)

## 残課題 (本 PR 対象外)

`commands/auth.rs` の OAuth scope に残る `read:messaging` / `write:messaging` は別件で対応。Misskey v2025 でこれらの scope が no-op か invalid かを確認した上で、必要なら `read:chat` / `write:chat` 系に置換する notecli PR + notedeck rev bump PR が必要。