### PR TITLE
feat(ai): AI Spotlight + sidebar.toggle capability + エラー表示改善

### DIFF
--- a/src/capabilities/builtins/column.ts
+++ b/src/capabilities/builtins/column.ts
@@ -500,6 +500,63 @@ export const columnUpdateSettingsCapability: Command = {
   },
 }
 
+/**
+ * `sidebar.toggle` — サイドバースロット (左ナビバー連動の単一カラム枠) を
+ * 指定 type で開閉する。既に同 type が開いていれば閉じる (toggle 動作)。
+ *
+ * 「サイドバーで通知を開いて」のような AI 依頼に対応するための capability。
+ * `column.add` (デッキに新規追加) とは別物: こちらは置換式の単一スロットを
+ * 操作する (= ナビバーボタンをクリックしたのと同じ動作)。
+ */
+export const sidebarToggleCapability: Command = {
+  id: 'sidebar.toggle',
+  label: 'サイドバーで開閉',
+  icon: 'ti-layout-sidebar',
+  category: 'column',
+  shortcuts: [],
+  aiTool: true,
+  permissions: [],
+  signature: {
+    description:
+      'サイドバースロットを指定タイプで開く (既に同タイプなら閉じる)。' +
+      ' navbar ボタンクリックと同じ動作。デッキへの新規追加ではない。',
+    params: {
+      type: {
+        type: 'string',
+        description:
+          'カラム種別 (notifications / chat / search / ai / memos など)',
+        enum: ADDABLE_COLUMN_TYPES,
+      },
+      accountId: {
+        type: 'string',
+        description: 'アカウント ID。省略時は cross-account (null)',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '{ type, opened: true 開いた / false 閉じた }',
+    },
+  },
+  visible: false,
+  execute: (params) => {
+    const type = typeof params?.type === 'string' ? params.type : ''
+    if (!ADDABLE_COLUMN_TYPES.includes(type as ColumnType)) {
+      throw new Error(
+        `Unsupported column type "${type}". ` +
+          `Supported: ${ADDABLE_COLUMN_TYPES.join(', ')}`,
+      )
+    }
+    const accountId =
+      typeof params?.accountId === 'string' ? params.accountId : null
+    const deck = useDeckStore()
+    deck.toggleSidebarColumn(type as ColumnType, accountId)
+    const after = deck.columns.find((c) => c.sidebar)
+    const opened = after != null && after.type === type
+    return { type, opened }
+  },
+}
+
 export const COLUMN_BUILTIN_CAPABILITIES: readonly Command[] = [
   columnActiveCapability,
   columnFocusedNoteCapability,
@@ -508,4 +565,5 @@ export const COLUMN_BUILTIN_CAPABILITIES: readonly Command[] = [
   columnRemoveCapability,
   columnMoveCapability,
   columnUpdateSettingsCapability,
+  sidebarToggleCapability,
 ]

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -36,6 +36,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'column.move',
         'column.remove',
         'column.updateSettings',
+        'sidebar.toggle',
         'drafts.create',
         'drafts.delete',
         'drafts.list',

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -1,10 +1,13 @@
-import { afterEach, describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Command } from '@/commands/registry'
 import {
   type AiConfig,
   defaultConfig,
   setPermissionPreset,
 } from '@/composables/useAiConfig'
+import { useSpotlightStore } from '@/composables/useSpotlight'
 import { dispatchCapability } from './dispatcher'
 import { _clearCapabilitiesForTest, registerCapability } from './registry'
 
@@ -32,6 +35,13 @@ function configWithPreset(preset: 'readonly' | 'safe' | 'full'): AiConfig {
 afterEach(() => {
   _clearCapabilitiesForTest()
 })
+
+// nextTick の microtask を flush するためのヘルパー (dispatcher は void nextTick で
+// spotlight を emit するので、await で済む)
+async function flushNextTick() {
+  await Promise.resolve()
+  await Promise.resolve()
+}
 
 describe('dispatchCapability', () => {
   it('returns ok + result for a registered no-permission capability', async () => {
@@ -464,5 +474,123 @@ describe('dispatchCapability — confirmation flow', () => {
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.code).toBe('permission_denied')
     expect(confirmCalls).toBe(0)
+  })
+})
+
+describe('dispatchCapability spotlight emission', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('column.add 成功時に新規カラム本体 (column:<id>) を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.add',
+        execute: (params) => ({
+          id: 'col-1',
+          type: (params as { type?: string } | undefined)?.type,
+        }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    const r = await dispatchCapability(
+      'column.add',
+      { type: 'notifications' },
+      configWithPreset('full'),
+    )
+
+    expect(r.ok).toBe(true)
+    await flushNextTick()
+    // bottombar / mobile-nav タブが反応する target
+    expect(store.isActive('column:col-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain('通知')
+    // ナビバー (サイドバースロット) は対象外
+    expect(store.isActive('navbar:notifications:null')).toBe(false)
+  })
+
+  it('column.add に accountId が指定されていても target は column id ベース', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.add',
+        execute: (params) => ({
+          id: 'col-2',
+          type: (params as { type?: string } | undefined)?.type,
+        }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'column.add',
+      { type: 'chat', accountId: 'abc' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('column:col-2')).toBe(true)
+  })
+
+  it('column.add 以外の capability では spotlight を emit しない', async () => {
+    registerCapability(makeCapability({ id: 'time.now', execute: () => 'now' }))
+
+    const store = useSpotlightStore()
+    await dispatchCapability('time.now', undefined, configWithPreset('full'))
+
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+  })
+
+  it('permission_denied のときは spotlight を emit しない', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.add',
+        permissions: ['notes.write'],
+        execute: () => ({ id: 'col-3', type: 'notifications' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    const r = await dispatchCapability(
+      'column.add',
+      { type: 'notifications' },
+      configWithPreset('readonly'),
+    )
+
+    expect(r.ok).toBe(false)
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+  })
+
+  it('execute_failed のときは spotlight を emit しない', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.add',
+        execute: () => {
+          throw new Error('boom')
+        },
+      }),
+    )
+
+    const store = useSpotlightStore()
+    const r = await dispatchCapability(
+      'column.add',
+      { type: 'notifications' },
+      configWithPreset('full'),
+    )
+
+    expect(r.ok).toBe(false)
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+  })
+
+  it('vi.useFakeTimers と無関係に highlight が同期反映される (Map にエントリが入る)', () => {
+    // 防御テスト: vi.useFakeTimers を使わなくても store API は同期で動く
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null')
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+    vi.useRealTimers()
   })
 })

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -18,7 +18,11 @@ import {
   type PermissionKey,
   resolvePermissions,
 } from '@/composables/useAiConfig'
-import { columnTargetId, useSpotlightStore } from '@/composables/useSpotlight'
+import {
+  columnTargetId,
+  navbarTargetId,
+  useSpotlightStore,
+} from '@/composables/useSpotlight'
 import {
   type ConfirmDecision,
   type ConfirmOptions,
@@ -167,6 +171,20 @@ function emitSpotlightFromCapability(
         '[spotlight] column.add succeeded but cannot derive target:',
         { newColumnId, type, result, params },
       )
+    }
+  } else if (capId === 'sidebar.toggle') {
+    // サイドバースロットを開閉した → ナビバーボタンが反応する target
+    const r = result as { type?: string; opened?: boolean } | null
+    const type = r?.type ?? (params?.type as string | undefined)
+    const accountId = (params?.accountId as string | null | undefined) ?? null
+    // 「開いた」ときだけ spotlight (閉じた = もうそのボタンを見る理由がない)
+    if (r?.opened && type) {
+      const label = COLUMN_LABELS[type] ?? type
+      const targetId = navbarTargetId(type, accountId)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}カラムをサイドバーに開きました`,
+      })
     }
   }
 }

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -10,12 +10,15 @@
  * ので、ユーザーが `safe` プリセットを選んでいれば書き込み系は自動 deny される。
  */
 
+import { nextTick } from 'vue'
+import { COLUMN_LABELS } from '@/columns/registry'
 import type { Command } from '@/commands/registry'
 import {
   type AiConfig,
   type PermissionKey,
   resolvePermissions,
 } from '@/composables/useAiConfig'
+import { columnTargetId, useSpotlightStore } from '@/composables/useSpotlight'
 import {
   type ConfirmDecision,
   type ConfirmOptions,
@@ -110,12 +113,60 @@ export async function dispatchCapability(
   }
   try {
     const result = await cap.execute(params, { aiConfig })
+    // AI 操作の可視化: 成功時のみ、対応する UI 要素を一時的に光らせる。
+    // DOM 更新後 (navbar に新 item が反映されてから) に highlight する。
+    // 防御: spotlight 副作用が万一失敗しても本体 (AI flow) に影響しないよう
+    // catch + Promise rejection 無視で完全分離する。
+    void nextTick(() => {
+      try {
+        emitSpotlightFromCapability(cap.id, params, result)
+      } catch (err) {
+        console.warn('[dispatcher] spotlight emit failed (ignored):', err)
+      }
+    }).catch((err) => {
+      console.warn('[dispatcher] spotlight nextTick rejected (ignored):', err)
+    })
     return { ok: true, result }
   } catch (e) {
     return {
       ok: false,
       code: 'execute_failed',
       error: e instanceof Error ? e.message : String(e),
+    }
+  }
+}
+
+/**
+ * Capability 実行成功後に、対応する UI 要素を spotlight する。
+ * ユーザークリックは dispatcher を通らないので、自然に AI 経由だけが光る。
+ * MVP は `column.add` → navbar ボタン のみ。Phase 2 で拡張。
+ */
+function emitSpotlightFromCapability(
+  capId: string,
+  params: Record<string, unknown> | undefined,
+  result: unknown,
+): void {
+  // === DEBUG: spotlight 発火を必ず追える console.log ===
+  console.debug('[spotlight] capability succeeded:', { capId, params, result })
+  if (capId === 'column.add') {
+    // 新規追加されたカラム本体 (= bottombar / mobile nav のタブが反応する)
+    // を spotlight する。ナビバー (= サイドバースロット) は AI による
+    // 新規カラム追加では破壊的になり得るので対象にしない (#feedback)。
+    const r = result as { id?: string; type?: string } | null
+    const newColumnId = r?.id
+    const type = r?.type ?? (params?.type as string | undefined)
+    if (newColumnId && type) {
+      const label = COLUMN_LABELS[type] ?? type
+      const targetId = columnTargetId(newColumnId)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}カラムを追加しました`,
+      })
+    } else {
+      console.warn(
+        '[spotlight] column.add succeeded but cannot derive target:',
+        { newColumnId, type, result, params },
+      )
     }
   }
 }

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -37,6 +37,7 @@ import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
+import { extractErrorMessage } from '@/utils/errors'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { resolveIdentity } from '@/utils/identity'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
@@ -706,7 +707,12 @@ async function sendMessage() {
       void generateAiTitleAsync(sessionId, text, finalAssistantText)
     }
   } catch (e) {
-    const message = e instanceof Error ? e.message : String(e)
+    // 診断: AI ストリーム失敗時の raw error を console に dump。
+    // [object Object] 表示の根本原因 (= 想定外の error shape) を追跡しやすくする。
+    console.error('[ai-column] stream error raw:', e)
+    // 任意の error shape (Error / `{code,message}` / 入れ子オブジェクト / 文字列)
+    // から表示可能な文字列を取り出す。`[object Object]` 化を防ぐ。
+    const message = extractErrorMessage(e)
     const cur = sessionsStore.get(sessionId)
     if (cur) {
       const last = cur.messages[cur.messages.length - 1]

--- a/src/components/deck/DeckBottomBar.vue
+++ b/src/components/deck/DeckBottomBar.vue
@@ -4,6 +4,7 @@ import { useCommandStore } from '@/commands/registry'
 import ColumnBadges from '@/components/common/ColumnBadges.vue'
 import { useColumnBadge } from '@/composables/useColumnBadge'
 import { useColumnTabs } from '@/composables/useColumnTabs'
+import { columnTargetId, useSpotlightStore } from '@/composables/useSpotlight'
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
@@ -51,6 +52,12 @@ function onAddColumnClick() {
 }
 
 const { getBadge, clearBadge } = useColumnBadge()
+const spotlightStore = useSpotlightStore()
+
+/** group のいずれかのカラム ID が spotlight 中なら true */
+function isGroupSpotlighted(group: readonly string[]): boolean {
+  return group.some((id) => spotlightStore.spotlights.has(columnTargetId(id)))
+}
 
 const {
   visibleGroups,
@@ -85,8 +92,16 @@ const {
         v-for="(group, gi) in visibleGroups"
         :key="groupPrimaryId(group)"
         class="_button"
-        :class="[$style.tab, { [$style.tabActive]: activeColumnIndex === gi }]"
-        @click="clearBadge(columnType(groupPrimaryId(group))); emit('scroll-to-column', gi)"
+        :class="[
+          $style.tab,
+          { [$style.tabActive]: activeColumnIndex === gi },
+          isGroupSpotlighted(group) && $style.spotlighted,
+        ]"
+        @click="
+          group.forEach((id) => spotlightStore.clear(columnTargetId(id)));
+          clearBadge(columnType(groupPrimaryId(group)));
+          emit('scroll-to-column', gi)
+        "
       >
         <div :class="$style.iconWrap">
           <i :class="'ti ti-' + columnIcon(groupPrimaryId(group))" />
@@ -235,6 +250,62 @@ const {
 
 .stackBadge { @include nav-stack-badge; }
 .badge { @include nav-badge; }
+
+// AI 操作の可視化 (Spotlight): Windows タスクバーの「新規起動」インジケーター風。
+// 朱色 #E34234 背景 + オレンジグラデーション枠線 + 上向き glow。
+// Misskey accent (#86b300, 黄緑) との warm/cool 対比で「AI 由来の出来事」を
+// 視覚的に分離しつつ、補色ではないので馴染む。
+//
+// 既存 .tabActive が ::after で短い緑バーを描いているので、spotlight 中は
+// それを隠して朱色バー (より長い) だけ見せる。
+.spotlighted {
+  position: relative;
+  isolation: isolate;
+
+  // spotlight 中は既存アクティブバー (緑) と被らないよう隠す
+  &.tabActive::after {
+    display: none;
+  }
+
+  // アイテム全体をクリーム→オレンジ→朱色のグラデで塗りつぶす
+  // 3 ストップで明度差を作ることでグラデが視認できる。alpha 0.85 で軽く透過。
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      180deg,
+      rgba(170, 30, 30, 0.55) 0%,
+      rgba(200, 55, 45, 0.3) 50%,
+      rgba(220, 90, 80, 0.05) 100%
+    );
+    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    pointer-events: none;
+    z-index: 0;
+    animation: spotlightFill 2.4s ease-out 1 forwards;
+  }
+
+  // 子要素 (アイコン/バッジ) を色レイヤーより上に持ち上げる
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::before {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}
+
+@keyframes spotlightFill {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
+}
 
 .actionBtn {
   display: flex;

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -20,6 +20,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { usePortal } from '@/composables/usePortal'
 import { useRippleEffect } from '@/composables/useRippleEffect'
 import { provideScrollDirection } from '@/composables/useScrollDirection'
+import { useSpotlightStore } from '@/composables/useSpotlight'
 import { useUpdater } from '@/composables/useUpdater'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
@@ -47,6 +48,7 @@ const {
 } = useNavigation()
 const commandStore = useCommandStore()
 const deckStore = useDeckStore()
+const spotlightStore = useSpotlightStore()
 const uiStore = useUiStore()
 const accountsStore = useAccountsStore()
 const isCompact = useIsCompactLayout()
@@ -233,6 +235,11 @@ function acceptCrossWindowDrop() {
 
 <template>
   <div :class="[$style.root, { [$style.mobile]: isCompact }]">
+    <!-- Spotlight 用 SR-only aria-live 領域 (AI 操作のテキスト読み上げ) -->
+    <div :class="$style.srOnly" aria-live="polite" aria-atomic="true">
+      {{ spotlightStore.lastAnnouncement }}
+    </div>
+
     <DeckNavbar
       ref="navbarRef"
       :mobile-drawer-open="mobileDrawerOpen"
@@ -352,6 +359,20 @@ function acceptCrossWindowDrop() {
   flex: 1;
   min-height: 0;
   width: 100%;
+}
+
+// Spotlight (AI 操作可視化) 用 SR-only aria-live region。
+// 視覚的には不可視、スクリーンリーダーのみ拾う。
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .mobile {

--- a/src/components/deck/DeckMobileNav.vue
+++ b/src/components/deck/DeckMobileNav.vue
@@ -3,6 +3,7 @@ import { ref, watch } from 'vue'
 import ColumnBadges from '@/components/common/ColumnBadges.vue'
 import { useColumnBadge } from '@/composables/useColumnBadge'
 import { useColumnTabs } from '@/composables/useColumnTabs'
+import { columnTargetId, useSpotlightStore } from '@/composables/useSpotlight'
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 
 const props = defineProps<{
@@ -35,6 +36,11 @@ watch(
 )
 
 const { getBadge } = useColumnBadge()
+const spotlightStore = useSpotlightStore()
+
+function isGroupSpotlighted(group: readonly string[]): boolean {
+  return group.some((id) => spotlightStore.spotlights.has(columnTargetId(id)))
+}
 
 const {
   visibleGroups,
@@ -64,8 +70,15 @@ const {
         v-for="(group, gi) in visibleGroups"
         :key="groupPrimaryId(group)"
         class="_button"
-        :class="[$style.tab, { [$style.active]: activeColumnIndex === gi }]"
-        @click="emit('scroll-to-column', gi)"
+        :class="[
+          $style.tab,
+          { [$style.active]: activeColumnIndex === gi },
+          isGroupSpotlighted(group) && $style.spotlighted,
+        ]"
+        @click="
+          group.forEach((id) => spotlightStore.clear(columnTargetId(id)));
+          emit('scroll-to-column', gi)
+        "
       >
         <div :class="$style.iconWrap">
           <i :class="'ti ti-' + columnIcon(groupPrimaryId(group))" />
@@ -169,5 +182,52 @@ const {
 
 .stackBadge { @include nav-stack-badge; }
 .badge { @include nav-badge; }
+
+// AI 操作の可視化 (Spotlight): Windows タスクバー風アンダーバー (朱色 + オレンジ枠)。
+// 既存 .active が ::after で短い緑バーを描くので、spotlight 中は隠して朱色バー優先。
+.spotlighted {
+  position: relative;
+  isolation: isolate;
+
+  &.active::after {
+    display: none;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      180deg,
+      rgba(170, 30, 30, 0.55) 0%,
+      rgba(200, 55, 45, 0.3) 50%,
+      rgba(220, 90, 80, 0.05) 100%
+    );
+    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    pointer-events: none;
+    z-index: 0;
+    animation: spotlightFill 2.4s ease-out 1 forwards;
+  }
+
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::before {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}
+
+@keyframes spotlightFill {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
+}
 
 </style>

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -15,6 +15,7 @@ import { useColumnBadge } from '@/composables/useColumnBadge'
 import { COLUMN_ICONS, COLUMN_LABELS } from '@/composables/useColumnTabs'
 import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNavigation } from '@/composables/useNavigation'
+import { navbarTargetId, useSpotlightStore } from '@/composables/useSpotlight'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import {
   type Account,
@@ -69,6 +70,14 @@ const realtimeModeStore = useRealtimeModeStore()
 const windowsStore = useWindowsStore()
 const isCompact = useIsCompactLayout()
 const { getBadge, clearBadge } = useColumnBadge()
+const spotlightStore = useSpotlightStore()
+
+function isNavSpotlighted(item: NavItem): boolean {
+  if (isNavDivider(item)) return false
+  return spotlightStore.spotlights.has(
+    navbarTargetId(item.type, item.accountId),
+  )
+}
 
 const accountAttentionCount = computed(
   () =>
@@ -124,6 +133,8 @@ function getNavAction(item: NavItem): () => void {
       /* divider has no action */
     }
   return () => {
+    // spotlight 中のボタンをユーザーがクリック = 認識した。即 clear
+    spotlightStore.clear(navbarTargetId(item.type, item.accountId))
     clearBadge(item.type)
     deckStore.toggleSidebarColumn(item.type, item.accountId, {
       ...item.columnProps,
@@ -488,7 +499,11 @@ defineExpose({
               <button
                 v-else
                 class="_button"
-                :class="[$style.item, { [$style.sidebarActive]: sidebarType === navItem.type }]"
+                :class="[
+                  $style.item,
+                  { [$style.sidebarActive]: sidebarType === navItem.type },
+                  isNavSpotlighted(navItem) && $style.spotlighted,
+                ]"
                 :title="navLabel(navItem)"
                 @click="hapticLight(); closeDrawerAndDo(getNavAction(navItem))"
               >
@@ -892,6 +907,51 @@ defineExpose({
   :global(.ti) {
     opacity: 1;
   }
+}
+
+// AI 操作の可視化 (Spotlight): Windows タスクバー風アンダーバー (朱色 + オレンジ枠)。
+// 現状 MVP では emit されないが、Phase 2 のサイドバー toggle 系 capability で
+// 自動的に光るよう infrastructure として常駐。.sidebarActive は背景色のみで
+// ::after/::before を使わないので隠す処理は不要。
+.spotlighted {
+  position: relative;
+  isolation: isolate;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(
+      180deg,
+      rgba(170, 30, 30, 0.55) 0%,
+      rgba(200, 55, 45, 0.3) 50%,
+      rgba(220, 90, 80, 0.05) 100%
+    );
+    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    pointer-events: none;
+    z-index: 0;
+    animation: spotlightFill 2.4s ease-out 1 forwards;
+  }
+
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::before {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}
+
+@keyframes spotlightFill {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .onlineActive {

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -1,6 +1,7 @@
 import { listen, type UnlistenFn } from '@tauri-apps/api/event'
 import { onScopeDispose, ref } from 'vue'
 import type { AiChatMessage, JsonValue } from '@/bindings'
+import { extractErrorMessage } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /** Single chat message stored in the conversation. */
@@ -218,7 +219,14 @@ export function useAiChat() {
           cleanup()
           resolve(finalText)
         } else if (p.kind === 'error') {
-          const message = p.error ?? '不明なエラー'
+          // p.error は型定義上 string だが、Rust 側から非文字列が来た場合の保険
+          console.error('[ai-chat] stream error event:', p.error)
+          const message =
+            p.error == null
+              ? '不明なエラー'
+              : typeof p.error === 'string'
+                ? p.error
+                : extractErrorMessage(p.error)
           lastError.value = message
           cleanup()
           reject(new Error(message))
@@ -243,7 +251,11 @@ export function useAiChat() {
           unwrap(res)
         })
         .catch((e) => {
-          const message = e instanceof Error ? e.message : String(e)
+          // 診断: Tauri unwrap で投げられた raw error を console に dump
+          console.error('[ai-chat] invoke error raw:', e)
+          // Tauri unwrap が raw `{code, message}` を投げてくるので、
+          // `String(e)` で `[object Object]` 化しないよう extractor を使う。
+          const message = extractErrorMessage(e)
           lastError.value = message
           cleanup()
           reject(new Error(message))
@@ -304,8 +316,9 @@ export async function sendAiChatOnce(opts: AiChatSendOptions): Promise<string> {
         unwrap(res)
       })
       .catch((e) => {
+        console.error('[ai-chat one-shot] invoke error raw:', e)
         unlisten?.()
-        const message = e instanceof Error ? e.message : String(e)
+        const message = extractErrorMessage(e)
         reject(new Error(message))
       })
   })

--- a/src/composables/useSpotlight.test.ts
+++ b/src/composables/useSpotlight.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment happy-dom
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  columnTargetId,
+  navbarTargetId,
+  useSpotlightStore,
+} from './useSpotlight'
+
+describe('useSpotlightStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('highlight() で entry が追加され isActive が true になる', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null')
+
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+    expect(store.spotlights.has('navbar:notifications:null')).toBe(true)
+  })
+
+  it('既定 durationMs (2400ms) 後に自動削除される', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null')
+
+    vi.advanceTimersByTime(2399)
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(store.isActive('navbar:notifications:null')).toBe(false)
+  })
+
+  it('durationMs を指定して任意の期間を設定できる', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:chat:null', { durationMs: 1000 })
+
+    vi.advanceTimersByTime(999)
+    expect(store.isActive('navbar:chat:null')).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(store.isActive('navbar:chat:null')).toBe(false)
+  })
+
+  it('同一 targetId を再 highlight すると expiresAt が更新される (古い timer は新 entry を消さない)', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null', { durationMs: 1000 })
+
+    // 500ms 経過: まだ生きている
+    vi.advanceTimersByTime(500)
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+
+    // 再 highlight (新しい expiresAt: now+1000)
+    store.highlight('navbar:notifications:null', { durationMs: 1000 })
+
+    // 元の timer が fire するタイミング (合計 1000ms)
+    vi.advanceTimersByTime(500)
+    // 古い timer は expiresAt が一致しないので削除しない
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+
+    // 新 timer が fire する (再 highlight から 1000ms)
+    vi.advanceTimersByTime(500)
+    expect(store.isActive('navbar:notifications:null')).toBe(false)
+  })
+
+  it('clear(targetId) で個別エントリを消せる', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null')
+    store.highlight('navbar:chat:null')
+
+    store.clear('navbar:notifications:null')
+
+    expect(store.isActive('navbar:notifications:null')).toBe(false)
+    expect(store.isActive('navbar:chat:null')).toBe(true)
+  })
+
+  it('clear() (引数なし) で全エントリを消せる', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null')
+    store.highlight('navbar:chat:null')
+
+    store.clear()
+
+    expect(store.spotlights.size).toBe(0)
+  })
+
+  it('lastAnnouncement は label 指定時のみ更新される', () => {
+    const store = useSpotlightStore()
+    expect(store.lastAnnouncement).toBe('')
+
+    store.highlight('navbar:notifications:null', { label: 'AI が通知を追加' })
+    expect(store.lastAnnouncement).toBe('AI が通知を追加')
+
+    // label 無しでは更新されない
+    store.highlight('navbar:chat:null')
+    expect(store.lastAnnouncement).toBe('AI が通知を追加')
+  })
+
+  it('複数 targetId が独立に管理される', () => {
+    const store = useSpotlightStore()
+    store.highlight('navbar:notifications:null', { durationMs: 1000 })
+    store.highlight('navbar:chat:null', { durationMs: 2000 })
+
+    vi.advanceTimersByTime(1000)
+    expect(store.isActive('navbar:notifications:null')).toBe(false)
+    expect(store.isActive('navbar:chat:null')).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+    expect(store.isActive('navbar:chat:null')).toBe(false)
+  })
+})
+
+describe('columnTargetId', () => {
+  it('column id を column:<id> 形式で組み立てる', () => {
+    expect(columnTargetId('col-1778')).toBe('column:col-1778')
+  })
+})
+
+describe('navbarTargetId', () => {
+  it('accountId が null のとき "null" 文字列を埋め込む', () => {
+    expect(navbarTargetId('notifications', null)).toBe(
+      'navbar:notifications:null',
+    )
+  })
+
+  it('accountId が文字列のときそれを埋め込む', () => {
+    expect(navbarTargetId('chat', 'abc123')).toBe('navbar:chat:abc123')
+  })
+})

--- a/src/composables/useSpotlight.ts
+++ b/src/composables/useSpotlight.ts
@@ -1,0 +1,100 @@
+/**
+ * useSpotlight — AI 操作の可視化機構。
+ *
+ * AI tool calling で UI が変化したとき、対象要素を一時的に「光らせる」ことで
+ * ユーザーが「何が起きたか」を目で追えるようにする。Kifi / Claude Cowork が
+ * 採用していた live UI feedback の系譜。
+ *
+ * 設計上の制約:
+ * - トリガーは AI 操作のみ (capability dispatcher 経由)。ユーザークリックは光らない
+ * - ターゲット ID は文字列規約: `navbar:${type}:${accountId ?? 'null'}` 等
+ *   登録要素が無ければ no-op (= UI 側が描画していなければ単に光らない)
+ *
+ * memory: feedback_no_onboarding_ui (静的ツアー禁止) と区別される反応的 feedback
+ */
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+interface Spotlight {
+  /** Date.now() ベースの期限 (この時刻に自動 clear される) */
+  expiresAt: number
+  /** SR-only テキスト用ラベル。省略時は読み上げなし */
+  label?: string
+}
+
+const DEFAULT_DURATION_MS = 2400
+
+export const useSpotlightStore = defineStore('spotlight', () => {
+  // Vue reactivity のため Map は常に new Map(...) で全置換する
+  const spotlights = ref<Map<string, Spotlight>>(new Map())
+
+  // aria-live region で読み上げる最新メッセージ
+  const lastAnnouncement = ref<string>('')
+
+  /**
+   * ターゲットを光らせる。
+   * @param targetId  e.g. `navbar:notifications:null`
+   * @param opts.label    SR 用テキスト (省略時は読み上げなし)
+   * @param opts.durationMs  既定 2400ms
+   */
+  function highlight(
+    targetId: string,
+    opts: { label?: string; durationMs?: number } = {},
+  ): void {
+    const duration = opts.durationMs ?? DEFAULT_DURATION_MS
+    const expiresAt = Date.now() + duration
+    const next = new Map(spotlights.value)
+    next.set(targetId, { expiresAt, label: opts.label })
+    spotlights.value = next
+
+    if (opts.label) {
+      lastAnnouncement.value = opts.label
+    }
+
+    // 期限到来時に自分のエントリだけ削除する (newer な再 highlight に踏まれない)
+    setTimeout(() => {
+      const m = new Map(spotlights.value)
+      const cur = m.get(targetId)
+      if (cur && cur.expiresAt === expiresAt) {
+        m.delete(targetId)
+        spotlights.value = m
+      }
+    }, duration)
+  }
+
+  function clear(targetId?: string): void {
+    if (targetId == null) {
+      spotlights.value = new Map()
+    } else if (spotlights.value.has(targetId)) {
+      const m = new Map(spotlights.value)
+      m.delete(targetId)
+      spotlights.value = m
+    }
+  }
+
+  function isActive(targetId: string): boolean {
+    return spotlights.value.has(targetId)
+  }
+
+  return { spotlights, lastAnnouncement, highlight, clear, isActive }
+})
+
+/**
+ * ターゲット ID を組み立てるヘルパー。規約変更時はここを直す。
+ *
+ * UI 領域固定ではなく、capability の意味に応じて使い分ける:
+ * - `column:${id}` — 個別カラム (ボトムバー / モバイルナビのタブが反応)
+ *   = AI が `column.add` 等で新しいデッキカラムを作ったとき
+ * - `navbar:${type}:${accountId}` — ナビバーボタン (サイドバースロット)
+ *   = AI がサイドバースロットの toggle / 切替を行ったとき (将来 capability)
+ *
+ * ナビバー = 現在のサイドバースロットを置換するトグル UI なので、新規カラム
+ * 追加 (デッキへの追加) では navbar を光らせない (置換ではないため誤誘導)。
+ */
+export function columnTargetId(columnId: string): string {
+  return `column:${columnId}`
+}
+
+export function navbarTargetId(type: string, accountId: string | null): string {
+  return `navbar:${type}:${accountId ?? 'null'}`
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -45,11 +45,42 @@ export class AppError extends Error {
     if (typeof e === 'object' && e !== null && 'code' in e && 'message' in e) {
       return new AppError(
         (e as { code: string }).code as ErrorCode,
-        (e as { message: string }).message,
+        extractErrorMessage((e as { message: unknown }).message),
       )
     }
     if (typeof e === 'string') return new AppError('UNKNOWN', e)
     if (e instanceof Error) return new AppError('UNKNOWN', e.message)
-    return new AppError('UNKNOWN', String(e))
+    return new AppError('UNKNOWN', extractErrorMessage(e))
   }
+}
+
+/**
+ * 任意の値から「表示可能なエラーメッセージ文字列」を抽出する。
+ * `String({})` が `[object Object]` を返してしまうのを避け、
+ * オブジェクトは JSON 表現で読める形に正規化する。
+ */
+export function extractErrorMessage(e: unknown): string {
+  if (e === null) return 'null'
+  if (e === undefined) return 'undefined'
+  if (typeof e === 'string') return e
+  if (typeof e === 'number' || typeof e === 'boolean') return String(e)
+  if (e instanceof Error) return e.message
+  if (typeof e === 'object') {
+    // 既知の shape を優先抽出
+    const o = e as Record<string, unknown>
+    if (typeof o.message === 'string') return o.message
+    if (typeof o.message === 'object' && o.message !== null) {
+      return extractErrorMessage(o.message)
+    }
+    if (typeof o.error === 'string') return o.error
+    if (typeof o.detail === 'string') return o.detail
+    if (typeof o.code === 'string') return o.code
+    // フォールバック: JSON 形式 (循環参照は捕捉)
+    try {
+      return JSON.stringify(e)
+    } catch {
+      return Object.prototype.toString.call(e)
+    }
+  }
+  return String(e)
 }


### PR DESCRIPTION
## Summary

- AI が capability dispatcher 経由で UI 操作したとき、対応 UI 要素を朱色グラデで光らせる **Spotlight 機構** を新設 (Kifi / Claude Computer Use の系譜)
- 「サイドバーで○○カラムを開いて」を AI が実行できる **`sidebar.toggle` capability** を追加 (既存 `column.add` とは別概念で、navbar ボタンクリックと同じ動作)
- AI ストリームで `[object Object]` と表示されていた **エラー表示を実メッセージに修正** (Tauri unwrap の生 error を `extractErrorMessage` で文字列化)

## なぜ

ユーザーが「AI が何をしたか分からない」「操作を覚えにくい」と感じる根本問題に対し、Welcome カラムや初回ガイドなどの静的 UI ではなく、**AI 動作の反応的フィードバック**として可視化する。memory `feedback_no_onboarding_ui` / `feedback_anti_engagement_design` と整合。

並行して OpenRouter 等の API エラー時に `⚠️ [object Object]` と表示されていた既存バグも修正 (Tauri unwrap が生 `{code, message}` を throw する仕様を補正)。

## 3 コミット構成

### 1. `fix(ai-chat): show proper error messages instead of [object Object]`

- `extractErrorMessage(e)` を `src/utils/errors.ts` に追加 (任意 shape から表示可能文字列を抽出)
- `useAiChat.ts` の 2 箇所と `DeckAiColumn.vue` の catch を置き換え
- 診断 `console.error('[ai-chat] error raw:', e)` も追加

### 2. `feat(ai): AI Spotlight — capability 実行を UI 上で可視化`

- `useSpotlight` (Pinia store + composable) — 期限管理付き Map で複数同時 highlight 対応
- `dispatcher` の execute 成功後に `nextTick` で emit (ユーザークリックは通らないので自然に AI 経由のみ)
- ターゲット ID 規約: `column:\${id}` (bottombar/mobile-nav タブ) / `navbar:\${type}:\${accountId}` (navbar ボタン)
- 視覚: OpenClaw 系朱色縦グラデ (#aa1e1e → 透明)、2.4 秒、`isolation: isolate` + `::before` で子要素より下に
- `.tabActive::after` / `.active::after` を spotlight 中は `display: none` で重ね合わせ回避
- アクセシビリティ: `aria-live=\"polite\"` SR テキスト + `prefers-reduced-motion` 対応
- 防御: spotlight 副作用は `try/catch + .catch` で AI flow から完全隔離
- MVP は `column.add` のみ反応 (次コミットで navbar 側も使われる)

### 3. `feat(capabilities): add sidebar.toggle for AI`

- 新 capability: type + accountId? を取り `toggleSidebarColumn` を呼ぶ
- 戻り値 `{ type, opened }` で「開いたのか閉じたのか」を AI に伝える
- dispatcher の spotlight emit に sidebar.toggle ブランチ追加 (opened=true のとき navbar 光る)
- これで前コミットの navbar インフラ (standby) が初めて実利用される

## memory 整合性

- ✅ `feedback_no_onboarding_ui`: 静的ツアー/チップではなく **反応的** feedback
- ✅ `feedback_anti_engagement_design`: engagement 誘導ではなく可視性
- ✅ `feedback_navbar_button_uniformity`: capability の意味に応じて target を選ぶ
- ✅ `feedback_no_welcome_column`: Welcome 廃止と整合する別軸の解決策
- ✅ `project_self_extending_ide_roadmap`: 自己拡張する IDE の見える化軸として位置付け
- 新規 memory: \`project_ai_spotlight.md\` で設計詳細を記録 (ローカル)

## Phase 2 / 残タスク

#576 でトラッキング。
- 他 capability の spotlight emit (column.remove / window.open / account.switch / notifications.markAllRead 等)
- 履歴パネル、設定トグル、stagger、初回 AI 自動デモ等

## Test plan

- [x] `pnpm typecheck` (vue-tsc) 緑
- [x] `pnpm lint` (biome) 緑
- [x] `pnpm test` (vitest) 緑 — 954 tests passed (新規 spotlight 単体 + dispatcher emit テスト)
- [ ] 手動: `pnpm tauri:dev` 起動、AI に「通知カラムを追加して」と依頼 → bottombar タブが朱色グラデで光る
- [ ] 手動: AI に「サイドバーで通知を開いて」と依頼 → navbar ボタンが朱色グラデで光る
- [ ] 手動: 不正な API キーで失敗 → `[object Object]` ではなく実エラー文表示
- [ ] 手動: モバイル幅で確認、`prefers-reduced-motion` 設定で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)