### PR TITLE
feat(memo): MemoCard 専用化 + Markdown 拡張 + persona avatar に accent 色

### DIFF
--- a/src/components/common/MemoCard.vue
+++ b/src/components/common/MemoCard.vue
@@ -1,0 +1,428 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { NoteVisibility } from '@/adapters/types'
+import type { StoredMemo } from '@/composables/useMemos'
+import { useNavigation } from '@/composables/useNavigation'
+import { type Account, getAccountAvatarUrl } from '@/stores/accounts'
+import { useEmojisStore } from '@/stores/emojis'
+import { useWindowsStore } from '@/stores/windows'
+import { formatTime } from '@/utils/formatTime'
+import MkAvatar from './MkAvatar.vue'
+import MkMfm from './MkMfm.vue'
+
+/**
+ * メモアイテム表示用コンポーネント (#493 / #500 後の独立化)。
+ *
+ * MkNote (Misskey 投稿用) は memo にとって過剰なレイヤを大量に持っている
+ * (reply chain / reactions / footer / OGP / channel badge / quote nest 等)。
+ * 加えて memo は実際のノートではないので合成 ID で navigateToDetail する
+ * と users/show が `INVALID_PARAM` で落ちるなどの破綻を起こす。
+ *
+ * MemoCard は MkNote の見た目を踏襲した薄い表示用 component。
+ * - avatar クリックで persona は skill-edit window、通常は user page
+ * - 合成 ID で API を叩こうとしない (= navigate しない)
+ * - reply / reaction / quote nest 等は持たない
+ *
+ * 本文 render は当面 MkMfm (Misskey 構文) のまま。markdown 構文 (`# 見出し`
+ * 等) のレンダリングは後続 PR で markdown-it を導入予定。
+ */
+
+const props = defineProps<{
+  account: Account
+  memo: StoredMemo
+  /**
+   * Cross-account ビューで `@user@host` 表示にしたい場合 true。
+   * persona memo (memo.author 埋め込みあり) では無視 (常に `@yui` 表示)。
+   */
+  showAccountHost?: boolean
+}>()
+
+const emojisStore = useEmojisStore()
+const windowsStore = useWindowsStore()
+const { navigateToUser } = useNavigation()
+
+const author = computed(() => props.memo.data.author ?? null)
+
+const isPersona = computed(() => author.value?.id.startsWith('skill:') ?? false)
+
+const displayName = computed(
+  () =>
+    author.value?.displayName ??
+    props.account.displayName ??
+    props.account.username,
+)
+
+const avatarUrl = computed(
+  () => author.value?.avatarUrl ?? getAccountAvatarUrl(props.account),
+)
+
+const handle = computed(() => {
+  if (author.value) {
+    // persona は host を持たない (= ローカル概念)。`@yui` のみ表示。
+    return `@${author.value.id.replace(/^skill:/, '')}`
+  }
+  if (props.showAccountHost) {
+    return `@${props.account.username}@${props.account.host}`
+  }
+  return `@${props.account.username}`
+})
+
+const text = computed(() => props.memo.data.text)
+
+const cw = computed(() => {
+  const d = props.memo.data
+  return d.showCw && d.cw ? d.cw : null
+})
+
+const visibility = computed(() => props.memo.data.visibility as NoteVisibility)
+const localOnly = computed(() => props.memo.data.localOnly)
+
+const updatedAtRelative = computed(() => formatTime(props.memo.updatedAt))
+const updatedAtAbsolute = computed(() =>
+  new Date(props.memo.updatedAt).toLocaleString(),
+)
+
+const emojiDict = computed(
+  () => emojisStore.cache.get(props.account.host) ?? {},
+)
+
+// CW / 長文折り畳み (MkNote と同じ閾値)
+const cwExpanded = ref(false)
+const longTextExpanded = ref(false)
+const LONG_TEXT_THRESHOLD = 500
+const LONG_TEXT_LINES = 8
+const isLongText = computed(() => {
+  const t = text.value
+  if (!t || cw.value !== null) return false
+  if (t.length > LONG_TEXT_THRESHOLD) return true
+  return t.split('\n').length > LONG_TEXT_LINES
+})
+
+function onAvatarClick(e: MouseEvent) {
+  e.stopPropagation()
+  if (isPersona.value && author.value) {
+    const skillId = author.value.id.replace(/^skill:/, '')
+    windowsStore.open('skill-edit', { skillId })
+    return
+  }
+  // 通常 memo: 保存先 account の user page (= memo の保存空間オーナー)
+  navigateToUser(props.account.id, props.account.userId)
+}
+
+const VISIBILITY_LABELS: Record<NoteVisibility, string> = {
+  public: '公開',
+  home: 'ホーム',
+  followers: 'フォロワー限定',
+  specified: 'ダイレクト',
+}
+
+// MkNote と同じ SVG path で表示 (見た目を完全に揃えるため)
+const VISIBILITY_ICONS: Record<NoteVisibility, string> = {
+  public:
+    'M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2v1.93zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39z',
+  home: 'M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z',
+  followers:
+    'M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zm-6 9c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zm3.1-9H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z',
+  specified:
+    'M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z',
+}
+</script>
+
+<template>
+  <article :class="$style.card">
+    <!-- persona memo: SVG mask + currentColor でテーマアクセント色化
+         (DeckAiColumn の personaIndicator と同じパターン)。
+         通常 memo: 普通の MkAvatar (img) 表示。 -->
+    <button
+      v-if="isPersona && avatarUrl"
+      type="button"
+      :class="$style.personaAvatar"
+      :title="displayName"
+      @click.stop="onAvatarClick"
+    >
+      <span
+        :class="$style.personaAvatarInner"
+        :style="{ '--icon-url': `url('${avatarUrl}')` }"
+        aria-hidden="true"
+      />
+    </button>
+    <MkAvatar
+      v-else
+      :avatar-url="avatarUrl"
+      :size="58"
+      :alt="displayName"
+      :class="$style.avatar"
+      @click.stop="onAvatarClick"
+    />
+
+    <div :class="$style.main">
+      <header :class="$style.header">
+        <span :class="$style.name">
+          <MkMfm
+            v-if="!isPersona"
+            :text="displayName"
+            :emojis="emojiDict"
+            :server-host="account.host"
+            plain
+          />
+          <template v-else>{{ displayName }}</template>
+        </span>
+        <span :class="$style.handle">{{ handle }}</span>
+        <span :class="$style.info">
+          <span :class="$style.time" :title="updatedAtAbsolute">{{ updatedAtRelative }}</span>
+          <i
+            v-if="localOnly"
+            class="ti ti-rocket-off"
+            :class="$style.visibilityIcon"
+            title="ローカルのみ"
+          />
+          <svg
+            v-if="visibility !== 'public'"
+            :class="$style.visibilityIcon"
+            viewBox="0 0 24 24"
+            width="14"
+            height="14"
+          >
+            <title>{{ VISIBILITY_LABELS[visibility] }}</title>
+            <path :d="VISIBILITY_ICONS[visibility]" fill="currentColor" />
+          </svg>
+        </span>
+      </header>
+
+      <!-- CW -->
+      <div v-if="cw !== null" :class="$style.cw">
+        <p :class="$style.cwText">
+          <MkMfm
+            :text="cw"
+            :emojis="emojiDict"
+            :server-host="account.host"
+          />
+        </p>
+        <button
+          :class="$style.toggle"
+          class="_button"
+          @click.stop="cwExpanded = !cwExpanded"
+        >
+          {{ cwExpanded ? '隠す' : 'もっと見る' }}
+          <span v-if="!cwExpanded && text" :class="$style.toggleChars">({{ text.length }}文字)</span>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div v-show="cw === null || cwExpanded" :class="$style.body">
+        <div
+          v-if="text"
+          :class="[$style.textContainer, { [$style.collapsed]: isLongText && !longTextExpanded }]"
+        >
+          <p :class="$style.text">
+            <MkMfm
+              :text="text"
+              :emojis="emojiDict"
+              :reaction-emojis="emojiDict"
+              :server-host="account.host"
+              markdown
+            />
+          </p>
+          <div v-if="isLongText && !longTextExpanded" :class="$style.fade" />
+        </div>
+        <button
+          v-if="isLongText"
+          :class="$style.toggle"
+          class="_button"
+          @click.stop="longTextExpanded = !longTextExpanded"
+        >
+          {{ longTextExpanded ? '隠す' : 'もっと見る' }}
+          <span v-if="!longTextExpanded && text" :class="$style.toggleChars">({{ text.length }}文字)</span>
+        </button>
+      </div>
+    </div>
+  </article>
+</template>
+
+<style lang="scss" module>
+// MkNote の article スタイルと 1:1 で揃える (size / padding / margin / 余白等)。
+// container query でカラム幅に応じて padding / font-size を縮小するのも MkNote と同じ。
+.card {
+  display: flex;
+  padding: 28px 32px;
+  font-size: 1.05em;
+  contain: content;
+  container-type: inline-size;
+}
+
+@container (max-width: 580px) {
+  .card { font-size: 0.95em; padding: 24px 26px; }
+}
+@container (max-width: 500px) {
+  .card { font-size: 0.9em; padding: 20px 22px; }
+}
+
+.avatar {
+  margin: 0 14px 0 0;
+  cursor: pointer;
+  transition: opacity var(--nd-duration-base);
+  flex-shrink: 0;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+/* persona memo の avatar: SVG mask + currentColor でテーマアクセント色化、
+   hover で背景反転 (= DeckAiColumn の personaIndicator と同じパターン)。 */
+.personaAvatar {
+  width: 58px;
+  height: 58px;
+  margin: 0 14px 0 0;
+  padding: 0;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--nd-accent);
+  cursor: pointer;
+  transition:
+    background var(--nd-duration-base),
+    color var(--nd-duration-base);
+
+  &:hover {
+    background: var(--nd-accent);
+    color: var(--nd-bg);
+  }
+}
+
+.personaAvatarInner {
+  width: 100%;
+  height: 100%;
+  background-color: currentColor;
+  -webkit-mask: var(--icon-url) center / contain no-repeat;
+  mask: var(--icon-url) center / contain no-repeat;
+}
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+
+.header {
+  display: flex;
+  align-items: baseline;
+  white-space: nowrap;
+  margin-bottom: 4px;
+  gap: 0;
+}
+
+.name {
+  flex-shrink: 1;
+  font-size: 1em;
+  font-weight: bold;
+  margin: 0 0.5em 0 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  color: var(--nd-fgHighlighted);
+
+  :deep(.mfm) {
+    white-space: nowrap;
+  }
+
+  :deep(.custom-emoji) {
+    height: 1.2em;
+    width: auto;
+  }
+}
+
+.handle {
+  flex-shrink: 9999999;
+  margin: 0 0.5em 0 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  opacity: 0.7;
+}
+
+.info {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: 0.9em;
+}
+
+.time {
+  opacity: 0.7;
+}
+
+.visibilityIcon {
+  opacity: 0.5;
+  font-size: 14px;
+}
+
+/* CW (MkNote と 1:1) */
+.cw {
+  margin-bottom: 4px;
+}
+
+.cwText {
+  font-weight: bold;
+  margin: 0;
+}
+
+/* もっと見る / 隠す ボタン (MkNote.cwToggle と 1:1) */
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  margin-top: 4px;
+  padding: 4px 12px;
+  min-height: 36px;
+  border: none;
+  border-radius: var(--nd-radius-full);
+  background: var(--nd-accentedBg);
+  color: var(--nd-accent);
+  font-size: 0.8em;
+  font-weight: normal;
+  cursor: pointer;
+  transition: background var(--nd-duration-base);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.toggleChars {
+  opacity: 0.7;
+  font-weight: normal;
+}
+
+.body {
+  overflow-wrap: break-word;
+}
+
+.textContainer {
+  position: relative;
+
+  &.collapsed {
+    max-height: 9em;
+    overflow: hidden;
+  }
+}
+
+.fade {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  background: linear-gradient(to bottom, transparent, var(--nd-panel));
+  pointer-events: none;
+}
+
+.text {
+  margin: 0;
+}
+</style>

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -17,6 +17,11 @@ const props = defineProps<{
   plain?: boolean
   myUsername?: string
   myHost?: string
+  /**
+   * Markdown 拡張 (heading / list) を有効化する。memo 表示等で使用 (opt-in)。
+   * ノート本文には影響しないので Misskey 互換性は保たれる。
+   */
+  markdown?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -41,7 +46,7 @@ function isMentionMe(username: string, host: string | null): boolean {
 
 const resolvedTokens = computed(() => {
   if (props.tokens) return props.tokens
-  return parseMfm(props.text ?? '')
+  return parseMfm(props.text ?? '', { markdown: props.markdown })
 })
 
 const emojiUrls = computed(() => {
@@ -428,7 +433,15 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Search --><div v-else-if="token.type === 'search'" :class="$style.mfmSearch"><input :class="$style.mfmSearchInput" type="text" :value="token.query" readonly /><button :class="$style.mfmSearchButton" @click.stop="openUrl(`https://www.google.com/search?q=${encodeURIComponent(token.query)}`)">検索</button></div><!--
     --><!-- Math Inline --><span v-else-if="token.type === 'mathInline'" :class="$style.mfmMath" v-html="renderKatex(token.value, false)"></span><!--
     --><!-- Math Block --><div v-else-if="token.type === 'mathBlock'" :class="$style.mfmMathBlock" v-html="renderKatex(token.value, true)"></div><!--
-    --><!-- Text --><template v-else>{{ token.value }}</template><!--
+    --><!-- Heading (Markdown 拡張) --><h1 v-else-if="token.type === 'heading' && token.level === 1" :class="[$style.mfmHeading, $style.mfmHeading1]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h1><!--
+    --><h2 v-else-if="token.type === 'heading' && token.level === 2" :class="[$style.mfmHeading, $style.mfmHeading2]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h2><!--
+    --><h3 v-else-if="token.type === 'heading' && token.level === 3" :class="[$style.mfmHeading, $style.mfmHeading3]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h3><!--
+    --><h4 v-else-if="token.type === 'heading' && token.level === 4" :class="[$style.mfmHeading, $style.mfmHeading4]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h4><!--
+    --><h5 v-else-if="token.type === 'heading' && token.level === 5" :class="[$style.mfmHeading, $style.mfmHeading5]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h5><!--
+    --><h6 v-else-if="token.type === 'heading'" :class="[$style.mfmHeading, $style.mfmHeading6]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></h6><!--
+    --><!-- List (Markdown 拡張、ordered) --><ol v-else-if="token.type === 'list' && token.ordered" :class="$style.mfmList"><li v-for="(item, j) in token.items" :key="j"><MkMfm :tokens="item" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></li></ol><!--
+    --><!-- List (Markdown 拡張、unordered) --><ul v-else-if="token.type === 'list'" :class="$style.mfmList"><li v-for="(item, j) in token.items" :key="j"><MkMfm :tokens="item" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" /></li></ul><!--
+    --><!-- Text --><template v-else-if="token.type === 'text'">{{ token.value }}</template><!--
   --></template></span>
 </template>
 
@@ -547,6 +560,28 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
   border-left: 3px solid var(--nd-divider, rgba(128, 128, 128, 0.3));
   color: var(--nd-fg-muted, var(--nd-fg));
   opacity: 0.85;
+}
+
+/* Markdown 拡張: heading (memo 用 opt-in) */
+.mfmHeading {
+  display: block;
+  margin: 0.6em 0 0.3em;
+  font-weight: bold;
+  line-height: 1.25;
+  color: var(--nd-fgHighlighted, var(--nd-fg));
+}
+.mfmHeading1 { font-size: 1.6em; }
+.mfmHeading2 { font-size: 1.4em; }
+.mfmHeading3 { font-size: 1.2em; }
+.mfmHeading4 { font-size: 1.05em; }
+.mfmHeading5 { font-size: 0.95em; opacity: 0.9; }
+.mfmHeading6 { font-size: 0.85em; opacity: 0.8; }
+
+/* Markdown 拡張: list */
+.mfmList {
+  display: block;
+  margin: 4px 0;
+  padding-left: 1.5em;
 }
 
 /* Search */

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, nextTick, ref, watch } from 'vue'
-import type { NormalizedNote, NoteVisibility } from '@/adapters/types'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
-import MkNote from '@/components/common/MkNote.vue'
+import MemoCard from '@/components/common/MemoCard.vue'
 import PopupMenu from '@/components/common/PopupMenu.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { saveDraft } from '@/composables/useDrafts'
@@ -17,11 +16,9 @@ import {
 import { type Account, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
-import { useEmojisStore } from '@/stores/emojis'
 import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
-import { buildPreviewNote } from '@/utils/buildPreviewNote'
 import { formatScheduleAbsolute } from '@/utils/scheduleFormat'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
@@ -37,7 +34,6 @@ const props = defineProps<{
 const accountsStore = useAccountsStore()
 const serversStore = useServersStore()
 const windowsStore = useWindowsStore()
-const emojisStore = useEmojisStore()
 const { confirm } = useConfirm()
 const toast = useToast()
 const { columnThemeVars } = useColumnTheme(() => props.column)
@@ -80,7 +76,6 @@ interface MemoEntry {
   key: string
   memo: StoredMemo
   context: MemoContext
-  note: NormalizedNote
   /** Memo の所属アカウント。cross-account ビューでメモごとに異なる。 */
   account: Account
 }
@@ -123,44 +118,11 @@ watch(
 )
 
 function buildEntry(acc: Account, key: string, memo: StoredMemo): MemoEntry {
-  const ctx = parseMemoKey(key)
-  const emojiDict = emojisStore.cache.get(acc.host) ?? {}
-  const note = buildPreviewNote({
-    account: acc,
-    id: `memo:${acc.id}:${key}`,
-    createdAt: memo.updatedAt,
-    text: memo.data.text || null,
-    cw: memo.data.showCw && memo.data.cw ? memo.data.cw : null,
-    visibility: memo.data.visibility as NoteVisibility,
-    localOnly: memo.data.localOnly,
-    replyId: ctx.kind === 'reply' ? ctx.refId : null,
-    renoteId: ctx.kind === 'renote' ? ctx.refId : null,
-    channelId: ctx.channelId,
-    poll: {
-      choices: memo.data.pollChoices,
-      multiple: memo.data.pollMultiple,
-      expiresAt: null,
-      show: memo.data.showPoll,
-    },
-    emojis: emojiDict,
-    reactionEmojis: emojiDict,
-    // memo.data.author 埋め込みブロックがあれば avatar / 表示名を上書き (#493)。
-    // skill が後で消えても author block は memo に永続化されているので壊れない。
-    author: memo.data.author,
-  })
-  // Cross-account ビューでは @username だけだとどのサーバーか分からないため
-  // host を埋めて MkNote 側で `@username@host` のフルアドレス表示にする。
-  // ただし memo.data.author で persona に上書き済みの場合 (= persona は
-  // ローカル概念で host を持たない) は host を埋めない (`@yui` のみ表示)。
-  if (isCrossAccount.value && !memo.data.author) {
-    note.user = { ...note.user, host: acc.host }
-  }
   return {
     key,
     memo,
-    context: ctx,
+    context: parseMemoKey(key),
     account: acc,
-    note,
   }
 }
 
@@ -405,9 +367,9 @@ function closeMenu() {
           </span>
         </div>
 
-        <!-- bubble phase で受け、内部 button (`もっと見る` / CW / mention /
-             link) の `.stop` 修飾子を活かす。MkNote 側は disable-article-click
-             で article 全体クリックの navigate を抑制 (合成 ID で 404 防止)。 -->
+        <!-- bubble phase で受け、MemoCard 内部 button (`もっと見る` / CW /
+             avatar) の `.stop` を活かす。MemoCard は MkNote と異なり
+             合成 ID で users/show を叩く navigation を持たない。 -->
         <div
           :class="$style.itemNoteBtn"
           role="button"
@@ -416,7 +378,11 @@ function closeMenu() {
           @click.stop="onOpenEditor(entry)"
           @keydown.enter="onOpenEditor(entry)"
         >
-          <MkNote :note="entry.note" embedded disable-article-click />
+          <MemoCard
+            :account="entry.account"
+            :memo="entry.memo"
+            :show-account-host="isCrossAccount"
+          />
         </div>
       </div>
     </div>

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -818,11 +818,14 @@ function handleReset() {
                 :checked="config.personaSkillId === s.id"
                 @change="config.personaSkillId = s.id"
               />
-              <img
+              <!-- SVG icon を accent 色で render (DeckAiColumn.personaIndicator と同じ
+                   mask + currentColor パターン) -->
+              <span
                 v-if="s.iconUrl"
-                :src="s.iconUrl"
-                :alt="s.name"
                 :class="$style.personaOptionAvatar"
+                :style="{ '--icon-url': `url('${s.iconUrl}')` }"
+                :title="s.name"
+                aria-hidden="true"
               />
               <i v-else class="ti ti-user-circle" :class="$style.personaOptionIcon" />
               <div :class="$style.personaOptionMain">
@@ -1480,12 +1483,16 @@ function handleReset() {
   flex-shrink: 0;
 }
 
+// SVG mask + currentColor でテーマアクセント色化 (DeckAiColumn.personaIndicator
+// と同じパターン)。ラスタ画像は表示できないが、persona icon は SVG 前提。
 .personaOptionAvatar {
   width: 24px;
   height: 24px;
-  border-radius: 50%;
-  object-fit: cover;
   flex-shrink: 0;
+  background-color: currentColor;
+  color: var(--nd-accent);
+  -webkit-mask: var(--icon-url) center / contain no-repeat;
+  mask: var(--icon-url) center / contain no-repeat;
 }
 
 .personaOptionMain {

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { markdown } from '@codemirror/lang-markdown'
 import { computed, defineAsyncComponent, ref, watch } from 'vue'
-import type { NormalizedNote, NoteVisibility } from '@/adapters/types'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import EditorTabs from '@/components/common/EditorTabs.vue'
-import MkNote from '@/components/common/MkNote.vue'
+import MemoCard from '@/components/common/MemoCard.vue'
 import PopupMenu from '@/components/common/PopupMenu.vue'
 import { saveDraft } from '@/composables/useDrafts'
 import { useEditorTabs } from '@/composables/useEditorTabs'
@@ -19,10 +18,8 @@ import {
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { type Account, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
-import { useEmojisStore } from '@/stores/emojis'
 import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
-import { buildPreviewNote } from '@/utils/buildPreviewNote'
 import { AppError } from '@/utils/errors'
 
 const CodeEditor = defineAsyncComponent(
@@ -44,7 +41,6 @@ const toast = useToast()
 
 const accountsStore = useAccountsStore()
 const serversStore = useServersStore()
-const emojisStore = useEmojisStore()
 
 const lang = markdown()
 
@@ -94,34 +90,6 @@ const updatedAt = computed(() => {
 })
 
 const notFound = computed(() => loaded.value && !memo.value)
-
-/** Synthesize a NormalizedNote from the memo so MkNote can render a preview. */
-const previewNote = computed<NormalizedNote | null>(() => {
-  const m = memo.value
-  const acc = account.value
-  if (!m || !acc) return null
-  const d = m.data
-  const emojiDict = emojisStore.cache.get(acc.host) ?? {}
-  return buildPreviewNote({
-    account: acc,
-    id: `memo:${acc.id}:${props.memoKey}`,
-    createdAt: m.updatedAt,
-    text: d.text || null,
-    cw: d.showCw && d.cw ? d.cw : null,
-    visibility: d.visibility as NoteVisibility,
-    localOnly: d.localOnly,
-    poll: {
-      choices: d.pollChoices,
-      multiple: d.pollMultiple,
-      expiresAt: null,
-      show: d.showPoll,
-    },
-    emojis: emojiDict,
-    reactionEmojis: emojiDict,
-    // memo.data.author 埋め込みブロックがあれば preview にも反映 (#493)
-    author: d.author,
-  })
-})
 
 // Expose this memo's file to the window header's "外部エディタで開く" button
 // (only meaningful in the code tab — but harmless in visual).
@@ -241,7 +209,7 @@ async function onDelete() {
       </div>
     </div>
 
-    <!-- Visual tab: rendered MFM preview -->
+    <!-- Visual tab: rendered preview -->
     <div v-show="tab === 'visual'" :class="$style.visualPanel">
       <div v-if="!loaded" :class="$style.placeholder">読み込み中…</div>
       <ColumnEmptyState
@@ -250,15 +218,14 @@ async function onDelete() {
         :image-url="serverNotFoundImageUrl"
         fallback-kind="notFound"
       />
-      <!-- 合成 ID での navigate は disable-article-click で抑制。capture を
-           外して内部 button (`もっと見る` 等) の click を活かす。右クリックは
-           従来通りメモメニューを開く。 -->
+      <!-- 右クリックでメモメニューを開く。click は MemoCard 内 (avatar /
+           もっと見る等) の handler に委ねる。 -->
       <div
-        v-else-if="previewNote"
+        v-else-if="memo && account"
         :class="$style.previewWrap"
         @contextmenu.capture="onContextMenu"
       >
-        <MkNote :note="previewNote" embedded disable-article-click />
+        <MemoCard :account="account" :memo="memo" />
       </div>
     </div>
 
@@ -344,8 +311,11 @@ async function onDelete() {
   scrollbar-width: thin;
 }
 
+// NoteDetailContent.focalNote 風の装飾だが border-top は EditorTabs の
+// border-bottom と二重になるので省略 (= EditorTabs の divider が
+// focal 上端の役割を兼ねる)。
 .previewWrap {
-  border-bottom: 1px solid var(--nd-divider);
+  background: var(--nd-panelHighlight);
 }
 
 .codePanel {

--- a/src/utils/mfm.ts
+++ b/src/utils/mfm.ts
@@ -3,13 +3,15 @@
  * Re-exports parser types and functions for convenience.
  */
 import { usePerformanceStore } from '@/stores/performance'
-import type { MfmToken } from './mfmParser'
+import type { MfmToken, ParseOptions } from './mfmParser'
 import { parseTokens } from './mfmParser'
 
-export type { MfmToken } from './mfmParser'
+export type { MfmToken, ParseOptions } from './mfmParser'
 export { parseTokens } from './mfmParser'
 
+// 標準 MFM と markdown 拡張は別 cache (token 構造が異なるため key を分ける)
 const parseCache = new Map<string, MfmToken[]>()
+const parseCacheMd = new Map<string, MfmToken[]>()
 const MAX_MFM_LENGTH = 10000
 
 function getMfmCacheMax(): number {
@@ -20,7 +22,7 @@ function getMfmCacheMax(): number {
   }
 }
 
-export function parseMfm(text: string): MfmToken[] {
+export function parseMfm(text: string, opts?: ParseOptions): MfmToken[] {
   if (!text) return []
 
   // Prevent excessive CPU/memory from extremely long MFM input
@@ -28,22 +30,24 @@ export function parseMfm(text: string): MfmToken[] {
     return [{ type: 'text', value: text }]
   }
 
-  const cached = parseCache.get(text)
+  const cache = opts?.markdown ? parseCacheMd : parseCache
+
+  const cached = cache.get(text)
   if (cached) {
     // LRU: move to end so it's evicted last
-    parseCache.delete(text)
-    parseCache.set(text, cached)
+    cache.delete(text)
+    cache.set(text, cached)
     return cached
   }
 
-  const tokens = parseTokens(text)
+  const tokens = parseTokens(text, opts)
 
   const cacheMax = getMfmCacheMax()
-  if (parseCache.size >= cacheMax) {
-    const first = parseCache.keys().next().value
-    if (first !== undefined) parseCache.delete(first)
+  if (cache.size >= cacheMax) {
+    const first = cache.keys().next().value
+    if (first !== undefined) cache.delete(first)
   }
-  parseCache.set(text, tokens)
+  cache.set(text, tokens)
 
   return tokens
 }

--- a/src/utils/mfmParser.ts
+++ b/src/utils/mfmParser.ts
@@ -33,6 +33,16 @@ export type MfmToken =
   | { type: 'search'; query: string }
   | { type: 'mathInline'; value: string }
   | { type: 'mathBlock'; value: string }
+  // Markdown 拡張 (memo 用、opt-in)。`parseTokens(text, { markdown: true })`
+  // で有効化される。Misskey 本家の MFM には存在しないので、ノート表示では
+  // 既存挙動を保つために明示 opt-in 設計とする (memo 表示でだけ有効化)。
+  | { type: 'heading'; level: number; children: MfmToken[] }
+  | { type: 'list'; ordered: boolean; items: MfmToken[][] }
+
+export interface ParseOptions {
+  /** Markdown 構文 (heading / list) を block レベルで解釈する。memo 用。 */
+  markdown?: boolean
+}
 
 const emojiRegex =
   /(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F)(?:\u200D(?:\p{Emoji_Presentation}|\p{Emoji}\uFE0F))*/gu
@@ -130,6 +140,7 @@ const inlinePatterns: PatternDef[] = [
 function parseQuoteBlock(
   text: string,
   pos: number,
+  opts: ParseOptions,
 ): { end: number; token: MfmToken } | null {
   if (text[pos] !== '>') return null
   // Must be at start of text or preceded by newline
@@ -157,7 +168,83 @@ function parseQuoteBlock(
   const inner = lines.join('\n')
   return {
     end: i,
-    token: { type: 'quote', children: parseTokens(inner) },
+    token: { type: 'quote', children: parseTokens(inner, opts) },
+  }
+}
+
+/**
+ * Markdown ATX heading (`# heading` 〜 `###### heading`)。
+ * 行頭でかつ `#` の連続後にスペースが必要。`#tag` (hashtag) とは衝突しない。
+ */
+function parseHeading(
+  text: string,
+  pos: number,
+  opts: ParseOptions,
+): { end: number; token: MfmToken } | null {
+  if (pos > 0 && text[pos - 1] !== '\n') return null
+  let level = 0
+  while (level < 6 && text[pos + level] === '#') level++
+  if (level === 0 || text[pos + level] !== ' ') return null
+  const lineStart = pos + level + 1
+  const nlIdx = text.indexOf('\n', lineStart)
+  const end = nlIdx < 0 ? text.length : nlIdx + 1
+  const content = text.slice(lineStart, nlIdx < 0 ? text.length : nlIdx)
+  return {
+    end,
+    token: { type: 'heading', level, children: parseTokens(content, opts) },
+  }
+}
+
+/**
+ * Markdown list — `- item` / `* item` / `1. item`。連続する同形式の行をまとめる。
+ * unordered の場合 marker (`-` か `*`) を統一して継続判定。
+ */
+function parseList(
+  text: string,
+  pos: number,
+  opts: ParseOptions,
+): { end: number; token: MfmToken } | null {
+  if (pos > 0 && text[pos - 1] !== '\n') return null
+  const orderedMatch = /^(\d+)\. /.exec(text.slice(pos))
+  let ordered: boolean
+  let firstMarker: string
+  if (orderedMatch) {
+    ordered = true
+    firstMarker = orderedMatch[0] as string
+  } else if (
+    (text[pos] === '-' || text[pos] === '*') &&
+    text[pos + 1] === ' '
+  ) {
+    ordered = false
+    firstMarker = `${text[pos]} `
+  } else {
+    return null
+  }
+
+  const items: MfmToken[][] = []
+  let i = pos
+  while (i < text.length) {
+    let prefixLen: number
+    if (ordered) {
+      const m = /^\d+\. /.exec(text.slice(i))
+      if (!m) break
+      prefixLen = (m[0] as string).length
+    } else {
+      // unordered は最初に検出した marker (`- ` or `* `) と一致する行のみ継続
+      if (!text.startsWith(firstMarker, i)) break
+      prefixLen = firstMarker.length
+    }
+    const lineStart = i + prefixLen
+    const nlIdx = text.indexOf('\n', lineStart)
+    const lineEnd = nlIdx < 0 ? text.length : nlIdx
+    items.push(parseTokens(text.slice(lineStart, lineEnd), opts))
+    i = nlIdx < 0 ? text.length : nlIdx + 1
+  }
+
+  if (items.length === 0) return null
+  return {
+    end: i,
+    token: { type: 'list', ordered, items },
   }
 }
 
@@ -184,6 +271,7 @@ function parseSearchBlock(
 function parseMathBlock(
   text: string,
   pos: number,
+  _opts: ParseOptions,
 ): { end: number; token: MfmToken } | null {
   if (text[pos] !== '\\' || text[pos + 1] !== '[') return null
   // Must be at start of text or preceded by newline
@@ -206,6 +294,7 @@ function parseMathBlock(
 function parseCodeBlock(
   text: string,
   pos: number,
+  _opts: ParseOptions,
 ): { end: number; token: MfmToken } | null {
   if (!text.startsWith('```', pos)) return null
   // Must be at start of text or preceded by newline
@@ -229,6 +318,7 @@ function parseCodeBlock(
 function parseFnBlock(
   text: string,
   pos: number,
+  opts: ParseOptions,
 ): { end: number; token: MfmToken } | null {
   if (text[pos] !== '$' || text[pos + 1] !== '[') return null
   let i = pos + 2
@@ -278,7 +368,7 @@ function parseFnBlock(
   const content = text.slice(contentStart, i)
   return {
     end: i + 1,
-    token: { type: 'fn', name, args, children: parseTokens(content) },
+    token: { type: 'fn', name, args, children: parseTokens(content, opts) },
   }
 }
 
@@ -294,6 +384,7 @@ const tagTypeMap: Record<string, MfmToken['type']> = {
 function parseTagBlock(
   text: string,
   pos: number,
+  opts: ParseOptions,
 ): { end: number; token: MfmToken } | null {
   for (const tag of ['small', 'center', 'plain', 'b', 'i', 's'] as const) {
     const open = `<${tag}>`
@@ -312,7 +403,7 @@ function parseTagBlock(
       | 'bold'
       | 'italic'
       | 'strike'
-    return { end, token: { type, children: parseTokens(content) } }
+    return { end, token: { type, children: parseTokens(content, opts) } }
   }
   return null
 }
@@ -325,13 +416,15 @@ function findFirstBlock(
   tryParse: (
     text: string,
     pos: number,
+    opts: ParseOptions,
   ) => { end: number; token: MfmToken } | null,
+  opts: ParseOptions,
 ): BlockMatch | null {
   let from = 0
   while (from < text.length) {
     const idx = text.indexOf(needle, from)
     if (idx < 0) return null
-    const result = tryParse(text, idx)
+    const result = tryParse(text, idx, opts)
     if (result) {
       return {
         index: idx,
@@ -358,7 +451,29 @@ function findFirstSearchBlock(text: string): BlockMatch | null {
   }
 }
 
-export function parseTokens(text: string): MfmToken[] {
+/**
+ * Markdown list 用の専用 finder。`-`, `*`, 数字 はテキスト中に頻出するため、
+ * findFirstBlock の単純な needle 検索ではなく行頭 marker を regex で
+ * 検出してから parseList に委ねる。
+ */
+function findFirstListBlock(
+  text: string,
+  opts: ParseOptions,
+): BlockMatch | null {
+  const re = /(?:^|\n)(?:[-*] |\d+\. )/g
+  const m = re.exec(text)
+  if (!m) return null
+  const index = m[0].startsWith('\n') ? m.index + 1 : m.index
+  const result = parseList(text, index, opts)
+  if (!result) return null
+  return {
+    index,
+    consumeLength: result.end - index,
+    token: result.token,
+  }
+}
+
+export function parseTokens(text: string, opts: ParseOptions = {}): MfmToken[] {
   if (!text) return []
 
   const tokens: MfmToken[] = []
@@ -369,17 +484,20 @@ export function parseTokens(text: string): MfmToken[] {
 
     // Block-level patterns
     const blockCandidates = [
-      findFirstBlock(remaining, '```', parseCodeBlock),
-      findFirstBlock(remaining, '$[', parseFnBlock),
-      findFirstBlock(remaining, '<small>', parseTagBlock),
-      findFirstBlock(remaining, '<center>', parseTagBlock),
-      findFirstBlock(remaining, '<plain>', parseTagBlock),
-      findFirstBlock(remaining, '<b>', parseTagBlock),
-      findFirstBlock(remaining, '<i>', parseTagBlock),
-      findFirstBlock(remaining, '<s>', parseTagBlock),
-      findFirstBlock(remaining, '>', parseQuoteBlock),
-      findFirstBlock(remaining, '\\[', parseMathBlock),
+      findFirstBlock(remaining, '```', parseCodeBlock, opts),
+      findFirstBlock(remaining, '$[', parseFnBlock, opts),
+      findFirstBlock(remaining, '<small>', parseTagBlock, opts),
+      findFirstBlock(remaining, '<center>', parseTagBlock, opts),
+      findFirstBlock(remaining, '<plain>', parseTagBlock, opts),
+      findFirstBlock(remaining, '<b>', parseTagBlock, opts),
+      findFirstBlock(remaining, '<i>', parseTagBlock, opts),
+      findFirstBlock(remaining, '<s>', parseTagBlock, opts),
+      findFirstBlock(remaining, '>', parseQuoteBlock, opts),
+      findFirstBlock(remaining, '\\[', parseMathBlock, opts),
       findFirstSearchBlock(remaining),
+      // Markdown 拡張 (memo 用 opt-in)
+      opts.markdown ? findFirstBlock(remaining, '#', parseHeading, opts) : null,
+      opts.markdown ? findFirstListBlock(remaining, opts) : null,
     ]
     for (const c of blockCandidates) {
       if (c && (!earliest || c.index < earliest.index)) {


### PR DESCRIPTION
## Summary

メモを `MkNote` (Misskey 投稿用) で表示していた構造を、メモ専用の `MemoCard` に切り替え。あわせて memo 本文の markdown 構文を render できるように MkMfm を拡張、persona avatar をテーマアクセント色化。

### きっかけ

- AI persona 作成メモのアイコンクリックで合成 ID `memo:<accountId>:<key>` から `users/show` を叩き `INVALID_PARAM` で落ちる
- メモは markdown ファイルなのに `# 見出し` が記号のまま表示
- persona avatar がチャットヘッダ等ではアクセント色化されているが、メモカード / AI 設定の persona option では通常の img のまま

## Changes

### MemoCard.vue 新規 ([src/components/common/MemoCard.vue](src/components/common/MemoCard.vue))

- avatar クリック: persona は `skill-edit` window、通常は user page
- 合成 ID で API を叩こうとしない (= 内部 navigate を持たない)
- reply / reaction / footer / quote nest 等は持たない (memo は実際のノートではない)
- もっと見る / CW 折り畳みは MkNote と同じ閾値・挙動
- 見た目は MkNote.article と 1:1 で揃える:
  - avatar size 58 / margin 14 / padding 28x32
  - 相対時間 (`formatTime`)、絶対時刻は title
  - cwToggle: full-width / accent bg / radius full / 0.8em
  - visibility icon は SVG path で MkNote と完全一致
  - **container query でカラム幅に応じて padding / font-size 縮小**
- **persona memo の avatar は SVG mask + currentColor でテーマアクセント色、hover で背景反転** (`DeckAiColumn.personaIndicator` と同じパターン)

### Markdown 拡張 (memo 用 opt-in)

Misskey 本家 (yamisskey) が markdown-it / marked / remark を一切使っておらず `sanitize-html` のみ採用していることを確認し、本家ポリシー追従のため MkMfm の token parser を拡張する方針に。

- [mfmParser.ts](src/utils/mfmParser.ts): `MfmToken` に `heading` / `list` を追加、`parseTokens(text, { markdown: true })` で opt-in 解釈
- [mfm.ts](src/utils/mfm.ts): `parseMfm` も `ParseOptions` 受取、cache を標準 / MD で分離
- [MkMfm.vue](src/components/common/MkMfm.vue): `markdown` prop、heading は h1-h6 (Vapor 互換のため v-if 分岐)、list は ul/ol で render
- ノート表示は markdown オプションを渡さないので **従来挙動維持** (Misskey 互換性に影響なし)

### 切替 / UI 整合

- [DeckMemoColumn.vue](src/components/deck/DeckMemoColumn.vue) / [MemoEditorContent.vue](src/components/window/MemoEditorContent.vue): MkNote → MemoCard
- `MemoEntry.note` / `buildPreviewNote` 経由を撤去 (memo 用 path)
- ビジュアルタブの previewWrap は `panelHighlight` 背景 (NoteDetailContent.focalNote 風)、border-top は EditorTabs の border-bottom と二重になるので省略

### AI 設定ウィンドウのペルソナ option avatar も統一

[AiSettingsContent.vue](src/components/window/AiSettingsContent.vue) の persona option avatar も `<img>` から SVG mask + currentColor へ。アクセント色で統一表示。

## Out of scope

- backlinks / `memo:<id>` link parser は別 PR (PR-4 / #494)
- 投稿フォーム経由のメモ作成と markdown の整合 (現状 MFM ピッカー入力 → markdown ベース text に inline 共存、`# heading` を draft 化すると Misskey に記号として送られる仕様)

## syntax 方針 (確定)

memo は markdown ベース + MFM token (`:emoji:` / `@user`) inline 共存。Pages syntax 案は AI 生成困難 + Obsidian 互換喪失で見送り。

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` (594 passed) 通過
- [ ] AI 作成メモの avatar クリック → `users/show` 404 が出ない、`skill-edit` window が開く
- [ ] AI 作成メモの avatar が accent 色で表示、hover で反転
- [ ] `# 見出し` `- list` `1. item` が render される
- [ ] 通常メモ作成・「もっと見る」「CW 開閉」の挙動は従来通り
- [ ] メモ詳細ウィンドウのビジュアルタブで余計な区切り線が消えている
- [ ] ノートカラム / ノート詳細ウィンドウは挙動 / 見た目変化なし (回帰確認)
- [ ] AI 設定ウィンドウの persona option avatar も accent 色

🤖 Generated with [Claude Code](https://claude.com/claude-code)