### PR TITLE
docs(site): Hackable を独立節として Architecture の直下に切り出し

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -236,22 +236,6 @@
         </div>
       </div>
 
-      <!-- Highlight: Hackable -->
-      <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text glass">
-          <span class="highlight-badge">Hackable</span>
-          <h3>Misskey 開発者なら、すぐ貢献できる</h3>
-          <p>フロントエンドは Misskey 本家と同じ <strong>Vue 3 + TypeScript</strong>。Misskey のコードが読める人なら、NoteDeck のコードもすぐに読めます。バックエンドの notecli は独立した Rust クレートとして分離設計されており、フロントエンドとバックエンドを独立して開発・テスト可能。</p>
-          <p>開発者ツール（DevTools）をアプリ内に内蔵し、localhost:19820 の <strong>API ドキュメントもアプリ内で閲覧可能</strong>。フォーク開発者やサーバー管理者にとっても、動作検証や拡張が容易な設計です。</p>
-          <ul class="highlight-list">
-            <li>Misskey 本家と同じ Vue 3 — 学習コストゼロ</li>
-            <li>notecli 分離設計 — フロント/バックエンド独立開発</li>
-            <li>DevTools 内蔵 — アプリ内でデバッグ完結</li>
-            <li>API ドキュメント内蔵（OpenAPI + Scalar UI）</li>
-            <li>AGPL-3.0 — フォーク・改変・再配布自由</li>
-          </ul>
-        </div>
-      </div>
     </div>
   </section>
 
@@ -356,6 +340,27 @@
           <div class="arch-tags">
             <span>reqwest</span><span>tokio</span><span>rusqlite</span><span>axum</span>
           </div>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- Hackable: developer experience built on the architecture above -->
+  <section class="section-default" id="hackable">
+    <div class="section-inner section-narrow">
+      <h2 class="section-title fade-in" data-direction="up">Misskey 開発者なら、すぐ貢献できる</h2>
+      <p class="section-sub fade-in" data-direction="up">上の構造そのものが、開発体験になっている。</p>
+      <div class="highlight-row fade-in" data-direction="up">
+        <div class="highlight-text glass">
+          <span class="highlight-badge">Hackable</span>
+          <p>Misskey 本家と同じ Vue 3 + TypeScript なので、本家のコードが読める人なら NoteDeck もそのまま読める。<strong>開発者ツールと API ドキュメントをアプリ内に内蔵</strong>し、フォーク開発者・サーバー管理者でも動作検証や拡張がアプリだけで完結する。</p>
+          <ul class="highlight-list">
+            <li>学習コストゼロ — Misskey のコードがそのまま読める</li>
+            <li>DevTools 内蔵 — アプリ内でデバッグ完結</li>
+            <li>API ドキュメント内蔵 (OpenAPI + Scalar UI)</li>
+            <li>AGPL-3.0 — フォーク・改変・再配布自由</li>
+          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Features Highlights の「Hackable」ブロックは機能ではなく開発体験 (DX) の話なので、Architecture (構造図) の直下に独立 section として切り出し。同時に arch-layer の説明と重複していた項目 (Vue 3 / notecli 分離) を整理。

## なぜ

- 「Misskey 開発者ならすぐ貢献できる」は **アプリの機能** ではなく **開発者向けの体験** — Features Highlights の中に置くと位置がずれる
- 構造図 (Architecture) と本文の重複: 「Vue 3 + TypeScript」「notecli 分離設計」が arch-layer に既出
- 重複削除でメッセージが鋭くなる

## 変更点

- Features Highlights から `Highlight: Hackable` を削除
- Architecture の直下に新セクション `#hackable` を追加
  - サブタイトル「上の構造そのものが、開発体験になっている。」で Architecture との関係を明示
  - 重複表現を削除し、`学習コストゼロ` / `DevTools 内蔵` / `API ドキュメント内蔵` / `AGPL-3.0` だけ残す
- section-default で配置 → Architecture (default) → Hackable (default) → Download (alt) の交代パターンを維持し、Download との境界が背景色で明確になる

## Test plan

- [ ] Cloudflare Pages 本番デプロイ (main) で Architecture の直下に Hackable が表示されることを確認
- [ ] モバイル幅でレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)