### PR TITLE
fix(memo): メモアイテムの「もっと見る」とカラム縦スクロールを修正

### DIFF
--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -54,6 +54,14 @@ const props = defineProps<{
   nearViewport?: boolean
   /** チャンネルカラム内など、チャンネル情報を重複表示したくない時に true */
   hideChannelBadge?: boolean
+  /**
+   * article 全体クリックでの navigateToDetail を抑制する。メモプレビュー等
+   * で合成 ID (`memo:<accountId>:<key>`) を渡すケースで、navigate すると
+   * 404 になるため使用。親側が wrapper の click handler でメモエディタ
+   * 等への遷移を行う想定 (= 親 wrapper は capture phase で click を奪わず
+   * bubble に任せる + 内部 button の `.stop` 修飾子に依存する)。
+   */
+  disableArticleClick?: boolean
 }>()
 
 /** Pure renote → show inner note, otherwise show note itself */
@@ -315,6 +323,7 @@ const activeModeFlags = computed(() => {
 })
 
 function navigateToDetail() {
+  if (props.disableArticleClick) return
   if (!props.detailed) {
     navToNote(props.note._accountId, props.note.id)
   }

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -403,17 +403,18 @@ function closeMenu() {
           </span>
         </div>
 
-        <!-- capture-phase click: MkNote 内部の navigateToDetail (合成IDなので
-             404 になる) より先に拾ってメモエディタウィンドウを開く。 -->
+        <!-- bubble phase で受け、内部 button (`もっと見る` / CW / mention /
+             link) の `.stop` 修飾子を活かす。MkNote 側は disable-article-click
+             で article 全体クリックの navigate を抑制 (合成 ID で 404 防止)。 -->
         <div
           :class="$style.itemNoteBtn"
           role="button"
           tabindex="0"
           title="このメモをエディタで開く"
-          @click.capture.prevent.stop="onOpenEditor(entry)"
+          @click.stop="onOpenEditor(entry)"
           @keydown.enter="onOpenEditor(entry)"
         >
-          <MkNote :note="entry.note" embedded />
+          <MkNote :note="entry.note" embedded disable-article-click />
         </div>
       </div>
     </div>

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -453,11 +453,22 @@ function closeMenu() {
 
 .embeddedForm {
   border-bottom: 1px solid var(--nd-divider);
+  flex-shrink: 0;
 }
 
+// DeckColumn.columnBody は overflow: hidden で固定高なので、メモ一覧側で
+// scroll container を作らないとアイテム展開時に内容がはみ出してスクロール
+// 不可になる (`tlScroller` 系と同じパターン)。
 .list {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--nd-scrollbarHandle) transparent;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
 }
 
 .item {

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -243,15 +243,15 @@ async function onDelete() {
         :image-url="serverNotFoundImageUrl"
         fallback-kind="notFound"
       />
-      <!-- Swallow clicks so MkNote's internal navigateToDetail (synthetic id
-           → 404) doesn't fire. Right-click still opens our memo menu. -->
+      <!-- 合成 ID での navigate は disable-article-click で抑制。capture を
+           外して内部 button (`もっと見る` 等) の click を活かす。右クリックは
+           従来通りメモメニューを開く。 -->
       <div
         v-else-if="previewNote"
         :class="$style.previewWrap"
-        @click.capture.prevent.stop
         @contextmenu.capture="onContextMenu"
       >
-        <MkNote :note="previewNote" embedded />
+        <MkNote :note="previewNote" embedded disable-article-click />
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

メモカラム周りで AI が作成した長文メモを契機に発覚した 2 件の修正。

### 1. 「もっと見る」が効かずエディタが開いてしまう

[DeckMemoColumn.vue](src/components/deck/DeckMemoColumn.vue) / [MemoEditorContent.vue](src/components/window/MemoEditorContent.vue) のメモプレビュー wrapper が `@click.capture.prevent.stop` で全クリックを capture phase で奪っており、MkNote 内部の `.stop` 修飾子付き button (`もっと見る` / `CW 隠す` / mention / link 等) すべての操作を吸収してしまっていた。

長文メモ (`LONG_TEXT_THRESHOLD = 500` 文字 / 8 行超) で「もっと見る」を押しても展開されずメモエディタが開く現象。

**修正:**
- `MkNote` に `disableArticleClick` prop を追加 → article 全体クリックでの `navigateToDetail` を no-op 化 (= 合成 ID `memo:<accountId>:<key>` で 404 になるのを防ぐ。これが元々親 wrapper が capture していた目的)
- 親 wrapper を bubble phase に変更 (`@click.capture.prevent.stop` → `@click.stop`)、内部 button の `.stop` を活かす

### 2. メモ展開後にカラムが縦スクロールしない

`DeckColumn.columnBody` は `overflow: hidden` で固定高なので、子側で scroll container を作る必要があるが [DeckMemoColumn.vue](src/components/deck/DeckMemoColumn.vue) の `.list` に `overflow-y: auto` が無く、メモを展開してカラム高を超えるとはみ出して見えなくなっていた。

**修正:** `.list` を `tlScroller` 系と同じ `overflow-y: auto` + `min-height: 0` + `overscroll-behavior: contain` の scroll container 化。投稿フォームは `flex-shrink: 0` で固定。

## Out of scope

- メモを Markdown として render する件 (`# 見出し` が記号のまま等) は依存追加 + style が広く別 PR で対応予定

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` (594 passed) 通過
- [ ] 長文メモ (500 文字超) で「もっと見る」展開・収納できる
- [ ] CW 付きメモで「もっと見る」(CW 開閉) が動作
- [ ] メモが多いカラムで縦スクロールが動作
- [ ] 短文メモは従来通り wrapper クリックでエディタが開く / 右クリックメニューも動作
- [ ] MemoEditorContent (window) の preview でも同様

🤖 Generated with [Claude Code](https://claude.com/claude-code)