### PR TITLE
chore(deps): bump notecli で MiAuth chat scope 置換に追従

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=5f80dbe2e5c083a61af81c5befd1e6736c12e02a#5f80dbe2e5c083a61af81c5befd1e6736c12e02a"
+source = "git+https://github.com/hitalin/notecli?rev=c3d1eff62bd2e68325e7108c7d771432f6ac93ea#c3d1eff62bd2e68325e7108c7d771432f6ac93ea"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "5f80dbe2e5c083a61af81c5befd1e6736c12e02a", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "c3d1eff62bd2e68325e7108c7d771432f6ac93ea", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"


### PR DESCRIPTION
## Summary

[hitalin/notecli#13](https://github.com/hitalin/notecli/pull/13) (マージ済) で MiAuth 認証時の permissions[] が legacy `read:messaging` / `write:messaging` から Misskey v2025 (#15686) の新スコープ `read:chat` / `write:chat` に置換された。本 PR はその rev bump のみ。

新 rev: `c3d1eff6`

## Why

新 NoteDeck で初回認証したユーザーは現状 v2025+ サーバーで chat 操作 (送信・削除・履歴取得) が `AUTHENTICATION_FAILED` になる可能性があった。本 PR を取り込むと再認証フロー以降の token に新スコープが付与される。

## 既存ユーザーの影響

token を保持中のユーザーは無影響 (token に焼き付けられたスコープはサーバ側がそのまま受理)。アカウント追加 / 再ログインを行うと自動で新スコープに更新される。NoteDeck はβリリース段階のため legacy スコープの後方互換は保持しない。

## Test plan

- [x] `cargo check` 通過 (Cargo.lock 更新)
- [ ] **動作確認 (未実施)**:
  - アカウント追加フローで MiAuth ページに `read:chat` / `write:chat` が表示される
  - 新規 token で chat 送信・削除・履歴取得が成功する