### PR TITLE
Release v0.28.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Test
         run: pnpm vitest run
+
+      - name: Rust tests (incl. OpenAPI snapshot)
+        run: cargo test --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Test
         run: pnpm vitest run
 
+      - name: Rust tests (incl. OpenAPI snapshot)
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
   build:
     needs: check
     permissions:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.28.0",
+  "version": "0.28.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=3e8283006710ff6c32efdf350eed2aa2a12fa75e#3e8283006710ff6c32efdf350eed2aa2a12fa75e"
+source = "git+https://github.com/hitalin/notecli?rev=59b39c2288b608cc81c434545eb1b3bdd757ba64#59b39c2288b608cc81c434545eb1b3bdd757ba64"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=c3d1eff62bd2e68325e7108c7d771432f6ac93ea#c3d1eff62bd2e68325e7108c7d771432f6ac93ea"
+source = "git+https://github.com/hitalin/notecli?rev=3e8283006710ff6c32efdf350eed2aa2a12fa75e#3e8283006710ff6c32efdf350eed2aa2a12fa75e"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2761,6 +2761,8 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "utoipa",
+ "utoipa-axum",
  "uuid",
  "windows-native-keyring-store",
  "zeroize",
@@ -2812,6 +2814,7 @@ dependencies = [
  "ulid",
  "url",
  "utoipa",
+ "utoipa-axum",
  "uuid",
  "windows",
  "zeroize",
@@ -6108,6 +6111,19 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c25bae5bccc842449ec0c5ddc5cbb6a3a1eaeac4503895dc105a1138f8234a0"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,9 +3,11 @@ name = "notedeck"
 version = "0.28.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
+# `gen_openapi` is a dev-only helper binary; keep `cargo run` (tauri dev) on the app.
+default-run = "notedeck"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "c3d1eff62bd2e68325e7108c7d771432f6ac93ea", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "3e8283006710ff6c32efdf350eed2aa2a12fa75e", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
@@ -43,6 +45,7 @@ encoding_rs = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = { version = "5", features = ["axum_extras"] }
+utoipa-axum = "0.2"
 tauri-plugin-os = "2"
 tauri-plugin-haptics = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default-run = "notedeck"
 
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "3e8283006710ff6c32efdf350eed2aa2a12fa75e", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "59b39c2288b608cc81c434545eb1b3bdd757ba64", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.28.0"
+version = "0.28.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 # `gen_openapi` is a dev-only helper binary; keep `cargo run` (tauri dev) on the app.

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -9,6 +9,19 @@
     "version": "0.28.0"
   },
   "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "operationId": "api_index",
+        "responses": {
+          "200": {
+            "description": "API name, version, auth hint, and the full endpoint list derived from this spec"
+          }
+        }
+      }
+    },
     "/api/accounts": {
       "get": {
         "tags": [
@@ -243,6 +256,22 @@
         ]
       }
     },
+    "/api/docs": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "operationId": "openapi_docs",
+        "responses": {
+          "200": {
+            "description": "Scalar API reference UI (HTML)",
+            "content": {
+              "text/html": {}
+            }
+          }
+        }
+      }
+    },
     "/api/events": {
       "get": {
         "tags": [
@@ -287,6 +316,19 @@
             "bearer_auth": []
           }
         ]
+      }
+    },
+    "/api/openapi.json": {
+      "get": {
+        "tags": [
+          "meta"
+        ],
+        "operationId": "openapi_json",
+        "responses": {
+          "200": {
+            "description": "This OpenAPI 3.1 specification, as JSON"
+          }
+        }
       }
     },
     "/api/{host}/note": {
@@ -2261,6 +2303,10 @@
     {
       "name": "events",
       "description": "Server-sent event stream"
+    },
+    {
+      "name": "meta",
+      "description": "API discovery and documentation"
     }
   ]
 }

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -1,0 +1,2266 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "NoteDeck API",
+    "description": "NoteDeck localhost API — Misskey desktop client control interface",
+    "license": {
+      "name": "MIT"
+    },
+    "version": "0.28.0"
+  },
+  "paths": {
+    "/api/accounts": {
+      "get": {
+        "tags": [
+          "accounts"
+        ],
+        "operationId": "list_accounts",
+        "responses": {
+          "200": {
+            "description": "Logged-in accounts (tokens stripped)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountPublic"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/commands": {
+      "get": {
+        "tags": [
+          "commands"
+        ],
+        "operationId": "list_commands",
+        "responses": {
+          "200": {
+            "description": "Available commands"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/commands/{command_id}/execute": {
+      "post": {
+        "tags": [
+          "commands"
+        ],
+        "operationId": "execute_command",
+        "parameters": [
+          {
+            "name": "command_id",
+            "in": "path",
+            "description": "Command ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Command result"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/deck/active": {
+      "get": {
+        "tags": [
+          "deck"
+        ],
+        "operationId": "get_deck_active",
+        "responses": {
+          "200": {
+            "description": "Active column info"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/deck/columns": {
+      "get": {
+        "tags": [
+          "deck"
+        ],
+        "operationId": "get_deck_columns",
+        "responses": {
+          "200": {
+            "description": "Deck columns list"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "deck"
+        ],
+        "operationId": "add_deck_column",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Column added"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/deck/columns/{column_id}": {
+      "delete": {
+        "tags": [
+          "deck"
+        ],
+        "operationId": "remove_deck_column",
+        "parameters": [
+          {
+            "name": "column_id",
+            "in": "path",
+            "description": "Column ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Column removed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/events": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "operationId": "sse_events",
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Comma-separated event type prefixes to filter the stream",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server-sent event stream (`text/event-stream`). Each event carries an `event:` type and a JSON `data:` payload. OpenAPI cannot model a streaming body, so the schema is shown as a string.",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/note": {
+      "post": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "create_note",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Created note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NormalizedNote"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No account for host",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/notes/{note_id}": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "get_note",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NormalizedNote"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "delete_note",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Note deleted"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/notes/{note_id}/children": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "get_note_children",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of items to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Direct replies to the note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNote"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/notes/{note_id}/conversation": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "get_note_conversation",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of items to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ancestor notes (conversation thread)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNote"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/notes/{note_id}/reactions": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "get_note_reactions",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by reaction type",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of reactions to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "until_id",
+            "in": "query",
+            "description": "Return reactions older than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Reactions on the note",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNoteReaction"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "create_reaction",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReactionBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Reaction added"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "notes"
+        ],
+        "operationId": "delete_reaction",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "description": "Note ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Reaction removed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Note or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/notifications": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "operationId": "get_notifications",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of items to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "since_id",
+            "in": "query",
+            "description": "Return items newer than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "until_id",
+            "in": "query",
+            "description": "Return items older than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNotification"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No account for host",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/search": {
+      "get": {
+        "tags": [
+          "search"
+        ],
+        "operationId": "search_notes",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search query string (required)",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matching notes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNote"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing query parameter: q",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No account for host",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/timeline/{tl_type}": {
+      "get": {
+        "tags": [
+          "timeline"
+        ],
+        "operationId": "get_timeline",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host (e.g. misskey.io)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tl_type",
+            "in": "path",
+            "description": "Timeline type: home | local | social | global",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of items to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "since_id",
+            "in": "query",
+            "description": "Return items newer than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "until_id",
+            "in": "query",
+            "description": "Return items older than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Timeline notes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNote"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No account for host",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/users/{user_id}": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "operationId": "get_user",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NormalizedUserDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/{host}/users/{user_id}/notes": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "operationId": "get_user_notes",
+        "parameters": [
+          {
+            "name": "host",
+            "in": "path",
+            "description": "Account host",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_id",
+            "in": "path",
+            "description": "User ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Max number of items to return (default 20)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "since_id",
+            "in": "query",
+            "description": "Return items newer than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "until_id",
+            "in": "query",
+            "description": "Return items older than this ID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Notes authored by the user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NormalizedNote"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User or account not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/proxy/image": {
+      "get": {
+        "tags": [
+          "proxy"
+        ],
+        "operationId": "proxy_image",
+        "parameters": [
+          {
+            "name": "url",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "w",
+            "in": "query",
+            "description": "Optional max width for thumbnail generation (e.g. 300)",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Optional output format (\"webp\" to convert)",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Proxied image (with 3-layer cache)"
+          },
+          "304": {
+            "description": "Not Modified (ETag match)"
+          },
+          "502": {
+            "description": "Upstream fetch failed"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AccountPublic": {
+        "type": "object",
+        "description": "Token を含まない、フロントエンド向け Account 構造体",
+        "required": [
+          "id",
+          "host",
+          "userId",
+          "username",
+          "software",
+          "hasToken"
+        ],
+        "properties": {
+          "avatarUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "displayName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "hasToken": {
+            "type": "boolean"
+          },
+          "host": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "software": {
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "ApiErrorResponse": {
+        "type": "object",
+        "description": "Error response body",
+        "required": [
+          "error",
+          "message"
+        ],
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error code (e.g. \"NOT_FOUND\", \"UNAUTHORIZED\")"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error message"
+          }
+        }
+      },
+      "AvatarDecoration": {
+        "type": "object",
+        "required": [
+          "id",
+          "url"
+        ],
+        "properties": {
+          "angle": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "flipH": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "offsetX": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "offsetY": {
+            "type": [
+              "number",
+              "null"
+            ],
+            "format": "double"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "Channel": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "color": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateNoteBody": {
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "cw": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Content warning"
+          },
+          "file_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "description": "Attached drive file IDs"
+          },
+          "local_only": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Federate locally only"
+          },
+          "renote_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Renote target note ID"
+          },
+          "reply_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Reply target note ID"
+          },
+          "scheduled_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Schedule the note for this ISO-8601 timestamp"
+          },
+          "text": {
+            "type": "string",
+            "description": "Note body text"
+          },
+          "visibility": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Visibility: public | home | followers | specified"
+          }
+        }
+      },
+      "NormalizedDriveFile": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "type",
+          "url"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "isSensitive": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "thumbnailUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "NormalizedNote": {
+        "type": "object",
+        "required": [
+          "id",
+          "_accountId",
+          "_serverHost",
+          "createdAt",
+          "user",
+          "visibility",
+          "renoteCount",
+          "repliesCount"
+        ],
+        "properties": {
+          "_accountId": {
+            "type": "string"
+          },
+          "_serverHost": {
+            "type": "string"
+          },
+          "channel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Channel"
+              }
+            ]
+          },
+          "channelId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "cw": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "emojis": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NormalizedDriveFile"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "isFavorited": {
+            "type": "boolean"
+          },
+          "localOnly": {
+            "type": "boolean"
+          },
+          "modeFlags": {
+            "type": "object",
+            "description": "Fork-specific mode flags (e.g., isNoteInYamiMode)",
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "myReaction": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "poll": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NormalizedPoll"
+              }
+            ]
+          },
+          "reactionAcceptance": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reactionEmojis": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "reactions": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "renote": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NormalizedNote"
+              }
+            ]
+          },
+          "renoteCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "renoteId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "repliesCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "reply": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NormalizedNote"
+              }
+            ]
+          },
+          "replyId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "text": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updatedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "uri": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "user": {
+            "$ref": "#/components/schemas/NormalizedUser"
+          },
+          "visibility": {
+            "type": "string"
+          },
+          "visibleUserIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "NormalizedNoteReaction": {
+        "type": "object",
+        "required": [
+          "id",
+          "createdAt",
+          "user",
+          "type"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/NormalizedUser"
+          }
+        }
+      },
+      "NormalizedNotification": {
+        "type": "object",
+        "required": [
+          "id",
+          "_accountId",
+          "_serverHost",
+          "createdAt",
+          "type"
+        ],
+        "properties": {
+          "_accountId": {
+            "type": "string"
+          },
+          "_serverHost": {
+            "type": "string"
+          },
+          "achievement": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "note": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NormalizedNote"
+              }
+            ]
+          },
+          "reaction": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reactions": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ReactionInfo"
+            },
+            "description": "Grouped reactions (for reaction:grouped type)"
+          },
+          "type": {
+            "type": "string"
+          },
+          "user": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/NormalizedUser"
+              }
+            ]
+          },
+          "users": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/NormalizedUser"
+            },
+            "description": "Grouped users (for renote:grouped type)"
+          }
+        }
+      },
+      "NormalizedPoll": {
+        "type": "object",
+        "required": [
+          "choices"
+        ],
+        "properties": {
+          "choices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NormalizedPollChoice"
+            }
+          },
+          "expiresAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "multiple": {
+            "type": "boolean"
+          }
+        }
+      },
+      "NormalizedPollChoice": {
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "isVoted": {
+            "type": "boolean"
+          },
+          "text": {
+            "type": "string"
+          },
+          "votes": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "NormalizedUser": {
+        "type": "object",
+        "required": [
+          "id",
+          "username"
+        ],
+        "properties": {
+          "avatarDecorations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvatarDecoration"
+            }
+          },
+          "avatarUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "emojis": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "host": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "instance": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UserInstance"
+              }
+            ]
+          },
+          "isBot": {
+            "type": "boolean"
+          },
+          "isCat": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "NormalizedUserDetail": {
+        "type": "object",
+        "required": [
+          "id",
+          "username"
+        ],
+        "properties": {
+          "avatarDecorations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvatarDecoration"
+            }
+          },
+          "avatarUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bannerUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "birthday": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "emojis": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserField"
+            }
+          },
+          "followedMessage": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "followersCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "followersVisibility": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "followingCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "followingVisibility": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "host": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "isBot": {
+            "type": "boolean"
+          },
+          "isCat": {
+            "type": "boolean"
+          },
+          "isFollowed": {
+            "type": "boolean"
+          },
+          "isFollowing": {
+            "type": "boolean"
+          },
+          "location": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "notesCount": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "onlineStatus": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserRole"
+            }
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "username": {
+            "type": "string"
+          }
+        }
+      },
+      "ReactionBody": {
+        "type": "object",
+        "required": [
+          "reaction"
+        ],
+        "properties": {
+          "reaction": {
+            "type": "string",
+            "description": "Reaction emoji (e.g. \"👍\" or \":custom_emoji:\")"
+          }
+        }
+      },
+      "ReactionInfo": {
+        "type": "object",
+        "required": [
+          "user",
+          "reaction"
+        ],
+        "properties": {
+          "reaction": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/NormalizedUser"
+          }
+        }
+      },
+      "UserField": {
+        "type": "object",
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "UserInstance": {
+        "type": "object",
+        "properties": {
+          "faviconUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "iconUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "themeColor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "UserRole": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "color": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "displayOrder": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "iconUrl": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "deck",
+      "description": "Deck state"
+    },
+    {
+      "name": "commands",
+      "description": "Command execution"
+    },
+    {
+      "name": "proxy",
+      "description": "Image proxy / CDN cache"
+    },
+    {
+      "name": "accounts",
+      "description": "Logged-in accounts"
+    },
+    {
+      "name": "timeline",
+      "description": "Timelines and user notes"
+    },
+    {
+      "name": "notes",
+      "description": "Note read / create / delete / reactions"
+    },
+    {
+      "name": "users",
+      "description": "User profiles"
+    },
+    {
+      "name": "search",
+      "description": "Note search"
+    },
+    {
+      "name": "events",
+      "description": "Server-sent event stream"
+    }
+  ]
+}

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.28.0"
+    "version": "0.28.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/bin/gen_openapi.rs
+++ b/src-tauri/src/bin/gen_openapi.rs
@@ -1,0 +1,20 @@
+//! Regenerates `src-tauri/openapi.json` from the live route annotations.
+//!
+//! Run after changing any HTTP route or response model:
+//!
+//! ```sh
+//! cargo run --bin gen_openapi
+//! ```
+//!
+//! The committed `openapi.json` is the external-facing API artifact and is
+//! verified in CI by `tests/openapi_snapshot.rs`.
+
+use std::path::Path;
+
+fn main() {
+    let spec = notedeck_lib::http_server::build_openapi();
+    let json = serde_json::to_string_pretty(&spec).expect("serialize OpenAPI spec");
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("openapi.json");
+    std::fs::write(&path, format!("{json}\n")).expect("write openapi.json");
+    println!("wrote {}", path.display());
+}

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -4,7 +4,6 @@ use axum::{
     http::{header::AUTHORIZATION, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Response},
-    routing::get,
     Json, Router,
 };
 use serde::Deserialize;
@@ -49,6 +48,7 @@ use notecli::event_bus::EventBus;
         (name = "users", description = "User profiles"),
         (name = "search", description = "Note search"),
         (name = "events", description = "Server-sent event stream"),
+        (name = "meta", description = "API discovery and documentation"),
     ),
 )]
 struct ApiDoc;
@@ -213,54 +213,32 @@ pub async fn serve(config: ServeConfig, ready_tx: tokio::sync::oneshot::Sender<(
     // what we serve. The spec is (re)built via build_openapi() so the served
     // /api/openapi.json, the Tauri command, and the committed snapshot all
     // share a single source of truth.
+    // The full spec — single source of truth, also handed to the meta routes
+    // so `/api` and `/api/openapi.json` serve it without a second derivation.
+    let openapi = Arc::new(build_openapi());
+
+    // Public meta routes (no auth): `/api` index, raw spec, Scalar UI.
+    let meta_routes = meta_openapi_router()
+        .layer(CorsLayer::permissive())
+        .with_state(MetaState {
+            openapi: openapi.clone(),
+            token_path: config.token_path.clone(),
+        });
+
+    // Merge every annotated route into one OpenApiRouter and serve the Router
+    // half. The spec half is discarded — `build_openapi()` above is canonical
+    // (identical content, shared with the snapshot test).
     let (api_router, _) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .merge(core_routes)
         .merge(deck_routes)
         .merge(proxy_routes)
+        .merge(meta_routes)
         .split_for_parts();
-    let openapi = Arc::new(build_openapi());
-
-    // Public index + docs (no auth). The `/api` endpoint list is derived from
-    // the spec via notecli::http_server::endpoints_from_spec — never hand-kept.
-    let meta_routes = {
-        let token_path = config.token_path.clone();
-        let index_spec = openapi.clone();
-        let json_spec = openapi.clone();
-        Router::new()
-            .route(
-                "/api",
-                get(move || {
-                    let token_path = token_path.clone();
-                    let spec = index_spec.clone();
-                    async move {
-                        Json(json!({
-                            "name": "notedeck",
-                            "version": env!("CARGO_PKG_VERSION"),
-                            "auth": "Bearer token required. Read token from the file at tokenPath.",
-                            "tokenPath": token_path,
-                            "docs": "/api/docs",
-                            "openapi": "/api/openapi.json",
-                            "endpoints": notecli::http_server::endpoints_from_spec(&spec),
-                        }))
-                    }
-                }),
-            )
-            .route(
-                "/api/openapi.json",
-                get(move || {
-                    let spec = json_spec.clone();
-                    async move { Json((*spec).clone()) }
-                }),
-            )
-            .route("/api/docs", get(openapi_docs))
-            .layer(CorsLayer::permissive())
-    };
 
     // Rate limiter for upstream Misskey API requests
     let rate_limiter = RateLimiter::new(config.perf);
 
     let app = Router::new()
-        .merge(meta_routes)
         .merge(api_router)
         .layer(middleware::from_fn_with_state(
             rate_limiter.clone(),
@@ -489,13 +467,17 @@ fn proxy_openapi_router() -> OpenApiRouter<DeckState> {
 ///
 /// The single source of truth for the spec: shared by [`serve`]'s
 /// `/api/openapi.json`, the `get_openapi_spec` Tauri command, the
-/// `gen-openapi` binary, and the snapshot test. Merges NoteDeck's deck/proxy
-/// routes and the notecli core routes into the [`ApiDoc`] base, then registers
-/// the `bearer_auth` security scheme once.
+/// `gen-openapi` binary, and the snapshot test. Merges NoteDeck's deck / proxy
+/// / meta routes and the notecli core routes into the [`ApiDoc`] base, then
+/// registers the `bearer_auth` security scheme once.
+///
+/// Every served route is covered — including the meta endpoints (`/api`,
+/// `/api/openapi.json`, `/api/docs`) — so the spec has no gaps.
 pub fn build_openapi() -> utoipa::openapi::OpenApi {
     let mut openapi = ApiDoc::openapi();
     openapi.merge(deck_openapi_router().split_for_parts().1);
     openapi.merge(proxy_openapi_router().split_for_parts().1);
+    openapi.merge(meta_openapi_router().split_for_parts().1);
     openapi.merge(notecli::http_server::core_openapi());
     SecurityAddon.modify(&mut openapi);
     openapi
@@ -506,6 +488,52 @@ pub fn openapi_spec() -> utoipa::openapi::OpenApi {
     build_openapi()
 }
 
+/// State for the public meta routes — carries the generated spec so `/api`
+/// and `/api/openapi.json` serve it directly, no second derivation.
+#[derive(Clone)]
+struct MetaState {
+    openapi: Arc<utoipa::openapi::OpenApi>,
+    token_path: String,
+}
+
+/// Public meta routes (no auth): API discovery, raw spec, Scalar UI.
+fn meta_openapi_router() -> OpenApiRouter<MetaState> {
+    OpenApiRouter::new()
+        .routes(routes!(api_index))
+        .routes(routes!(openapi_json))
+        .routes(routes!(openapi_docs))
+}
+
+#[utoipa::path(
+    get, path = "/api", tag = "meta",
+    responses((status = 200, description = "API name, version, auth hint, and the \
+        full endpoint list derived from this spec")),
+)]
+async fn api_index(State(state): State<MetaState>) -> Json<Value> {
+    Json(json!({
+        "name": "notedeck",
+        "version": env!("CARGO_PKG_VERSION"),
+        "auth": "Bearer token required. Read token from the file at tokenPath.",
+        "tokenPath": state.token_path,
+        "docs": "/api/docs",
+        "openapi": "/api/openapi.json",
+        "endpoints": notecli::http_server::endpoints_from_spec(&state.openapi),
+    }))
+}
+
+#[utoipa::path(
+    get, path = "/api/openapi.json", tag = "meta",
+    responses((status = 200, description = "This OpenAPI 3.1 specification, as JSON")),
+)]
+async fn openapi_json(State(state): State<MetaState>) -> Json<utoipa::openapi::OpenApi> {
+    Json((*state.openapi).clone())
+}
+
+#[utoipa::path(
+    get, path = "/api/docs", tag = "meta",
+    responses((status = 200, description = "Scalar API reference UI (HTML)",
+        content_type = "text/html")),
+)]
 async fn openapi_docs() -> axum::response::Html<&'static str> {
     axum::response::Html(
         r#"<!DOCTYPE html>

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -4,7 +4,7 @@ use axum::{
     http::{header::AUTHORIZATION, StatusCode},
     middleware::{self, Next},
     response::{IntoResponse, Response},
-    routing::{delete, get, post},
+    routing::get,
     Json, Router,
 };
 use serde::Deserialize;
@@ -13,7 +13,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tauri::AppHandle;
 use tower_http::cors::CorsLayer;
-use utoipa::{IntoParams, OpenApi, ToSchema};
+use utoipa::{IntoParams, Modify, OpenApi, ToSchema};
+use utoipa_axum::{router::OpenApiRouter, routes};
 
 use subtle::ConstantTimeEq;
 
@@ -24,6 +25,13 @@ use notecli::api::MisskeyClient;
 use notecli::db::Database;
 use notecli::event_bus::EventBus;
 
+/// Base OpenAPI metadata (info + tags) for the full NoteDeck API.
+///
+/// Paths and component schemas are NOT listed here — they are collected
+/// structurally via [`OpenApiRouter`] + `routes!` so a route cannot be added
+/// without appearing in the spec. NoteDeck owns the complete tag list because
+/// it is the host that produces the final merged spec (NoteDeck-specific tags
+/// plus the notecli core tags).
 #[derive(OpenApi)]
 #[openapi(
     info(
@@ -31,17 +39,17 @@ use notecli::event_bus::EventBus;
         description = "NoteDeck localhost API — Misskey desktop client control interface",
         license(name = "MIT"),
     ),
-    paths(
-        get_deck_columns, add_deck_column, remove_deck_column,
-        get_deck_active, list_commands, execute_command, proxy_image,
-    ),
-    components(schemas(ApiErrorResponse)),
     tags(
         (name = "deck", description = "Deck state"),
         (name = "commands", description = "Command execution"),
         (name = "proxy", description = "Image proxy / CDN cache"),
+        (name = "accounts", description = "Logged-in accounts"),
+        (name = "timeline", description = "Timelines and user notes"),
+        (name = "notes", description = "Note read / create / delete / reactions"),
+        (name = "users", description = "User profiles"),
+        (name = "search", description = "Note search"),
+        (name = "events", description = "Server-sent event stream"),
     ),
-    modifiers(&SecurityAddon),
 )]
 struct ApiDoc;
 
@@ -169,7 +177,8 @@ pub struct ServeConfig {
 /// Phase 2: attach routes and start serving. Requires DB/client.
 /// Sends `()` on `ready_tx` once routes are built and the server is about to accept connections.
 pub async fn serve(config: ServeConfig, ready_tx: tokio::sync::oneshot::Sender<()>) {
-    // Build core Misskey API routes from notecli
+    // Build core Misskey API routes from notecli (OpenApiRouter — route
+    // registration and OpenAPI spec generation stay in lockstep).
     let notecli_state = notecli::http_server::AppState::new(
         config.db,
         config.client,
@@ -186,58 +195,8 @@ pub async fn serve(config: ServeConfig, ready_tx: tokio::sync::oneshot::Sender<(
         image_cache: config.image_cache,
     };
 
-    // NoteDeck index (public, includes all endpoints)
-    let index_route = {
-        let token_path = config.token_path.clone();
-        Router::new()
-            .route(
-                "/api",
-                get(move || async move {
-                    Json(json!({
-                        "name": "notedeck",
-                        "version": env!("CARGO_PKG_VERSION"),
-                        "auth": "Bearer token required. Read token from the file at tokenPath.",
-                        "tokenPath": token_path,
-                        "docs": "/api/docs",
-                        "openapi": "/api/openapi.json",
-                        "endpoints": [
-                            { "method": "GET",    "path": "/api",                                  "description": "This endpoint list" },
-                            { "method": "GET",    "path": "/api/accounts",                         "description": "List accounts (no tokens)" },
-                            { "method": "GET",    "path": "/api/{host}/timeline/{type}",           "description": "Get timeline notes" },
-                            { "method": "GET",    "path": "/api/{host}/notifications",             "description": "Get notifications" },
-                            { "method": "POST",   "path": "/api/{host}/note",                      "description": "Create a note" },
-                            { "method": "GET",    "path": "/api/{host}/search?q=...",              "description": "Search notes" },
-                            { "method": "GET",    "path": "/api/{host}/notes/{id}",                "description": "Get a note" },
-                            { "method": "DELETE", "path": "/api/{host}/notes/{id}",                "description": "Delete a note" },
-                            { "method": "GET",    "path": "/api/{host}/notes/{id}/children",       "description": "Get note replies" },
-                            { "method": "GET",    "path": "/api/{host}/notes/{id}/conversation",   "description": "Get note conversation" },
-                            { "method": "GET",    "path": "/api/{host}/notes/{id}/reactions",      "description": "Get note reactions" },
-                            { "method": "POST",   "path": "/api/{host}/notes/{id}/reactions",      "description": "Add reaction" },
-                            { "method": "DELETE", "path": "/api/{host}/notes/{id}/reactions",      "description": "Remove reaction" },
-                            { "method": "GET",    "path": "/api/{host}/users/{id}",                "description": "Get user detail" },
-                            { "method": "GET",    "path": "/api/{host}/users/{id}/notes",          "description": "Get user notes" },
-                            { "method": "GET",    "path": "/api/events",                           "description": "SSE event stream" },
-                            { "method": "GET",    "path": "/api/deck/columns",                     "description": "List deck columns" },
-                            { "method": "POST",   "path": "/api/deck/columns",                     "description": "Add deck column" },
-                            { "method": "DELETE", "path": "/api/deck/columns/{id}",                "description": "Remove deck column" },
-                            { "method": "GET",    "path": "/api/deck/active",                      "description": "Get active column" },
-                            { "method": "GET",    "path": "/api/commands",                         "description": "List commands" },
-                            { "method": "POST",   "path": "/api/commands/{id}/execute",            "description": "Execute command" },
-                        ]
-                    }))
-                }),
-            )
-            .layer(CorsLayer::permissive())
-    };
-
     // Authenticated NoteDeck-specific routes (deck, commands)
-    let deck_routes = Router::new()
-        .route("/api/deck/columns", get(get_deck_columns))
-        .route("/api/deck/columns", post(add_deck_column))
-        .route("/api/deck/columns/{column_id}", delete(remove_deck_column))
-        .route("/api/deck/active", get(get_deck_active))
-        .route("/api/commands", get(list_commands))
-        .route("/api/commands/{command_id}/execute", post(execute_command))
+    let deck_routes = deck_openapi_router()
         .layer(middleware::from_fn_with_state(
             deck_state.clone(),
             deck_auth_middleware,
@@ -245,22 +204,64 @@ pub async fn serve(config: ServeConfig, ready_tx: tokio::sync::oneshot::Sender<(
         .layer(CorsLayer::permissive())
         .with_state(deck_state.clone());
 
-    // Public routes (no auth)
-    let public_routes = Router::new()
-        .route("/proxy/image", get(proxy_image))
-        .route("/api/openapi.json", get(openapi_json))
-        .route("/api/docs", get(openapi_docs))
+    // Public image proxy (no auth)
+    let proxy_routes = proxy_openapi_router()
         .layer(CorsLayer::permissive())
         .with_state(deck_state);
+
+    // Merge every annotated route into one OpenApiRouter — the Router half is
+    // what we serve. The spec is (re)built via build_openapi() so the served
+    // /api/openapi.json, the Tauri command, and the committed snapshot all
+    // share a single source of truth.
+    let (api_router, _) = OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .merge(core_routes)
+        .merge(deck_routes)
+        .merge(proxy_routes)
+        .split_for_parts();
+    let openapi = Arc::new(build_openapi());
+
+    // Public index + docs (no auth). The `/api` endpoint list is derived from
+    // the spec via notecli::http_server::endpoints_from_spec — never hand-kept.
+    let meta_routes = {
+        let token_path = config.token_path.clone();
+        let index_spec = openapi.clone();
+        let json_spec = openapi.clone();
+        Router::new()
+            .route(
+                "/api",
+                get(move || {
+                    let token_path = token_path.clone();
+                    let spec = index_spec.clone();
+                    async move {
+                        Json(json!({
+                            "name": "notedeck",
+                            "version": env!("CARGO_PKG_VERSION"),
+                            "auth": "Bearer token required. Read token from the file at tokenPath.",
+                            "tokenPath": token_path,
+                            "docs": "/api/docs",
+                            "openapi": "/api/openapi.json",
+                            "endpoints": notecli::http_server::endpoints_from_spec(&spec),
+                        }))
+                    }
+                }),
+            )
+            .route(
+                "/api/openapi.json",
+                get(move || {
+                    let spec = json_spec.clone();
+                    async move { Json((*spec).clone()) }
+                }),
+            )
+            .route("/api/docs", get(openapi_docs))
+            .layer(CorsLayer::permissive())
+    };
 
     // Rate limiter for upstream Misskey API requests
     let rate_limiter = RateLimiter::new(config.perf);
 
     let app = Router::new()
-        .merge(index_route)
-        .merge(core_routes)
-        .merge(deck_routes)
-        .merge(public_routes)
+        .merge(meta_routes)
+        .merge(api_router)
         .layer(middleware::from_fn_with_state(
             rate_limiter.clone(),
             rate_limit::rate_limit_middleware,
@@ -467,13 +468,42 @@ async fn execute_command(
 
 // --- OpenAPI docs ---
 
-/// Return the OpenAPI spec (used by both the HTTP endpoint and the Tauri command).
-pub fn openapi_spec() -> utoipa::openapi::OpenApi {
-    ApiDoc::openapi()
+/// NoteDeck-specific deck/command routes, as an [`OpenApiRouter`].
+/// Used by both [`serve`] (runtime router) and [`build_openapi`] (state-free
+/// spec) — `routes!` keeps registration and spec in lockstep.
+fn deck_openapi_router() -> OpenApiRouter<DeckState> {
+    OpenApiRouter::new()
+        .routes(routes!(get_deck_columns, add_deck_column))
+        .routes(routes!(remove_deck_column))
+        .routes(routes!(get_deck_active))
+        .routes(routes!(list_commands))
+        .routes(routes!(execute_command))
 }
 
-async fn openapi_json() -> Json<utoipa::openapi::OpenApi> {
-    Json(openapi_spec())
+/// Public image-proxy route, as an [`OpenApiRouter`].
+fn proxy_openapi_router() -> OpenApiRouter<DeckState> {
+    OpenApiRouter::new().routes(routes!(proxy_image))
+}
+
+/// Build the full merged OpenAPI spec without any runtime state.
+///
+/// The single source of truth for the spec: shared by [`serve`]'s
+/// `/api/openapi.json`, the `get_openapi_spec` Tauri command, the
+/// `gen-openapi` binary, and the snapshot test. Merges NoteDeck's deck/proxy
+/// routes and the notecli core routes into the [`ApiDoc`] base, then registers
+/// the `bearer_auth` security scheme once.
+pub fn build_openapi() -> utoipa::openapi::OpenApi {
+    let mut openapi = ApiDoc::openapi();
+    openapi.merge(deck_openapi_router().split_for_parts().1);
+    openapi.merge(proxy_openapi_router().split_for_parts().1);
+    openapi.merge(notecli::http_server::core_openapi());
+    SecurityAddon.modify(&mut openapi);
+    openapi
+}
+
+/// Return the OpenAPI spec (used by the Tauri command `get_openapi_spec`).
+pub fn openapi_spec() -> utoipa::openapi::OpenApi {
+    build_openapi()
 }
 
 async fn openapi_docs() -> axum::response::Html<&'static str> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,9 @@ use tauri_plugin_global_shortcut::GlobalShortcutExt;
 mod commands;
 #[cfg(target_os = "windows")]
 mod hwheel_hook;
-mod http_server;
+/// Public so the `gen-openapi` binary and the OpenAPI snapshot test can call
+/// [`http_server::build_openapi`].
+pub mod http_server;
 mod image_cache;
 mod migrations;
 mod ogp;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tests/openapi_snapshot.rs
+++ b/src-tauri/tests/openapi_snapshot.rs
@@ -1,0 +1,19 @@
+//! Guards that the committed `openapi.json` snapshot stays in sync with the
+//! route annotations. Because routes are registered via `utoipa-axum`'s
+//! `routes!` macro, the spec always reflects the code — this test makes the
+//! committed artifact a reviewable diff: any API surface change shows up in
+//! `openapi.json` in the PR.
+//!
+//! If this test fails, run `cargo run --bin gen_openapi` and commit the result.
+
+#[test]
+fn openapi_snapshot_is_current() {
+    let spec = notedeck_lib::http_server::build_openapi();
+    let generated = serde_json::to_string_pretty(&spec).expect("serialize OpenAPI spec");
+    let committed = include_str!("../openapi.json");
+    assert_eq!(
+        generated.trim(),
+        committed.trim(),
+        "openapi.json is stale — run `cargo run --bin gen_openapi` and commit the result",
+    );
+}


### PR DESCRIPTION
## 変更内容

v0.28.0 以降の変更点（バージョンバンプを除く）:

- feat(api): OpenAPI spec を全 22 エンドポイントに拡張
- feat(api): メタエンドポイント 3 本も OpenAPI spec に掲載し全数網羅
- chore(deps): notecli を main マージ後の rev に再ピン

## なぜ

OpenAPI spec を全エンドポイント網羅まで拡張したパッチリリース。notecli 依存も main マージ後の rev に再ピン。

🤖 Generated with [Claude Code](https://claude.com/claude-code)