### PR TITLE
feat(ai-chat-reactions): chat.react / unreact を AI 開放

### DIFF
--- a/src/capabilities/builtins/chat.test.ts
+++ b/src/capabilities/builtins/chat.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CHAT_BUILTIN_CAPABILITIES,
+  chatReactCapability,
+  chatUnreactCapability,
+} from './chat'
+
+describe('chat reaction capabilities — declaration', () => {
+  it.each([
+    ['chat.react', chatReactCapability] as const,
+    ['chat.unreact', chatUnreactCapability] as const,
+  ])('%s declares notes.react permission + confirmation', (id, cap) => {
+    expect(cap.id).toBe(id)
+    expect(cap.permissions).toEqual(['notes.react'])
+    expect(cap.requiresConfirmation).toBe(true)
+    expect(cap.aiTool).toBe(true)
+    expect(cap.signature?.params?.messageId?.optional).not.toBe(true)
+    expect(cap.signature?.params?.reaction?.optional).not.toBe(true)
+  })
+
+  it('throw when messageId/reaction missing', async () => {
+    await expect(chatReactCapability.execute({})).rejects.toThrow(
+      /messageId is required/,
+    )
+    await expect(
+      chatReactCapability.execute({ messageId: 'm1' }),
+    ).rejects.toThrow(/reaction is required/)
+    await expect(chatUnreactCapability.execute({})).rejects.toThrow(
+      /messageId is required/,
+    )
+    await expect(
+      chatUnreactCapability.execute({ messageId: 'm1' }),
+    ).rejects.toThrow(/reaction is required/)
+  })
+})
+
+describe('CHAT_BUILTIN_CAPABILITIES', () => {
+  it('contains react / unreact', () => {
+    const ids = CHAT_BUILTIN_CAPABILITIES.map((c) => c.id).sort()
+    expect(ids).toEqual(['chat.react', 'chat.unreact'])
+  })
+})

--- a/src/capabilities/builtins/chat.ts
+++ b/src/capabilities/builtins/chat.ts
@@ -1,0 +1,119 @@
+import type { Command } from '@/commands/registry'
+import { useAccountsStore } from '@/stores/accounts'
+import { commands, unwrap } from '@/utils/tauriInvoke'
+
+/**
+ * Chat reaction 系 capability — Misskey 新 Chat API (v2025) のメッセージに
+ * リアクションを付け外しする。chat 相手に見える絵文字なので、`notes.react`
+ * permission を再利用 (= 同レベルの可逆操作)。
+ *
+ * メッセージ送信そのものは別 capability (chat.* の send 系) が将来必要だが、
+ * 本 PR では reaction のみに絞る。
+ */
+
+function pickString(v: unknown): string | undefined {
+  if (typeof v !== 'string') return undefined
+  const t = v.trim()
+  return t.length > 0 ? t : undefined
+}
+
+function resolveAccountId(input: unknown): string {
+  const explicit = typeof input === 'string' ? input.trim() : ''
+  if (explicit) return explicit
+  const store = useAccountsStore()
+  const id = store.activeAccountId
+  if (!id) throw new Error('chat: no active account')
+  return id
+}
+
+const ACCOUNT_ID_PARAM_DESC =
+  'どのアカウントで実行するか。未指定なら active アカウント。' +
+  ' 別サーバーのカラムから操作するときは `<currentColumn>.accountId` を渡す。'
+
+export const chatReactCapability: Command = {
+  id: 'chat.react',
+  label: 'チャットメッセージにリアクション',
+  icon: 'ti-mood-smile',
+  category: 'note',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notes.react'],
+  requiresConfirmation: true,
+  signature: {
+    description:
+      'Misskey 新 Chat (v2025) のメッセージにリアクションを付ける。reaction は ' +
+      '`:name:` 形式または Unicode 絵文字。messageId は chat カラム表示中の' +
+      'メッセージから取得する想定。',
+    params: {
+      messageId: { type: 'string', description: '対象メッセージ id' },
+      reaction: {
+        type: 'string',
+        description: 'リアクション (`:thinking_face:` / `👍` 等)',
+      },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '{ ok: true, messageId, reaction }',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const messageId = pickString(params?.messageId)
+    const reaction = pickString(params?.reaction)
+    if (!messageId) throw new Error('chat.react: messageId is required')
+    if (!reaction) throw new Error('chat.react: reaction is required')
+    const accountId = resolveAccountId(params?.accountId)
+    unwrap(await commands.apiReactChatMessage(accountId, messageId, reaction))
+    return { ok: true, messageId, reaction }
+  },
+}
+
+export const chatUnreactCapability: Command = {
+  id: 'chat.unreact',
+  label: 'チャットメッセージのリアクションを解除',
+  icon: 'ti-mood-x',
+  category: 'note',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['notes.react'],
+  requiresConfirmation: true,
+  signature: {
+    description:
+      'Misskey Chat メッセージから自分のリアクションを解除する。reaction は' +
+      ' 付けたときと同じ値 (チャットでは複数 reaction を 1 ユーザーが付けられるため、' +
+      ' note のリアクションと違って種別指定が必要)。',
+    params: {
+      messageId: { type: 'string', description: '対象メッセージ id' },
+      reaction: { type: 'string', description: '解除する reaction 種別' },
+      accountId: {
+        type: 'string',
+        description: ACCOUNT_ID_PARAM_DESC,
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '{ ok: true, messageId, reaction }',
+    },
+  },
+  visible: false,
+  execute: async (params) => {
+    const messageId = pickString(params?.messageId)
+    const reaction = pickString(params?.reaction)
+    if (!messageId) throw new Error('chat.unreact: messageId is required')
+    if (!reaction) throw new Error('chat.unreact: reaction is required')
+    const accountId = resolveAccountId(params?.accountId)
+    unwrap(await commands.apiUnreactChatMessage(accountId, messageId, reaction))
+    return { ok: true, messageId, reaction }
+  },
+}
+
+export const CHAT_BUILTIN_CAPABILITIES: readonly Command[] = [
+  chatReactCapability,
+  chatUnreactCapability,
+]

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -14,6 +14,8 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'ai.sessions.read',
         'ai.sessions.search',
         'ai.setPersona',
+        'chat.react',
+        'chat.unreact',
         'clipboard.read',
         'clipboard.write',
         'clips.addNote',

--- a/src/capabilities/builtins/index.ts
+++ b/src/capabilities/builtins/index.ts
@@ -2,6 +2,7 @@ import type { Command } from '@/commands/registry'
 import { ACCOUNT_BUILTIN_CAPABILITIES } from './account'
 import { AI_BUILTIN_CAPABILITIES } from './ai'
 import { AI_SESSIONS_BUILTIN_CAPABILITIES } from './aiSessions'
+import { CHAT_BUILTIN_CAPABILITIES } from './chat'
 import { CLIPBOARD_BUILTIN_CAPABILITIES } from './clipboard'
 import { CLIPS_BUILTIN_CAPABILITIES } from './clips'
 import { COLUMN_BUILTIN_CAPABILITIES } from './column'
@@ -51,6 +52,7 @@ export const ALL_BUILTIN_CAPABILITIES: readonly Command[] = [
   ...NOTES_BUILTIN_CAPABILITIES,
   ...NOTES_WRITE_BUILTIN_CAPABILITIES,
   ...CLIPS_BUILTIN_CAPABILITIES,
+  ...CHAT_BUILTIN_CAPABILITIES,
   ...DRAFTS_BUILTIN_CAPABILITIES,
   ...USER_BUILTIN_CAPABILITIES,
   ...NOTIFICATIONS_BUILTIN_CAPABILITIES,


### PR DESCRIPTION
## Summary

- Misskey 新 Chat API (v2025) のメッセージリアクション付け外し
- 既存 `notes.react` / `notes.unreact` と対称
- `notes.react` permission を再利用 (= 同レベルの可逆操作)

## Capability surface

| id | perm | 確認 UI | 用途 |
|---|---|---|---|
| `chat.react` | `notes.react` | 標準 | チャットメッセージにリアクション付与 |
| `chat.unreact` | `notes.react` | 標準 | リアクション解除 (種別指定必須) |

## 設計判断

- chat の reaction は note と違って 1 ユーザーが複数 reaction を付けられるため、unreact は reaction 種別を要求 (note では note 単位削除でよい)
- adapter は chat 系メソッドを持たないので Rust command を直接叩く
- メッセージ送信は別 capability (`chat.send` 等) として将来追加可能。本 PR は reaction のみに絞る

## Test plan

- [ ] `pnpm test` (806 passing 確認済)
- [ ] `pnpm typecheck` / `pnpm lint` 確認済
- [ ] 実機: chat メッセージに `chat.react({ messageId, reaction: "👍" })` で付与
- [ ] 実機: `chat.unreact` で解除
- [ ] 実機: 同 messageId に複数 reaction を付けられる (note と違って)

🤖 Generated with [Claude Code](https://claude.com/claude-code)