### PR TITLE
docs: README のセキュリティモデル節を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,6 @@ yay -S misskey-notedeck-bin
 nix run github:hitalin/notedeck
 ```
 
-## セキュリティモデル
-
-NoteDeck は Misskey トークン・AI API キー・外部サービス接続 (Secret Vault) のシークレットを **OS のキーチェーン** (macOS Keychain / Windows Credential Manager / Linux Secret Service) に格納し、フロントエンドや AI には raw な値を渡しません。外部 API へのリクエストは Rust 側でシークレットを注入し、SSRF 防御 (loopback / private アドレス拒否、DNS pinning、リダイレクト再検証) を通します。
-
-ただし **同じ OS ユーザーで動く他のプロセス** (同一アカウント上のマルウェア等) は防御対象外です。OS キーチェーンは「別ユーザー・リモートからの窃取」を防ぎますが、同一ユーザー権限を持つプロセスからの読み取りは OS の責務であり、NoteDeck では防げません。高い脅威環境では OS レベルの対策 (フルディスク暗号化、信頼できるソフトウェアのみの実行) を併用してください。
-
 ## 貢献する
 
 PR を歓迎します。詳しくは [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -547,6 +547,7 @@ skill / widget / plugin / theme の **write 系 capability** (`skills.replaceSec
 
 | 項目 | 状態 | 備考 |
 |------|------|------|
+| 同一 OS ユーザーの他プロセス | 受容 | OS キーチェーンは別ユーザー・リモートからの窃取を防ぐが、同一ユーザー権限のプロセス (同一アカウント上のマルウェア等) からの読み取りは OS の責務。高い脅威環境ではフルディスク暗号化・信頼できるソフトウェアのみの実行を併用する |
 | CSP `unsafe-eval` | 受容 | AiScript エンジンが必要とするため除去不可 |
 | SSRF DNS TOCTOU | 受容 | デスクトップアプリでは脅威が限定的。DNS 解決後の IP 再検証は VPN / 社内 Misskey ユーザーをブロックするため実装しない |
 | Tor (.onion) 非対応 | 受容 | HTTPS 強制の緩和はセキュリティ劣化を招き、SOCKS5 対応も VPN には不要。`.onion` Misskey インスタンスの需要もないため対応しない |


### PR DESCRIPTION
## なぜ

README の「セキュリティモデル」節は `SECURITY.md`（全 11 章）が既に網羅しており冗長だった。READMEはインストールと概要に絞る。

## 変更

- README.md: 「セキュリティモデル」節（2 段落）を削除。ドキュメントナビ行の `[Security](SECURITY.md)` リンクは維持
- SECURITY.md: README にしかなかった「同一 OS ユーザーの他プロセスは防御対象外」の脅威モデル但し書きを「11. 既知の制限」表に移設

🤖 Generated with [Claude Code](https://claude.com/claude-code)