### PR TITLE
feat(ai): <memos> AI context への link expand + referencedBy 添付 (#494 follow-up)

### DIFF
--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -558,14 +558,23 @@ async function sendMessage() {
         ? Object.entries(loadAllMemos(activeAccountId))
         : []
 
-      // memosConfig.excludeTags があれば AI 注入から該当 tag メモを除外 (#492)
-      const excludeTags = aiConfig.value.dataSources.memosConfig?.excludeTags
+      // memosConfig.excludeTags があれば AI 注入から該当 tag メモを除外 (#492)。
+      // expandLinks / includeBacklinks (#494) も同 config で制御 (default true)。
+      const memosCfg = aiConfig.value.dataSources.memosConfig
+      const allMemosByAccount = activeAccountId
+        ? new Map([[activeAccountId, loadAllMemos(activeAccountId)]])
+        : new Map()
       const contextBlock = buildAiContextBlock(aiConfig.value, {
         activeAccount: accountsStore.activeAccount,
         currentColumn: focusedColumn ?? props.column,
         visibleNotes: projectVisibleItems(visibleNotesRaw, focusedColumn?.type),
         recentConversation: projectRecentConversation(history),
-        memos: projectMemos(memoEntries, undefined, excludeTags),
+        memos: projectMemos(memoEntries, {
+          excludeTags: memosCfg?.excludeTags,
+          expandLinks: memosCfg?.expandLinks !== false,
+          includeBacklinks: memosCfg?.includeBacklinks !== false,
+          allMemosByAccount,
+        }),
         accounts: accountsStore.accounts,
         persona: personaIdentity
           ? {

--- a/src/components/window/AiSettingsContent.vue
+++ b/src/components/window/AiSettingsContent.vue
@@ -397,6 +397,37 @@ function selectPermissionPreset(preset: PresetKey) {
   showPermissionsPresetDropdown.value = false
 }
 
+// --- memosConfig (#494) — expandLinks / includeBacklinks toggle ---
+// undefined はどちらも default true として解釈する (= 後付け設定なので既存
+// プロファイルが false に倒れないよう、明示的に false を書いた場合のみ off)。
+const memoExpandLinks = computed(
+  () => config.value.dataSources.memosConfig?.expandLinks !== false,
+)
+const memoIncludeBacklinks = computed(
+  () => config.value.dataSources.memosConfig?.includeBacklinks !== false,
+)
+
+function ensureMemosConfig(): { excludeTags: string[] } & Record<
+  string,
+  unknown
+> {
+  const cfg = config.value.dataSources
+  if (!cfg.memosConfig) {
+    cfg.memosConfig = { excludeTags: [] }
+  }
+  return cfg.memosConfig
+}
+
+function toggleMemoExpandLinks() {
+  const m = ensureMemosConfig()
+  m.expandLinks = !memoExpandLinks.value
+}
+
+function toggleMemoIncludeBacklinks() {
+  const m = ensureMemosConfig()
+  m.includeBacklinks = !memoIncludeBacklinks.value
+}
+
 function togglePermissionCustom(key: PermissionKey) {
   config.value.permissions.custom[key] = !config.value.permissions.custom[key]
 }
@@ -971,6 +1002,68 @@ function handleReset() {
                 :class="{ on: resolvedDataSources[key] }"
                 :aria-checked="resolvedDataSources[key]"
                 :disabled="config.dataSources.preset !== 'custom'"
+                role="switch"
+              >
+                <span class="nd-toggle-switch-knob" />
+              </button>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Memos (#494) — link expand / backlinks の詳細設定 -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('memos')">
+          <i class="ti ti-notes" />
+          メモの渡し方
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.memos }]" />
+        </button>
+        <template v-if="expandedSections.memos">
+          <div :class="$style.toggleList">
+            <div
+              :class="[
+                $style.switchRow,
+                { [$style.switchRowDisabled]: !resolvedDataSources.memos },
+              ]"
+              @click="resolvedDataSources.memos && toggleMemoExpandLinks()"
+            >
+              <i class="ti ti-link" :class="$style.switchRowIcon" />
+              <div :class="$style.switchRowLabelStack">
+                <span :class="$style.switchRowLabel">リンク先メモを展開</span>
+                <span :class="$style.switchRowSubLabel">
+                  本文の `[name](memo:&lt;id&gt;)` で参照されているメモを 1 階層自動で AI に渡す。OFF にすると AI は明示的に `memos.backlinks` 等を呼ばない限り参照先を見ない。
+                </span>
+              </div>
+              <button
+                class="nd-toggle-switch"
+                :class="{ on: memoExpandLinks }"
+                :aria-checked="memoExpandLinks"
+                :disabled="!resolvedDataSources.memos"
+                role="switch"
+              >
+                <span class="nd-toggle-switch-knob" />
+              </button>
+            </div>
+
+            <div
+              :class="[
+                $style.switchRow,
+                { [$style.switchRowDisabled]: !resolvedDataSources.memos },
+              ]"
+              @click="resolvedDataSources.memos && toggleMemoIncludeBacklinks()"
+            >
+              <i class="ti ti-arrow-back-up" :class="$style.switchRowIcon" />
+              <div :class="$style.switchRowLabelStack">
+                <span :class="$style.switchRowLabel">バックリンクを添付</span>
+                <span :class="$style.switchRowSubLabel">
+                  各メモに `referencedBy: [...]` を付けて「どのメモから参照されているか」を AI に伝える。
+                </span>
+              </div>
+              <button
+                class="nd-toggle-switch"
+                :class="{ on: memoIncludeBacklinks }"
+                :aria-checked="memoIncludeBacklinks"
+                :disabled="!resolvedDataSources.memos"
                 role="switch"
               >
                 <span class="nd-toggle-switch-knob" />

--- a/src/composables/useAiConfig.ts
+++ b/src/composables/useAiConfig.ts
@@ -73,7 +73,13 @@ export interface DataSourcesConfig {
    * 無効化された場合は本設定は無視される (= enabled は cap layer)。
    * - `excludeTags`: AI への注入から除外する tag (= 「AI に見せたくない
    *   private メモ」をユーザーが任意の tag 名で指定可能)。
-   * - default `[]` (= 何も除外しない)。
+   *   default `[]` (= 何も除外しない)。
+   * - `expandLinks`: メモ本文の `[name](memo:<id>)` link 先メモを 1 階層
+   *   AI context に展開する (#494)。default `true`。 token を抑えたい場合
+   *   off にすると link 先メモは AI には見えなくなる (= AI が
+   *   `memos.backlinks` を呼ぶか手動で参照する必要)。
+   * - `includeBacklinks`: 各メモに `referencedBy: [memoKey, ...]` を opt-in
+   *   添付して AI に渡す (#494)。default `true`。
    *
    * 値は free string (NoteDeck は enumerate しない)。skill body 等で
    * 「私のところでは hidden tag を AI に見せない」のようにユーザーが
@@ -81,6 +87,8 @@ export interface DataSourcesConfig {
    */
   memosConfig?: {
     excludeTags: string[]
+    expandLinks?: boolean
+    includeBacklinks?: boolean
   }
 }
 

--- a/src/composables/useAiSystemContext.test.ts
+++ b/src/composables/useAiSystemContext.test.ts
@@ -697,7 +697,7 @@ describe('projectMemos', () => {
           makeMemo(`m${i}`, `2026-01-0${i + 1}T00:00:00Z`),
         ] as MemoEntry,
     )
-    expect(projectMemos(entries, 2)).toHaveLength(2)
+    expect(projectMemos(entries, { limit: 2 })).toHaveLength(2)
   })
 
   it('emits tags only when non-empty (token saving)', () => {
@@ -730,7 +730,7 @@ describe('projectMemos', () => {
         makeMemo('draft memo', '2026-03-01T00:00:00Z', ['draft', 'idea']),
       ],
     ]
-    const out = projectMemos(entries, undefined, ['hidden'])
+    const out = projectMemos(entries, { excludeTags: ['hidden'] })
     expect(out.map((m) => m.id)).toEqual(['20260301000000', '20260101000000'])
   })
 
@@ -738,7 +738,7 @@ describe('projectMemos', () => {
     const entries: MemoEntry[] = [
       ['20260101000000', makeMemo('a', '2026-01-01T00:00:00Z', ['hidden'])],
     ]
-    expect(projectMemos(entries, undefined, [])).toHaveLength(1)
+    expect(projectMemos(entries, { excludeTags: [] })).toHaveLength(1)
   })
 
   it('emits author block (id+displayName) when memo has author embed (#493)', () => {
@@ -778,6 +778,125 @@ describe('projectMemos', () => {
     ]
     const out = projectMemos(entries)
     expect(out[0]).not.toHaveProperty('author')
+  })
+
+  it('expandLinks adds memos referenced by primary entries (#494)', () => {
+    const a = makeMemo(
+      'see [b](memo:20260102000000) and [c](memo:20260103000000)',
+      '2026-05-10T10:00:00Z',
+    )
+    const b = makeMemo('memo b body', '2026-04-10T00:00:00Z')
+    const c = makeMemo('memo c body', '2026-03-10T00:00:00Z')
+    const allMemosByAccount = new Map([
+      [
+        'acc-1',
+        {
+          '20260101000000': a,
+          '20260102000000': b,
+          '20260103000000': c,
+        },
+      ],
+    ])
+    const out = projectMemos([['20260101000000', a]], {
+      expandLinks: true,
+      allMemosByAccount,
+    })
+    expect(out.map((m) => m.id).sort()).toEqual([
+      '20260101000000',
+      '20260102000000',
+      '20260103000000',
+    ])
+    const expanded = out.filter((m) => m.expandedFromLink)
+    expect(expanded.map((m) => m.id).sort()).toEqual([
+      '20260102000000',
+      '20260103000000',
+    ])
+  })
+
+  it('expandLinks respects excludeTags (#494)', () => {
+    const a = makeMemo('[hidden](memo:20260102000000)', '2026-05-10T00:00:00Z')
+    const hidden = makeMemo('private', '2026-04-10T00:00:00Z', ['hidden'])
+    const allMemosByAccount = new Map([
+      [
+        'acc-1',
+        {
+          '20260101000000': a,
+          '20260102000000': hidden,
+        },
+      ],
+    ])
+    const out = projectMemos([['20260101000000', a]], {
+      expandLinks: true,
+      excludeTags: ['hidden'],
+      allMemosByAccount,
+    })
+    expect(out.map((m) => m.id)).toEqual(['20260101000000'])
+  })
+
+  it('expandLinks caps results at expandBudget', () => {
+    const seed = makeMemo(
+      '[1](memo:20260101000000) [2](memo:20260102000000) [3](memo:20260103000000)',
+      '2026-05-10T00:00:00Z',
+    )
+    const allMemosByAccount = new Map([
+      [
+        'acc-1',
+        {
+          '20260200000000': seed,
+          '20260101000000': makeMemo('1', '2026-01-01T00:00:00Z'),
+          '20260102000000': makeMemo('2', '2026-02-01T00:00:00Z'),
+          '20260103000000': makeMemo('3', '2026-03-01T00:00:00Z'),
+        },
+      ],
+    ])
+    const out = projectMemos([['20260200000000', seed]], {
+      expandLinks: true,
+      expandBudget: 2,
+      allMemosByAccount,
+    })
+    const expanded = out.filter((m) => m.expandedFromLink)
+    expect(expanded.length).toBe(2)
+  })
+
+  it('includeBacklinks attaches referencedBy ids (#494)', () => {
+    const target = makeMemo('the target', '2026-05-10T00:00:00Z')
+    const caller1 = makeMemo(
+      'see [t](memo:20260510120000)',
+      '2026-04-01T00:00:00Z',
+    )
+    const caller2 = makeMemo(
+      'also [x](memo:20260510120000)',
+      '2026-03-01T00:00:00Z',
+    )
+    const allMemosByAccount = new Map([
+      [
+        'acc-1',
+        {
+          '20260510120000': target,
+          '20260101000000': caller1,
+          '20260102000000': caller2,
+        },
+      ],
+    ])
+    const out = projectMemos([['20260510120000', target]], {
+      includeBacklinks: true,
+      allMemosByAccount,
+    })
+    const targetRow = out.find((m) => m.id === '20260510120000')
+    expect(targetRow?.referencedBy?.sort()).toEqual([
+      '20260101000000',
+      '20260102000000',
+    ])
+  })
+
+  it('includeBacklinks omits referencedBy when no callers', () => {
+    const target = makeMemo('lonely', '2026-05-10T00:00:00Z')
+    const allMemosByAccount = new Map([['acc-1', { '20260510120000': target }]])
+    const out = projectMemos([['20260510120000', target]], {
+      includeBacklinks: true,
+      allMemosByAccount,
+    })
+    expect(out[0]).not.toHaveProperty('referencedBy')
   })
 })
 

--- a/src/composables/useAiSystemContext.ts
+++ b/src/composables/useAiSystemContext.ts
@@ -11,8 +11,9 @@
 
 import type { Account } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
+import { extractMemoRefs } from '@/utils/memoLinks'
 import { type AiConfig, resolveDataSources } from './useAiConfig'
-import type { StoredMemo } from './useMemos'
+import type { StoredMemo, StoredMemos } from './useMemos'
 
 /**
  * AI に送ってはいけないフィールド名 (credential / 機密データ)。
@@ -225,17 +226,45 @@ export interface ProjectedMemo {
    * が無ければ省略 (= ユーザー本人と暗黙解釈)。
    */
   author?: { id: string; displayName: string }
+  /**
+   * `[name](memo:<id>)` link を辿って自動展開された memo にだけ true (#494)。
+   * 通常 memo には付かない (= 直接列挙された memo と区別する目印)。
+   */
+  expandedFromLink?: true
+  /**
+   * このメモを参照しているメモ id 一覧 (= backlinks)。`includeBacklinks`
+   * オプション true 時にだけ添付される (#494)。空配列なら省略。
+   */
+  referencedBy?: string[]
 }
 
 export type MemoEntry = readonly [memoKey: string, memo: StoredMemo]
 
+export interface ProjectMemosOptions {
+  limit?: number
+  excludeTags?: readonly string[]
+  /** memo: link 先の memo を 1 階層 budget cap 内で context に追加 (#494) */
+  expandLinks?: boolean
+  /** 各 memo に referencedBy 配列を添付 (#494) */
+  includeBacklinks?: boolean
+  /**
+   * link expand / backlinks 計算用のフルメモ map。expand or backlinks 有効時
+   * に必須。entries で渡されない memo を resolve する根拠。Map<accountId, StoredMemos>。
+   */
+  allMemosByAccount?: Map<string, StoredMemos>
+  /** expand 時の最大件数 cap (#494)。default 5。 */
+  expandBudget?: number
+}
+
+const DEFAULT_EXPAND_BUDGET = 5
+
 export function projectMemos(
   entries: readonly MemoEntry[] | undefined,
-  limit = MAX_MEMOS,
-  excludeTags: readonly string[] = [],
+  options: ProjectMemosOptions = {},
 ): ProjectedMemo[] {
   if (!entries || entries.length === 0) return []
-  const excludeSet = new Set(excludeTags)
+  const limit = options.limit ?? MAX_MEMOS
+  const excludeSet = new Set(options.excludeTags ?? [])
   const filtered =
     excludeSet.size === 0
       ? entries
@@ -245,21 +274,83 @@ export function projectMemos(
   const sorted = [...filtered].sort(([, a], [, b]) =>
     a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0,
   )
-  return sorted.slice(0, limit).map(([memoKey, memo]) => {
-    const projected: ProjectedMemo = {
-      id: memoKey,
-      text: memo.data.text,
-      updatedAt: memo.updatedAt,
-    }
-    if (memo.data.tags.length > 0) projected.tags = memo.data.tags
-    if (memo.data.author) {
-      projected.author = {
-        id: memo.data.author.id,
-        displayName: memo.data.author.displayName,
+  const primary = sorted.slice(0, limit)
+  const projected: ProjectedMemo[] = primary.map(([memoKey, memo]) =>
+    projectOneMemo(memoKey, memo),
+  )
+
+  // --- Link expand: budget cap 内で参照先メモを追加 (#494) ---
+  if (options.expandLinks && options.allMemosByAccount) {
+    const budget = options.expandBudget ?? DEFAULT_EXPAND_BUDGET
+    const known = new Set(primary.map(([k]) => k))
+    let added = 0
+    for (const [, memo] of primary) {
+      if (added >= budget) break
+      const refs = extractMemoRefs(memo.data.text)
+      for (const ref of refs) {
+        if (added >= budget) break
+        if (known.has(ref)) continue
+        // excludeTags も expand 対象に効かせる (= 同じ private 扱いを引き継ぐ)
+        const found = lookupMemo(ref, options.allMemosByAccount)
+        if (!found) continue
+        if (
+          excludeSet.size > 0 &&
+          found.data.tags.some((t) => excludeSet.has(t))
+        ) {
+          continue
+        }
+        const row = projectOneMemo(ref, found)
+        row.expandedFromLink = true
+        projected.push(row)
+        known.add(ref)
+        added++
       }
     }
-    return projected
-  })
+  }
+
+  // --- Backlinks 添付 (#494) ---
+  if (options.includeBacklinks && options.allMemosByAccount) {
+    for (const row of projected) {
+      const callers: string[] = []
+      for (const memos of options.allMemosByAccount.values()) {
+        for (const [callerKey, callerMemo] of Object.entries(memos)) {
+          if (callerKey === row.id) continue
+          const refs = extractMemoRefs(callerMemo.data.text)
+          if (refs.includes(row.id)) callers.push(callerKey)
+        }
+      }
+      if (callers.length > 0) row.referencedBy = callers
+    }
+  }
+
+  return projected
+}
+
+function projectOneMemo(memoKey: string, memo: StoredMemo): ProjectedMemo {
+  const row: ProjectedMemo = {
+    id: memoKey,
+    text: memo.data.text,
+    updatedAt: memo.updatedAt,
+  }
+  if (memo.data.tags.length > 0) row.tags = memo.data.tags
+  if (memo.data.author) {
+    row.author = {
+      id: memo.data.author.id,
+      displayName: memo.data.author.displayName,
+    }
+  }
+  return row
+}
+
+function lookupMemo(
+  memoKey: string,
+  allMemosByAccount: Map<string, StoredMemos>,
+): StoredMemo | null {
+  for (const memos of allMemosByAccount.values()) {
+    const m = memos[memoKey]
+    if (m) return m
+  }
+  return null
 }
 
 function projectOneNote(n: unknown): ProjectedNote {

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -730,17 +730,23 @@ export function useHeartbeatDaemon() {
       ? Object.entries(loadAllMemos(heartbeatActiveAccountId))
       : []
 
-    // chat と同じく memosConfig.excludeTags を尊重 (#492)
-    const heartbeatExcludeTags =
-      config.value.dataSources.memosConfig?.excludeTags
+    // chat と同じく memosConfig.excludeTags / expandLinks / includeBacklinks を
+    // 尊重 (#492 / #494)
+    const heartbeatMemosCfg = config.value.dataSources.memosConfig
+    const heartbeatAllMemos = heartbeatActiveAccountId
+      ? new Map([
+          [heartbeatActiveAccountId, loadAllMemos(heartbeatActiveAccountId)],
+        ])
+      : new Map()
     const notedeckContext = buildAiContextBlock(config.value, {
       activeAccount: accountsStore.activeAccount,
       currentColumn: null,
-      memos: projectMemos(
-        heartbeatMemoEntries,
-        undefined,
-        heartbeatExcludeTags,
-      ),
+      memos: projectMemos(heartbeatMemoEntries, {
+        excludeTags: heartbeatMemosCfg?.excludeTags,
+        expandLinks: heartbeatMemosCfg?.expandLinks !== false,
+        includeBacklinks: heartbeatMemosCfg?.includeBacklinks !== false,
+        allMemosByAccount: heartbeatAllMemos,
+      }),
       accounts: accountsStore.accounts,
     })
     const heartbeatContext = `<heartbeat-skills>\n${skillBodies.join('\n\n---\n\n')}\n</heartbeat-skills>`


### PR DESCRIPTION
## Summary

PR #502 で導入した memo: link parser / `memos.backlinks` capability の **follow-up**。AI が memo: link を意識せず関連メモを把握できるよう `<memos>` ブロックに自動展開する機構を追加。これで v6 プラン #494 が完全完結。

## Changes

### `aiConfig.memosConfig` 拡張

[useAiConfig.ts](src/composables/useAiConfig.ts) の `memosConfig` に optional flag (default true):
- `expandLinks?: boolean` — 本文の `[name](memo:<id>)` link 先を 1 階層 context に展開
- `includeBacklinks?: boolean` — 各 memo に `referencedBy: [memoKey,...]` を opt-in 添付

undefined はどちらも **default true** (= 既存プロファイルが false に倒れないよう、明示的に false を書いた場合のみ off)。

### `projectMemos` API リファクタ

第 2 / 第 3 引数 (limit / excludeTags) を **options object に集約**。今後の引数追加をしやすくする狙いも兼ねる:

```ts
projectMemos(entries, {
  limit?, excludeTags?,
  expandLinks?, includeBacklinks?,
  allMemosByAccount?, expandBudget?,
})
```

呼び出し側 ([DeckAiColumn.vue](src/components/deck/DeckAiColumn.vue) / [useHeartbeatDaemon.ts](src/composables/useHeartbeatDaemon.ts)) を新 API に更新。

### `ProjectedMemo` 拡張

- `expandedFromLink?: true` — 自動展開された memo の目印 (= 直接列挙された memo と区別)
- `referencedBy?: string[]` — backlinks (= caller memoKey 配列)

`excludeTags` は **expand 対象にも適用** (= private tag の memo は link 先でも context に入らない)。

### AI 設定 UI

[AiSettingsContent.vue](src/components/window/AiSettingsContent.vue) に「メモの渡し方」セクションを追加:
- リンク先メモを展開 (toggle、default ON)
- バックリンクを添付 (toggle、default ON)

`dataSources.memos` が OFF のときは disabled で表示 (= cap layer に従う)。

## test

[useAiSystemContext.test.ts](src/composables/useAiSystemContext.test.ts) に 5 件追加:
- expandLinks adds memos referenced by primary entries
- expandLinks respects excludeTags
- expandLinks caps results at expandBudget
- includeBacklinks attaches referencedBy ids
- includeBacklinks omits referencedBy when no callers

既存 projectMemos 呼び出しを options object 形式に更新。

**621 tests pass** (前: 616、+5 件)。

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` / `pnpm test` (621 passed)
- [ ] AI 設定ウィンドウの「メモの渡し方」セクションで toggle 動作
- [ ] memo A 本文に `[他](memo:<B>)` を書いて A だけ表示する状況で AI に質問 → AI が memo B の中身も把握している (`<memos>` に B が含まれる)
- [ ] toggle OFF にすると AI に展開されない (= `memos.backlinks` の明示呼び出しが必要に)
- [ ] `excludeTags` に hidden があり、expand 先 memo に hidden tag があれば context に出ない
- [ ] HEARTBEAT (`useHeartbeatDaemon`) でも同じ挙動

## v6 プラン完全完結 🎉

- ✅ #491 (#495): persona foundation
- ✅ #492 (#496): memo capability tags / list / search / delete
- ✅ #493 (#497): memo author 埋め込み
- ✅ #494 (#502): memo:<id> link parser + memos.backlinks
- ✅ #494 follow-up (本 PR): AI context への link expand + referencedBy

🤖 Generated with [Claude Code](https://claude.com/claude-code)