### PR TITLE
feat(ai-meta-heartbeat): meta.heartbeat (read only) で HEARTBEAT 設定可視化

### DIFF
--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -49,6 +49,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'memos.update',
         'meta.activeSkills',
         'meta.config',
+        'meta.heartbeat',
         'meta.permissions',
         'meta.persona',
         'misstore.search',

--- a/src/capabilities/builtins/meta.test.ts
+++ b/src/capabilities/builtins/meta.test.ts
@@ -66,11 +66,12 @@ describe('meta.config', () => {
 })
 
 describe('META_BUILTIN_CAPABILITIES', () => {
-  it('contains 4 meta capabilities', () => {
+  it('contains 5 meta capabilities (incl. heartbeat read)', () => {
     const ids = META_BUILTIN_CAPABILITIES.map((c) => c.id).sort()
     expect(ids).toEqual([
       'meta.activeSkills',
       'meta.config',
+      'meta.heartbeat',
       'meta.permissions',
       'meta.persona',
     ])

--- a/src/capabilities/builtins/meta.ts
+++ b/src/capabilities/builtins/meta.ts
@@ -163,9 +163,64 @@ export const metaConfigCapability: Command = {
   },
 }
 
+/**
+ * `meta.heartbeat` — HEARTBEAT daemon の現在設定スナップショットを返す
+ * (read only)。AI 自身が「自分の起動条件 / 暴走防止上限」を理解できるが、
+ * **編集は塞ぐ** (memory: feedback_ai_capability_scope の `heartbeat.write`
+ * 塞ぐリスト — AI が interval / dailyMaxAiRuns を変えると自己強化 loop で
+ * コスト爆発する)。
+ */
+export const metaHeartbeatCapability: Command = {
+  id: 'meta.heartbeat',
+  label: 'HEARTBEAT 設定スナップショット',
+  icon: 'ti-activity',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      'HEARTBEAT daemon の現在設定 (enabled / intervalMinutes / target / ' +
+      'dailyMaxAiRuns / onDailyLimit / desktopNotification / cheapCheck) を' +
+      '読み取り専用で返す。AI 自身の起動条件を理解するため。' +
+      '**編集は塞がれている** (AI が自分の interval を変えると暴走するため)。',
+    params: {},
+    returns: {
+      type: 'object',
+      description:
+        '{ enabled, intervalMinutes, target, dailyMaxAiRuns, onDailyLimit, desktopNotification, cheapCheck: { enabled, maxSkipHours }, permissionsPreset }',
+    },
+    cheap: true,
+  },
+  visible: false,
+  execute: (_params, ctx) => {
+    if (!ctx?.aiConfig) {
+      throw new Error(
+        'meta.heartbeat: aiConfig が ctx に渡される dispatchCapability 経由で呼ばれる必要があります',
+      )
+    }
+    const hb = ctx.aiConfig.heartbeat
+    return {
+      enabled: hb.enabled,
+      intervalMinutes: hb.intervalMinutes,
+      target: hb.target,
+      dailyMaxAiRuns: hb.dailyMaxAiRuns,
+      onDailyLimit: hb.onDailyLimit,
+      desktopNotification: hb.desktopNotification,
+      cheapCheck: {
+        enabled: hb.cheapCheck.enabled,
+        maxSkipHours: hb.cheapCheck.maxSkipHours,
+      },
+      // permissions の生 map は素出ししない (= meta.config と同様の方針)
+      permissionsPreset: hb.permissions.preset,
+    }
+  },
+}
+
 export const META_BUILTIN_CAPABILITIES: readonly Command[] = [
   metaPermissionsCapability,
   metaActiveSkillsCapability,
   metaPersonaCapability,
   metaConfigCapability,
+  metaHeartbeatCapability,
 ]


### PR DESCRIPTION
## Summary

- AI 自身が HEARTBEAT daemon の起動条件 / 暴走防止上限を理解できる read only capability
- **編集は永久に塞ぐ** (memory: feedback_ai_capability_scope の塞ぐリスト)

## Capability

| id | perm | cheap | 用途 |
|---|---|---|---|
| `meta.heartbeat` | (none) | ✓ | HEARTBEAT 設定 read only スナップショット |

戻り値: `{ enabled, intervalMinutes, target, dailyMaxAiRuns, onDailyLimit, desktopNotification, cheapCheck: { enabled, maxSkipHours }, permissionsPreset }`

## 設計判断 (重要)

- **read のみ。編集系は永久に追加しない。**
- AI が `heartbeat.intervalMinutes` / `dailyMaxAiRuns` を変えられると、自己強化 loop でコスト爆発するリスク (= 「もっと頻繁に起動して」→ 1 分 interval にして 24×60 = 1440 回/日)
- 既存 `meta.config` / `meta.permissions` と同じ `ctx.aiConfig` 経由パターン
- `permissions` の生 map は素出ししない (preset だけ返す = `meta.config` の方針踏襲)

## Test plan

- [ ] `pnpm test` (802 passing 確認済)
- [ ] `pnpm typecheck` / `pnpm lint` 確認済
- [ ] 実機: AI チャットで `meta.heartbeat` 呼び出し → JSON で現設定が返る
- [ ] 実機: HEARTBEAT 設定 UI で値を変更 → 次回 capability 呼び出しで反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)