### PR TITLE
feat(ai-notes-delete): notes.delete を AI 開放 (慎重カテゴリ)

### DIFF
--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -53,6 +53,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'navbar.set',
         'notes.children',
         'notes.create',
+        'notes.delete',
         'notes.react',
         'notes.search',
         'notes.show',

--- a/src/capabilities/builtins/notes-write.test.ts
+++ b/src/capabilities/builtins/notes-write.test.ts
@@ -101,9 +101,40 @@ describe('notes.react capability', () => {
   })
 })
 
+describe('notes.delete capability', () => {
+  it('declares notes.write permission, danger confirmation function, aiTool', async () => {
+    const cap = NOTES_WRITE_BUILTIN_CAPABILITIES.find(
+      (c) => c.id === 'notes.delete',
+    )
+    if (!cap) throw new Error('notes.delete not found')
+    expect(cap.permissions).toEqual(['notes.write'])
+    expect(cap.aiTool).toBe(true)
+    expect(typeof cap.requiresConfirmation).toBe('function')
+    const opts =
+      typeof cap.requiresConfirmation === 'function'
+        ? await cap.requiresConfirmation({ noteId: 'n1' })
+        : null
+    expect(opts?.type).toBe('danger')
+    expect(opts?.message).toContain('元に戻せません')
+  })
+
+  it('requires noteId', async () => {
+    const cap = NOTES_WRITE_BUILTIN_CAPABILITIES.find(
+      (c) => c.id === 'notes.delete',
+    )
+    if (!cap) throw new Error('notes.delete not found')
+    await expect(cap.execute({})).rejects.toThrow(/noteId is required/)
+  })
+})
+
 describe('NOTES_WRITE_BUILTIN_CAPABILITIES', () => {
-  it('contains create / react / unreact', () => {
+  it('contains create / react / unreact / delete', () => {
     const ids = NOTES_WRITE_BUILTIN_CAPABILITIES.map((c) => c.id).sort()
-    expect(ids).toEqual(['notes.create', 'notes.react', 'notes.unreact'])
+    expect(ids).toEqual([
+      'notes.create',
+      'notes.delete',
+      'notes.react',
+      'notes.unreact',
+    ])
   })
 })

--- a/src/capabilities/builtins/notes-write.ts
+++ b/src/capabilities/builtins/notes-write.ts
@@ -228,8 +228,69 @@ export const notesUnreactCapability: Command = {
   },
 }
 
+/**
+ * `notes.delete` — 自分のノートを削除する (慎重カテゴリ、不可逆)。
+ *
+ * 削除済みノートは復元できない (Misskey の挙動)。確認 UI は関数形式で
+ * `type: 'danger'` を明示し、戻せないことをメッセージに書く。AI が
+ * 「整理しといて」と気軽に呼ばないよう、permission も notes.write を要求
+ * (= safe preset では通らない)。
+ */
+export const notesDeleteCapability: Command = {
+  id: 'notes.delete',
+  label: 'ノートを削除',
+  icon: 'ti-trash',
+  category: 'note',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notes.write'],
+  requiresConfirmation: (params) => {
+    const noteId = typeof params?.noteId === 'string' ? params.noteId : ''
+    return {
+      title: 'ノートを削除',
+      message:
+        `noteId \`${noteId}\` を削除します。この操作は元に戻せません ` +
+        '(リノート・引用・お気に入り・クリップ等も同時に消えます)。',
+      okLabel: '削除',
+      cancelLabel: 'やめる',
+      type: 'danger',
+    }
+  },
+  signature: {
+    description:
+      '自分のノートを削除する。**元に戻せない**。リノート / 引用 / お気に入り / ' +
+      'クリップに含まれている場合もすべて連鎖して見えなくなる。他人のノートは削除不可。' +
+      ' 別サーバーで操作するときは accountId を指定する。',
+    params: {
+      noteId: {
+        type: 'string',
+        description: '削除する noteId (自分のノートのみ)',
+      },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '`{ deleted: true, noteId }`',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const noteId = pickString(params?.noteId)
+    if (!noteId) throw new Error('notes.delete: noteId is required')
+    const accountId = pickString(params?.accountId)
+    const api = await getApiAdapter(accountId)
+    await api.deleteNote(noteId)
+    return { deleted: true, noteId }
+  },
+}
+
 export const NOTES_WRITE_BUILTIN_CAPABILITIES: readonly Command[] = [
   notesCreateCapability,
   notesReactCapability,
   notesUnreactCapability,
+  notesDeleteCapability,
 ]


### PR DESCRIPTION
## Summary

- `notes.delete` を AI 開放
- 「このノート消して」「過去のノート整理して」が会話で完結
- 元に戻せない不可逆操作のため慎重カテゴリ、danger 確認 UI 必須

## Capability

| id | perm | 確認 UI | 用途 |
|---|---|---|---|
| `notes.delete` | `notes.write` | danger (関数形式、メッセージで不可逆性明示) | 自分のノート削除 |

## 設計判断

- 確認メッセージで「元に戻せません」「リノート / 引用 / お気に入り / クリップも連鎖して消える」を明示
- adapter.deleteNote 経由 (= 既存 NoteMoreMenu と同じパス)
- 他人のノートは Misskey API 側で拒否
- block / report と違って自分のコンテンツに対する操作なので、慎重だが塞ぐリストには入れない

## Test plan

- [ ] `pnpm test` (804 passing 確認済)
- [ ] `pnpm typecheck` 確認済
- [ ] `pnpm lint` 確認済
- [ ] 実機: 自分のノートに `notes.delete({ noteId })` → danger ダイアログ → 承認後削除
- [ ] 実機: 他人のノート id を渡すと Misskey 側でエラー

🤖 Generated with [Claude Code](https://claude.com/claude-code)