### PR TITLE
fix(memo): persona memo の screen name / コードタブ author 表示を修正

### DIFF
--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -149,8 +149,10 @@ function buildEntry(acc: Account, key: string, memo: StoredMemo): MemoEntry {
     author: memo.data.author,
   })
   // Cross-account ビューでは @username だけだとどのサーバーか分からないため
-  // host を埋めて MkNote 側で `@username@host` のフルアドレス表示にする
-  if (isCrossAccount.value) {
+  // host を埋めて MkNote 側で `@username@host` のフルアドレス表示にする。
+  // ただし memo.data.author で persona に上書き済みの場合 (= persona は
+  // ローカル概念で host を持たない) は host を埋めない (`@yui` のみ表示)。
+  if (isCrossAccount.value && !memo.data.author) {
     note.user = { ...note.user, host: acc.host }
   }
   return {

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -75,6 +75,13 @@ const serverNotFoundImageUrl = computed(() => {
 })
 
 const author = computed(() => {
+  // memo.data.author 埋め込み (#493) があれば persona の身元を表示
+  // (例: `唯 (@yui)`)。なければ保存先 account の `@user@host`。
+  const embedded = memo.value?.data.author
+  if (embedded) {
+    const handle = embedded.id.replace(/^skill:/, '')
+    return `${embedded.displayName} (@${handle})`
+  }
   const acc = account.value
   if (!acc) return null
   return `@${acc.username}@${acc.host}`

--- a/src/utils/buildPreviewNote.test.ts
+++ b/src/utils/buildPreviewNote.test.ts
@@ -29,7 +29,7 @@ describe('buildPreviewNote', () => {
     expect(note.user.username).toBe('taka')
   })
 
-  it('overrides name/avatarUrl with author embed (#493)', () => {
+  it('overrides name/avatarUrl/username/id with author embed (#493)', () => {
     const note = buildPreviewNote({
       account: ACCOUNT,
       id: 'memo:acc-1:20260101010101',
@@ -44,11 +44,15 @@ describe('buildPreviewNote', () => {
         avatarUrl: 'https://example.com/aizu.svg',
       },
     })
-    // username は account 由来のまま (= memo の保存空間オーナー)
-    expect(note.user.username).toBe('taka')
     // 表示名 / アバターは author で上書き (= persona の身元)
     expect(note.user.name).toBe('藍')
     expect(note.user.avatarUrl).toBe('https://example.com/aizu.svg')
+    // username は author.id から `skill:` prefix を除いたもの (= persona id)
+    expect(note.user.username).toBe('aizu-9k2x')
+    // host は null (persona はローカル概念で host を持たない)
+    expect(note.user.host).toBe(null)
+    // user.id も author.id (= persona と同一視できる identity)
+    expect(note.user.id).toBe('skill:aizu-9k2x')
   })
 
   it('falls back to account avatarUrl when author has no avatarUrl', () => {

--- a/src/utils/buildPreviewNote.ts
+++ b/src/utils/buildPreviewNote.ts
@@ -28,9 +28,10 @@ export interface BuildPreviewNoteOptions {
   reactionEmojis?: Record<string, string>
   /**
    * 著者の埋め込みオーバーライド (#493)。memo.data.author 由来。
-   * 指定時、note.user の name と avatarUrl をこの値で上書き (= persona memo
-   * を avatar+名前で見分けられるようにする)。username は account 由来のまま
-   * 残し、@username 表示は維持する。
+   * 指定時、note.user の name / avatarUrl / username / host を author に揃える
+   * (= persona memo を持ち主アカウントとは別の身元として表示する)。
+   * username は author.id から `skill:` prefix を除いた値 (例: `skill:yui` →
+   * `yui`)、host は null (= ローカル persona、@yui のみ表示)。
    */
   author?: { id: string; displayName: string; avatarUrl?: string }
 }
@@ -54,6 +55,9 @@ export function buildPreviewNote(
   opts: BuildPreviewNoteOptions,
 ): NormalizedNote {
   const { account } = opts
+  const authorUsername = opts.author
+    ? opts.author.id.replace(/^skill:/, '')
+    : account.username
   const note: NormalizedNote = {
     id: opts.id,
     _accountId: account.id,
@@ -62,8 +66,8 @@ export function buildPreviewNote(
     text: opts.text,
     cw: opts.cw,
     user: {
-      id: account.userId,
-      username: account.username,
+      id: opts.author ? opts.author.id : account.userId,
+      username: authorUsername,
       host: null,
       name: opts.author?.displayName ?? account.displayName,
       avatarUrl: opts.author?.avatarUrl ?? getAccountAvatarUrl(account),


### PR DESCRIPTION
## Summary

PR #497 (#493) で「username = 保存空間オーナー (= account 由来)」としていたが、persona が書いた memo を表示すると `唯 @hitalin@yami.ski` のように persona の身元と保存先 account が混ざって混乱を生んでいた。

加えて [MemoEditorContent.vue](src/components/window/MemoEditorContent.vue) のコードタブ meta の `author` 行が memo の `author` 埋め込みブロックを完全に無視して保存先 account の `@user@host` を表示していた (= author block が存在するファイルでも反映されない明確なバグ)。

## Changes

- [buildPreviewNote.ts](src/utils/buildPreviewNote.ts): author 埋め込みあり → user の `name` / `avatarUrl` に加え `username` / `host` / `id` も persona に揃える
  - `username` = `author.id.replace(/^skill:/, '')` (例: `skill:yui` → `yui`)
  - `host` = null (persona はローカル概念で host を持たない)
  - `user.id` = `author.id`
- [DeckMemoColumn.vue](src/components/deck/DeckMemoColumn.vue): cross-account ビューで host を埋める処理は author 埋め込みあり memo では skip (`@yui@yami.ski` のような混合表示防止)
- [MemoEditorContent.vue](src/components/window/MemoEditorContent.vue): コードタブの `author` meta を `memo.data.author` 優先で表示 (`唯 (@yui)`)、無いときだけ account 由来にフォールバック
- [buildPreviewNote.test.ts](src/utils/buildPreviewNote.test.ts): テスト更新 (username/host/id も persona override される assertion に変更)

## Result

persona memo は `唯 @yui` の身元のみで完結。保存先 account の `@username@host` は表示されない (= persona の identity が前面に出る)。

| 状態 | 修正前 | 修正後 |
|---|---|---|
| 通常メモ | `Taka @hitalin@yami.ski` | `Taka @hitalin@yami.ski` (変化なし) |
| persona memo (例: yui) | `唯 @hitalin@yami.ski` | `唯 @yui` |
| コードタブ author meta | `@hitalin@yami.ski` | `唯 (@yui)` (persona memo 時) |

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` (594 passed) 通過
- [ ] persona (skill: isPersona) で AI に memo を作らせ → アイテム表示が `唯 @yui` のみ
- [ ] 同 memo をコードタブで開く → meta の author が `唯 (@yui)` 表示
- [ ] 通常 memo (author 未指定) は `Taka @hitalin@yami.ski` で従来通り
- [ ] cross-account メモカラムで persona memo に `@yui@yami.ski` のような host 混入が無い

🤖 Generated with [Claude Code](https://claude.com/claude-code)