### PR TITLE
fix(build): gen_openapi の macOS バンドル失敗を修正

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,6 +6,14 @@ edition = "2021"
 # `gen_openapi` is a dev-only helper binary; keep `cargo run` (tauri dev) on the app.
 default-run = "notedeck"
 
+# `gen_openapi` is gated behind a feature so neither `cargo build` nor the Tauri
+# bundler picks it up — otherwise the macOS universal build fails trying to
+# bundle a binary that was never lipo'd. Regenerate with:
+#   cargo run --bin gen_openapi --features gen-openapi
+[[bin]]
+name = "gen_openapi"
+required-features = ["gen-openapi"]
+
 [dependencies]
 notecli = { git = "https://github.com/hitalin/notecli", rev = "59b39c2288b608cc81c434545eb1b3bdd757ba64", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
@@ -62,6 +70,8 @@ windows = { version = "0.61", features = [
 [features]
 default = ["desktop"]
 desktop = ["tauri/tray-icon", "dep:tauri-plugin-global-shortcut", "dep:tauri-plugin-autostart", "dep:tauri-plugin-updater", "dep:tauri-plugin-process"]
+# Enables the `gen_openapi` dev-only helper binary.
+gen-openapi = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/bin/gen_openapi.rs
+++ b/src-tauri/src/bin/gen_openapi.rs
@@ -3,7 +3,7 @@
 //! Run after changing any HTTP route or response model:
 //!
 //! ```sh
-//! cargo run --bin gen_openapi
+//! cargo run --bin gen_openapi --features gen-openapi
 //! ```
 //!
 //! The committed `openapi.json` is the external-facing API artifact and is

--- a/src-tauri/tests/openapi_snapshot.rs
+++ b/src-tauri/tests/openapi_snapshot.rs
@@ -4,7 +4,7 @@
 //! committed artifact a reviewable diff: any API surface change shows up in
 //! `openapi.json` in the PR.
 //!
-//! If this test fails, run `cargo run --bin gen_openapi` and commit the result.
+//! If this test fails, run `cargo run --bin gen_openapi --features gen-openapi` and commit the result.
 
 #[test]
 fn openapi_snapshot_is_current() {
@@ -14,6 +14,6 @@ fn openapi_snapshot_is_current() {
     assert_eq!(
         generated.trim(),
         committed.trim(),
-        "openapi.json is stale — run `cargo run --bin gen_openapi` and commit the result",
+        "openapi.json is stale — run `cargo run --bin gen_openapi --features gen-openapi` and commit the result",
     );
 }


### PR DESCRIPTION
## 変更内容

v0.28.1 の release ワークフローで macOS universal ビルドが失敗した問題を修正。

- `gen_openapi` を `required-features = ["gen-openapi"]` でゲート
- デフォルトの `cargo build` / `tauri build` の対象外にし、Tauri バンドラーが取り込まないようにする

## なぜ

OpenAPI PR で新規追加した dev 専用バイナリ `gen_openapi` を Tauri バンドラーが universal バイナリとして取り込もうとしたが、lipo されていないため `binary does not exist` で macOS ビルドが失敗していた。snapshot テスト (`openapi_snapshot.rs`) は `build_openapi()` を直接呼ぶためバイナリには依存せず、影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)