### PR TITLE
feat(ai): memo に author 埋め込みブロック + Identity 反映 (#493)

### DIFF
--- a/src/capabilities/builtins/memos-read.ts
+++ b/src/capabilities/builtins/memos-read.ts
@@ -23,6 +23,7 @@ interface ProjectedMemoRow {
   text: string
   updatedAt: string
   tags?: string[]
+  author?: { id: string; displayName: string; avatarUrl?: string }
 }
 
 function pickString(input: unknown): string | undefined {
@@ -61,6 +62,7 @@ function projectRow(memoKey: string, memo: StoredMemo): ProjectedMemoRow {
     updatedAt: memo.updatedAt,
   }
   if (memo.data.tags.length > 0) row.tags = memo.data.tags
+  if (memo.data.author) row.author = { ...memo.data.author }
   return row
 }
 
@@ -85,7 +87,7 @@ export const memosListCapability: Command = {
   signature: {
     description:
       'NoteDeck のローカル memo を絞り込んで列挙する。' +
-      ' tag / 経過日数 / 部分一致クエリでフィルタ可能。' +
+      ' tag / 経過日数 / 部分一致クエリ / 作者でフィルタ可能。' +
       ' updatedAt 降順、limit 件で打ち切り (default 10、最大 50)。' +
       ' AI は memos.search でキーワード検索する前に memos.list で全体像を' +
       ' 把握するのが効率的。',
@@ -93,6 +95,13 @@ export const memosListCapability: Command = {
       tag: {
         type: 'string',
         description: '指定すると tags にこの値が含まれるメモのみ返す',
+        optional: true,
+      },
+      authorId: {
+        type: 'string',
+        description:
+          '指定すると author.id がこの値のメモのみ返す (`skill:<id>` で persona' +
+          ' 別のメモ抽出、ユーザー本人は author 未設定なので "self" を渡すと該当)',
         optional: true,
       },
       olderThanDays: {
@@ -120,7 +129,7 @@ export const memosListCapability: Command = {
     returns: {
       type: 'array',
       description:
-        '`{ id, text, updatedAt, tags? }` の配列。空配列なら一致なし',
+        '`{ id, text, updatedAt, tags?, author? }` の配列。空配列なら一致なし',
     },
     cheap: true,
   },
@@ -129,6 +138,7 @@ export const memosListCapability: Command = {
     await ensureMemosLoaded()
     const accountId = resolveAccountId(params?.accountId)
     const tag = pickString(params?.tag)
+    const authorIdFilter = pickString(params?.authorId)
     const olderThanDays = pickPositiveNumber(params?.olderThanDays)
     const queryRaw = pickString(params?.query)
     const queryLower = queryRaw?.toLowerCase()
@@ -142,6 +152,14 @@ export const memosListCapability: Command = {
     const entries: Array<[string, StoredMemo]> = Object.entries(all)
     const filtered = entries.filter(([, memo]) => {
       if (tag && !memo.data.tags.includes(tag)) return false
+      if (authorIdFilter) {
+        // "self" sentinel = author 未設定 (= ユーザー本人) のみ
+        if (authorIdFilter === 'self') {
+          if (memo.data.author) return false
+        } else if (memo.data.author?.id !== authorIdFilter) {
+          return false
+        }
+      }
       if (olderThanIso && memo.updatedAt > olderThanIso) return false
       if (queryLower && !memo.data.text.toLowerCase().includes(queryLower)) {
         return false
@@ -168,11 +186,18 @@ export const memosSearchCapability: Command = {
       ' 大小無視の substring + 直近更新の recency boost で並べ、' +
       ' limit 件 (default 10、最大 50) を返す。embedding 由来の semantic' +
       ' 検索はないので、ヒットしない場合は AI が言い換え (例:「旅行」→' +
-      '「出張」「バカンス」) で再試行することを想定。',
+      '「出張」「バカンス」) で再試行することを想定。' +
+      ' authorId で persona / 本人別のメモ検索も可能。',
     params: {
       query: {
         type: 'string',
         description: '検索文字列 (空文字不可、大小無視の部分一致)',
+      },
+      authorId: {
+        type: 'string',
+        description:
+          '指定すると author.id がこの値のメモのみ検索 (`skill:<id>` / "self")',
+        optional: true,
       },
       limit: {
         type: 'number',
@@ -187,7 +212,7 @@ export const memosSearchCapability: Command = {
     },
     returns: {
       type: 'array',
-      description: '`{ id, text, updatedAt, tags? }` の配列',
+      description: '`{ id, text, updatedAt, tags?, author? }` の配列',
     },
     cheap: true,
   },
@@ -196,15 +221,24 @@ export const memosSearchCapability: Command = {
     await ensureMemosLoaded()
     const query = pickString(params?.query)
     if (!query) throw new Error('memos.search: query is required')
+    const authorIdFilter = pickString(params?.authorId)
     const limit = clampLimit(params?.limit)
     const accountId = resolveAccountId(params?.accountId)
     const queryLower = query.toLowerCase()
 
     const all = loadAllMemos(accountId)
     const entries: Array<[string, StoredMemo]> = Object.entries(all)
-    const hits = entries.filter(([, memo]) =>
-      memo.data.text.toLowerCase().includes(queryLower),
-    )
+    const hits = entries.filter(([, memo]) => {
+      if (!memo.data.text.toLowerCase().includes(queryLower)) return false
+      if (authorIdFilter) {
+        if (authorIdFilter === 'self') {
+          if (memo.data.author) return false
+        } else if (memo.data.author?.id !== authorIdFilter) {
+          return false
+        }
+      }
+      return true
+    })
     // recency boost: 単純に updatedAt 降順 (= 新しいほど上位)。
     // 本格的な BM25 / TF-IDF はオーバーキル、まず使い始めて必要なら拡張。
     hits.sort(([, a], [, b]) => compareUpdatedAtDesc(a, b))

--- a/src/capabilities/builtins/memos.ts
+++ b/src/capabilities/builtins/memos.ts
@@ -8,6 +8,7 @@ import {
   saveMemo,
 } from '@/composables/useMemos'
 import { useAccountsStore } from '@/stores/accounts'
+import { resolveIdentity } from '@/utils/identity'
 
 /**
  * Phase 5+: AI がローカルメモ (Zettelkasten 形式 markdown) を作成 / 編集する
@@ -55,7 +56,32 @@ function resolveAccountId(input: unknown): string {
   return active
 }
 
-function emptyMemoData(text: string, tags: string[] = []): MemoData {
+/**
+ * authorId から memo の author 埋め込みブロックを組み立てる (#493)。
+ * 解決不可なら null を返さずエラー (= 偽 ID で memo に「存在しない作者」が
+ * 記録されるのを防ぐ)。Identity 解決時点でのスナップショットなので、後で
+ * skill / account が削除されても memo の author block は残る (immutable)。
+ */
+function buildAuthorBlock(authorId: string): MemoData['author'] {
+  const identity = resolveIdentity(authorId)
+  if (!identity) {
+    throw new Error(
+      `memos: authorId "${authorId}" is not resolvable (skill not installed / not isPersona / account not found)`,
+    )
+  }
+  const author: NonNullable<MemoData['author']> = {
+    id: identity.id,
+    displayName: identity.displayName,
+  }
+  if (identity.avatarUrl) author.avatarUrl = identity.avatarUrl
+  return author
+}
+
+function emptyMemoData(
+  text: string,
+  tags: string[] = [],
+  author?: MemoData['author'],
+): MemoData {
   return {
     text,
     cw: '',
@@ -68,6 +94,7 @@ function emptyMemoData(text: string, tags: string[] = []): MemoData {
     showPoll: false,
     scheduledAt: null,
     tags,
+    author,
   }
 }
 
@@ -88,8 +115,10 @@ export const memosCreateCapability: Command = {
   signature: {
     description:
       'NoteDeck のローカル markdown メモを新規作成する。' +
-      ' text + 任意の tags のみ指定可。CW / visibility / poll 等の投稿用フィールドは触らない' +
+      ' text + 任意の tags / authorId 指定可。CW / visibility / poll 等の投稿用フィールドは触らない' +
       ' (= デフォルト値で作成)。memoKey は Zettelkasten 形式 (`YYYYMMDDHHmmss`) で自動採番。' +
+      ' authorId を渡すと <persona> block の指示通り memo に author 埋め込みブロックが' +
+      ' 記録される (skill / account の表示情報を作成時に snapshot)。' +
       ' 投稿前に確認モーダルが出る。',
     params: {
       text: {
@@ -103,6 +132,15 @@ export const memosCreateCapability: Command = {
           ' ユーザーが skill body 等で意味付けするので AI は文脈に応じて分類タグを付ける',
         optional: true,
       },
+      authorId: {
+        type: 'string',
+        description:
+          '作者の Identity ID (`skill:<persona-id>` / Misskey accountId 等)。' +
+          ' 未指定 = ユーザー本人扱い。<persona> block で指示された persona の' +
+          ' authorId をここに渡すと、その persona のアイコン / 名前が memo に' +
+          ' 埋め込まれて UI で表示される',
+        optional: true,
+      },
       accountId: {
         type: 'string',
         description: ACCOUNT_ID_PARAM_DESC,
@@ -112,7 +150,7 @@ export const memosCreateCapability: Command = {
     returns: {
       type: 'object',
       description:
-        '`{ id, text, updatedAt, accountId, tags? }` — id は Zettelkasten 形式の memoKey',
+        '`{ id, text, updatedAt, accountId, tags?, author? }` — id は Zettelkasten 形式',
     },
   },
   visible: false,
@@ -120,10 +158,16 @@ export const memosCreateCapability: Command = {
     const text = pickString(params?.text)
     if (!text) throw new Error('memos.create: text is required')
     const tags = pickStringArray(params?.tags) ?? []
+    const authorIdInput = pickString(params?.authorId)
+    const author = authorIdInput ? buildAuthorBlock(authorIdInput) : undefined
     const accountId = resolveAccountId(params?.accountId)
     await ensureMemosLoaded()
     const memoKey = generateMemoKey()
-    const stored = saveMemo(accountId, memoKey, emptyMemoData(text, tags))
+    const stored = saveMemo(
+      accountId,
+      memoKey,
+      emptyMemoData(text, tags, author),
+    )
     const result: Record<string, unknown> = {
       id: memoKey,
       text: stored.data.text,
@@ -131,6 +175,7 @@ export const memosCreateCapability: Command = {
       accountId,
     }
     if (stored.data.tags.length > 0) result.tags = stored.data.tags
+    if (stored.data.author) result.author = stored.data.author
     return result
   },
 }
@@ -147,7 +192,7 @@ export const memosUpdateCapability: Command = {
   requiresConfirmation: true,
   signature: {
     description:
-      '既存ローカルメモの text / tags を更新する (どちらも optional、未指定なら維持)。' +
+      '既存ローカルメモの text / tags / authorId を更新する (すべて optional、未指定なら維持)。' +
       ' CW / visibility 等の他のフィールドは既存値を保持。' +
       ' id は <memos> ブロックで参照できる Zettelkasten 形式 memoKey。' +
       ' 投稿前に確認モーダルが出る。',
@@ -167,6 +212,14 @@ export const memosUpdateCapability: Command = {
           '新しい tags 配列 (未指定なら既存維持)。空配列 [] を渡すと tags を全削除',
         optional: true,
       },
+      authorId: {
+        type: 'string',
+        description:
+          '作者を変更する場合の Identity ID (空文字 "" を渡すと author を消す)。' +
+          ' 通常は memo の作者を変える用途なし。AI が persona として書いた memo を' +
+          ' ユーザー本人に戻す等の特殊操作で使う',
+        optional: true,
+      },
       accountId: {
         type: 'string',
         description: ACCOUNT_ID_PARAM_DESC,
@@ -175,7 +228,7 @@ export const memosUpdateCapability: Command = {
     },
     returns: {
       type: 'object',
-      description: '`{ id, text, updatedAt, accountId, tags? }`',
+      description: '`{ id, text, updatedAt, accountId, tags?, author? }`',
     },
   },
   visible: false,
@@ -184,8 +237,21 @@ export const memosUpdateCapability: Command = {
     if (!id) throw new Error('memos.update: id is required')
     const text = pickString(params?.text)
     const tags = pickStringArray(params?.tags)
-    if (text === undefined && tags === undefined) {
-      throw new Error('memos.update: at least one of text / tags is required')
+    // authorId: 未指定 (param に key 自体ない) = 既存維持、空文字 "" = author 削除、
+    // 値あり = resolveIdentity で再 snapshot
+    let authorPatch: { author: MemoData['author'] } | undefined
+    if (params && 'authorId' in params) {
+      const raw = params.authorId
+      if (typeof raw === 'string' && raw.trim() === '') {
+        authorPatch = { author: undefined }
+      } else if (typeof raw === 'string') {
+        authorPatch = { author: buildAuthorBlock(raw.trim()) }
+      }
+    }
+    if (text === undefined && tags === undefined && authorPatch === undefined) {
+      throw new Error(
+        'memos.update: at least one of text / tags / authorId is required',
+      )
     }
     const accountId = resolveAccountId(params?.accountId)
     await ensureMemosLoaded()
@@ -197,6 +263,7 @@ export const memosUpdateCapability: Command = {
       ...existing.data,
       text: text ?? existing.data.text,
       tags: tags ?? existing.data.tags,
+      author: authorPatch ? authorPatch.author : existing.data.author,
     })
     const result: Record<string, unknown> = {
       id,
@@ -205,6 +272,7 @@ export const memosUpdateCapability: Command = {
       accountId,
     }
     if (stored.data.tags.length > 0) result.tags = stored.data.tags
+    if (stored.data.author) result.author = stored.data.author
     return result
   },
 }

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -144,6 +144,9 @@ function buildEntry(acc: Account, key: string, memo: StoredMemo): MemoEntry {
     },
     emojis: emojiDict,
     reactionEmojis: emojiDict,
+    // memo.data.author 埋め込みブロックがあれば avatar / 表示名を上書き (#493)。
+    // skill が後で消えても author block は memo に永続化されているので壊れない。
+    author: memo.data.author,
   })
   // Cross-account ビューでは @username だけだとどのサーバーか分からないため
   // host を埋めて MkNote 側で `@username@host` のフルアドレス表示にする

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -111,6 +111,8 @@ const previewNote = computed<NormalizedNote | null>(() => {
     },
     emojis: emojiDict,
     reactionEmojis: emojiDict,
+    // memo.data.author 埋め込みブロックがあれば preview にも反映 (#493)
+    author: d.author,
   })
 })
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -740,6 +740,45 @@ describe('projectMemos', () => {
     ]
     expect(projectMemos(entries, undefined, [])).toHaveLength(1)
   })
+
+  it('emits author block (id+displayName) when memo has author embed (#493)', () => {
+    const memo: StoredMemo = {
+      updatedAt: '2026-01-01T00:00:00Z',
+      data: {
+        text: 'persona memo',
+        cw: '',
+        showCw: false,
+        visibility: 'public',
+        localOnly: false,
+        fileIds: [],
+        pollChoices: [],
+        pollMultiple: false,
+        showPoll: false,
+        scheduledAt: null,
+        tags: [],
+        author: {
+          id: 'skill:aizu-9k2x',
+          displayName: '藍',
+          avatarUrl: 'https://example.com/aizu.svg',
+        },
+      },
+    }
+    const out = projectMemos([['20260101000000', memo]])
+    expect(out[0]?.author).toEqual({
+      id: 'skill:aizu-9k2x',
+      displayName: '藍',
+    })
+    // avatarUrl は AI には不要なので落とす
+    expect(out[0]?.author).not.toHaveProperty('avatarUrl')
+  })
+
+  it('omits author when memo has no author embed', () => {
+    const entries: MemoEntry[] = [
+      ['20260101000000', makeMemo('plain memo', '2026-01-01T00:00:00Z')],
+    ]
+    const out = projectMemos(entries)
+    expect(out[0]).not.toHaveProperty('author')
+  })
 })
 
 describe('buildAiContextBlock — memos', () => {

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -219,6 +219,12 @@ export interface ProjectedMemo {
   updatedAt: string
   /** 任意の自由記述タグ (#492)。空配列なら省略 (token 節約)。 */
   tags?: string[]
+  /**
+   * 著者の埋め込み情報 (#493)。`{ id, displayName }` のみ AI に渡す
+   * (avatarUrl は AI には不要、画像は UI のみで使う)。memo に author block
+   * が無ければ省略 (= ユーザー本人と暗黙解釈)。
+   */
+  author?: { id: string; displayName: string }
 }
 
 export type MemoEntry = readonly [memoKey: string, memo: StoredMemo]
@@ -246,6 +252,12 @@ export function projectMemos(
       updatedAt: memo.updatedAt,
     }
     if (memo.data.tags.length > 0) projected.tags = memo.data.tags
+    if (memo.data.author) {
+      projected.author = {
+        id: memo.data.author.id,
+        displayName: memo.data.author.displayName,
+      }
+    }
     return projected
   })
 }

--- a/src/composables/useMemos.ts
+++ b/src/composables/useMemos.ts
@@ -28,6 +28,22 @@ export interface MemoData {
    * 設定可能。default: `[]`。
    */
   tags: string[]
+  /**
+   * 著者の埋め込みメタデータ (#493)。Git commit の Author header / Misskey
+   * note の user フィールドと同型の document intrinsic property。
+   * cache ではなく memo 自体の真のデータなので、参照先 (skill / account)
+   * が後で消えても表示は壊れない (= immutable)。
+   *
+   * - `id`: Identity ID (`skill:<persona-id>` or accountId)
+   * - `displayName` / `avatarUrl`: 作成時に snapshot された表示用情報
+   *
+   * 未指定 = ユーザー本人 (= accountId にフォールバック表示)。
+   */
+  author?: {
+    id: string
+    displayName: string
+    avatarUrl?: string
+  }
 }
 
 export interface StoredMemo {
@@ -189,8 +205,26 @@ function toFrontmatterSource(
   }
   if (d.scheduledAt) frontmatter.scheduledAt = d.scheduledAt
   if (d.tags.length > 0) frontmatter.tags = d.tags
+  if (d.author) {
+    const authorBlock: Record<string, unknown> = {
+      id: d.author.id,
+      displayName: d.author.displayName,
+    }
+    if (d.author.avatarUrl) authorBlock.avatarUrl = d.author.avatarUrl
+    frontmatter.author = authorBlock
+  }
 
   return buildMemoSource(d.text, frontmatter)
+}
+
+function parseAuthorBlock(raw: unknown): MemoData['author'] {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const r = raw as Record<string, unknown>
+  const id = typeof r.id === 'string' ? r.id : ''
+  const displayName = typeof r.displayName === 'string' ? r.displayName : ''
+  if (!id || !displayName) return undefined
+  const avatarUrl = typeof r.avatarUrl === 'string' ? r.avatarUrl : undefined
+  return avatarUrl ? { id, displayName, avatarUrl } : { id, displayName }
 }
 
 function parseMemoContent(fileContent: string): {
@@ -229,6 +263,7 @@ function parseMemoContent(fileContent: string): {
     tags: Array.isArray(fm.tags)
       ? fm.tags.filter((x): x is string => typeof x === 'string')
       : [],
+    author: parseAuthorBlock(fm.author),
   }
 
   return { accountId, stored: { updatedAt, data }, createdAt }

--- a/src/defaults/skills/notedeck-memo.md
+++ b/src/defaults/skills/notedeck-memo.md
@@ -1,7 +1,7 @@
 ---
 id: notedeck-memo
 name: NoteDeck メモを尊重する
-version: 0.1.0
+version: 0.2.0
 description: ユーザーがローカルに書き溜めたメモを永続的なコンテキストとして扱う
 mode: always
 scope: global
@@ -30,9 +30,30 @@ builtIn: true
 3. メモの内容と現在のユーザー依頼が衝突するときは、ユーザーに確認する。
 4. 個別のメモを引用するときは「メモに『...』とありました」のように出典を示す。
 
-## メモの作成・更新
+## メモのフィールド
+
+- `text`: 本文 (markdown)
+- `tags`: 任意の自由記述タグ。ユーザーが skill body 等で意味付ける
+  (例: `hidden` で AI 注入除外、`idea` で発想メモ、等)
+- `author`: 作者の埋め込みメタデータ。`id` が `skill:<persona-id>` なら
+  AI persona が書いたメモ、それ以外はユーザー本人のメモ。author 未指定 =
+  ユーザー本人の暗黙扱い
+
+## メモの作成・更新・整理
 
 ユーザーが「これメモっといて」「メモに残しておいて」のように依頼したら、
 `memos.create` capability で新規作成する (`memos.write` 権限が必要)。
-既存メモへの追記・編集は `memos.update` を使う。
-いずれも実行前に確認モーダルが出るのでユーザー判断を尊重すること。
+
+- `<persona>` block でこのセッションの persona id が指示されていれば、
+  `memos.create` の `authorId` 引数にその id を渡す (= persona の作者
+  メタデータが memo に埋め込まれて UI で表示される)
+- ユーザー本人のメモなら `authorId` を渡さない (= author 未設定で保存)
+- 既存メモへの追記・編集は `memos.update`、削除は `memos.delete`
+- 整理ポリシーは skill body に書かれている指示に従う (= NoteDeck は値を
+  enumerate せず、ユーザーが各自定義する設計)
+
+メモを探すには `memos.list` (絞り込み列挙) / `memos.search` (本文部分一致)。
+`tag` / `authorId` / `olderThanDays` / `query` でフィルタ可能。
+
+いずれの write capability も実行前に確認モーダルが出るので、ユーザー判断を
+尊重すること (= 勝手に大量 create / delete しない)。

--- a/src/utils/buildPreviewNote.test.ts
+++ b/src/utils/buildPreviewNote.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { Account } from '@/stores/accounts'
+import { buildPreviewNote } from './buildPreviewNote'
+
+const ACCOUNT: Account = {
+  id: 'acc-1',
+  host: 'misskey.example',
+  userId: 'u1',
+  username: 'taka',
+  displayName: 'Taka',
+  avatarUrl: 'https://example.com/taka.png',
+  software: 'misskey-dev/misskey',
+  hasToken: true,
+}
+
+describe('buildPreviewNote', () => {
+  it('uses account displayName/avatarUrl when no author override', () => {
+    const note = buildPreviewNote({
+      account: ACCOUNT,
+      id: 'memo:acc-1:20260101010101',
+      createdAt: '2026-01-01T01:01:01Z',
+      text: 'hello',
+      cw: null,
+      visibility: 'public',
+      localOnly: false,
+    })
+    expect(note.user.name).toBe('Taka')
+    expect(note.user.avatarUrl).toBe('https://example.com/taka.png')
+    expect(note.user.username).toBe('taka')
+  })
+
+  it('overrides name/avatarUrl with author embed (#493)', () => {
+    const note = buildPreviewNote({
+      account: ACCOUNT,
+      id: 'memo:acc-1:20260101010101',
+      createdAt: '2026-01-01T01:01:01Z',
+      text: 'persona memo',
+      cw: null,
+      visibility: 'public',
+      localOnly: false,
+      author: {
+        id: 'skill:aizu-9k2x',
+        displayName: '藍',
+        avatarUrl: 'https://example.com/aizu.svg',
+      },
+    })
+    // username は account 由来のまま (= memo の保存空間オーナー)
+    expect(note.user.username).toBe('taka')
+    // 表示名 / アバターは author で上書き (= persona の身元)
+    expect(note.user.name).toBe('藍')
+    expect(note.user.avatarUrl).toBe('https://example.com/aizu.svg')
+  })
+
+  it('falls back to account avatarUrl when author has no avatarUrl', () => {
+    const note = buildPreviewNote({
+      account: ACCOUNT,
+      id: 'memo:acc-1:20260101010101',
+      createdAt: '2026-01-01T01:01:01Z',
+      text: 'persona memo',
+      cw: null,
+      visibility: 'public',
+      localOnly: false,
+      author: {
+        id: 'skill:no-icon',
+        displayName: 'no-icon persona',
+      },
+    })
+    expect(note.user.name).toBe('no-icon persona')
+    expect(note.user.avatarUrl).toBe('https://example.com/taka.png')
+  })
+})

--- a/src/utils/buildPreviewNote.ts
+++ b/src/utils/buildPreviewNote.ts
@@ -26,6 +26,13 @@ export interface BuildPreviewNoteOptions {
   poll?: PreviewPollInput
   emojis?: Record<string, string>
   reactionEmojis?: Record<string, string>
+  /**
+   * 著者の埋め込みオーバーライド (#493)。memo.data.author 由来。
+   * 指定時、note.user の name と avatarUrl をこの値で上書き (= persona memo
+   * を avatar+名前で見分けられるようにする)。username は account 由来のまま
+   * 残し、@username 表示は維持する。
+   */
+  author?: { id: string; displayName: string; avatarUrl?: string }
 }
 
 function buildPoll(input: PreviewPollInput): NormalizedPoll | undefined {
@@ -58,8 +65,8 @@ export function buildPreviewNote(
       id: account.userId,
       username: account.username,
       host: null,
-      name: account.displayName,
-      avatarUrl: getAccountAvatarUrl(account),
+      name: opts.author?.displayName ?? account.displayName,
+      avatarUrl: opts.author?.avatarUrl ?? getAccountAvatarUrl(account),
     },
     visibility: opts.visibility,
     emojis: opts.emojis ?? {},


### PR DESCRIPTION
Closes #493

Depends on #491 (PR #495 merged) + #492 (PR #496 merged).

## 概要

memo に \`author = { id, displayName, avatarUrl? }\` を frontmatter 埋め込みブロックとして追加 (Git commit Author header / Misskey note user 埋め込みパターン)。**cache ではなく document intrinsic property** — skill uninstall / rename で過去 memo は immutable に古値固定。

## なぜ

PR-1 (#491) で persona 基盤、PR-2 (#492) で memo capability が揃ったので、AI が persona として書いたメモを **視覚的に区別** する仕上げ。 これでペルソナ機能の loop が完成 (= AI 設定で persona 選択 → AI に「メモして」 → memo column に persona の avatar+名前で表示)。

## 設計判断

- **author は埋め込み (cache でない)** — 参照先 skill/account 消失で何も壊れない、Obsidian 等 portability も確保
- **skill rename / icon 変更で過去 memo は古値のまま** (Git commit Author header の immutable semantic と同型)
- **`buildAuthorBlock` で resolveIdentity → snapshot embed** — 偽 ID 防止のため解決不可は throw
- **buildPreviewNote の author override は name + avatarUrl のみ** (username は account 由来 = 「保存空間オーナー」を維持)
- **MemoEditorContent の author セレクタ UI は今回スコープ外** — AI capability 経由で十分操作可、UI 編集需要が出たら別 PR

## 実装範囲

### schema
- \`MemoData.author?: { id, displayName, avatarUrl? }\`
- frontmatter 双方向 (author block parser、空 / 不正は undefined)
- 既存メモは author 未指定 → 表示時 account fallback (後方互換)

### AI context
- \`ProjectedMemo.author?: { id, displayName }\` (avatarUrl は AI 不要)
- projectMemos で author を渡す

### capability
- \`memos.create\` / \`memos.update\` の params に \`authorId?\`
- 内部で \`resolveIdentity\` → 偽 ID は throw、解決成功で author block embed
- \`memos.update\` は authorId 空文字 "" で author 削除、未指定で既存維持
- \`memos.list\` / \`memos.search\` の \`authorId\` フィルタ ("self" sentinel = author 未設定のみ)

### UI
- \`buildPreviewNote\` に author オーバーライド受け入れ
- DeckMemoColumn / MemoEditorContent preview で author 反映 (persona の avatar+名前で表示)
- username は account 由来のまま (= 保存空間オーナー)

### docs
- \`notedeck-memo.md\` 文面更新 (tags / author / list / search の説明)

### test
- \`buildPreviewNote.test.ts\` 新規 (author override + fallback)
- \`projectMemos\` に author 関連 test 追加

\`pnpm lint\` / \`pnpm typecheck\` / \`pnpm test\` (594) すべて green。

## 検証

- AI 設定でペルソナ=aizu、新規 session 作成 → AI に「メモして」
- → memos.create が authorId='skill:aizu-...' で実行 (\`<persona>\` block 由来)
- → DeckMemoColumn で aizu のアバター+名前で表示
- skill aizu を uninstall または name/iconUrl 変更 → **過去 memo は古値のまま** (immutable)
- 既存メモ (author 未指定) は従来通り account 表示
- メモ \`.md\` を Obsidian で開く → frontmatter author ブロックで識別可能

## 並行性

- #494 (memo: link) と互いに独立、並行可能。\`memos-read.ts\` への追記が衝突するくらい (small follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)