### PR TITLE
feat(aiscript): AI が AiScript を LSP フィードバックループで書けるようにする (#553)

### DIFF
--- a/src/aiscript/codemirror/linter.ts
+++ b/src/aiscript/codemirror/linter.ts
@@ -1,42 +1,21 @@
 import { type Diagnostic, linter } from '@codemirror/lint'
-import { Parser } from '@syuilo/aiscript'
-import { sanitizeCode } from '@/aiscript/sanitize'
+import { validateAiScript } from '@/aiscript/validate'
 
 export const aiscriptLinter = linter(
   (view) => {
-    const diagnostics: Diagnostic[] = []
-    const code = sanitizeCode(view.state.doc.toString())
-    if (!code.trim()) return diagnostics
+    const result = validateAiScript(view.state.doc.toString())
+    if (result.ok) return []
 
-    try {
-      const parser = new Parser()
-      parser.parse(code)
-    } catch (e) {
-      if (e instanceof Error) {
-        // Try to extract line info from error message
-        const lineMatch = e.message.match(/at line (\d+)/i)
-        let from = 0
-        let to = code.length
-
-        if (lineMatch) {
-          const lineNum = parseInt(lineMatch[1] ?? '0', 10)
-          const line = view.state.doc.line(
-            Math.min(lineNum, view.state.doc.lines),
-          )
-          from = line.from
-          to = line.to
-        }
-
-        diagnostics.push({
-          from,
-          to,
-          severity: 'error',
-          message: e.message,
-        })
+    return result.diagnostics.map((d): Diagnostic => {
+      const lineNum = Math.min(Math.max(1, d.line), view.state.doc.lines)
+      const line = view.state.doc.line(lineNum)
+      return {
+        from: line.from,
+        to: line.to,
+        severity: d.severity === 'error' ? 'error' : 'warning',
+        message: d.message,
       }
-    }
-
-    return diagnostics
+    })
   },
   { delay: 500 },
 )

--- a/src/aiscript/lsp/worker.ts
+++ b/src/aiscript/lsp/worker.ts
@@ -1,6 +1,6 @@
 /// <reference lib="webworker" />
 
-import { Parser } from '@syuilo/aiscript'
+import { validateAiScript } from '../validate'
 
 // LSP message parameter types
 interface LspTextDocument {
@@ -40,16 +40,6 @@ interface LspDiagnostic {
 // Document storage
 const documents = new Map<string, string>()
 const diagnosticTimers = new Map<string, ReturnType<typeof setTimeout>>()
-
-// Inline sanitize to avoid path alias issues in workers
-function sanitizeCode(code: string): string {
-  return code
-    .replace(/\uFEFF/g, '')
-    .replace(/\u200B|\u200C|\u200D|\u200E|\u200F|\u2060/g, '')
-    .replace(/\u00A0/g, ' ')
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-}
 
 // Built-in completions data
 const keywords = [
@@ -321,40 +311,17 @@ function validateDocument(uri: string) {
   const text = documents.get(uri)
   if (text === undefined) return
 
-  const code = sanitizeCode(text)
-  const diagnostics: LspDiagnostic[] = []
-
-  if (code.trim()) {
-    try {
-      const parser = new Parser()
-      parser.parse(code)
-    } catch (e) {
-      if (e instanceof Error) {
-        const lineMatch = e.message.match(/at line (\d+)/i)
-        let startLine = 0
-        let endChar = 0
-
-        if (lineMatch) {
-          const lineNum = Math.max(0, parseInt(lineMatch[1] ?? '0', 10) - 1)
-          const lines = text.split('\n')
-          startLine = Math.min(lineNum, lines.length - 1)
-          endChar = (lines[startLine] ?? '').length
-        } else {
-          endChar = (text.split('\n')[0] ?? '').length
-        }
-
-        diagnostics.push({
-          range: {
-            start: { line: startLine, character: 0 },
-            end: { line: startLine, character: endChar },
-          },
-          severity: DiagnosticSeverity.Error,
-          message: e.message,
-          source: 'aiscript',
-        })
-      }
-    }
-  }
+  const result = validateAiScript(text)
+  // LSP は 0-based 行/列、validateAiScript は 1-based なので変換
+  const diagnostics: LspDiagnostic[] = result.diagnostics.map((d) => ({
+    range: {
+      start: { line: d.line - 1, character: d.column - 1 },
+      end: { line: d.endLine - 1, character: d.endColumn - 1 },
+    },
+    severity: DiagnosticSeverity.Error,
+    message: d.message,
+    source: 'aiscript',
+  }))
 
   notify('textDocument/publishDiagnostics', { uri, diagnostics })
 }

--- a/src/aiscript/validate.test.ts
+++ b/src/aiscript/validate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { validateAiScript } from './validate'
+
+describe('validateAiScript', () => {
+  it('returns ok: true with empty diagnostics for valid AiScript', () => {
+    const r = validateAiScript('let x = 1\nlet y = x + 2')
+    expect(r).toEqual({ ok: true, diagnostics: [] })
+  })
+
+  it('returns ok: true for empty / whitespace-only source', () => {
+    expect(validateAiScript('').ok).toBe(true)
+    expect(validateAiScript('   \n\t  ').ok).toBe(true)
+  })
+
+  it('returns ok: false with diagnostics for syntax error', () => {
+    const r = validateAiScript('let x = ')
+    expect(r.ok).toBe(false)
+    expect(r.diagnostics.length).toBeGreaterThan(0)
+    expect(r.diagnostics[0]?.severity).toBe('error')
+    expect(r.diagnostics[0]?.line).toBeGreaterThanOrEqual(1)
+  })
+
+  it('reports a 1-based line number on multi-line errors', () => {
+    const src = ['let a = 1', 'let b = 2', 'let c = ('].join('\n')
+    const r = validateAiScript(src)
+    expect(r.ok).toBe(false)
+    expect(r.diagnostics[0]?.line).toBeGreaterThanOrEqual(1)
+  })
+
+  it('strips BOM and zero-width chars before parsing', () => {
+    const r = validateAiScript('﻿let ​x = 1')
+    expect(r.ok).toBe(true)
+  })
+
+  it('accepts entryPoint option without throwing', () => {
+    const r = validateAiScript('let x = 1', { entryPoint: 'plugin' })
+    expect(r.ok).toBe(true)
+  })
+})

--- a/src/aiscript/validate.ts
+++ b/src/aiscript/validate.ts
@@ -1,0 +1,72 @@
+/**
+ * AiScript 構文検証の共有モジュール。
+ *
+ * - LSP worker / CodeMirror linter / `aiscript.validate` capability の 3 経路で
+ *   同じ Parser 呼び出しを使うための単一窓口
+ * - 同期 Parser ベース。意味解析 (未定義変数 / 名前空間タイポ / 引数 arity) は
+ *   将来公式 LSP を web worker 化したときに置き換える (Phase 2)
+ */
+
+import { Parser } from '@syuilo/aiscript'
+import { sanitizeCode } from './sanitize'
+
+export type DiagnosticSeverity = 'error' | 'warning' | 'info' | 'hint'
+
+export interface AiScriptDiagnostic {
+  severity: DiagnosticSeverity
+  message: string
+  /** 1-based 行番号 (LSP / IDE 慣例) */
+  line: number
+  /** 1-based 列番号 */
+  column: number
+  endLine: number
+  endColumn: number
+}
+
+export interface ValidateResult {
+  ok: boolean
+  diagnostics: AiScriptDiagnostic[]
+}
+
+export interface ValidateOptions {
+  /** 将来的に entryPoint 別チェック (plugin = メタヘッダ必須 等) を分岐させるための余地 */
+  entryPoint?: 'plugin' | 'widget'
+}
+
+export function validateAiScript(
+  src: string,
+  _options: ValidateOptions = {},
+): ValidateResult {
+  const code = sanitizeCode(src)
+  if (!code.trim()) {
+    return { ok: true, diagnostics: [] }
+  }
+
+  try {
+    const parser = new Parser()
+    parser.parse(code)
+    return { ok: true, diagnostics: [] }
+  } catch (e) {
+    return { ok: false, diagnostics: [parserErrorToDiagnostic(e, code)] }
+  }
+}
+
+function parserErrorToDiagnostic(e: unknown, code: string): AiScriptDiagnostic {
+  const message = e instanceof Error ? e.message : String(e)
+  const lineMatch = message.match(/at line (\d+)/i)
+  const lines = code.split('\n')
+  let line = 1
+  if (lineMatch) {
+    const parsed = Number.parseInt(lineMatch[1] ?? '1', 10)
+    line = Math.min(Math.max(1, parsed), lines.length)
+  }
+  const endColumn = Math.max(1, (lines[line - 1] ?? '').length + 1)
+  return {
+    severity: 'error',
+    message,
+    line,
+    column: 1,
+    endLine: line,
+    endColumn,
+  }
+}

--- a/src/capabilities/builtins/aiscript.test.ts
+++ b/src/capabilities/builtins/aiscript.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AISCRIPT_BUILTIN_CAPABILITIES,
+  aiscriptValidateCapability,
+  preflightValidateSrc,
+} from './aiscript'
+
+describe('aiscript.validate capability — declaration', () => {
+  it('exposes the expected metadata', () => {
+    expect(aiscriptValidateCapability.id).toBe('aiscript.validate')
+    expect(aiscriptValidateCapability.aiTool).toBe(true)
+    expect(aiscriptValidateCapability.permissions).toEqual([])
+    expect(aiscriptValidateCapability.signature?.cheap).toBe(true)
+  })
+
+  it('is included in AISCRIPT_BUILTIN_CAPABILITIES', () => {
+    expect(AISCRIPT_BUILTIN_CAPABILITIES.map((c) => c.id)).toContain(
+      'aiscript.validate',
+    )
+  })
+})
+
+describe('aiscript.validate capability — execute', () => {
+  it('throws when src is missing', () => {
+    expect(() => aiscriptValidateCapability.execute({})).toThrow(
+      /src is required/,
+    )
+  })
+
+  it('returns ok: true for valid AiScript', () => {
+    const r = aiscriptValidateCapability.execute({
+      src: 'let x = 1',
+    }) as { ok: boolean; diagnostics: unknown[] }
+    expect(r.ok).toBe(true)
+    expect(r.diagnostics).toEqual([])
+  })
+
+  it('returns ok: false with diagnostics for broken AiScript', () => {
+    const r = aiscriptValidateCapability.execute({
+      src: 'let x = ',
+    }) as { ok: boolean; diagnostics: Array<{ severity: string }> }
+    expect(r.ok).toBe(false)
+    expect(r.diagnostics.length).toBeGreaterThan(0)
+    expect(r.diagnostics[0]?.severity).toBe('error')
+  })
+
+  it('accepts entryPoint param without throwing', () => {
+    const r = aiscriptValidateCapability.execute({
+      src: 'let x = 1',
+      entryPoint: 'plugin',
+    }) as { ok: boolean }
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('preflightValidateSrc helper', () => {
+  it('returns null when src is missing (= dispatcher proceeds to confirm)', () => {
+    expect(preflightValidateSrc({}, 'plugin')).toBeNull()
+    expect(preflightValidateSrc(undefined, 'widget')).toBeNull()
+  })
+
+  it('returns null when src is syntactically valid', () => {
+    expect(preflightValidateSrc({ src: 'let x = 1' }, 'plugin')).toBeNull()
+  })
+
+  it('returns a PreflightFailure with diagnostics JSON when src is broken', () => {
+    const r = preflightValidateSrc({ src: 'let x = (' }, 'plugin')
+    expect(r).not.toBeNull()
+    expect(r?.error).toContain('構文エラー')
+    expect(r?.error).toContain('diagnostics:')
+    // diagnostics JSON が AI 側で parse できる形で埋まっている
+    const jsonStart = r?.error.indexOf('[')
+    expect(jsonStart).toBeGreaterThan(-1)
+    if (jsonStart !== undefined && jsonStart > -1 && r) {
+      const diagnostics = JSON.parse(r.error.slice(jsonStart))
+      expect(Array.isArray(diagnostics)).toBe(true)
+      expect(diagnostics[0]?.severity).toBe('error')
+    }
+  })
+})

--- a/src/capabilities/builtins/aiscript.ts
+++ b/src/capabilities/builtins/aiscript.ts
@@ -1,0 +1,82 @@
+import { validateAiScript } from '@/aiscript/validate'
+import type { Command, PreflightFailure } from '@/commands/registry'
+
+/**
+ * AiScript 系 capability — AI が生成した AiScript ソースを構文検証する
+ * (= LSP フィードバックループの中核, #553)。
+ *
+ * AI が `plugins.create` / `widgets.create` を呼ぶ前に必ずここを通す運用に
+ * することで、syntax error の入った src がユーザー確認ダイアログに到達する
+ * 前に AI 側で修正できる。dispatcher 側の preflight でも同じ検証が走るので
+ * 二重防壁になる。
+ *
+ * readonly capability (permissions: []) で副作用なし。
+ */
+
+export const aiscriptValidateCapability: Command = {
+  id: 'aiscript.validate',
+  label: 'AiScript を構文検証する',
+  icon: 'ti-check',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      'AiScript ソースを構文検証し、エラー一覧を返す。プラグイン/ウィジェット' +
+      'を `plugins.create` / `plugins.update` / `widgets.create` / `widgets.update`' +
+      'で保存する前に必ず通して、diagnostics が空でなければ src を修正して再度' +
+      'validate するループを回すこと。3 回試して直らないなら diagnostics を' +
+      'ユーザーに見せて相談する。',
+    params: {
+      src: { type: 'string', description: 'AiScript ソースコード' },
+      entryPoint: {
+        type: 'string',
+        description: "'plugin' | 'widget' (省略可)",
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description:
+        '{ ok: boolean, diagnostics: Array<{severity, message, line, column, endLine, endColumn}> }' +
+        '。line / column は 1-based。',
+    },
+    cheap: true,
+  },
+  visible: false,
+  execute: (params) => {
+    const src = typeof params?.src === 'string' ? params.src : null
+    if (src === null) throw new Error('aiscript.validate: src is required')
+    const entryPoint =
+      params?.entryPoint === 'plugin' || params?.entryPoint === 'widget'
+        ? params.entryPoint
+        : undefined
+    return validateAiScript(src, { entryPoint })
+  },
+}
+
+export const AISCRIPT_BUILTIN_CAPABILITIES: readonly Command[] = [
+  aiscriptValidateCapability,
+]
+
+/**
+ * `plugins.create` / `plugins.update` / `widgets.create` / `widgets.update` の
+ * preflight 用ヘルパ。params.src を AiScript として validate し、構文エラーが
+ * あれば PreflightFailure を返す。dispatcher は確認ダイアログを出さずに AI へ
+ * diagnostics を tool_result で返す (= AI 内ループで自動修復させる)。
+ */
+export function preflightValidateSrc(
+  params: Record<string, unknown> | undefined,
+  entryPoint: 'plugin' | 'widget',
+): PreflightFailure | null {
+  if (typeof params?.src !== 'string') return null
+  const result = validateAiScript(params.src, { entryPoint })
+  if (result.ok) return null
+  return {
+    error:
+      'AiScript の構文エラーがあります。diagnostics を読んで src を修正し、' +
+      '修正後の src で再度この capability を呼び出してください。\n' +
+      `diagnostics: ${JSON.stringify(result.diagnostics)}`,
+  }
+}

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -14,6 +14,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'ai.sessions.read',
         'ai.sessions.search',
         'ai.setPersona',
+        'aiscript.validate',
         'announcements.list',
         'antenna.list',
         'antenna.notes',

--- a/src/capabilities/builtins/index.ts
+++ b/src/capabilities/builtins/index.ts
@@ -2,6 +2,7 @@ import type { Command } from '@/commands/registry'
 import { ACCOUNT_BUILTIN_CAPABILITIES } from './account'
 import { AI_BUILTIN_CAPABILITIES } from './ai'
 import { AI_SESSIONS_BUILTIN_CAPABILITIES } from './aiSessions'
+import { AISCRIPT_BUILTIN_CAPABILITIES } from './aiscript'
 import { ANNOUNCEMENTS_BUILTIN_CAPABILITIES } from './announcements'
 import { ANTENNA_BUILTIN_CAPABILITIES } from './antenna'
 import { CHANNEL_BUILTIN_CAPABILITIES } from './channel'
@@ -82,6 +83,7 @@ export const ALL_BUILTIN_CAPABILITIES: readonly Command[] = [
   ...TASKS_BUILTIN_CAPABILITIES,
   ...UI_BUILTIN_CAPABILITIES,
   ...AI_BUILTIN_CAPABILITIES,
+  ...AISCRIPT_BUILTIN_CAPABILITIES,
   ...PERSONA_BUILTIN_CAPABILITIES,
   ...SKILLS_BUILTIN_CAPABILITIES,
   ...WIDGETS_BUILTIN_CAPABILITIES,

--- a/src/capabilities/builtins/plugins.test.ts
+++ b/src/capabilities/builtins/plugins.test.ts
@@ -108,6 +108,39 @@ describe('plugin capabilities — declaration', () => {
   })
 })
 
+describe('plugins.create / plugins.update — preflight (#553)', () => {
+  it('plugins.create has a preflight hook', () => {
+    expect(typeof pluginsCreateCapability.preflight).toBe('function')
+  })
+
+  it('plugins.update has a preflight hook', () => {
+    expect(typeof pluginsUpdateCapability.preflight).toBe('function')
+  })
+
+  it('preflight returns null for syntactically valid AiScript src', async () => {
+    const r = await pluginsCreateCapability.preflight?.({
+      name: 'demo',
+      src: 'let x = 1',
+    })
+    expect(r).toBeNull()
+  })
+
+  it('preflight returns a failure with diagnostics JSON for broken src', async () => {
+    const r = await pluginsCreateCapability.preflight?.({
+      name: 'demo',
+      src: 'let x = (',
+    })
+    expect(r).not.toBeNull()
+    expect(r?.error).toMatch(/構文エラー/)
+    expect(r?.error).toMatch(/diagnostics:/)
+  })
+
+  it('preflight returns null when src is missing (= execute will throw with a clearer message)', async () => {
+    const r = await pluginsCreateCapability.preflight?.({ name: 'demo' })
+    expect(r).toBeNull()
+  })
+})
+
 describe('PLUGINS_BUILTIN_CAPABILITIES', () => {
   it('contains all 8 plugin capabilities (incl. history / revert)', () => {
     const ids = PLUGINS_BUILTIN_CAPABILITIES.map((c) => c.id).sort()

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -2,6 +2,7 @@ import { parsePluginMeta } from '@/aiscript/plugin-api'
 import type { Command } from '@/commands/registry'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
 import { getSnapshotAt, listSnapshots } from '@/utils/historyFs'
+import { preflightValidateSrc } from './aiscript'
 
 interface PluginSnapshot {
   src: string
@@ -117,6 +118,7 @@ export const pluginsCreateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['plugins.write'],
+  preflight: (params) => preflightValidateSrc(params, 'plugin'),
   requiresConfirmation: (params) => ({
     title: 'プラグインをインストール',
     message:
@@ -214,6 +216,7 @@ export const pluginsUpdateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['plugins.write'],
+  preflight: (params) => preflightValidateSrc(params, 'plugin'),
   requiresConfirmation: (params) => {
     const installId =
       typeof params?.installId === 'string' ? params.installId : ''

--- a/src/capabilities/builtins/widgets.ts
+++ b/src/capabilities/builtins/widgets.ts
@@ -5,6 +5,7 @@ import {
   type WidgetMeta,
 } from '@/stores/widgets'
 import { getSnapshotAt, listSnapshots } from '@/utils/historyFs'
+import { preflightValidateSrc } from './aiscript'
 
 interface WidgetSnapshot {
   src: string
@@ -110,6 +111,7 @@ export const widgetsCreateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['widgets.write'],
+  preflight: (params) => preflightValidateSrc(params, 'widget'),
   requiresConfirmation: (params) => {
     const name = typeof params?.name === 'string' ? params.name : ''
     const src = typeof params?.src === 'string' ? params.src : ''
@@ -183,6 +185,7 @@ export const widgetsUpdateCapability: Command = {
   shortcuts: [],
   aiTool: true,
   permissions: ['widgets.write'],
+  preflight: (params) => preflightValidateSrc(params, 'widget'),
   requiresConfirmation: (params) => {
     const installId =
       typeof params?.installId === 'string' ? params.installId : ''

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -281,6 +281,80 @@ describe('dispatchCapability — confirmation flow', () => {
     ])
   })
 
+  it('runs preflight BEFORE confirm and returns preflight_failed (skipping confirm)', async () => {
+    let confirmCalls = 0
+    registerCapability(
+      makeCapability({
+        id: 'plugins.create',
+        permissions: ['plugins.write'],
+        preflight: () => ({ error: 'bad src: diagnostics: [...]' }),
+        requiresConfirmation: true,
+        execute: () => 'should not run',
+      }),
+    )
+    const r = await dispatchCapability(
+      'plugins.create',
+      { src: 'broken' },
+      configWithPreset('full'),
+      {
+        confirmFn: async () => {
+          confirmCalls++
+          return true
+        },
+      },
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('preflight_failed')
+      expect(r.error).toContain('diagnostics:')
+    }
+    expect(confirmCalls).toBe(0)
+  })
+
+  it('continues to confirm + execute when preflight returns null', async () => {
+    let executed = false
+    registerCapability(
+      makeCapability({
+        id: 'plugins.create',
+        permissions: ['plugins.write'],
+        preflight: () => null,
+        requiresConfirmation: true,
+        execute: () => {
+          executed = true
+          return 'created'
+        },
+      }),
+    )
+    const r = await dispatchCapability(
+      'plugins.create',
+      { src: 'let x = 1' },
+      configWithPreset('full'),
+      { confirmFn: async () => true },
+    )
+    expect(r).toEqual({ ok: true, result: 'created' })
+    expect(executed).toBe(true)
+  })
+
+  it('supports async preflight', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'plugins.create',
+        permissions: ['plugins.write'],
+        preflight: async () => ({ error: 'async fail' }),
+      }),
+    )
+    const r = await dispatchCapability(
+      'plugins.create',
+      undefined,
+      configWithPreset('full'),
+    )
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.code).toBe('preflight_failed')
+      expect(r.error).toBe('async fail')
+    }
+  })
+
   it('checks permissions BEFORE confirm (no confirm if denied)', async () => {
     let confirmCalls = 0
     registerCapability(

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -23,6 +23,7 @@ import { getCapability, listCapabilities } from './registry'
 export type DispatchErrorCode =
   | 'unknown_capability'
   | 'permission_denied'
+  | 'preflight_failed'
   | 'execute_failed'
   | 'user_cancelled'
 
@@ -71,6 +72,17 @@ export async function dispatchCapability(
       ok: false,
       code: 'permission_denied',
       error: `Permission denied for ${capabilityId}: required [${denied.join(', ')}] not allowed by current ai.json5 settings`,
+    }
+  }
+  // preflight (入力検証 — 確認ダイアログより前に走る)
+  if (cap.preflight) {
+    const failure = await cap.preflight(params)
+    if (failure) {
+      return {
+        ok: false,
+        code: 'preflight_failed',
+        error: failure.error,
+      }
     }
   }
   // 確認ダイアログ (write 系などで requiresConfirmation: true)

--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -88,6 +88,22 @@ export interface Command {
     | ((
         params: Record<string, unknown> | undefined,
       ) => ConfirmOptions | null | Promise<ConfirmOptions | null>)
+  /**
+   * confirm ダイアログより前に走る入力検証フック。`null` を返したら通常フロー、
+   * `{ error }` を返したら dispatcher が `{ ok: false, code: 'preflight_failed' }`
+   * で即時 fail-fast する (= confirm を出さず AI に diagnostics を返す)。
+   *
+   * 用途: AI が壊れた src を渡してきたとき、ユーザー確認ダイアログ表示前に
+   * 弾いて AI 内ループで自動修復させる二重防壁 (#553)。
+   */
+  preflight?: (
+    params: Record<string, unknown> | undefined,
+  ) => PreflightFailure | null | Promise<PreflightFailure | null>
+}
+
+export interface PreflightFailure {
+  /** AI へそのまま返るエラー文字列。診断 JSON を埋め込んでよい。 */
+  error: string
 }
 
 export const useCommandStore = defineStore('commands', () => {

--- a/src/composables/useSlashCommand.ts
+++ b/src/composables/useSlashCommand.ts
@@ -43,6 +43,7 @@ export type SlashRunResult =
         | 'parse_error'
         | 'unknown_capability'
         | 'permission_denied'
+        | 'preflight_failed'
         | 'execute_failed'
         | 'user_cancelled'
       displayName: string

--- a/src/defaults/skills/aiscript-author.md
+++ b/src/defaults/skills/aiscript-author.md
@@ -1,0 +1,228 @@
+---
+id: aiscript-author
+name: AiScript 文法リファレンス
+version: 1.0.0
+description: AiScript 0.16 の値型・制御構文・名前空間付き組込み関数・プラグイン/ウィジェットのハンドラ規約を集約したリファレンス。プラグインやウィジェットを生成する前に参照する。
+mode: always
+scope: global
+builtIn: true
+isPersona: false
+---
+
+# AiScript 0.16 文法リファレンス
+
+NoteDeck のプラグイン・ウィジェットは AiScript 0.16 で書く。書き出す前に
+このリファレンスで構文を確認し、`aiscript.validate` で必ず検証する。
+
+公式ドキュメント: https://aiscript-dev.github.io/ja/
+
+## メタヘッダ (プラグインは必須、ウィジェットは省略可)
+
+```
+/// @ 0.16.0
+### {
+  name: "Name"
+  version: "1.0.0"
+  author: "Author"
+  description: "..."
+  permissions: []
+  config: {
+    threshold: {
+      type: "number"
+      label: "閾値"
+      default: 5
+    }
+  }
+}
+```
+
+- `///` ヘッダ行は **半角空白の有無に厳密** (`/// @ 0.16.0`)
+- `###` ブロック内はキー: 値 (カンマ不要)
+- `config` は省略可。書くと UI で設定値を編集できる
+- ウィジェット (`widgets.create`) はメタヘッダなしでも動くが、書くと管理しやすい
+
+## 値型
+
+| 型 | 例 | リテラル |
+|---|---|---|
+| num | `42`, `3.14`, `-1` | 整数 / 浮動小数 |
+| str | `"hello"`, `'world'` | 二重引用符・単一引用符どちらも |
+| bool | `true`, `false` | |
+| null | `null` | |
+| arr | `[1, 2, 3]` | |
+| obj | `{ a: 1, b: 2 }` | キーは bare-word 可 |
+| fn | `@(x) { x * 2 }` | 後述 |
+
+## 変数宣言
+
+```
+let x = 1       // 不変 (再代入不可)
+var y = 2       // 可変 (再代入可)
+y = 3           // OK
+y += 4          // OK (複合代入)
+```
+
+**落とし穴**: `let` で宣言した変数は再代入できない。ループ内で値を更新したい
+変数は `var` を使う。
+
+## 制御構文
+
+```
+if cond { ... } elif other { ... } else { ... }
+
+for let i, 10 { ... }            // 0..9
+each let item, arr { ... }       // 配列を走査
+
+loop {
+  if done break
+  continue
+}
+
+match value {
+  case 1 => "one"
+  case 2 => "two"
+  default => "other"
+}
+```
+
+- `for` の上限は引数 2 つ目 (= `for let i, n` で `i` は 0 から `n-1`)
+- `match` の各 arm は `=>` で続ける
+
+## 関数
+
+```
+@greet(name: str): str {
+  `Hello, {name}`              // テンプレ文字列は backtick + {expr}
+}
+
+let double = @(x) { x * 2 }    // 無名関数
+```
+
+- 引数の型注釈は `(name: type)` 形式
+- 戻り値の型注釈は `): type {` 形式
+- 関数本体最後の式が暗黙の戻り値 (return 不要)
+
+## 配列・オブジェクトアクセス
+
+```
+let arr = [10, 20, 30]
+arr[0]            // 10 — bracket index
+arr.0             // 同じ意味、dot index も使える
+
+let obj = { foo: 1 }
+obj.foo           // 1
+obj["foo"]        // 1
+```
+
+**落とし穴**: AiScript 0.16 では `arr:0` のような colon index 構文は使わない
+(配列要素アクセスはあくまで bracket か dot)。
+
+## 名前空間付き組込み
+
+呼び出しは `Namespace:member(args)` のコロン記法。
+
+### Mk: (Misskey 連携 — プラグイン専用)
+
+| 関数 | 機能 |
+|---|---|
+| `Mk:dialog(title, text)` | モーダル表示 |
+| `Mk:confirm(title, text)` | 確認ダイアログ (bool 返り) |
+| `Mk:api(endpoint, params)` | Misskey API 呼び出し (例: `Mk:api('notes/create', { text: 'hi' })`) |
+| `Mk:save(key, value)` | 永続保存 (プラグイン固有領域) |
+| `Mk:load(key)` | 永続値取得 |
+| `Mk:url()` | サーバー URL |
+
+### Core: (基本ユーティリティ)
+
+| 関数 | 機能 |
+|---|---|
+| `Core:v` | AiScript バージョン |
+| `Core:type(x)` | 型名 |
+| `Core:to_str(x)` | 文字列化 |
+| `Core:sleep(ms)` | 待機 |
+| `Core:abort(msg)` | 中断 |
+| `Core:range(a, b)` | a..b の配列 |
+
+### Math: / Str: / Arr: / Obj: / Json: / Date: / Async: / Uri: / Util: / Error:
+
+代表的なもの:
+- `Math:pi`, `Math:sin(x)`, `Math:floor(x)`, `Math:random()` (0..1)
+- `Str:len(s)`, `Str:to_arr(s)`, `Str:upper(s)`, `Str:lower(s)`
+- `Arr:len(a)`, `Arr:push(a, x)`, `Arr:map(a, fn)`, `Arr:filter(a, fn)`, `Arr:reduce(a, fn, init)`
+- `Obj:keys(o)`, `Obj:vals(o)`, `Obj:has(o, key)`
+- `Json:stringify(x)`, `Json:parse(s)`
+- `Date:now()`, `Date:year()`, `Date:hour()`
+- `Async:interval(ms, fn)`, `Async:timeout(ms, fn)`
+- `Util:uuid()`
+
+### Ui: (ウィジェット UI 構築)
+
+`Ui:render([components])` でルートを描画。
+
+```
+Ui:render([
+  Ui:C:text({ text: "Hello" })
+  Ui:C:button({
+    text: "Click"
+    onClick: @() { Mk:dialog("clicked", "!") }
+  })
+])
+```
+
+主要コンポーネント (Ui:C:*):
+- `text` — 静的テキスト
+- `mfm` — MFM フォーマット文字列
+- `button` — ボタン (`onClick` 必須)
+- `textInput`, `numberInput` — 入力
+- `switch`, `select` — トグル / 選択
+- `container`, `folder` — レイアウト
+
+## プラグインのハンドラ
+
+```
+@on_note(note) { ... }          // 新着ノートをストリームで観測
+@note_post_pre(note) { ... }    // 投稿直前 (note を加工して戻すと差し替え)
+@note_view(note) { ... }        // タイムライン表示時 (UI 加工)
+```
+
+- ハンドラは `@<name>(arg) { ... }` 構文
+- 引数 `note` は obj (`note.text`, `note.userId`, `note.user.username` など)
+- 戻り値で note 自体を加工できるハンドラ (`note_post_pre`) と、副作用のみの
+  ハンドラ (`on_note`, `note_view`) がある
+
+## ウィジェットの本体
+
+ウィジェットはハンドラを持たず、トップレベルで `Ui:render(...)` を呼ぶ
+(または初期化処理を書く)。`Mk:save` / `Mk:load` で状態を持てる。
+
+```
+/// @ 0.16.0
+var count = (Mk:load("count") or 0)
+
+Ui:render([
+  Ui:C:text({ text: `Count: {count}` })
+  Ui:C:button({
+    text: "+1"
+    onClick: @() {
+      count += 1
+      Mk:save("count", count)
+    }
+  })
+])
+```
+
+## よくある落とし穴 (= `aiscript.validate` で弾かれがち)
+
+| 症状 | 原因 | 直し方 |
+|---|---|---|
+| `unexpected token` | `let` の再代入 | `var` に変える |
+| `Reserved word "...". Line N` | `class` / `enum` / `import` 等の予約語をシンボル名に使った | 別名にする |
+| `unexpected ":"` | `arr:0` で要素アクセス | `arr[0]` または `arr.0` |
+| `unexpected EOF` | `### { ... }` の `}` を閉じ忘れ | 閉じる |
+| `Math.pi` が undefined | `.` でなく `:` | `Math:pi` |
+| ハンドラが発火しない | `@on_note(note) { ... }` の `@` を忘れ、または引数なし | `@on_note(note)` シグネチャを守る |
+
+## 参考
+
+- 公式リファレンス (型・全組込み): https://aiscript-dev.github.io/ja/reference/
+- AiScript Playground (実行確認): https://aiscript-dev.github.io/aiscript/

--- a/src/defaults/skills/plugin-author.md
+++ b/src/defaults/skills/plugin-author.md
@@ -15,9 +15,10 @@ isPersona: false
 `plugins.create` capability を呼ぶ。インストール確認ダイアログはこちらでは
 組み立てなくてよい (dispatcher が自動で MisStore カード風 UI を出す)。
 
-ユーザーがウィジェット (画面上の小道具) を頼んだ場合は `widgets.create` を
-代わりに呼ぶ。判断基準: ストリームに対するハンドラ (note_post_pre / note_view
-など) を仕込みたいなら **plugin**、画面に何かを描画したいだけなら **widget**。
+ユーザーがウィジェット (画面上の小道具) を頼んだ場合は `widget-author` skill の
+方針に従って `widgets.create` を呼ぶ。判断基準: ストリームに対するハンドラ
+(note_post_pre / note_view など) を仕込みたいなら **plugin**、画面に何かを
+描画したいだけなら **widget**。
 
 AiScript の文法・組込み関数・名前空間は別スキル `aiscript-author` に詳しく
 まとめてある。書く前に必ずそちらを参照すること。

--- a/src/defaults/skills/plugin-author.md
+++ b/src/defaults/skills/plugin-author.md
@@ -1,7 +1,7 @@
 ---
 id: plugin-author
 name: プラグイン作者
-version: 1.0.0
+version: 1.1.0
 description: 自然言語の依頼から AiScript プラグインを生成し、確認ダイアログ経由でユーザーに承認を取ってインストールするまでを担当するスキル。
 mode: always
 scope: global
@@ -18,6 +18,36 @@ isPersona: false
 ユーザーがウィジェット (画面上の小道具) を頼んだ場合は `widgets.create` を
 代わりに呼ぶ。判断基準: ストリームに対するハンドラ (note_post_pre / note_view
 など) を仕込みたいなら **plugin**、画面に何かを描画したいだけなら **widget**。
+
+AiScript の文法・組込み関数・名前空間は別スキル `aiscript-author` に詳しく
+まとめてある。書く前に必ずそちらを参照すること。
+
+## 必ず守るフィードバックループ — validate → 修正 → re-validate
+
+`plugins.create` / `plugins.update` / `widgets.create` / `widgets.update` を
+呼ぶ前に、**必ず** `aiscript.validate` capability で src を構文検証する。
+
+```
+aiscript.validate({ src: "/// @ 0.16.0\n### { ... }\n@on_note(...) { ... }", entryPoint: "plugin" })
+```
+
+返り値:
+- `{ ok: true, diagnostics: [] }` → そのまま `plugins.create` を呼ぶ
+- `{ ok: false, diagnostics: [{ severity, message, line, column, ... }] }` →
+  diagnostics を読んで src を修正し、再度 `aiscript.validate` を呼ぶ
+
+このループを **最大 3 回** 回す。それでも直らないなら diagnostics をそのまま
+ユーザーに見せて「ここで詰まりました」と相談する (= 黙って壊れた src を保存しない)。
+
+### 二重防壁
+
+`aiscript.validate` をスキップして直接 `plugins.create` を呼んでも、dispatcher
+の preflight が同じ検証を走らせる。構文エラーがあれば確認ダイアログを出す**前**
+に `{ ok: false, code: 'preflight_failed', error: '...diagnostics: [...]' }`
+が tool_result で返るので、AI は自動的にループへ戻れる。
+
+ただしユーザー体験的には事前 validate のほうが速い (= preflight で弾かれると
+1 round-trip 余分にかかる) ので、必ず `aiscript.validate` を先に呼ぶこと。
 
 ## AiScript メタヘッダ (必須)
 
@@ -71,7 +101,9 @@ create が成功したら短く伝える:
 
 1. `plugins.list` で対象を特定 (name で照合)
 2. `plugins.read` で現状の src を取得
-3. 必要な差分だけを反映した **全文** を書き、`plugins.update` を呼ぶ
+3. 必要な差分だけを反映した **全文** を書く
+4. `aiscript.validate` で構文検証 (上記ループ)
+5. `plugins.update` を呼ぶ
 
 `plugins.update` も確認ダイアログが出る (= ユーザー承認が必要)。
 
@@ -93,11 +125,5 @@ create が成功したら短く伝える:
 - 先回りで勝手に有効化・削除しない (ユーザー意図の明示が必要)
 - 不要に過大な permissions を要求しない (= 最小権限の原則)
 - ヘッダの name と `plugins.create` の name 引数を食い違わせない
-
-## AiScript の主要 API (リファレンス)
-
-- 投稿フック: `@on_note(note) { ... }`、`@note_post_pre(note) { ... }`
-- 通知: `Mk:dialog(title, text)`, `Mk:confirm(...)`
-- 永続: `Mk:save(key, value)`, `Mk:load(key)`
-- HTTP: `Mk:api('endpoint', params)` (Misskey API)
-- 文字列・配列・数値は AiScript 標準ライブラリ参照
+- `aiscript.validate` をスキップしない (= シンタックスエラーで preflight に
+  弾かれると無駄な round-trip になる)

--- a/src/defaults/skills/widget-author.md
+++ b/src/defaults/skills/widget-author.md
@@ -1,0 +1,145 @@
+---
+id: widget-author
+name: ウィジェット作者
+version: 1.0.0
+description: 自然言語の依頼から AiScript ウィジェットを生成し、確認ダイアログ経由でユーザーに承認を取ってインストールするまでを担当するスキル。
+mode: always
+scope: global
+builtIn: true
+isPersona: false
+---
+
+# ウィジェット作者 — 自然言語 → AiScript (UI)
+
+ユーザーが「○○を表示するウィジェット作って」「カウンタの小道具がほしい」など、
+**画面に何かを描画する** 依頼をしたら、AiScript ソースを書いて
+`widgets.create` capability を呼ぶ。インストール確認ダイアログはこちらでは
+組み立てなくてよい (dispatcher が自動で MisStore カード風 UI を出す)。
+
+ストリーム (新着ノート / 投稿前加工 / タイムライン表示) に介入したい場合は
+**プラグイン** の領域なので `plugin-author` skill の方針に従って `plugins.create`
+を呼ぶこと。
+
+AiScript の文法・組込み関数・名前空間は別スキル `aiscript-author` に詳しく
+まとめてある。書く前に必ずそちらを参照すること。
+
+## 必ず守るフィードバックループ — validate → 修正 → re-validate
+
+`widgets.create` / `widgets.update` を呼ぶ前に、**必ず**
+`aiscript.validate` capability で src を構文検証する。
+
+```
+aiscript.validate({ src: "/// @ 0.16.0\nUi:render([...])", entryPoint: "widget" })
+```
+
+返り値:
+- `{ ok: true, diagnostics: [] }` → そのまま `widgets.create` を呼ぶ
+- `{ ok: false, diagnostics: [{ severity, message, line, column, ... }] }` →
+  diagnostics を読んで src を修正し、再度 `aiscript.validate` を呼ぶ
+
+このループを **最大 3 回** 回す。それでも直らないなら diagnostics をそのまま
+ユーザーに見せて「ここで詰まりました」と相談する (= 黙って壊れた src を保存しない)。
+
+### 二重防壁
+
+`aiscript.validate` をスキップして直接 `widgets.create` を呼んでも、dispatcher
+の preflight が同じ検証を走らせる。構文エラーがあれば確認ダイアログを出す**前**
+に `{ ok: false, code: 'preflight_failed', error: '...diagnostics: [...]' }`
+が tool_result で返るので、AI は自動的にループへ戻れる。
+
+ただしユーザー体験的には事前 validate のほうが速いので、必ず
+`aiscript.validate` を先に呼ぶこと。
+
+## ウィジェットの最小構成
+
+ウィジェットはハンドラを持たず、トップレベルで `Ui:render(...)` を呼ぶ。
+メタヘッダはプラグインと違って **必須ではない** が、書くと管理しやすい。
+
+```
+/// @ 0.16.0
+Ui:render([
+  Ui:C:text({ text: "Hello, world" })
+])
+```
+
+`Mk:save` / `Mk:load` でウィジェット固有領域に状態を持てる:
+
+```
+/// @ 0.16.0
+var count = (Mk:load("count") or 0)
+
+Ui:render([
+  Ui:C:text({ text: `Count: {count}` })
+  Ui:C:button({
+    text: "+1"
+    onClick: @() {
+      count += 1
+      Mk:save("count", count)
+    }
+  })
+])
+```
+
+主要 UI コンポーネント (`Ui:C:*`) と組込み関数の一覧は `aiscript-author`
+skill の「Ui: (ウィジェット UI 構築)」セクションを参照。
+
+## `widgets.create` 呼び出し方
+
+```
+widgets.create({
+  name: "ウィジェット名",
+  src: "/// @ 0.16.0\nUi:render([...])",
+  autoRun: false   // 省略可、default: false
+})
+```
+
+`autoRun` の挙動:
+- `false` (default, **推奨**) — カラム表示時に手動で「起動」ボタンを押す必要がある。
+  ユーザーが意図せずコードが走るのを防ぐ
+- `true` — カラム表示時に自動で AiScript が走る。`@on_note` 相当の副作用は
+  ないが、`Mk:api` を叩くウィジェットなどは autoRun=true だと意図せずネットワーク
+  アクセスが発生する点に注意
+
+**ユーザーが「すぐ動かしたい」「自動で表示したい」と明示しない限り
+`autoRun: false` (= default) のままにすること**。後から `widgets.setAutoRun` で
+切り替えられる (= 可逆な toggle 操作なので confirm なし)。
+
+## 作成後にユーザーに伝えること
+
+create が成功したら短く伝える:
+
+> 「ウィジェット『○○』をインストールしました。ウィジェットカラムから
+> 起動してください。」
+
+`autoRun: true` で作った場合は「カラムを開くと自動で動きます」と一言添える。
+
+## 既存ウィジェットの編集
+
+ユーザーが「さっきのウィジェットを修正して」と言ったら:
+
+1. `widgets.list` で対象を特定 (name で照合)
+2. `widgets.read` で現状の src を取得
+3. 必要な差分だけを反映した **全文** を書く
+4. `aiscript.validate` で構文検証 (上記ループ)
+5. `widgets.update` を呼ぶ
+
+`widgets.update` も確認ダイアログが出る (= ユーザー承認が必要)。
+
+## 自動実行・削除・ロールバック
+
+ユーザーから明示的に依頼されたら以下も呼べる:
+
+- **`widgets.setAutoRun`**: `autoRun` の on/off を切り替える可逆操作なので
+  confirm なしで即実行される。先回りで勝手に autoRun=true にしない
+- **`widgets.delete`**: 不可逆削除 (`Mk:save` 領域も消える)。ユーザーが
+  「もう要らない」「消して」とはっきり言ったときだけ呼ぶ
+- **`widgets.revert`**: 編集履歴 (`widgets.history` で取得) の特定 index に
+  戻す。ユーザーが「さっきの状態に戻して」と言ったときに使う
+
+## やらないこと
+
+- 先回りで勝手に `autoRun: true` にしない (ユーザー意図の明示が必要)
+- ストリーム介入が必要な依頼をウィジェットで実装しようとしない (= plugin に振り分ける)
+- 描画したいだけの依頼を無理に plugin にしない (= ハンドラがないなら widget)
+- `aiscript.validate` をスキップしない (= シンタックスエラーで preflight に
+  弾かれると無駄な round-trip になる)


### PR DESCRIPTION
## Summary

- `aiscript.validate` capability (`aiTool: true`, `permissions: []`, `cheap: true`) を新規追加。AI が `plugins.create` / `widgets.create` 前に呼んで diagnostics を取れる
- Command に `preflight` フックを追加し、dispatcher は permission 後・confirm 前に走らせる。`plugins.create`/`update` / `widgets.create`/`update` で構文検証を preflight 化、壊れた src は確認ダイアログを出さず `preflight_failed` で AI に diagnostics を返す二重防壁
- skill を 3 ファイルに整理: `plugin-author` (手順 / handler) + `widget-author` (手順 / UI) + `aiscript-author` (0.16 文法サマリ)、すべて `mode: always`
- LSP worker / CodeMirror linter の Parser 重複呼び出しを `src/aiscript/validate.ts` に集約

Closes #553 (Phase 1)。Phase 2 (公式 `@aiscript-dev/aiscript-languageserver` の web worker 化による意味解析) は別 issue で対応。

## なぜ

AI は `plugins.create` を呼んだ後でしか構文エラーに気付けず、サイレント失敗 (「保存はできたが動かない」「`@on_note` のシグネチャ違反」) が頻発していた。人間が VSCode で赤線を見ながら直すのと同じ「validate → 修正 → re-validate」ループを AI 内で回せるようにし、ユーザー確認ダイアログに壊れた src が到達するのを防ぐ。

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 898/898 pass (新規: validate.test.ts / aiscript.test.ts / dispatcher preflight / plugins preflight)
- [ ] AI チャットで「Hello を出すプラグイン作って」→ AI が validate を先に呼んで confirm 到達
- [ ] 故意に壊れた src で `plugins.create` を呼ばせて、confirm が出ずに AI が自動再生成するのを確認
- [ ] CodeMirror エディタの AiScript 赤線表示に regress なし

## DoD 対応 (#553)

| Issue DoD | 対応箇所 |
|---|---|
| `aiscript.validate` registry + `aiTool: true` | `src/capabilities/builtins/aiscript.ts` |
| 構文エラーが行・列・メッセージ付きで返る | `src/aiscript/validate.ts` (1-based line/column) |
| skill に validate ループ明記 | `plugin-author.md` / `widget-author.md` (3 回 retry) |
| 壊れた src で confirm 前に diagnostics 返却 | dispatcher preflight + `preflightValidateSrc` |
| vitest 3 ケース | validate.test.ts + aiscript.test.ts + dispatcher.test.ts + plugins.test.ts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)