### PR TITLE
docs(site): プラットフォームとしての NoteDeck をランディングに追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -139,6 +139,35 @@
           <p>Stream Inspector で WS 受信をリアルタイム監視。Note / Notification / User の Raw JSON ビュー、settings.json の内蔵エディタ。機密フィールドは自動マスク。Misskey の挙動を学ぶ最短ルート。</p>
         </div>
       </div>
+
+      <h3 class="pillars-subtitle fade-in" data-direction="up">閉じた箱ではない、プラットフォームとして</h3>
+      <p class="pillars-sublead fade-in" data-direction="up">NoteDeck を <em>使う</em> だけではなく <em>素材</em> にできる 3 つ。</p>
+      <div class="pillars-grid">
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          </div>
+          <h3>自己拡張する IDE</h3>
+          <p class="pillar-lead">AiScript で <strong>デッキの挙動そのものを書き換える。</strong></p>
+          <p>プラグインから検索・投稿・カラム操作・外部 HTTP・通知・メモなど、NoteDeck の全機能を <code>Nd:call</code> で呼べる。新コマンドを書けばコマンドパレットに即登録され、AI ツールとしても自動公開。改造の摩擦をゼロに。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+          </div>
+          <h3>外部から駆動できる</h3>
+          <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
+          <p>localhost の HTTP API (Bearer トークン認証) で外部スクリプトから操作。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有する。Stream Deck・Raycast・MCP との連携もこの仕組みで延長線上に。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+          </div>
+          <h3>AI と一緒に育つ IDE</h3>
+          <p class="pillar-lead">AI に「テーマ install して」「ここ覚えておいて」が <strong>そのまま頼める。</strong></p>
+          <p>AI がストアからテーマ・ウィジット・スキル・プラグインを検索 → 推薦 → 確認して install (必要なら自前生成も)。プラグインが追加コマンドを登録すれば AI のツールも自動で増える。会話の中で観察したことは学習履歴として蓄積され、次のセッションでも参照される — AI と人間が、二人で育てる IDE。</p>
+        </div>
+      </div>
     </div>
   </section>
   <!-- Guest mode CTA -->


### PR DESCRIPTION
## Summary

「なぜ IDE を名乗るのか」の直下に 3 ピラーを新設し、これまで全くアピールできていなかった「自己拡張・外部連携・AI と一緒に育つ」プラットフォーム側面を訴求します。PR #515 (Nd:* API 再設計) や #505 (自己拡張する IDE epic) の中身がランディングで伝わるよう、機能ではなく **思想軸** で 3 つに整理。

## 新 3 ピラー

1. **自己拡張する IDE** — AiScript で挙動を書き換える。capability registry 経由で検索・投稿・カラム操作・外部 HTTP・通知・メモなど NoteDeck の全機能を `Nd:call` で呼べる
2. **外部から駆動できる** — localhost HTTP API (Bearer トークン認証) で外部スクリプトから操作。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有
3. **AI と一緒に育つ IDE** — AI に「テーマ install して」「ここ覚えておいて」がそのまま頼める。MisStore からの検索・推薦・install (必要なら自前生成も)、新プラグインのコマンドが自動で AI ツールに追加、会話の中で観察したことが学習履歴として蓄積

## Test plan

- [ ] 手動: `site/index.html` をブラウザで開き、3 ピラーが既存 2 ピラー (IDE 項目) の直下に同じスタイルで表示されることを確認
- [ ] 手動: モバイル幅で grid が縦並びになることを確認
- [ ] 手動: SVG アイコン (code / share-2 / book-open) がライト/ダークどちらでも視認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)