### PR TITLE
fix(confirm): 長文 message でダイアログが viewport を超えるのを防ぐ

### DIFF
--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -113,6 +113,11 @@ useNativeDialog(dialogRef, visible, {
 .body {
   padding: 4px 20px 12px;
   text-align: center;
+  // 長文 message (e.g. AI capability の params JSON) で
+  // ダイアログが viewport を超えないようスクロール可能にする
+  max-height: 60vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .message {
@@ -121,6 +126,8 @@ useNativeDialog(dialogRef, visible, {
   font-size: 0.85em;
   line-height: 1.5;
   opacity: 0.8;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .actions {


### PR DESCRIPTION
## Summary

AI capability の `requiresConfirmation` 経由で出る確認ダイアログで、長文メモを `memos.create` しようとするとダイアログが画面外まで伸びて操作できなくなる問題の修正。

[dispatcher.ts:117-120](src/capabilities/dispatcher.ts#L117-L120) が params を `JSON.stringify` で message に流し込むため、本文 markdown が長いメモを保存しようとすると確認 / キャンセルボタンに到達できなかった。

## Changes

[AppConfirm.vue](src/components/common/AppConfirm.vue) の `.body` をスクロール可能化:

- `.body` に `max-height: 60vh` + `overflow-y: auto` + `overscroll-behavior: contain`
- `.message` に `white-space: pre-wrap` + `word-break: break-word`

短い "削除しますか?" 系の確認の見た目には影響しない (内容が body に収まる範囲ではスクロールバーが出ないため)。

## Out of scope

dispatcher 側で長文 params を切り詰めて確認ダイアログ向けに整形する案は別途検討。本 PR は「画面外で操作不能」のクリティカル UX 問題の最短 fix のみ。

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` 通過
- [ ] AI チャットで長文の `memos.create` を起こす → 確認ダイアログがスクロールでき、ボタンに到達できる
- [ ] 短い確認 (`memos.delete` 等) の見た目に変化がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)