### PR TITLE
docs(site): 外部から駆動できるピラーを平易な言葉で書き直し

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -157,7 +157,7 @@
           </div>
           <h3>外部から駆動できる</h3>
           <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
-          <p>localhost:19820 の REST API (Bearer トークン認証 / OAuth 不要) で投稿・TL 取得・カラム操作・コマンド実行を HTTP 制御。20+ エンドポイントは OpenAPI で自動ドキュメント生成、SSE でリアルタイムイベント受信。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有 — Raycast・Obsidian・Stream Deck・MCP・自作ボット、どれも同じ仕組みで繋がる。</p>
+          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークン渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも、<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck・自作ボット、一度書けば全経路から呼べる。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">


### PR DESCRIPTION
## Summary

直前 PR #521 のピラー本文 (ローカル HTTP API) が技術用語過多で読みにくかったので、一般ユーザーにも伝わる平易な表現に書き直し。

## なぜ

`localhost:19820` / `Bearer` / `OAuth` / `20+ エンドポイント` / `OpenAPI` / `SSE` / `tool calling` / `capability registry` / `MCP` といった技術用語が並ぶと、本来の訴求 (= 一度書けば AI も外部ツールも同じ仕組みで繋がる) が埋もれる。

## Before / After

**Before**:
> localhost:19820 の REST API (Bearer トークン認証 / OAuth 不要) で投稿・TL 取得・カラム操作・コマンド実行を HTTP 制御。20+ エンドポイントは OpenAPI で自動ドキュメント生成、SSE でリアルタイムイベント受信。AI tool calling / AiScript / HTTP API / CLI / コマンドパレットの 5 経路が単一の capability registry を共有 — Raycast・Obsidian・Stream Deck・MCP・自作ボット、どれも同じ仕組みで繋がる。

**After**:
> ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークン渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも、**同じ操作セットを共有する設計**だから、Raycast・Obsidian・Stream Deck・自作ボット、一度書けば全経路から呼べる。

## Test plan

- [ ] Cloudflare Pages 本番デプロイ (main) で書き直し後の文面が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)