### PR TITLE
feat(ai): persona foundation — skill isPersona + Identity + session snapshot (#491)

### DIFF
--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -1196,15 +1196,24 @@ function onKeydown(e: KeyboardEvent) {
 
 // Persona indicator — チャットヘッダに「現在の persona」を表示する read-only
 // バッジ。スキルカラムのアイテムアイコンと同型の `mask + currentColor` パターン
-// を採用 (= SVG をテーマアクセント色で着色)。これによりカスタムテーマの色が
-// 反映され、persona 表示が「ただのアバター」ではなく「ユーザーがカスタム
-// した AI の identity」として強調される。
+// で SVG をテーマアクセント色で着色する。
+//
+// hover 時はプロファイル切替インディケーターの UI 慣例に従い、背景にアクセント色を
+// 敷いて SVG 側を「抜く」形に反転 (= color: var(--nd-bg) に切り替え、SVG 部分が
+// 背景色で打ち抜かれて見える)。
 .personaIndicator {
   overflow: hidden;
   padding: 0;
   opacity: 1;
   cursor: default;
   color: var(--nd-accent);
+  background: transparent;
+  transition: background var(--nd-duration-base), color var(--nd-duration-base);
+
+  &:hover {
+    background: var(--nd-accent);
+    color: var(--nd-bg);
+  }
 }
 
 .personaIndicatorAvatar {

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -38,7 +38,7 @@ import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
-import { getIdentityAvatarUrl, resolveIdentity } from '@/utils/identity'
+import { resolveIdentity } from '@/utils/identity'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -886,11 +886,13 @@ function onKeydown(e: KeyboardEvent) {
         :class="[$style.headerAction, $style.personaIndicator]"
         :title="`Persona: ${currentPersona.displayName} (AI 設定で変更)`"
       >
-        <img
+        <span
+          v-if="currentPersona.avatarUrl"
           :class="$style.personaIndicatorAvatar"
-          :src="getIdentityAvatarUrl(currentPersona)"
-          :alt="currentPersona.displayName"
+          :style="{ '--icon-url': `url('${currentPersona.avatarUrl}')` }"
+          aria-hidden="true"
         />
+        <i v-else class="ti ti-user-circle" />
       </div>
       <button
         class="_button"
@@ -1192,22 +1194,25 @@ function onKeydown(e: KeyboardEvent) {
   }
 }
 
-// Persona indicator — チャットヘッダに「現在の persona」を avatar 表示する
-// read-only バッジ。クリックでの切替は無し (= persona は AI 設定ウィンドウで
-// 一括管理される同一性設定なので、チャット文脈で hat を付け替えるような
-// 意味付けを持たせない)。
+// Persona indicator — チャットヘッダに「現在の persona」を表示する read-only
+// バッジ。スキルカラムのアイテムアイコンと同型の `mask + currentColor` パターン
+// を採用 (= SVG をテーマアクセント色で着色)。これによりカスタムテーマの色が
+// 反映され、persona 表示が「ただのアバター」ではなく「ユーザーがカスタム
+// した AI の identity」として強調される。
 .personaIndicator {
   overflow: hidden;
   padding: 0;
   opacity: 1;
   cursor: default;
+  color: var(--nd-accent);
 }
 
 .personaIndicatorAvatar {
   width: 100%;
   height: 100%;
-  object-fit: cover;
-  border-radius: var(--nd-radius-sm);
+  background-color: currentColor;
+  -webkit-mask: var(--icon-url) center / contain no-repeat;
+  mask: var(--icon-url) center / contain no-repeat;
 }
 
 // --- セッション一覧ビュー ---

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -38,6 +38,7 @@ import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
+import { getIdentityAvatarUrl, resolveIdentity } from '@/utils/identity'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -77,6 +78,20 @@ const titleGen = useAiChat()
 // `column.aiCurrentSessionId` を reactive に橋渡し。useAiConversation は
 // この ref の変化を購読してメッセージ参照を切り替える。
 const currentSessionId = computed(() => props.column.aiCurrentSessionId ?? null)
+
+// Persona (#491) — session 作成時に snapshot された session.personaSkillId
+// から解決。aiConfig.personaSkillId は新規 session のデフォルトに過ぎず、
+// 過去 session の persona 表示を上書きしない (= Git commit Author 型 immutable)。
+// dangling (skill 削除 / isPersona OFF) のときは null。
+const currentSession = computed(() =>
+  currentSessionId.value
+    ? (sessionsStore.get(currentSessionId.value) ?? null)
+    : null,
+)
+const currentPersona = computed(() => {
+  const id = currentSession.value?.personaSkillId
+  return id ? resolveIdentity(`skill:${id}`) : null
+})
 
 const conversation = useAiConversation(currentSessionId)
 const messages = conversation.messages
@@ -403,9 +418,13 @@ async function generateAiTitleAsync(
 /** 必要なら新規セッションを作って ID を返す。 */
 function ensureSession(): string {
   if (currentSessionId.value) return currentSessionId.value
+  // Persona (#491): 新規 session 作成時に aiConfig.personaSkillId を snapshot。
+  // 後で global 設定を変更しても過去 session の persona は固定されたまま
+  // (= Git commit の Author header と同じ immutable semantic)。
   const session = sessionsStore.createNew({
     model: aiConfig.value[aiConfig.value.provider]?.model ?? '',
     provider: aiConfig.value.provider,
+    personaSkillId: aiConfig.value.personaSkillId || undefined,
   })
   deckStore.updateColumn(props.column.id, {
     aiCurrentSessionId: session.id,
@@ -472,7 +491,22 @@ async function sendMessage() {
 
   activeStreamSessionId.value = sessionId
 
-  const skillsPrompt = skillsStore.composedSystemPrompt() || ''
+  // Persona (#491) — session 作成時 snapshot された personaSkillId を読む
+  // (= 過去 session は当時の persona、新規 session は aiConfig 由来のデフォルト)。
+  // skill body を skillsPrompt に session-only で含め、<persona> block を
+  // system prompt に注入。dangling 時は通常チャット動作。
+  const personaSkillId =
+    sessionsStore.get(sessionId)?.personaSkillId || undefined
+  const personaIdentity = personaSkillId
+    ? resolveIdentity(`skill:${personaSkillId}`)
+    : null
+  // identity が解決できない (= 該当 skill 不在 or isPersona=false) なら扱わない
+  const effectivePersonaSkillId = personaIdentity ? personaSkillId : undefined
+  const skillsPrompt =
+    skillsStore.composedSystemPrompt(
+      effectivePersonaSkillId ? [effectivePersonaSkillId] : [],
+      effectivePersonaSkillId,
+    ) || ''
   // ユーザーが Timeline をクリックしていないケースに備えて、fallback として
   // 画面上に存在する最初の TIMELINE_LIKE カラムを使う。
   const focusedColumnId =
@@ -531,6 +565,13 @@ async function sendMessage() {
         recentConversation: projectRecentConversation(history),
         memos: projectMemos(memoEntries),
         accounts: accountsStore.accounts,
+        persona: personaIdentity
+          ? {
+              id: personaIdentity.id,
+              displayName: personaIdentity.displayName,
+              bio: personaIdentity.bio,
+            }
+          : undefined,
       })
       const system = joinSystemPrompt(skillsPrompt, contextBlock)
 
@@ -840,6 +881,17 @@ function onKeydown(e: KeyboardEvent) {
     </template>
 
     <template v-if="viewMode === 'chat'" #header-meta>
+      <div
+        v-if="currentPersona"
+        :class="[$style.headerAction, $style.personaIndicator]"
+        :title="`Persona: ${currentPersona.displayName} (AI 設定で変更)`"
+      >
+        <img
+          :class="$style.personaIndicatorAvatar"
+          :src="getIdentityAvatarUrl(currentPersona)"
+          :alt="currentPersona.displayName"
+        />
+      </div>
       <button
         class="_button"
         :class="$style.headerAction"
@@ -1138,6 +1190,24 @@ function onKeydown(e: KeyboardEvent) {
     background: var(--nd-buttonHoverBg);
     opacity: 1;
   }
+}
+
+// Persona indicator — チャットヘッダに「現在の persona」を avatar 表示する
+// read-only バッジ。クリックでの切替は無し (= persona は AI 設定ウィンドウで
+// 一括管理される同一性設定なので、チャット文脈で hat を付け替えるような
+// 意味付けを持たせない)。
+.personaIndicator {
+  overflow: hidden;
+  padding: 0;
+  opacity: 1;
+  cursor: default;
+}
+
+.personaIndicatorAvatar {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: var(--nd-radius-sm);
 }
 
 // --- セッション一覧ビュー ---

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -39,6 +39,7 @@ import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useAccountsStore } from '@/stores/accounts'
+import { useSkillsStore } from '@/stores/skills'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const jsonLang = json()
@@ -371,6 +372,21 @@ const resolvedPermissions = computed(() =>
 const resolvedDataSources = computed(() =>
   resolveDataSources(config.value.dataSources),
 )
+
+// Persona (#491) — `isPersona: true` な skill 一覧をセレクタ候補として提供。
+// 値は SkillMeta.id (raw)。AI チャット側で `skill:<id>` プレフィックスを付けて
+// resolveIdentity に渡す。空文字 = persona なし (汎用 AI)。
+const skillsStore = useSkillsStore()
+skillsStore.ensureLoaded()
+const personaCandidates = computed(() =>
+  skillsStore.skills.filter((s) => s.isPersona),
+)
+const currentPersonaSkill = computed(() => {
+  const id = config.value.personaSkillId
+  if (!id) return null
+  const s = skillsStore.get(id)
+  return s?.isPersona ? s : null
+})
 
 function selectPermissionPreset(preset: PresetKey) {
   config.value.permissions = setPermissionPreset(
@@ -762,6 +778,66 @@ function handleReset() {
               </button>
             </div>
           </template>
+        </template>
+      </div>
+
+      <!-- Persona (#491) -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('persona')">
+          <i class="ti ti-user-circle" />
+          ペルソナ
+          <span :class="$style.statusBadge">
+            <i class="ti ti-info-circle" :class="$style.badgeNone" />
+            {{ currentPersonaSkill ? currentPersonaSkill.name : 'なし' }}
+          </span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.persona }]" />
+        </button>
+        <template v-if="expandedSections.persona">
+          <div :class="$style.keyHint">
+            <i class="ti ti-info-circle" />
+            **新規セッション**のデフォルトペルソナです。新しいチャット / heartbeat / task を開始したときに、ここで選んだペルソナが session に snapshot されます。**過去のセッション**は作成時のペルソナを保持し続けるため (Git commit の Author と同じ immutable semantic)、ここを変更しても遡って書き換わりません。
+          </div>
+          <div :class="$style.personaList">
+            <label :class="[$style.personaOption, { [$style.personaOptionActive]: !config.personaSkillId }]">
+              <input
+                type="radio"
+                :checked="!config.personaSkillId"
+                @change="config.personaSkillId = ''"
+              />
+              <i class="ti ti-user-off" :class="$style.personaOptionIcon" />
+              <span :class="$style.personaOptionName">ペルソナなし (汎用 AI)</span>
+            </label>
+            <label
+              v-for="s in personaCandidates"
+              :key="s.id"
+              :class="[$style.personaOption, { [$style.personaOptionActive]: config.personaSkillId === s.id }]"
+            >
+              <input
+                type="radio"
+                :checked="config.personaSkillId === s.id"
+                @change="config.personaSkillId = s.id"
+              />
+              <img
+                v-if="s.iconUrl"
+                :src="s.iconUrl"
+                :alt="s.name"
+                :class="$style.personaOptionAvatar"
+              />
+              <i v-else class="ti ti-user-circle" :class="$style.personaOptionIcon" />
+              <div :class="$style.personaOptionMain">
+                <div :class="$style.personaOptionName">{{ s.name }}</div>
+                <div v-if="s.description" :class="$style.personaOptionDesc">
+                  {{ s.description }}
+                </div>
+              </div>
+            </label>
+            <div v-if="personaCandidates.length === 0" :class="$style.personaEmpty">
+              <i class="ti ti-info-circle" />
+              <span>
+                ペルソナ候補がありません。Skill 編集ウィンドウで「Persona」を ON にしたスキルがここに表示されます。
+              </span>
+            </div>
+          </div>
         </template>
       </div>
 
@@ -1353,6 +1429,100 @@ function handleReset() {
     flex-shrink: 0;
     margin-top: 2px;
     color: var(--nd-accent);
+  }
+}
+
+// --- Persona selector (#491) ---
+
+.personaList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.personaOption {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: var(--nd-radius-sm);
+  cursor: pointer;
+  transition: background var(--nd-duration-base);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+
+  input[type='radio'] {
+    flex-shrink: 0;
+    margin: 0;
+  }
+}
+
+.personaOptionActive {
+  background: color-mix(in srgb, var(--nd-accent) 10%, transparent);
+
+  &:hover {
+    background: color-mix(in srgb, var(--nd-accent) 14%, transparent);
+  }
+}
+
+.personaOptionIcon {
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.personaOptionAvatar {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+}
+
+.personaOptionMain {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.personaOptionName {
+  font-size: 0.85em;
+  font-weight: 500;
+  color: var(--nd-fg);
+}
+
+.personaOptionDesc {
+  font-size: 0.7em;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.personaEmpty {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 10px;
+  font-size: 0.75em;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  line-height: 1.5;
+
+  i {
+    flex-shrink: 0;
+    margin-top: 1px;
   }
 }
 

--- a/src/components/window/SkillEditContent.vue
+++ b/src/components/window/SkillEditContent.vue
@@ -33,6 +33,7 @@ const description = ref('')
 const author = ref('')
 const version = ref('')
 const mode = ref<SkillMode>('manual')
+const isPersona = ref(false)
 const body = ref('')
 
 const dirty = ref(false)
@@ -50,6 +51,7 @@ watch(
     author.value = s.author ?? ''
     version.value = s.version
     mode.value = s.mode
+    isPersona.value = !!s.isPersona
     body.value = s.body
     dirty.value = false
     suppressDirty = false
@@ -68,7 +70,7 @@ function scheduleSave() {
   }, 500)
 }
 
-watch([name, description, author, version, mode, body], scheduleSave)
+watch([name, description, author, version, mode, isPersona, body], scheduleSave)
 
 function save() {
   if (!skill.value) return
@@ -78,6 +80,7 @@ function save() {
     author: author.value || undefined,
     version: version.value || skill.value.version,
     mode: mode.value,
+    isPersona: isPersona.value,
     body: body.value,
   })
   dirty.value = false
@@ -157,6 +160,21 @@ const statusText = computed(() => {
           <span>
             HEARTBEAT 有効時、tick ごとにこの skill body を AI に読ませます
             (#411 / OpenClaw HEARTBEAT.md 相当)。
+          </span>
+        </div>
+        <div :class="$style.row">
+          <label :class="$style.label">Persona</label>
+          <label :class="$style.toggleRow">
+            <input v-model="isPersona" type="checkbox" />
+            <span>このスキルを AI セッションの persona 候補にする</span>
+          </label>
+        </div>
+        <div v-if="isPersona" :class="$style.modeHint">
+          <i class="ti ti-user-circle" />
+          <span>
+            ON にすると、AI セッションヘッダの persona セレクタにこのスキルが
+            表示されます。選択中のセッションで AI はこの persona として振る舞い、
+            memo の作者として記録されます (#491)。
           </span>
         </div>
         <div v-if="isBuiltIn || isFromStore" :class="$style.note">
@@ -263,6 +281,20 @@ const statusText = computed(() => {
   span {
     color: var(--nd-fg);
     opacity: 0.75;
+  }
+}
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--nd-fg);
+  cursor: pointer;
+  user-select: none;
+
+  input {
+    margin: 0;
   }
 }
 

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -187,6 +187,15 @@ export interface AiConfig {
   permissions: PermissionsConfig
   dataSources: DataSourcesConfig
   heartbeat: HeartbeatConfig
+  /**
+   * このアプリで AI が振る舞う persona (#491)。skill で `isPersona: true`
+   * を設定したものから 1 つ選択する。空文字 / 未指定 = 通常の汎用 AI として
+   * 動作 (chat / heartbeat / command / task すべて persona なし)。
+   *
+   * persona は session ごとに切り替えるものではなく、「この AI は誰か」と
+   * いう同一性設定として扱う (= AI 設定全体の一部)。
+   */
+  personaSkillId?: string
 }
 
 export const PROVIDER_KEYS: readonly ProviderKey[] = [

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -749,6 +749,59 @@ describe('buildAiContextBlock — memos', () => {
   })
 })
 
+describe('buildAiContextBlock — persona (#491)', () => {
+  it('emits <persona> block with id, displayName, and authorId instruction', () => {
+    const cfg = configWithDataSources('readonly')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      persona: {
+        id: 'skill:aizu-9k2x',
+        displayName: '藍',
+      },
+    })
+    expect(block).toContain('<persona>')
+    expect(block).toContain('藍')
+    expect(block).toContain('skill:aizu-9k2x')
+    // memos.create / authorId 規約も注入されること
+    expect(block).toContain('authorId')
+  })
+
+  it('includes bio line when persona has bio', () => {
+    const cfg = configWithDataSources('readonly')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      persona: {
+        id: 'skill:aizu',
+        displayName: 'aizu',
+        bio: 'Misskey の妖精',
+      },
+    })
+    expect(block).toContain('Misskey の妖精')
+  })
+
+  it('omits <persona> block when persona is undefined', () => {
+    const cfg = configWithDataSources('readonly')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+    })
+    expect(block).not.toContain('<persona>')
+  })
+
+  it('persona is session-driven, not gated by dataSources flags', () => {
+    // dataSources で memos / visibleNotes 等を全部切っても persona は渡せば出る
+    const cfg = configWithDataSources('readonly')
+    const block = buildAiContextBlock(cfg, {
+      activeAccount: null,
+      currentColumn: null,
+      persona: { id: 'skill:p', displayName: 'P' },
+    })
+    expect(block).toContain('<persona>')
+  })
+})
+
 describe('joinSystemPrompt', () => {
   it('returns undefined when both inputs are empty', () => {
     expect(joinSystemPrompt('', '')).toBeUndefined()

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -63,6 +63,19 @@ export interface AiContextInput {
    * どのサーバーか」を即把握できる。
    */
   accounts?: readonly Account[]
+  /**
+   * セッションの persona (#491)。session.personaSkillId が指定された
+   * チャットでこのフィールドが渡され、`<persona>` block が system prompt
+   * 末尾の `<notedeck-context>` 内に注入される。AI は block の指示を読んで
+   * `authorId='<id>'` で memos.create を呼ぶ。
+   *
+   * avatarUrl は AI に不要なので含めない (= UI 表示専用)。
+   */
+  persona?: {
+    id: string
+    displayName: string
+    bio?: string
+  }
 }
 
 /** AI に渡す可視ノートの上限件数。 */
@@ -345,6 +358,24 @@ export function buildAiContextBlock(
   }
   if (ds.memos && ctx.memos && ctx.memos.length > 0) {
     parts.push(`  <memos>\n${jsonBlock(ctx.memos)}\n  </memos>`)
+  }
+  // persona block (#491) — session.personaSkillId 由来。dataSources で
+  // on/off せず、session 自身が persona を持っていれば常に注入する。
+  // block + instruction を一体型 prose で書き、AI が役割を確実に把握できる
+  // ようにする (memos.create の authorId 規約も同 block 内で示す)。
+  if (ctx.persona) {
+    const lines: string[] = ['  <persona>']
+    lines.push(
+      `    あなたは ${ctx.persona.displayName} (id: ${ctx.persona.id}) として振る舞う。`,
+    )
+    lines.push(
+      `    memos.create / memos.update を呼ぶ際は authorId='${ctx.persona.id}' を指定する。`,
+    )
+    if (ctx.persona.bio) {
+      lines.push(`    bio: ${ctx.persona.bio}`)
+    }
+    lines.push('  </persona>')
+    parts.push(lines.join('\n'))
   }
 
   if (parts.length === 0) return ''

--- a/src/defaults/ai.json5
+++ b/src/defaults/ai.json5
@@ -66,6 +66,12 @@
   //     readonly preset = write 系 / external network を全て deny (推奨 default)
   //     daemon 側で resolve → 各 capability の required permissions と照合して
   //     満たさないものを tool 一覧から除外
+
+  // Persona (#491): この AI が振る舞う人格を `isPersona: true` な skill から選ぶ。
+  // 未指定 = 汎用 AI。AI 設定ウィンドウで切替可能。chat / heartbeat / command /
+  // task すべての session に同じ persona が反映される (= 同一性設定)。
+  personaSkillId: '',
+
   heartbeat: {
     enabled: false,
     intervalMinutes: 30,

--- a/src/stores/aiSessions.ts
+++ b/src/stores/aiSessions.ts
@@ -42,6 +42,14 @@ export interface AiSessionMeta {
   messageCount: number
   /** 最後のメッセージ本文プレビュー (drawer 表示用、120 文字 trim)。空可。 */
   lastMessagePreview: string
+  /**
+   * このセッションが作成された時点の persona skill id (#491、snapshot)。
+   * `aiConfig.personaSkillId` (= 新規セッションのデフォルト) と独立に session
+   * 自身が値を保持するため、後でグローバル設定を変えても過去セッションの
+   * persona 表示は固定されたまま (Git commit の Author header と同じ
+   * immutable semantic)。空文字 / 未指定 = persona なしで作成された session。
+   */
+  personaSkillId?: string
 }
 
 /** メタ + 本文。chat 以外の kind が増えたら discriminated union 化する。 */
@@ -75,6 +83,7 @@ const KNOWN_FIELDS = new Set([
   'createdAt',
   'updatedAt',
   'messages',
+  'personaSkillId',
 ])
 
 function serialize(session: AiSession): string {
@@ -89,6 +98,7 @@ function serialize(session: AiSession): string {
     updatedAt: session.updatedAt,
     messages: session.messages,
   }
+  if (session.personaSkillId) out.personaSkillId = session.personaSkillId
   if (session.unknownFields) {
     for (const [k, v] of Object.entries(session.unknownFields)) {
       out[k] = v
@@ -126,6 +136,10 @@ function deserialize(raw: string): AiSession | null {
     // drawer 表示用 preview は listSorted() 側で computed する。AiSession 自体には
     // 永続化せず、空文字を入れて型を満たす。
     lastMessagePreview: '',
+    personaSkillId:
+      typeof r.personaSkillId === 'string' && r.personaSkillId
+        ? r.personaSkillId
+        : undefined,
     unknownFields:
       Object.keys(unknownFields).length > 0 ? unknownFields : undefined,
   }
@@ -205,6 +219,7 @@ export const useAiSessionsStore = defineStore('aiSessions', () => {
       updatedAt: s.updatedAt,
       messageCount: s.messages.length,
       lastMessagePreview: buildLastMessagePreview(s.messages),
+      personaSkillId: s.personaSkillId,
     }))
     arr.sort((a, b) => b.updatedAt - a.updatedAt)
     return arr
@@ -213,12 +228,18 @@ export const useAiSessionsStore = defineStore('aiSessions', () => {
   /**
    * 新規セッションを生成してキャッシュに登録。ファイル書込は最初の
    * `updateMessages()` または `setTitle()` 呼び出し時に走る。
+   *
+   * `personaSkillId` を渡すと session に snapshot 保存される (#491)。
+   * 呼出側は `aiConfig.personaSkillId` をデフォルトとして渡すのが想定 —
+   * 一度 session 作成後は global 設定変更で過去 session の persona 表示は
+   * 変わらない (Git commit Author header と同じ immutable semantic)。
    */
   function createNew(opts: {
     model: string
     provider: string
     title?: string
     kind?: AiSessionKind
+    personaSkillId?: string
   }): AiSession {
     const existing = new Set(sessions.value.keys())
     const id = generateSessionId(new Date(), existing)
@@ -235,6 +256,7 @@ export const useAiSessionsStore = defineStore('aiSessions', () => {
       messageCount: 0,
       messages: [],
       lastMessagePreview: '',
+      personaSkillId: opts.personaSkillId || undefined,
     }
     sessions.value.set(id, session)
     sessions.value = new Map(sessions.value)

--- a/src/stores/skills.ts
+++ b/src/stores/skills.ts
@@ -48,6 +48,20 @@ export interface SkillMeta {
    * 型は常に `string[]` (空配列含む) — `triggers` と同じパターン。
    */
   cheapCheckCapabilities: string[]
+  /**
+   * Persona-eligible flag (#491): この skill を AI session の persona
+   * 候補として扱うか。true のとき:
+   * - AI session のチャットヘッダ persona セレクタに表示される
+   * - session.personaSkillId として選ばれると `<persona>` block が
+   *   system prompt に注入され、authorId='skill:<id>' の memo を作れる
+   *
+   * skill.iconUrl は「skill そのもののアイコン」(例: 翻訳 skill のレンチ)、
+   * persona の avatar は「想起されるキャラクターの顔」と意味が違うので、
+   * iconUrl 有無ではなく明示フラグで判別する。
+   *
+   * 未指定 = false。
+   */
+  isPersona?: boolean
 }
 
 export function generateSkillId(name: string): string {
@@ -76,6 +90,7 @@ interface SkillFrontmatter {
   updatedAt?: number
   iconUrl?: string
   cheapCheckCapabilities?: string[]
+  isPersona?: boolean
 }
 
 function asArray(v: unknown): string[] {
@@ -106,6 +121,7 @@ function frontmatterFromMeta(skill: SkillMeta): Record<string, unknown> {
   if (skill.cheapCheckCapabilities && skill.cheapCheckCapabilities.length > 0) {
     out.cheapCheckCapabilities = skill.cheapCheckCapabilities
   }
+  if (skill.isPersona) out.isPersona = true
   return out
 }
 
@@ -143,6 +159,7 @@ function metaFromFrontmatter(
     builtIn: !!fm.builtIn,
     iconUrl: fm.iconUrl,
     cheapCheckCapabilities: asArray(fm.cheapCheckCapabilities),
+    isPersona: !!fm.isPersona,
   }
 }
 
@@ -232,11 +249,26 @@ export const useSkillsStore = defineStore('skills', () => {
   /**
    * Phase 2 で AI provider に渡す system prompt を組み立てるためのヘルパ。
    * mode='always' + 明示的に active な mode='manual' のスキルを宣言順で結合する。
+   *
+   * #491 拡張:
+   * - `extraSkillIds`: session-only に追加する skill (= activeIds を汚さず
+   *   その session だけで含める。session.personaSkillId 注入で使う)
+   * - `excludePersonaSkillsExcept`: 指定 id 以外の `isPersona: true` skill を
+   *   除外 (= 複数 always-persona があるとき session の persona 以外を抑制)
    */
-  function composedSystemPrompt(): string {
+  function composedSystemPrompt(
+    extraSkillIds: readonly string[] = [],
+    excludePersonaSkillsExcept?: string,
+  ): string {
     const set = new Set(effectiveActiveIds.value)
+    for (const id of extraSkillIds) set.add(id)
     return skills.value
       .filter((s) => set.has(s.id))
+      .filter((s) => {
+        if (excludePersonaSkillsExcept === undefined) return true
+        if (!s.isPersona) return true
+        return s.id === excludePersonaSkillsExcept
+      })
       .map((s) => s.body.trim())
       .filter((b) => b.length > 0)
       .join('\n\n')

--- a/src/utils/identity.test.ts
+++ b/src/utils/identity.test.ts
@@ -1,0 +1,125 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAccountsStore } from '@/stores/accounts'
+import { useSkillsStore } from '@/stores/skills'
+import {
+  extractSkillIdFromIdentity,
+  isPersonaIdentityId,
+  listPersonaIdentities,
+  personaIdentityId,
+  resolveIdentity,
+} from './identity'
+
+describe('identity helpers', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('personaIdentityId prefixes skill: to skill id', () => {
+    expect(personaIdentityId('aizu-9k2x')).toBe('skill:aizu-9k2x')
+  })
+
+  it('isPersonaIdentityId detects skill: prefix', () => {
+    expect(isPersonaIdentityId('skill:aizu')).toBe(true)
+    expect(isPersonaIdentityId('acc-1234')).toBe(false)
+    expect(isPersonaIdentityId('')).toBe(false)
+  })
+
+  it('extractSkillIdFromIdentity strips skill: prefix', () => {
+    expect(extractSkillIdFromIdentity('skill:aizu-9k2x')).toBe('aizu-9k2x')
+    expect(extractSkillIdFromIdentity('acc-1234')).toBe(null)
+    expect(extractSkillIdFromIdentity('skill:')).toBe(null)
+  })
+
+  it('resolveIdentity returns null for unknown / dangling ids', () => {
+    expect(resolveIdentity('')).toBe(null)
+    expect(resolveIdentity('skill:nonexistent')).toBe(null)
+    expect(resolveIdentity('acc-nonexistent')).toBe(null)
+  })
+
+  it('resolveIdentity returns persona Identity for isPersona=true skill', () => {
+    const skills = useSkillsStore()
+    skills.add({
+      id: 'aizu-9k2x',
+      name: '藍',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: 'persona body',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+      iconUrl: 'https://example.com/aizu.svg',
+      description: 'aizu persona bio',
+    })
+    const id = resolveIdentity('skill:aizu-9k2x')
+    expect(id).not.toBeNull()
+    expect(id?.kind).toBe('persona')
+    expect(id?.id).toBe('skill:aizu-9k2x')
+    expect(id?.displayName).toBe('藍')
+    expect(id?.avatarUrl).toBe('https://example.com/aizu.svg')
+    expect(id?.bio).toBe('aizu persona bio')
+  })
+
+  it('resolveIdentity rejects skill without isPersona flag', () => {
+    const skills = useSkillsStore()
+    skills.add({
+      id: 'tool-skill',
+      name: 'tool',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: '',
+      cheapCheckCapabilities: [],
+      // isPersona 未指定 (= false)
+    })
+    expect(resolveIdentity('skill:tool-skill')).toBe(null)
+  })
+
+  it('listPersonaIdentities returns only isPersona=true skills', () => {
+    const skills = useSkillsStore()
+    skills.add({
+      id: 'aizu',
+      name: 'aizu',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: '',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+    })
+    skills.add({
+      id: 'tool',
+      name: 'tool',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: '',
+      cheapCheckCapabilities: [],
+    })
+    skills.add({
+      id: 'orin',
+      name: 'orin',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: '',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+    })
+    const list = listPersonaIdentities()
+    expect(list.map((p) => p.id).sort()).toEqual(['skill:aizu', 'skill:orin'])
+  })
+
+  it('resolveIdentity returns account Identity for non-skill ids (smoke test)', () => {
+    // 実 accountsStore は Tauri 環境で初期化されるため、ここでは
+    // accounts が空であることを確認するだけ (= null fallback)
+    const accounts = useAccountsStore()
+    expect(accounts.accounts.length).toBe(0)
+    expect(resolveIdentity('acc-1234')).toBe(null)
+  })
+})

--- a/src/utils/identity.ts
+++ b/src/utils/identity.ts
@@ -1,0 +1,117 @@
+/**
+ * Identity 抽象 (#491) — 「誰か」を表す論理概念。
+ *
+ * NoteDeck では行動主体 (Account: Misskey/guest) と人格 (Persona: skill
+ * with isPersona=true) は別概念。両者を unify せず、Identity という flat
+ * な参照層を作って memo の author 等で使う。
+ *
+ * - Account = サーバー接続を持つ行動主体 (notes.create 等の capability で
+ *   実 user として振る舞う)
+ * - Persona = ローカルの人格 (memo の著者として振る舞う、Misskey に投稿
+ *   主としては現れない)
+ *
+ * 直交設計のため、Account 型は god-type 化しない (= kind discriminator を
+ * 既存 Account に追加しない)。Identity は別レイヤーとして並走する。
+ */
+
+import { type Account, useAccountsStore } from '@/stores/accounts'
+import { type SkillMeta, useSkillsStore } from '@/stores/skills'
+
+export type IdentityKind = 'account' | 'persona'
+
+/**
+ * Identity = 「誰か」を表す flat 構造。
+ *
+ * `kind` は 2-way (account / persona) のみ。Account 内の guest 区別は
+ * Identity 層では扱わず、必要なら呼出元が Account 層の `isGuestAccount`
+ * で判定する (= 行動主体としての差は account 層の関心、Identity 層は
+ * 表示や著者参照の関心)。
+ */
+export interface Identity {
+  /** Identity ID — `skill:<...>` プレフィックスは persona、それ以外は Account.id。 */
+  id: string
+  kind: IdentityKind
+  displayName: string
+  avatarUrl?: string
+  bio?: string
+}
+
+const PERSONA_PREFIX = 'skill:'
+
+/**
+ * Identity ID を生成する小さなヘルパ。
+ * - `personaIdentityId('aizu-9k2x')` → `'skill:aizu-9k2x'`
+ * - `accountIdentityId('acc-1234')` → `'acc-1234'` (= そのまま)
+ */
+export function personaIdentityId(skillId: string): string {
+  return `${PERSONA_PREFIX}${skillId}`
+}
+
+export function isPersonaIdentityId(id: string): boolean {
+  return id.startsWith(PERSONA_PREFIX)
+}
+
+/**
+ * Identity ID から元の skill id を取り出す。persona でないなら null。
+ */
+export function extractSkillIdFromIdentity(id: string): string | null {
+  if (!isPersonaIdentityId(id)) return null
+  return id.slice(PERSONA_PREFIX.length) || null
+}
+
+function fromAccount(account: Account): Identity {
+  return {
+    id: account.id,
+    kind: 'account',
+    displayName: account.displayName || account.username,
+    avatarUrl: account.avatarUrl ?? undefined,
+  }
+}
+
+function fromPersonaSkill(skill: SkillMeta): Identity {
+  return {
+    id: personaIdentityId(skill.id),
+    kind: 'persona',
+    displayName: skill.name,
+    avatarUrl: skill.iconUrl,
+    bio: skill.description,
+  }
+}
+
+/**
+ * Identity ID から Identity を解決する。
+ * 都度 store を引くので skill / account の rename / icon 変更が即反映される
+ * (= cache せず live 解決)。見つからなければ null (= dangling)。
+ *
+ * persona 候補は `isPersona === true` の skill のみ受理する。フラグなしの
+ * skill を identity として返さないことで、persona セレクタの整合性を担保する。
+ */
+export function resolveIdentity(id: string): Identity | null {
+  if (!id) return null
+  if (isPersonaIdentityId(id)) {
+    const skillId = extractSkillIdFromIdentity(id)
+    if (!skillId) return null
+    const skill = useSkillsStore().get(skillId)
+    if (!skill || !skill.isPersona) return null
+    return fromPersonaSkill(skill)
+  }
+  const account = useAccountsStore().accounts.find((a) => a.id === id)
+  if (!account) return null
+  return fromAccount(account)
+}
+
+/** persona-eligible な skill 一覧 (UI セレクタ候補)。 */
+export function listPersonaIdentities(): Identity[] {
+  const skills = useSkillsStore().skills
+  return skills.filter((s) => s.isPersona).map(fromPersonaSkill)
+}
+
+/** Identity から表示用 avatar URL を取り出す (なければ generic placeholder)。 */
+export function getIdentityAvatarUrl(identity: Identity): string {
+  return identity.avatarUrl || '/avatar-default.svg'
+}
+
+/** Identity から表示用ラベル (= displayName)。 */
+export function getIdentityLabel(identity: Identity): string {
+  return identity.displayName
+}

--- a/tests/stores/skills.test.ts
+++ b/tests/stores/skills.test.ts
@@ -107,3 +107,103 @@ describe('skills store / setHeartbeat & heartbeatSkills', () => {
     expect(store.heartbeatSkills.map((s) => s.id)).toEqual(['a', 'c'])
   })
 })
+
+describe('skills store / composedSystemPrompt with #491 extensions', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('extraSkillIds includes session-only skills not in activeIds', () => {
+    const store = useSkillsStore()
+    // always-mode skill: 自動的に effective active
+    store.add({
+      id: 'a',
+      name: 'A',
+      version: '0.1.0',
+      mode: 'always',
+      triggers: [],
+      scope: 'global',
+      body: 'BODY-A',
+      cheapCheckCapabilities: [],
+    })
+    // manual-mode skill: 明示 activate しない
+    store.add({
+      id: 'b',
+      name: 'B',
+      version: '0.1.0',
+      mode: 'manual',
+      triggers: [],
+      scope: 'global',
+      body: 'BODY-B',
+      cheapCheckCapabilities: [],
+    })
+    expect(store.composedSystemPrompt()).toBe('BODY-A')
+    // extraSkillIds で session-only に b を含める
+    expect(store.composedSystemPrompt(['b'])).toContain('BODY-A')
+    expect(store.composedSystemPrompt(['b'])).toContain('BODY-B')
+  })
+
+  it('excludePersonaSkillsExcept removes other persona skills', () => {
+    const store = useSkillsStore()
+    // 2 個の always + isPersona skill
+    store.add({
+      id: 'aizu',
+      name: 'aizu',
+      version: '0.1.0',
+      mode: 'always',
+      triggers: [],
+      scope: 'global',
+      body: 'AIZU',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+    })
+    store.add({
+      id: 'orin',
+      name: 'orin',
+      version: '0.1.0',
+      mode: 'always',
+      triggers: [],
+      scope: 'global',
+      body: 'ORIN',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+    })
+    // 通常: 両方が effective active 扱いで両方の body が出る
+    const both = store.composedSystemPrompt()
+    expect(both).toContain('AIZU')
+    expect(both).toContain('ORIN')
+    // session で persona='aizu' を選択 → aizu のみ含まれ orin は除外
+    const aizuOnly = store.composedSystemPrompt([], 'aizu')
+    expect(aizuOnly).toContain('AIZU')
+    expect(aizuOnly).not.toContain('ORIN')
+  })
+
+  it('excludePersonaSkillsExcept does not affect non-persona skills', () => {
+    const store = useSkillsStore()
+    store.add({
+      id: 'tool',
+      name: 'tool',
+      version: '0.1.0',
+      mode: 'always',
+      triggers: [],
+      scope: 'global',
+      body: 'TOOL',
+      cheapCheckCapabilities: [],
+    })
+    store.add({
+      id: 'aizu',
+      name: 'aizu',
+      version: '0.1.0',
+      mode: 'always',
+      triggers: [],
+      scope: 'global',
+      body: 'AIZU',
+      cheapCheckCapabilities: [],
+      isPersona: true,
+    })
+    // tool は isPersona=false なので exclusion フィルタの対象外
+    const out = store.composedSystemPrompt([], 'aizu')
+    expect(out).toContain('TOOL')
+    expect(out).toContain('AIZU')
+  })
+})


### PR DESCRIPTION
Closes #491

## 概要

AI persona を **skill エンティティの拡張** として first-class に扱う基盤。独立 store / 独立永続化ファイル / 専用編集 UI は作らず、既存 skill 仕組みを活用 (DRY、MisStore 整合)。

ペルソナは「**新規セッション**のデフォルト = aiConfig.personaSkillId」 + 「**session 作成時に snapshot** = AiSession.personaSkillId」の 2 層構造。過去 session は作成時のペルソナを保持し、global 設定を変更しても書き換わらない (Git commit Author header の immutable semantic と同型)。

## 設計判断 (v6 plan より)

- **persona = skill (with isPersona=true)** — 独立 entity を作らず DRY、MisStore で aizu が既に skill として配信されている事実と整合
- **「AI persona をアカウント同等」は採用しない** — Account = 行動主体 / Persona = 著者 で別概念に分離 (god-type 化を回避)
- **memo の author は Git commit Author 型 immutable** (PR-3 で別途実装) — 同じ snapshot semantic を session.personaSkillId にも適用
- **per-session 切替セレクタは作らない** — persona は「この AI は誰か」という同一性設定なので、AI 設定で一括管理。session ヘッダは read-only avatar バッジ
- **skill.iconUrl ≠ persona avatar** — skill のアイコンは「skill そのもの」、persona の avatar は「キャラクター」と意味が違うため `isPersona` は明示フラグ

## 実装範囲

### schema 拡張

- \`SkillMeta.isPersona?: boolean\` — frontmatter 双方向対応
- \`AiSession.personaSkillId?: string\` — 作成時 snapshot、forward-compat 機構を活用 (KNOWN_FIELDS)
- \`AiConfig.personaSkillId?: string\` — 新規 session のデフォルト値、ai.json5 default 含む

### 新規ユーティリティ

- \`src/utils/identity.ts\` — Identity flat 型 (kind: 'account'|'persona') + \`resolveIdentity\` + \`listPersonaIdentities\`
- guest 判別は account 層の既存 \`isGuestAccount\` を流用、Identity 層では 2-way

### system prompt 統合

- \`composedSystemPrompt(extraSkillIds, excludePersonaSkillsExcept)\` 拡張 — session-only skill 包含 + 複数 always-persona 衝突回避
- \`buildAiContextBlock\` に \`<persona>\` block 追加 — block + instruction 一体型 prose で AI に役割と \`memos.create\` の \`authorId\` 規約を伝える
- \`composeChatSystemPrompt\` は新規定義せず既存 \`joinSystemPrompt\` を活用 (= chat path は同じ流れで OK)

### UI

- AI 設定ウィンドウ: 「ペルソナ」セクション (radio list + isPersona=true skill 候補) + 説明文「新規 session のデフォルト」明記
- DeckAiColumn ヘッダ: 現セッションの persona avatar を read-only バッジ表示
- DeckAiColumn 新規 session 作成時: aiConfig.personaSkillId を snapshot
- DeckAiColumn チャット送信時: session.personaSkillId を読み skill body + \`<persona>\` を注入
- SkillEditContent: \`isPersona\` toggle + 説明文

### \`useAccountsStore\` には触らない

既存 Account 型は無傷、Misskey API 経路に副作用なし。

## test

- \`identity.test.ts\` 新規 — resolveIdentity / listPersonaIdentities / id prefix helpers
- \`tests/stores/skills.test.ts\` 拡張 — composedSystemPrompt の extraSkillIds / excludePersonaSkillsExcept
- \`useAiSystemContext.test.ts\` 拡張 — \`<persona>\` block の出力形式と session-driven 性

\`pnpm lint\` / \`pnpm typecheck\` / \`pnpm test\` (581) すべて green。

## 検証

- skill 2 個 (aizu / orin) を \`isPersona: true\` で作成
- AI 設定でペルソナ=aizu に設定 → 新規 session 作成 → ヘッダに aizu アバター
- AI に「メモして」 → memos.create に \`<persona>\` block 由来の authorId が渡る (PR-3 で memo 反映)
- AI 設定でペルソナ=orin に変更 → 新規 session で orin、**過去の aizu session は aizu のまま** (immutable)
- ペルソナ=なし に戻す → 新規 session は汎用 AI、過去 session は影響なし
- 旧版 NoteDeck で session を開いてもファイルが壊れない (forward-compat)

## 並行性

- PR-2 (#492 memo capability) / PR-4 (#494 memo: link) と完全独立並行可
- PR-3 (#493 memo author) は本 PR + #492 マージ後に着手

## MisStore (別作業)

- registry schema に \`isPersona: boolean\` を追加検討
- aizu skill が \`isPersona: true\` で配信されるよう更新提案

🤖 Generated with [Claude Code](https://claude.com/claude-code)