### PR TITLE
docs(site): プラットフォーム 3 ピラーを動線で整理し直す

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -140,16 +140,16 @@
         </div>
       </div>
 
-      <h3 class="pillars-subtitle fade-in" data-direction="up">閉じた箱ではない、プラットフォームとして</h3>
-      <p class="pillars-sublead fade-in" data-direction="up">NoteDeck を <em>使う</em> だけではなく <em>素材</em> にできる 3 つ。</p>
+      <h3 class="pillars-subtitle fade-in" data-direction="up">プラットフォームとして</h3>
+      <p class="pillars-sublead fade-in" data-direction="up">NoteDeck が <em>閉じた箱</em> ではなく <em>開いた箱</em> であるための３つ。</p>
       <div class="pillars-grid">
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
           </div>
           <h3>自己拡張する IDE</h3>
-          <p class="pillar-lead">AiScript で <strong>デッキの挙動そのものを書き換える。</strong></p>
-          <p>プラグインから検索・投稿・カラム操作・外部 HTTP・通知・メモなど、NoteDeck の全機能を <code>Nd:call</code> で呼べる。新コマンドを書けばコマンドパレットに即登録され、AI ツールとしても自動公開。改造の摩擦をゼロに。</p>
+          <p class="pillar-lead">デッキの挙動も、<strong>世界の情報も、取り込む。</strong></p>
+          <p>検索・投稿・カラム操作・通知・メモなど NoteDeck の全機能に加え、翻訳・天気・GitHub など <strong>Web UI が CORS で触れない任意の外部 API</strong> までを AiScript・AI から直接叩ける (ネイティブアプリだけの特権)。新コマンドを書けばコマンドパレットに即登録、AI ツールとしても自動公開。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
@@ -157,7 +157,7 @@
           </div>
           <h3>外部から駆動できる</h3>
           <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
-          <p>localhost の HTTP API (Bearer トークン認証) で外部スクリプトから操作。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有する。Stream Deck・Raycast・MCP との連携もこの仕組みで延長線上に。</p>
+          <p>localhost の HTTP API (Bearer トークン認証) で外部スクリプト・別アプリからデッキを操作。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有する。Stream Deck・Raycast・MCP との連携もこの延長線上に。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
@@ -165,7 +165,7 @@
           </div>
           <h3>AI と一緒に育つ IDE</h3>
           <p class="pillar-lead">AI に「テーマ install して」「ここ覚えておいて」が <strong>そのまま頼める。</strong></p>
-          <p>AI がストアからテーマ・ウィジット・スキル・プラグインを検索 → 推薦 → 確認して install (必要なら自前生成も)。プラグインが追加コマンドを登録すれば AI のツールも自動で増える。会話の中で観察したことは学習履歴として蓄積され、次のセッションでも参照される — AI と人間が、二人で育てる IDE。</p>
+          <p>AI がストアからテーマ・ウィジット・スキル・プラグインを検索・推薦・install (必要なら自前生成も)。会話の中で観察したことは学習履歴として蓄積され、次のセッションへ持ち越される — AI と人間が、二人で育てる IDE。</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

PR #516 で追加したプラットフォーム 3 ピラーを **「動線」で再整理** し、特に「任意の外部 API を取得できる = ブラウザの壁を越えるネイティブクライアントの優位性」が伝わるよう書き直し。

## 3 ピラーの境界 (動線で分離)

| # | タイトル | 動線 | できる凄さ |
|---|---|---|---|
| 1 | **自己拡張する IDE** | 内 → 外 / 自己改造 | `Nd:call` で NoteDeck の全機能 + **Web UI が CORS で触れない任意の外部 API** (翻訳・天気・GitHub …) を AiScript・AI から直接叩ける (ネイティブだけの特権) |
| 2 | **外部から駆動できる** | 外 → 内 | localhost HTTP API で物理ボタン / CLI / 別アプリからデッキを操作。5 経路統一 (UI / AiScript / HTTP / CLI / AI tool) |
| 3 | **AI と一緒に育つ IDE** | AI ⇄ 人間 / 共進化 | AI がストアから install (or 自前生成)、会話の中で観察したことは学習履歴として持ち越し |

## 変更点

- 1 番目「自己拡張する IDE」のリードを `デッキの挙動も、世界の情報も、取り込む。` に変更し、本文に「Web UI が CORS で触れない任意の外部 API までも AiScript・AI から直接叩ける (ネイティブアプリだけの特権)」を追記
- 2 番目は当初の「外部から駆動できる」軸に戻す (PR #516 で一度合体させたが、動線が違うので独立した方が境界が明確)
- 3 番目は重複表現 (プラグイン追加コマンドが AI tool に自動公開 = 1 番目に既出) を削って簡潔化

## Test plan

- [ ] 手動: `site/index.html` をブラウザで開き、3 ピラーの順序・文言が想定通りに表示されることを確認
- [ ] 手動: モバイル幅で grid が縦並びになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)