### PR TITLE
feat(confirm): widgets / themes / skills の write 確認 UI もストアカード風に統一

### DIFF
--- a/src/capabilities/builtins/skills.test.ts
+++ b/src/capabilities/builtins/skills.test.ts
@@ -29,10 +29,10 @@ describe('skill capabilities — declaration', () => {
     expect(() => skillsReadCapability.execute({})).toThrow(/id is required/)
   })
 
-  it('skills.append: write permission, requires confirmation, requires id+content', () => {
+  it('skills.append: write permission, install preview confirmation, requires id+content', () => {
     expect(skillsAppendCapability.id).toBe('skills.append')
     expect(skillsAppendCapability.permissions).toEqual(['skills.write'])
-    expect(skillsAppendCapability.requiresConfirmation).toBe(true)
+    expect(typeof skillsAppendCapability.requiresConfirmation).toBe('function')
     expect(() => skillsAppendCapability.execute({ id: 'x' })).toThrow(
       /content is required/,
     )
@@ -41,10 +41,12 @@ describe('skill capabilities — declaration', () => {
     )
   })
 
-  it('skills.replaceSection: write permission, requires confirmation, requires id+heading', () => {
+  it('skills.replaceSection: write permission, install preview confirmation, requires id+heading', () => {
     expect(skillsReplaceSectionCapability.id).toBe('skills.replaceSection')
     expect(skillsReplaceSectionCapability.permissions).toEqual(['skills.write'])
-    expect(skillsReplaceSectionCapability.requiresConfirmation).toBe(true)
+    expect(typeof skillsReplaceSectionCapability.requiresConfirmation).toBe(
+      'function',
+    )
     expect(() => skillsReplaceSectionCapability.execute({ id: 'x' })).toThrow(
       /heading is required/,
     )

--- a/src/capabilities/builtins/skills.ts
+++ b/src/capabilities/builtins/skills.ts
@@ -106,7 +106,29 @@ export const skillsAppendCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['skills.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    const content = typeof params?.content === 'string' ? params.content : ''
+    const cur = useSkillsStore().skills.find((s) => s.id === id)
+    if (!cur) return null
+    return {
+      title: 'スキル本文に追記',
+      message:
+        `${cur.name} の本文に ${content.length} 文字を追記します。` +
+        ' frontmatter は触れません。',
+      installPreview: {
+        kind: 'skill',
+        name: cur.name,
+        version: cur.version,
+        description: `${cur.mode} mode / ${cur.scope} scope`,
+      },
+      code: content,
+      codeLanguage: 'markdown',
+      okLabel: '追記',
+      cancelLabel: 'やめる',
+      type: 'normal',
+    }
+  },
   signature: {
     description:
       'skill 本文の末尾に markdown を追記する。skill 全体を書き換える' +
@@ -156,7 +178,30 @@ export const skillsReplaceSectionCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['skills.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    const heading = typeof params?.heading === 'string' ? params.heading : ''
+    const content = typeof params?.content === 'string' ? params.content : ''
+    const cur = useSkillsStore().skills.find((s) => s.id === id)
+    if (!cur) return null
+    return {
+      title: 'スキルのセクションを置換',
+      message:
+        `${cur.name} の \`## ${heading}\` セクションを ${content.length} 文字に置換します。` +
+        ' 該当 heading が無ければ末尾に新規追加します (idempotent)。',
+      installPreview: {
+        kind: 'skill',
+        name: cur.name,
+        version: cur.version,
+        description: `${cur.mode} mode / ${cur.scope} scope`,
+      },
+      code: `## ${heading}\n\n${content}`,
+      codeLanguage: 'markdown',
+      okLabel: '置換',
+      cancelLabel: 'やめる',
+      type: 'warning',
+    }
+  },
   signature: {
     description:
       'skill 本文の `## <heading>` セクションを置換する。該当 heading が' +
@@ -331,7 +376,33 @@ export const skillsRevertCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['skills.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: async (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    const index = typeof params?.index === 'number' ? params.index : -1
+    const cur = useSkillsStore().skills.find((s) => s.id === id)
+    if (!cur || index < 0) return null
+    const basename = cur.name || cur.id
+    const entry = await getSnapshotAt<SkillSnapshot>('skill', basename, index)
+    if (!entry) return null
+    return {
+      title: 'スキルを過去の状態に戻す',
+      message:
+        `${cur.name} を編集履歴 #${index} ` +
+        `(${new Date(entry.at).toLocaleString()}) の本文に戻します。` +
+        ' 現在の body は上書きされます。',
+      installPreview: {
+        kind: 'skill',
+        name: cur.name,
+        version: cur.version,
+        description: `${cur.mode} mode / ${cur.scope} scope`,
+      },
+      code: entry.snapshot.body,
+      codeLanguage: 'markdown',
+      okLabel: 'この状態に戻す',
+      cancelLabel: 'やめる',
+      type: 'warning',
+    }
+  },
   signature: {
     description:
       'skill を編集履歴の index 番目の snapshot に戻す。skills.history で index を取得。',

--- a/src/capabilities/builtins/theme.test.ts
+++ b/src/capabilities/builtins/theme.test.ts
@@ -60,11 +60,11 @@ describe('theme.read capability', () => {
 })
 
 describe('theme.create capability', () => {
-  it('declares theme.write permission, requires confirmation', () => {
+  it('declares theme.write permission, install preview confirmation', () => {
     expect(themeCreateCapability.id).toBe('theme.create')
     expect(themeCreateCapability.permissions).toEqual(['theme.write'])
     expect(themeCreateCapability.aiTool).toBe(true)
-    expect(themeCreateCapability.requiresConfirmation).toBe(true)
+    expect(typeof themeCreateCapability.requiresConfirmation).toBe('function')
   })
 
   it('rejects missing name / invalid base / missing props', async () => {
@@ -109,10 +109,10 @@ describe('theme.create capability', () => {
 })
 
 describe('theme.update capability', () => {
-  it('declares theme.write permission, requires confirmation', () => {
+  it('declares theme.write permission, install preview confirmation', () => {
     expect(themeUpdateCapability.id).toBe('theme.update')
     expect(themeUpdateCapability.permissions).toEqual(['theme.write'])
-    expect(themeUpdateCapability.requiresConfirmation).toBe(true)
+    expect(typeof themeUpdateCapability.requiresConfirmation).toBe('function')
   })
 
   it('throws when id is missing', async () => {

--- a/src/capabilities/builtins/theme.ts
+++ b/src/capabilities/builtins/theme.ts
@@ -170,7 +170,29 @@ export const themeCreateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['theme.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: (params) => {
+    const name = typeof params?.name === 'string' ? params.name : ''
+    const base = typeof params?.base === 'string' ? params.base : ''
+    const props = isStringRecord(params?.props) ? params.props : null
+    const id = typeof params?.id === 'string' ? params.id : ''
+    return {
+      title: 'テーマをインストール',
+      message: `AI が生成した ${base === 'light' ? 'ライト' : 'ダーク'} テーマをインストールします。`,
+      installPreview: {
+        kind: 'theme',
+        name,
+        version: id || undefined,
+        description: props
+          ? `${Object.keys(props).length} 個の CSS 変数を含む ${base} テーマ`
+          : undefined,
+      },
+      code: props ? JSON.stringify(props, null, 2) : '',
+      codeLanguage: 'json',
+      okLabel: 'インストール',
+      cancelLabel: 'やめる',
+      type: 'normal',
+    }
+  },
   signature: {
     description:
       '新規テーマを作成して installedThemes に追加する。' +
@@ -245,7 +267,37 @@ export const themeUpdateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['theme.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    const cur = useThemeStore().installedThemes.find((t) => t.id === id)
+    if (!cur) return null
+    const newName =
+      typeof params?.name === 'string' && params.name.length > 0
+        ? params.name
+        : cur.name
+    const newBase =
+      params?.base === 'dark' || params?.base === 'light'
+        ? params.base
+        : (cur.base ?? 'dark')
+    const patch = isStringRecord(params?.props) ? params.props : null
+    return {
+      title: 'テーマを更新',
+      message: patch
+        ? `${cur.name} の ${Object.keys(patch).length} 個の CSS 変数を更新します。`
+        : `${cur.name} のメタ情報を更新します。`,
+      installPreview: {
+        kind: 'theme',
+        name: newName,
+        version: id,
+        description: `${newBase} テーマ`,
+      },
+      code: patch ? JSON.stringify(patch, null, 2) : '',
+      codeLanguage: 'json',
+      okLabel: '更新',
+      cancelLabel: 'やめる',
+      type: 'warning',
+    }
+  },
   signature: {
     description:
       '既存テーマの props / name / base を部分更新する。指定された' +
@@ -346,7 +398,31 @@ export const themeRevertCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['theme.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: async (params) => {
+    const id = typeof params?.id === 'string' ? params.id : ''
+    const index = typeof params?.index === 'number' ? params.index : -1
+    if (!id || index < 0) return null
+    const entry = await getSnapshotAt<ThemeSnapshot>('theme', id, index)
+    if (!entry) return null
+    const snap = entry.snapshot
+    return {
+      title: 'テーマを過去の状態に戻す',
+      message:
+        `${snap.name} を編集履歴 #${index} ` +
+        `(${new Date(entry.at).toLocaleString()}) の状態に戻します。`,
+      installPreview: {
+        kind: 'theme',
+        name: snap.name,
+        version: snap.id,
+        description: `${snap.base ?? 'dark'} テーマ / ${Object.keys(snap.props).length} 変数`,
+      },
+      code: JSON.stringify(snap.props, null, 2),
+      codeLanguage: 'json',
+      okLabel: 'この状態に戻す',
+      cancelLabel: 'やめる',
+      type: 'warning',
+    }
+  },
   signature: {
     description: 'テーマ props を編集履歴の index 番目に戻す。',
     params: {

--- a/src/capabilities/builtins/widgets.test.ts
+++ b/src/capabilities/builtins/widgets.test.ts
@@ -73,10 +73,10 @@ describe('widget capabilities — declaration', () => {
     expect(widgetsSetAutoRunCapability.requiresConfirmation).not.toBe(true)
   })
 
-  it('widgets.delete: write permission, requires confirmation (= 不可逆)', () => {
+  it('widgets.delete: write permission, install preview confirmation (= 不可逆)', () => {
     expect(widgetsDeleteCapability.id).toBe('widgets.delete')
     expect(widgetsDeleteCapability.permissions).toEqual(['widgets.write'])
-    expect(widgetsDeleteCapability.requiresConfirmation).toBe(true)
+    expect(typeof widgetsDeleteCapability.requiresConfirmation).toBe('function')
     expect(() => widgetsDeleteCapability.execute({})).toThrow(
       /installId is required/,
     )

--- a/src/capabilities/builtins/widgets.ts
+++ b/src/capabilities/builtins/widgets.ts
@@ -286,7 +286,25 @@ export const widgetsDeleteCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['widgets.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: (params) => {
+    const installId =
+      typeof params?.installId === 'string' ? params.installId : ''
+    const cur = useWidgetsStore().getWidget(installId)
+    if (!cur) return null
+    return {
+      title: 'ウィジェットを削除',
+      message:
+        `${cur.name} を削除します。AiScript ソース・メタ・` +
+        'Mk:save 領域がすべて消えます (= 不可逆)。',
+      installPreview: {
+        kind: 'widget',
+        name: cur.name,
+      },
+      okLabel: '削除',
+      cancelLabel: 'やめる',
+      type: 'danger',
+    }
+  },
   signature: {
     description:
       'ウィジェットを削除する。AiScript ソース・メタ・Mk:save 領域' +
@@ -360,7 +378,31 @@ export const widgetsRevertCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['widgets.write'],
-  requiresConfirmation: true,
+  requiresConfirmation: async (params) => {
+    const installId =
+      typeof params?.installId === 'string' ? params.installId : ''
+    const index = typeof params?.index === 'number' ? params.index : -1
+    const cur = useWidgetsStore().getWidget(installId)
+    if (!cur || index < 0) return null
+    const basename = cur.name || cur.installId
+    const entry = await getSnapshotAt<WidgetSnapshot>('widget', basename, index)
+    if (!entry) return null
+    return {
+      title: 'ウィジェットを過去の状態に戻す',
+      message:
+        `${cur.name} を編集履歴 #${index} (${new Date(entry.at).toLocaleString()}) ` +
+        'の状態に戻します。現在の AiScript ソースは上書きされます。',
+      installPreview: {
+        kind: 'widget',
+        name: entry.snapshot.name ?? cur.name,
+      },
+      code: entry.snapshot.src,
+      codeLanguage: 'is',
+      okLabel: 'この状態に戻す',
+      cancelLabel: 'やめる',
+      type: 'warning',
+    }
+  },
   signature: {
     description: 'ウィジェット src を編集履歴の index 番目に戻す。',
     params: {

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -7,6 +7,13 @@ import { useVaporTransition } from '@/composables/useVaporTransition'
 import { type ConfirmIcon, useConfirm } from '@/stores/confirm'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 
+const INSTALL_PREVIEW_ICON = {
+  plugin: 'ti-puzzle',
+  widget: 'ti-layout-grid-add',
+  theme: 'ti-palette',
+  skill: 'ti-book',
+} as const
+
 const { visible: show, options, resolve } = useConfirm()
 
 const iconType = computed<Exclude<ConfirmIcon, 'none'> | null>(() => {
@@ -70,7 +77,7 @@ useNativeDialog(dialogRef, visible, {
           <p v-if="options.message" :class="$style.message">{{ options.message }}</p>
           <div v-if="options.installPreview" :class="$style.installPreview">
             <div :class="$style.installIcon">
-              <i :class="['ti', options.installPreview.kind === 'widget' ? 'ti-layout-grid-add' : 'ti-puzzle']" />
+              <i :class="['ti', INSTALL_PREVIEW_ICON[options.installPreview.kind]]" />
             </div>
             <div :class="$style.installBody">
               <div :class="$style.installRow1">

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -36,14 +36,17 @@ export interface ConfirmOptions {
   /** code 用の言語キー (default: 'json')。`highlightCode` の lang と一致。 */
   codeLanguage?: string
   /**
-   * プラグイン / ウィジェットのインストール / 更新を確認するときに、MisStore の
-   * カード風の構造化プレビューを表示する。指定された場合 AppConfirm が
-   * `message` の下、`code` の上にレンダリングする。AI tool calling 経由の
-   * `plugins.create` / `widgets.create` 等で「ストアタブと統一感のある確認 UI」
-   * を出すために使う。
+   * MisStore でストア配布されている 4 種類 (plugin / widget / theme / skill)
+   * のインストール / 更新 / 削除 / ロールバックを確認するときに、ストアカード
+   * 風の構造化プレビューを表示する。指定された場合 AppConfirm が `message` の
+   * 下、`code` の上にレンダリングする。AI tool calling 経由の各 write
+   * capability で「ストアタブと統一感のある確認 UI」を出すために使う。
+   *
+   * `permissions` は plugin / widget の Misskey 互換 permission 配列。
+   * theme / skill では未使用 (空配列か省略)。
    */
   installPreview?: {
-    kind: 'plugin' | 'widget'
+    kind: 'plugin' | 'widget' | 'theme' | 'skill'
     name: string
     version?: string
     author?: string


### PR DESCRIPTION
## Summary

PR #530 で plugins と widgets.create/update のみが MisStore のインストールカード風 UI (installPreview) で確認ダイアログを出していたが、残りの write capability は汎用 JSON 表示の confirm のままだった。**4 種類のストア配布アイテム全 write capability** で統一感のある確認 UI を出すよう揃える。

## Before / After

### Before
- 「Solarized テーマ作って」 → 引数 JSON を生のまま表示するだけの confirm
- 「self-profile の追記して」 → 同上

### After
- いずれも MisStore のストアタブと同じカード風 UI (icon + name + version + description + プレビュー)

## 変更内容

### 型拡張
- `ConfirmOptions.installPreview.kind` を `'plugin' | 'widget' | 'theme' | 'skill'` に拡張

### UI
- AppConfirm でアイコンを 4 種類に分岐 (`puzzle` / `layout-grid-add` / `palette` / `book`) — kind → icon のテーブルで宣言的に管理

### 各 capability の installPreview 化
- **widgets**: `delete` (danger) / `revert` (warning + snapshot src プレビュー)
- **themes**: `create` / `update` / `revert` (props を JSON code で表示)
- **skills**: `append` / `replaceSection` / `revert` (markdown プレビュー、skill の `mode/scope` を description に表示)

### テスト
- 各 capability テストの `requiresConfirmation` 型期待値を `function` に更新

## 統一後の状況

| 種類 | confirm UI |
|---|---|
| plugins (`create`/`update`/`setActive`/`delete`/`revert`) | installPreview (puzzle) |
| widgets (`create`/`update`/`delete`/`revert`) | installPreview (layout-grid) |
| themes (`create`/`update`/`revert`) | installPreview (palette) |
| skills (`append`/`replaceSection`/`revert`) | installPreview (book) |

可逆な toggle 系 (`plugins.setActive(false)` / `widgets.setAutoRun` / `skills.toggle` / `theme.apply`) は引き続き confirm 不要のまま。

## Test plan

- [x] `pnpm test` (738 tests pass)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] 手動 E2E (Tauri dev):
  - [ ] 「Solarized 風のテーマ作って」 → theme installPreview (palette icon + props JSON プレビュー) → インストール
  - [ ] 「self-profile スキルの ## 学習中 セクションを更新して」 → skill installPreview (book icon + markdown プレビュー) → 置換
  - [ ] widgets.delete を呼ぶ場面 (例: 「テストウィジェット消して」) → installPreview (layout-grid icon, danger)
  - [ ] テーマ・ウィジェット・スキルの revert で snapshot プレビューが出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)