### PR TITLE
feat(ai-user-search): ユーザーあいまい検索を AI 開放

### DIFF
--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -67,6 +67,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'time.now',
         'ui.notify',
         'user.lookup',
+        'user.search',
         'widgets.create',
         'widgets.delete',
         'widgets.history',

--- a/src/capabilities/builtins/user.test.ts
+++ b/src/capabilities/builtins/user.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { USER_BUILTIN_CAPABILITIES, userLookupCapability } from './user'
+import {
+  USER_BUILTIN_CAPABILITIES,
+  userLookupCapability,
+  userSearchCapability,
+} from './user'
 
 describe('user.lookup capability', () => {
   it('declares account.read permission and aiTool: true', () => {
@@ -25,9 +29,26 @@ describe('user.lookup capability', () => {
   })
 })
 
+describe('user.search capability', () => {
+  it('declares account.read permission, aiTool, cheap, array return', () => {
+    expect(userSearchCapability.id).toBe('user.search')
+    expect(userSearchCapability.permissions).toEqual(['account.read'])
+    expect(userSearchCapability.aiTool).toBe(true)
+    expect(userSearchCapability.signature?.cheap).toBe(true)
+    expect(userSearchCapability.signature?.returns?.type).toBe('array')
+  })
+
+  it('marks query as required and limit/accountId as optional', () => {
+    const params = userSearchCapability.signature?.params
+    expect(params?.query?.optional).not.toBe(true)
+    expect(params?.limit?.optional).toBe(true)
+    expect(params?.accountId?.optional).toBe(true)
+  })
+})
+
 describe('USER_BUILTIN_CAPABILITIES', () => {
-  it('contains user.lookup', () => {
-    expect(USER_BUILTIN_CAPABILITIES).toHaveLength(1)
-    expect(USER_BUILTIN_CAPABILITIES).toContain(userLookupCapability)
+  it('contains user.lookup + user.search', () => {
+    const ids = USER_BUILTIN_CAPABILITIES.map((c) => c.id).sort()
+    expect(ids).toEqual(['user.lookup', 'user.search'])
   })
 })

--- a/src/capabilities/builtins/user.ts
+++ b/src/capabilities/builtins/user.ts
@@ -3,6 +3,7 @@ import type { ApiAdapter } from '@/adapters/types'
 import type { Command } from '@/commands/registry'
 import { stripCredentials } from '@/composables/useAiSystemContext'
 import { useAccountsStore } from '@/stores/accounts'
+import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /**
  * `user.lookup` — username (+ optional host) から Misskey ユーザー情報を引く。
@@ -88,6 +89,71 @@ export const userLookupCapability: Command = {
   },
 }
 
+/**
+ * `user.search` — username / display name の部分一致でユーザーを探す。
+ *
+ * `user.lookup` は完全一致な `@user@host` から 1 件引く動線、こちらは「○○ さん
+ * 誰だっけ?」のようなあいまい検索で複数候補を返す。Misskey `users/search-by-username-and-name`
+ * を使う。adapter 経由ではなく `apiSearchUsersByQuery` を直接叩く
+ * (NormalizedUser 配列に正規化済み)。
+ */
+export const userSearchCapability: Command = {
+  id: 'user.search',
+  label: 'ユーザーをあいまい検索',
+  icon: 'ti-search',
+  category: 'account',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['account.read'],
+  signature: {
+    description:
+      'username / display name の部分一致でユーザーを検索する (Misskey ' +
+      '`users/search-by-username-and-name` 相当)。空 query なら最近やり取りした' +
+      'ユーザー一覧。完全一致での 1 件引きは user.lookup を使う。',
+    params: {
+      query: {
+        type: 'string',
+        description: '検索文字列 (空文字なら最近のユーザー一覧)',
+      },
+      limit: {
+        type: 'number',
+        description: '取得件数 (1-100, default 10)',
+        optional: true,
+      },
+      accountId: {
+        type: 'string',
+        description:
+          'どのアカウントの adapter で検索するか。未指定なら active アカウント。',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'array',
+      description:
+        'NormalizedUser の配列 (id / username / host / name / avatarUrl)',
+    },
+    cheap: true,
+  },
+  visible: false,
+  execute: async (params) => {
+    const query = typeof params?.query === 'string' ? params.query : ''
+    const limitRaw = typeof params?.limit === 'number' ? params.limit : 10
+    const limit = Math.max(1, Math.min(100, Math.floor(limitRaw)))
+    const accountId =
+      typeof params?.accountId === 'string' &&
+      params.accountId.trim().length > 0
+        ? params.accountId.trim()
+        : null
+    const store = useAccountsStore()
+    const id = accountId ?? store.activeAccountId
+    if (!id) throw new Error('user.search: no active account')
+    const raw = unwrap(await commands.apiSearchUsersByQuery(id, query, limit))
+    if (!Array.isArray(raw)) return []
+    return raw.map((u) => stripCredentials(u as Record<string, unknown>))
+  },
+}
+
 export const USER_BUILTIN_CAPABILITIES: readonly Command[] = [
   userLookupCapability,
+  userSearchCapability,
 ]


### PR DESCRIPTION
## Summary

- 既存 `user.lookup` (完全一致 1 件) に対する補完: `user.search` (部分一致 N 件)
- 「○○ さん誰だっけ?」のような曖昧検索で複数候補を返す
- read 系で危険度低、`account.read` permission を再利用

## Capability

| id | perm | cheap | 用途 |
|---|---|---|---|
| `user.search` | `account.read` | ✓ | Misskey `users/search-by-username-and-name` 相当 |

## 実装ポイント

- adapter ではなく既存 `apiSearchUsersByQuery` を直接叩く (= 補完 UI 系で確立されたパス)
- limit は 1-100 にクランプ (default 10)
- `stripCredentials` で AI に渡る user オブジェクトから機密 (token 等) を剝がす
- 空 query なら最近やり取りしたユーザー一覧 (Misskey API 仕様準拠)

## Test plan

- [ ] `pnpm test` (740 passing 確認済)
- [ ] `pnpm typecheck` 確認済
- [ ] `pnpm lint` 確認済
- [ ] 実機: `user.search({ query: "hit" })` で部分一致するユーザー一覧が返る
- [ ] 実機: 空 query で最近のユーザーが返る
- [ ] 実機: `accountId` 明示で別サーバーの検索ができる

🤖 Generated with [Claude Code](https://claude.com/claude-code)