### PR TITLE
Release v0.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.20.0",
+  "version": "0.20.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6#b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6"
+source = "git+https://github.com/hitalin/notecli?rev=4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad#4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=1489d3ecd5df56335d58491a3a238a9d0121a87d#1489d3ecd5df56335d58491a3a238a9d0121a87d"
+source = "git+https://github.com/hitalin/notecli?rev=b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6#b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad#4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad"
+source = "git+https://github.com/hitalin/notecli?rev=5f80dbe2e5c083a61af81c5befd1e6736c12e02a#5f80dbe2e5c083a61af81c5befd1e6736c12e02a"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=5f80dbe2e5c083a61af81c5befd1e6736c12e02a#5f80dbe2e5c083a61af81c5befd1e6736c12e02a"
+source = "git+https://github.com/hitalin/notecli?rev=c3d1eff62bd2e68325e7108c7d771432f6ac93ea#c3d1eff62bd2e68325e7108c7d771432f6ac93ea"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "5f80dbe2e5c083a61af81c5befd1e6736c12e02a", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "4b40c340b5bc81d5e01b06834ce5b13c5d2bf2ad", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.20.0"
+version = "0.20.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "1489d3ecd5df56335d58491a3a238a9d0121a87d", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "b4786e1a9a8afdd1310e057dcdc189b93bcb2ee6", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey IDE — integrated deck environment for browsing, posting
 edition = "2021"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "5f80dbe2e5c083a61af81c5befd1e6736c12e02a", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "c3d1eff62bd2e68325e7108c7d771432f6ac93ea", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -294,6 +294,29 @@ pub async fn api_unreact_chat_message(
         .await
 }
 
+// --- Chat delete ---
+
+/// Misskey 新 Chat API の `chat/messages/delete` をラップする (#468)。
+/// Misskey はハード削除のみで、削除成功後 WS `chat:deleted` event が
+/// 配信される。notecli 側の streaming.rs がそれを受けて
+/// `chat_messages_cache` から自動削除し、フロントには
+/// `stream-chat-message-deleted` event が emit される。フロントの
+/// QuerySubscription はその event を受けて UI からも消すため、
+/// この command の呼び出し側で楽観更新は不要。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_delete_chat_message(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    message_id: String,
+) -> Result<()> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client
+        .delete_chat_message(&host, &token, &message_id)
+        .await
+}
+
 // --- Legacy messaging ---
 
 #[tauri::command]

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -187,6 +187,10 @@ pub async fn api_get_chat_room_messages(
     Ok(msgs)
 }
 
+/// Misskey 新 Chat API の `chat/messages/create-to-{user,room}` をラップする。
+/// `text` / `file_id` は両方 Option で、どちらか一方は必須 (Misskey 側で
+/// バリデーション)。`user_id` / `room_id` も両方 Option で、どちらか一方は必須
+/// (こちらは本関数で先回り検証)。
 #[tauri::command]
 #[specta::specta]
 pub async fn api_create_chat_message(
@@ -194,19 +198,22 @@ pub async fn api_create_chat_message(
     account_id: String,
     user_id: Option<String>,
     room_id: Option<String>,
-    text: String,
+    text: Option<String>,
+    file_id: Option<String>,
 ) -> Result<ChatMessage> {
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials(&db, &account_id)?;
+    let text_ref = text.as_deref();
+    let file_id_ref = file_id.as_deref();
     let msg = match (user_id, room_id) {
         (Some(uid), _) => {
             client
-                .create_chat_message_to_user(&host, &token, &uid, &text)
+                .create_chat_message_to_user(&host, &token, &uid, text_ref, file_id_ref)
                 .await?
         }
         (_, Some(rid)) => {
             client
-                .create_chat_message_to_room(&host, &token, &rid, &text)
+                .create_chat_message_to_room(&host, &token, &rid, text_ref, file_id_ref)
                 .await?
         }
         _ => {

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -324,16 +324,3 @@ pub async fn api_delete_chat_message(
         .await
 }
 
-// --- Legacy messaging ---
-
-#[tauri::command]
-#[specta::specta]
-pub async fn api_create_messaging_message(
-    app_state: State<'_, AppState>,
-    account_id: String,
-    params: serde_json::Value,
-) -> Result<ChatMessage> {
-    let (db, client) = app_state.ready().await;
-    let (host, token) = get_credentials(&db, &account_id)?;
-    client.create_messaging_message(&host, &token, params).await
-}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::api_read_announcement,
             commands::api_react_chat_message,
             commands::api_unreact_chat_message,
+            commands::api_delete_chat_message,
             commands::api_create_messaging_message,
             commands::api_search_users_by_query,
             commands::api_search_hashtags,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,7 +180,6 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             commands::api_react_chat_message,
             commands::api_unreact_chat_message,
             commands::api_delete_chat_message,
-            commands::api_create_messaging_message,
             commands::api_search_users_by_query,
             commands::api_search_hashtags,
             commands::api_ap_show,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/api.ts
+++ b/src/adapters/misskey/api.ts
@@ -690,7 +690,8 @@ export class MisskeyApi implements ApiAdapter {
   async createChatMessage(params: {
     userId?: string
     roomId?: string
-    text: string
+    text?: string
+    fileId?: string
   }): Promise<ChatMessage> {
     this.requireAuth()
     return unwrapAny(
@@ -698,7 +699,8 @@ export class MisskeyApi implements ApiAdapter {
         this.accountId,
         params.userId ?? null,
         params.roomId ?? null,
-        params.text,
+        params.text ?? null,
+        params.fileId ?? null,
       ),
     )
   }

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -851,6 +851,23 @@ async apiUnreactChatMessage(accountId: string, messageId: string, reaction: stri
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Misskey 新 Chat API の `chat/messages/delete` をラップする (#468)。
+ * Misskey はハード削除のみで、削除成功後 WS `chat:deleted` event が
+ * 配信される。notecli 側の streaming.rs がそれを受けて
+ * `chat_messages_cache` から自動削除し、フロントには
+ * `stream-chat-message-deleted` event が emit される。フロントの
+ * QuerySubscription はその event を受けて UI からも消すため、
+ * この command の呼び出し側で楽観更新は不要。
+ */
+async apiDeleteChatMessage(accountId: string, messageId: string) : Promise<Result<null, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_delete_chat_message", { accountId, messageId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async apiCreateMessagingMessage(accountId: string, params: JsonValue) : Promise<Result<ChatMessage, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_create_messaging_message", { accountId, params }) };

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1394,9 +1394,15 @@ async apiGetChatRoomMessages(accountId: string, roomId: string, limit: number | 
     else return { status: "error", error: e  as any };
 }
 },
-async apiCreateChatMessage(accountId: string, userId: string | null, roomId: string | null, text: string) : Promise<Result<ChatMessage, { code: string; message: string }>> {
+/**
+ * Misskey 新 Chat API の `chat/messages/create-to-{user,room}` をラップする。
+ * `text` / `file_id` は両方 Option で、どちらか一方は必須 (Misskey 側で
+ * バリデーション)。`user_id` / `room_id` も両方 Option で、どちらか一方は必須
+ * (こちらは本関数で先回り検証)。
+ */
+async apiCreateChatMessage(accountId: string, userId: string | null, roomId: string | null, text: string | null, fileId: string | null) : Promise<Result<ChatMessage, { code: string; message: string }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("api_create_chat_message", { accountId, userId, roomId, text }) };
+    return { status: "ok", data: await TAURI_INVOKE("api_create_chat_message", { accountId, userId, roomId, text, fileId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -868,14 +868,6 @@ async apiDeleteChatMessage(accountId: string, messageId: string) : Promise<Resul
     else return { status: "error", error: e  as any };
 }
 },
-async apiCreateMessagingMessage(accountId: string, params: JsonValue) : Promise<Result<ChatMessage, { code: string; message: string }>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("api_create_messaging_message", { accountId, params }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
 async apiSearchUsersByQuery(accountId: string, query: string, limit: number | null) : Promise<Result<JsonValue, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_search_users_by_query", { accountId, query, limit }) };

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -40,11 +40,13 @@ const displayUser = computed(() => {
   if (!u) return null
   return {
     name: u.name || u.username,
+    hasName: !!u.name,
     avatarUrl: u.avatarUrl ?? null,
     avatarDecorations: u.avatarDecorations ?? [],
     username: u.username,
     host: u.host ?? null,
     isCat: u.isCat,
+    emojis: u.emojis ?? {},
   }
 })
 
@@ -185,7 +187,14 @@ usePortal(lightboxPortalRef)
     <div :class="$style.chatBubbleWrapper">
       <div :class="$style.chatBubble">
         <div v-if="!isMine && displayUser" :class="$style.chatSender">
-          {{ displayUser.name }}
+          <MkMfm
+            v-if="displayUser.hasName"
+            :text="displayUser.name"
+            :emojis="displayUser.emojis"
+            :server-host="serverHost"
+            plain
+          />
+          <template v-else>{{ displayUser.username }}</template>
         </div>
         <div v-if="message.text" :class="$style.chatText">
           <MkMfm :text="message.text" :server-host="serverHost" @mention-hover="onMentionHover" @mention-leave="onMentionLeave" />

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -2,6 +2,7 @@
 import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue'
 import type { ChatMessage, NormalizedUser } from '@/adapters/types'
 import MkAvatar from '@/components/common/MkAvatar.vue'
+import MkChatMessageMoreMenu from '@/components/common/MkChatMessageMoreMenu.vue'
 import MkMfm from '@/components/common/MkMfm.vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useHoverPopup } from '@/composables/useHoverPopup'
@@ -25,7 +26,10 @@ if (props.accountId) provideNoteAccountId(props.accountId)
 const emit = defineEmits<{
   react: [messageId: string, reaction: string]
   unreact: [messageId: string, reaction: string]
+  delete: [messageId: string]
 }>()
+
+const moreMenuRef = ref<InstanceType<typeof MkChatMessageMoreMenu> | null>(null)
 
 const { reactionUrl } = useEmojiResolver()
 
@@ -185,7 +189,10 @@ usePortal(lightboxPortalRef)
       :is-cat="displayUser.isCat"
     />
     <div :class="$style.chatBubbleWrapper">
-      <div :class="$style.chatBubble">
+      <div
+        :class="$style.chatBubble"
+        @contextmenu.prevent.stop="moreMenuRef?.open($event)"
+      >
         <div v-if="!isMine && displayUser" :class="$style.chatSender">
           <MkMfm
             v-if="displayUser.hasName"
@@ -262,6 +269,13 @@ usePortal(lightboxPortalRef)
       </button>
     </div>
   </div>
+
+  <MkChatMessageMoreMenu
+    ref="moreMenuRef"
+    :message="message"
+    :is-mine="!!isMine"
+    @delete="emit('delete', $event)"
+  />
 
   <div v-if="mentionPopup.isVisible.value && mentionUserId" ref="mentionPortalRef">
     <MkUserPopup

--- a/src/components/common/MkChatMessageMoreMenu.vue
+++ b/src/components/common/MkChatMessageMoreMenu.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ChatMessage } from '@/adapters/types'
+import PopupMenu from './PopupMenu.vue'
+
+const props = defineProps<{
+  message: ChatMessage
+  isMine: boolean
+}>()
+
+const emit = defineEmits<{
+  delete: [messageId: string]
+}>()
+
+const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
+const showDeleteConfirm = ref(false)
+
+function open(e: MouseEvent) {
+  popupMenuRef.value?.open(e)
+}
+
+function close() {
+  popupMenuRef.value?.close()
+}
+
+function resetSubViews() {
+  showDeleteConfirm.value = false
+}
+
+async function copyAndClose(text: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.style.cssText = 'position:fixed;opacity:0'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    document.body.removeChild(ta)
+  }
+  close()
+}
+
+function confirmDelete() {
+  emit('delete', props.message.id)
+  close()
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <PopupMenu ref="popupMenuRef" @close="resetSubViews">
+    <!-- Delete confirm -->
+    <template v-if="showDeleteConfirm">
+      <div class="_popupConfirmText">このメッセージを削除しますか？</div>
+      <button class="_popupItem _popupItemDanger" @click="confirmDelete">
+        <i class="ti ti-trash" />
+        削除
+      </button>
+      <button class="_popupItem" @click="showDeleteConfirm = false">
+        <i class="ti ti-x" />
+        キャンセル
+      </button>
+    </template>
+
+    <!-- Main menu -->
+    <template v-else>
+      <button v-if="message.text" class="_popupItem" @click="copyAndClose(message.text!)">
+        <i class="ti ti-copy" />
+        内容をコピー
+      </button>
+      <template v-if="isMine">
+        <div v-if="message.text" class="_popupDivider" />
+        <button class="_popupItem _popupItemDanger" @click="showDeleteConfirm = true">
+          <i class="ti ti-trash" />
+          削除
+        </button>
+      </template>
+    </template>
+  </PopupMenu>
+</template>

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -883,6 +883,24 @@ async function handleUnreact(messageId: string, reaction: string) {
   }
 }
 
+/**
+ * チャットメッセージを Misskey 側から削除する (#468)。
+ * 削除成功後 WS `chat:deleted` event が配信され、QuerySubscription の
+ * `onDelete` 経由で UI から自動的に消える。先回りで `removeMessage()`
+ * しても dedup window で吸収されるが、楽観更新は不要なのでここでは行わない。
+ */
+async function handleDelete(messageId: string) {
+  const accId = activeAccountId.value
+  if (!accId) return
+  if (!ensureActiveAccountAuth()) return
+
+  try {
+    unwrap(await commands.apiDeleteChatMessage(accId, messageId))
+  } catch (e) {
+    handleActionError(e)
+  }
+}
+
 function pickReaction(reaction: string) {
   if (reactionTargetId.value) {
     handleReact(reactionTargetId.value, reaction)
@@ -1273,6 +1291,7 @@ onBeforeUnmount(() => {
               :other-avatar-url="currentRoomId ? undefined : conversationOtherAvatarUrl ?? undefined"
               @react="handleReact"
               @unreact="handleUnreact"
+              @delete="handleDelete"
             />
           </div>
         </template>

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -15,7 +15,7 @@ import type {
   ChatMessage,
   NormalizedDriveFile,
 } from '@/adapters/types'
-import type { ChatReactionUser, JsonValue } from '@/bindings'
+import type { ChatReactionUser } from '@/bindings'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
@@ -773,17 +773,21 @@ async function sendMessage() {
   if (!accId) return
   if (!ensureActiveAccountAuth()) return
 
+  // Misskey v2025 で legacy `messaging/messages/create` (`apiCreateMessagingMessage`) は
+  // 削除済みなので、新 Chat API #15686 の `chat/messages/create-to-{user,room}`
+  // (`apiCreateChatMessage`) に統一する。text / fileId のいずれか一方でも送信可能。
   isSending.value = true
   try {
-    const params: Record<string, unknown> = {
-      text: messageText.value.trim() || undefined,
-    }
-    if (currentOtherId.value) params.userId = currentOtherId.value
-    if (currentRoomId.value) params.roomId = currentRoomId.value
-    if (attachedFile.value) params.fileId = attachedFile.value.id
-
+    const text = messageText.value.trim() || null
+    const fileId = attachedFile.value?.id ?? null
     const sent = unwrap(
-      await commands.apiCreateMessagingMessage(accId, params as JsonValue),
+      await commands.apiCreateChatMessage(
+        accId,
+        currentOtherId.value,
+        currentRoomId.value,
+        text,
+        fileId,
+      ),
     ) as unknown as ChatMessage
     messageText.value = ''
     attachedFile.value = null

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -20,6 +20,7 @@ import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
 import MkChatMessage from '@/components/common/MkChatMessage.vue'
+import MkDrivePicker from '@/components/common/MkDrivePicker.vue'
 import MkReactionPicker from '@/components/common/MkReactionPicker.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
 import {
@@ -144,9 +145,8 @@ const conversationServerHost = ref<string | null>(null)
 const messageText = ref('')
 const isSending = ref(false)
 const showEmojiPicker = ref(false)
+const showDrivePicker = ref(false)
 const attachedFile = ref<NormalizedDriveFile | null>(null)
-const isUploading = ref(false)
-const fileInput = ref<HTMLInputElement | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 
 let chatSub: ChannelSubscription | null = null
@@ -746,7 +746,7 @@ function goBack() {
 }
 
 const canSend = computed(() => {
-  if (isSending.value || isUploading.value) return false
+  if (isSending.value) return false
   return messageText.value.trim().length > 0 || attachedFile.value !== null
 })
 
@@ -808,45 +808,19 @@ function pickEmoji(reaction: string) {
   showEmojiPicker.value = false
 }
 
-function openFilePicker() {
-  fileInput.value?.click()
+/**
+ * 通常ノートの投稿フォーム ([MkPostForm.vue]) と同じ MkDrivePicker フローに統一する。
+ * Drive 上の既存ファイルを選ぶ操作と新規アップロードの両方が picker 内で完結する。
+ */
+function toggleDrivePicker() {
+  if (!ensureActiveAccountAuth()) return
+  showDrivePicker.value = !showDrivePicker.value
 }
 
-async function onFileSelected(e: Event) {
-  const input = e.target as HTMLInputElement
-  const files = input.files
-  if (!files || !files[0]) return
-
-  if (!ensureActiveAccountAuth()) {
-    input.value = ''
-    return
-  }
-
-  const accId = activeAccountId.value
-  // For cross-account, get adapter via multiAdapters; for per-account, use getAdapter()
-  const adapter = isCrossAccount.value
-    ? accId
-      ? await multiAdapters.getOrCreate(accId)
-      : null
-    : getAdapter()
-  if (!adapter) return
-
-  isUploading.value = true
-  try {
-    const file = files[0]
-    const buffer = await file.arrayBuffer()
-    const data = Array.from(new Uint8Array(buffer))
-    attachedFile.value = await adapter.api.uploadFile(
-      file.name,
-      data,
-      file.type || 'application/octet-stream',
-    )
-  } catch (e) {
-    handleActionError(e)
-  } finally {
-    isUploading.value = false
-    input.value = ''
-  }
+function onDrivePicked(files: NormalizedDriveFile[]) {
+  // Misskey の chat/messages/create は fileId を 1 つしか受け付けないので先頭のみ採用する。
+  if (files.length > 0 && files[0]) attachedFile.value = files[0]
+  showDrivePicker.value = false
 }
 
 function removeAttachment() {
@@ -1293,12 +1267,13 @@ onBeforeUnmount(() => {
             <i class="ti ti-x" />
           </button>
         </div>
-        <div v-if="isUploading" :class="$style.chatUploading">
-          <i class="ti ti-loader-2 nd-spin" /> アップロード中...
-        </div>
         <div :class="$style.chatInputRow">
           <div :class="$style.chatInputActions">
-            <button :class="$style.chatActionBtn" title="ファイル" @click="openFilePicker">
+            <button
+              :class="[$style.chatActionBtn, { [$style.active]: showDrivePicker }]"
+              title="ドライブ"
+              @click.stop="toggleDrivePicker"
+            >
               <i class="ti ti-photo" />
             </button>
             <button :class="$style.chatActionBtn" title="絵文字" @click.stop="showEmojiPicker = !showEmojiPicker">
@@ -1329,13 +1304,14 @@ onBeforeUnmount(() => {
             @pick="pickEmoji"
           />
         </div>
-        <input
-          ref="fileInput"
-          type="file"
-          style="display: none"
-          accept="image/*,video/*,audio/*"
-          @change="onFileSelected"
-        />
+        <!-- Drive picker (below input row) -->
+        <div v-if="showDrivePicker && activeAccountId" :class="$style.chatDrivePopup" @click.stop>
+          <MkDrivePicker
+            :account-id="activeAccountId"
+            @pick="onDrivePicked"
+            @close="showDrivePicker = false"
+          />
+        </div>
       </div>
     </div>
   </DeckColumn>
@@ -1549,13 +1525,6 @@ onBeforeUnmount(() => {
   }
 }
 
-.chatUploading {
-  font-size: 0.8em;
-  opacity: 0.5;
-  padding: 2px 8px 4px;
-}
-
-
 .chatInputRow {
   display: flex;
   align-items: flex-end;
@@ -1585,6 +1554,12 @@ onBeforeUnmount(() => {
   &:hover {
     opacity: 0.8;
     background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.05));
+  }
+
+  &.active {
+    opacity: 1;
+    color: var(--nd-accent);
+    background: var(--nd-accentedBg, rgba(134, 179, 0, 0.15));
   }
 }
 
@@ -1641,6 +1616,17 @@ onBeforeUnmount(() => {
   right: 0;
   max-height: 320px;
   overflow: auto;
+  background: var(--nd-popup);
+  border-radius: 12px 12px 0 0;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+  z-index: var(--nd-z-menu);
+}
+
+.chatDrivePopup {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
   background: var(--nd-popup);
   border-radius: 12px 12px 0 0;
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -34,6 +34,7 @@ import { useNoteSound } from '@/composables/useNoteSound'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useChatMessageStore } from '@/stores/chatMessageStore'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -74,7 +75,26 @@ const {
 const accountsStore = useAccountsStore()
 const multiAdapters = useMultiAccountAdapters()
 const chatMessageStore = useChatMessageStore()
+const serversStore = useServersStore()
 const { prefetch: prefetchThreads } = useChatThreadPrefetch()
+
+/** cross-account history entry のサーバー favicon URL を解決する。 */
+function resolveEntryServerIcon(host: string): string {
+  return (
+    serversStore.servers.get(host)?.iconUrl || `https://${host}/favicon.ico`
+  )
+}
+
+/** 2 アカウント以上ログイン中の cross-account view でのみサーバーバッジを出す。 */
+const showServerBadge = computed(
+  () => isCrossAccount.value && accountsStore.accounts.length >= 2,
+)
+
+function entryBadgeTitle(entry: HistoryEntry): string {
+  const acc = accountsStore.accounts.find((a) => a.id === entry.accountId)
+  if (!acc) return entry.serverHost
+  return `@${acc.username}@${acc.host}`
+}
 
 /**
  * 操作対象アカウントが投稿可能 (token 保持) かをチェックする (#460)。
@@ -1165,21 +1185,29 @@ onBeforeUnmount(() => {
           :class="$style.historyItem"
           @click="openConversation(entry)"
         >
-          <MkAvatar
-            v-if="entry.avatarUrl"
-            :avatar-url="entry.avatarUrl"
-            :decorations="entry.avatarDecorations ?? []"
-            :size="36"
-          />
-          <div v-else :class="$style.historyAvatarPlaceholder">
-            <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
+          <div :class="$style.historyAvatarWrap">
+            <MkAvatar
+              v-if="entry.avatarUrl"
+              :avatar-url="entry.avatarUrl"
+              :decorations="entry.avatarDecorations ?? []"
+              :size="36"
+            />
+            <div v-else :class="$style.historyAvatarPlaceholder">
+              <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
+            </div>
+            <img
+              v-if="showServerBadge"
+              :src="resolveEntryServerIcon(entry.serverHost)"
+              :class="$style.historyServerBadge"
+              :title="entryBadgeTitle(entry)"
+              @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
+            />
           </div>
           <div :class="$style.historyInfo">
             <div :class="$style.historyName">{{ entry.name }}</div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
           <div :class="$style.historyMeta">
-            <span :class="$style.historyHost">{{ entry.serverHost }}</span>
             <span :class="$style.historyTime">{{ formatTime(entry.message.createdAt) }}</span>
           </div>
         </button>
@@ -1388,6 +1416,13 @@ onBeforeUnmount(() => {
   }
 }
 
+.historyAvatarWrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+}
+
 .historyAvatarPlaceholder {
   width: 36px;
   height: 36px;
@@ -1396,8 +1431,21 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-shrink: 0;
   opacity: 0.5;
+}
+
+.historyServerBadge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--nd-panel);
+  box-shadow: 0 0 0 2px var(--nd-panel);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .historyInfo {
@@ -1428,15 +1476,6 @@ onBeforeUnmount(() => {
   align-items: flex-end;
   gap: 2px;
   flex-shrink: 0;
-}
-
-.historyHost {
-  font-size: 0.7em;
-  opacity: 0.35;
-  max-width: 80px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .historyTime {

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -21,6 +21,7 @@ import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
 import MkChatMessage from '@/components/common/MkChatMessage.vue'
 import MkDrivePicker from '@/components/common/MkDrivePicker.vue'
+import MkMfm from '@/components/common/MkMfm.vue'
 import MkReactionPicker from '@/components/common/MkReactionPicker.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
 import {
@@ -159,6 +160,10 @@ interface HistoryEntry {
   message: ChatMessage
   isRoom: boolean
   name: string
+  /** 表示名 (`name`) が user-defined か (false なら fallback の username/roomId を使用)。 */
+  hasName: boolean
+  /** name に含まれる `:shortcode:` を画像に解決するための辞書。 */
+  emojis?: Record<string, string>
   avatarUrl?: string
   avatarDecorations?: AvatarDecoration[]
   otherId?: string
@@ -248,6 +253,10 @@ function buildCrossAccountHistoryEntries(
         message: msg,
         isRoom: true,
         name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        // ChatRoom には emojis 辞書が無いので、最新メッセージ送信者の辞書で代替する
+        // (同一サーバー上の shortcode は同じ辞書で解決できる)
+        emojis: msg.fromUser?.emojis ?? undefined,
         avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
         avatarDecorations: msg.fromUser?.avatarDecorations,
         roomId: msg.toRoomId,
@@ -266,6 +275,8 @@ function buildCrossAccountHistoryEntries(
         message: msg,
         isRoom: false,
         name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
         avatarUrl: other?.avatarUrl ?? undefined,
         avatarDecorations: other?.avatarDecorations,
         otherId,
@@ -535,6 +546,8 @@ function getHistoryEntries() {
     message: ChatMessage
     isRoom: boolean
     name: string
+    hasName: boolean
+    emojis?: Record<string, string>
     avatarUrl?: string
     avatarDecorations?: AvatarDecoration[]
   }[] = []
@@ -548,6 +561,8 @@ function getHistoryEntries() {
         message: msg,
         isRoom: true,
         name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        emojis: msg.fromUser?.emojis ?? undefined,
         avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
         avatarDecorations: msg.fromUser?.avatarDecorations,
       })
@@ -563,6 +578,8 @@ function getHistoryEntries() {
         message: msg,
         isRoom: false,
         name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
         avatarUrl: other?.avatarUrl ?? undefined,
         avatarDecorations: other?.avatarDecorations,
       })
@@ -1178,7 +1195,16 @@ onBeforeUnmount(() => {
             />
           </div>
           <div :class="$style.historyInfo">
-            <div :class="$style.historyName">{{ entry.name }}</div>
+            <div :class="$style.historyName">
+              <MkMfm
+                v-if="entry.hasName"
+                :text="entry.name"
+                :emojis="entry.emojis"
+                :server-host="entry.serverHost"
+                plain
+              />
+              <template v-else>{{ entry.name }}</template>
+            </div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
           <div :class="$style.historyMeta">
@@ -1209,7 +1235,16 @@ onBeforeUnmount(() => {
             <i :class="entry.isRoom ? 'ti ti-users' : 'ti ti-user'" />
           </div>
           <div :class="$style.historyInfo">
-            <div :class="$style.historyName">{{ entry.name }}</div>
+            <div :class="$style.historyName">
+              <MkMfm
+                v-if="entry.hasName"
+                :text="entry.name"
+                :emojis="entry.emojis"
+                :server-host="account?.host"
+                plain
+              />
+              <template v-else>{{ entry.name }}</template>
+            </div>
             <div :class="$style.historyPreview">{{ entry.message.text || '(ファイル)' }}</div>
           </div>
         </button>


### PR DESCRIPTION
## Summary

v0.20.1 patch リリース。チャット機能の UI ポリッシュ + メッセージ削除/コピー (#468) + 新規送信 API の現行 chat API 切替 + MiAuth chat scope 追従が中心。

## Highlights

- **チャット (#478)**: 履歴一覧/送信者名にカスタム絵文字、ファイル添付の Drive Picker 統一、cross-account 履歴のサーバーアイコンバッジ化
- **チャット (#468 / #479)**: メッセージ右クリックメニュー「内容をコピー」「削除」+ `api_delete_chat_message` Tauri command
- **チャット (#480)**: 新規メッセージ送信を `chat/messages/create-to-{user,room}` に切替、legacy `api_create_messaging_message` 撤去
- **deps (#481)**: notecli を MiAuth chat scope 置換に追従して bump

## Changes

- chore: bump version to 0.20.1
- chore(deps): bump notecli で MiAuth chat scope 置換に追従 (#481)
- chore(deps): bump notecli で legacy create_messaging_message 関数撤去に追従
- refactor(chat): legacy api_create_messaging_message Tauri command を撤去
- fix(chat): 新規メッセージ送信を chat/messages/create-to-{user,room} に切替 (#480)
- chore(deps): bump notecli で text/fileId optional 化に追従
- feat(chat): メッセージ右クリックメニューで「内容をコピー」「削除」 (#468)
- feat(chat): api_delete_chat_message Tauri command を追加
- chore(deps): bump notecli to add chat/messages/delete API
- feat(chat): 履歴一覧の相手名 / ルーム名にもカスタム絵文字を描画
- feat(chat): ファイル添付を Drive Picker 経由に統一
- feat(chat): cross-account 履歴で host テキストをサーバーアイコンバッジに置換
- feat(chat): メッセージ送信者名にカスタム絵文字を描画 (#478)

## Release checklist

- [x] バージョン同期 (package.json / Cargo.toml / tauri.conf.json / Cargo.lock)
- [ ] CI (lint / typecheck / test) パス確認
- [ ] develop → main マージ
- [ ] \`v0.20.1\` タグ作成 + push (release CI トリガー)
- [ ] GitHub Release draft 確認 → publish