### PR TITLE
feat(ai): Spotlight Phase 2a — 4 capability に emit 拡張

### DIFF
--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -593,4 +593,112 @@ describe('dispatchCapability spotlight emission', () => {
     expect(store.isActive('navbar:notifications:null')).toBe(true)
     vi.useRealTimers()
   })
+
+  it('column.remove は視覚 spotlight なし、announce のみ', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.remove',
+        execute: () => undefined,
+      }),
+    )
+
+    const store = useSpotlightStore()
+    const r = await dispatchCapability(
+      'column.remove',
+      { id: 'col-xxx' },
+      configWithPreset('full'),
+    )
+
+    expect(r.ok).toBe(true)
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+    expect(store.lastAnnouncement).toContain('削除')
+  })
+
+  it('column.move 成功時に column:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.move',
+        execute: (params) => ({
+          moved: true,
+          columnId: (params as { columnId?: string } | undefined)?.columnId,
+          targetIndex: 0,
+        }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'column.move',
+      { columnId: 'col-move-1', targetIndex: 2 },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('column:col-move-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain('移動')
+  })
+
+  it('column.updateSettings 成功時に column:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'column.updateSettings',
+        execute: (params) => ({
+          updated: true,
+          columnId: (params as { columnId?: string } | undefined)?.columnId,
+          applied: ['name'],
+        }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'column.updateSettings',
+      { columnId: 'col-set-1', name: 'New name' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('column:col-set-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain('更新')
+  })
+
+  it('notifications.markRead 成功時に navbar:notifications:<accountId> を spotlight', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notifications.markRead',
+        execute: () => ({ markedAccounts: 1 }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notifications.markRead',
+      { accountId: 'acc-1' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('navbar:notifications:acc-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain('既読')
+  })
+
+  it('notifications.markRead accountId 省略時は navbar:notifications:null を spotlight', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notifications.markRead',
+        execute: () => ({ markedAccounts: 3 }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notifications.markRead',
+      undefined,
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('navbar:notifications:null')).toBe(true)
+  })
 })

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -28,6 +28,7 @@ import {
   type ConfirmOptions,
   useConfirm,
 } from '@/stores/confirm'
+import { useDeckStore } from '@/stores/deck'
 import { sanitizeToolName } from './identifier'
 import { getCapability, listCapabilities } from './registry'
 
@@ -186,6 +187,43 @@ function emitSpotlightFromCapability(
         label: `AI が${label}カラムをサイドバーに開きました`,
       })
     }
+  } else if (capId === 'column.remove') {
+    // 削除は対象 DOM が消えるので視覚 spotlight 無し。SR テキストのみ announce。
+    // type は ID から逆引きできない (既に削除済み) → 汎用文
+    useSpotlightStore().announce('AI がカラムを削除しました')
+  } else if (capId === 'column.move') {
+    // 移動後の位置で該当カラムタブを光らせる
+    const r = result as { columnId?: string } | null
+    if (r?.columnId) {
+      const col = useDeckStore().getColumn(r.columnId)
+      const label = col?.type ? (COLUMN_LABELS[col.type] ?? col.type) : 'カラム'
+      const targetId = columnTargetId(r.columnId)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}カラムを移動しました`,
+      })
+    }
+  } else if (capId === 'column.updateSettings') {
+    const r = result as { columnId?: string; applied?: string[] } | null
+    if (r?.columnId) {
+      const col = useDeckStore().getColumn(r.columnId)
+      const label = col?.type ? (COLUMN_LABELS[col.type] ?? col.type) : 'カラム'
+      const fields = r.applied?.join(', ') ?? '設定'
+      const targetId = columnTargetId(r.columnId)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}カラムの${fields}を更新しました`,
+      })
+    }
+  } else if (capId === 'notifications.markRead') {
+    // accountId 指定があれば per-account の navbar、なければ null (全アカウント)
+    const accountId =
+      typeof params?.accountId === 'string' ? params.accountId : null
+    const targetId = navbarTargetId('notifications', accountId)
+    console.debug('[spotlight] highlight target:', targetId)
+    useSpotlightStore().highlight(targetId, {
+      label: 'AI が通知を既読化しました',
+    })
   }
 }
 

--- a/src/composables/useSpotlight.test.ts
+++ b/src/composables/useSpotlight.test.ts
@@ -101,6 +101,25 @@ describe('useSpotlightStore', () => {
     expect(store.lastAnnouncement).toBe('AI が通知を追加')
   })
 
+  it('announce() は spotlights には影響せず lastAnnouncement だけ更新', () => {
+    const store = useSpotlightStore()
+    expect(store.spotlights.size).toBe(0)
+    expect(store.lastAnnouncement).toBe('')
+
+    store.announce('AI がカラムを削除しました')
+
+    expect(store.lastAnnouncement).toBe('AI がカラムを削除しました')
+    // 視覚 spotlight には影響しない (削除系などターゲット DOM が無い場合用)
+    expect(store.spotlights.size).toBe(0)
+  })
+
+  it('announce() に空文字を渡すと lastAnnouncement を上書きしない', () => {
+    const store = useSpotlightStore()
+    store.announce('first message')
+    store.announce('')
+    expect(store.lastAnnouncement).toBe('first message')
+  })
+
   it('複数 targetId が独立に管理される', () => {
     const store = useSpotlightStore()
     store.highlight('navbar:notifications:null', { durationMs: 1000 })

--- a/src/composables/useSpotlight.ts
+++ b/src/composables/useSpotlight.ts
@@ -76,7 +76,15 @@ export const useSpotlightStore = defineStore('spotlight', () => {
     return spotlights.value.has(targetId)
   }
 
-  return { spotlights, lastAnnouncement, highlight, clear, isActive }
+  /**
+   * 視覚 spotlight 無しで SR 用テキストだけ流す。削除系のように DOM が
+   * 消えてしまう capability や、視覚化対象が無い裏方処理の通知に使う。
+   */
+  function announce(message: string): void {
+    if (message) lastAnnouncement.value = message
+  }
+
+  return { spotlights, lastAnnouncement, highlight, clear, isActive, announce }
 })
 
 /**


### PR DESCRIPTION
## Summary

- PR #577 (MVP: column.add + sidebar.toggle) の延長として、既存 AI-callable capability で emit 追加可能な 4 つを一括対応
- 新規 capability / 新 target 規約は導入せず、既存パターンの単純拡張に絞ったスコープ
- 視覚 spotlight 対象が無いケース用に `useSpotlightStore.announce(message)` を新設

## なぜ

Issue #576 の高優先項目から「既存 capability に emit 追加」分を消化し、本来の目的 = Phase 3 (AI 案内モード / Kifi 風) に向けた capability カバレッジを広げる。

## 対象 capability (4 件)

| capability | target | 説明 |
|---|---|---|
| \`column.remove\` | (なし、announce のみ) | DOM が消えるため SR テキストのみ |
| \`column.move\` | \`column:<id>\` | 移動後の位置で光る |
| \`column.updateSettings\` | \`column:<id>\` | 変更フィールド名を SR テキストに含める |
| \`notifications.markRead\` | \`navbar:notifications:<accountId>\` | バッジ消失と連動 |

## 設計の主な変更点

### `useSpotlightStore.announce(message)` 追加

視覚 spotlight 無しで \`lastAnnouncement\` だけ更新するメソッド。削除系のように DOM が消えてしまう capability や、視覚化対象が無い裏方処理の通知に使う。今後 DOM 消失系の capability で再利用できるよう infrastructure 化。

### `emitSpotlightFromCapability` に 4 ブランチ追加

- column.remove → \`announce()\` のみ
- column.move / column.updateSettings → \`getColumn()\` で type を逆引きしてラベル化、\`columnTargetId()\` で highlight
- notifications.markRead → \`navbarTargetId('notifications', accountId)\` で highlight

## Test plan

- [x] \`pnpm typecheck\` 緑
- [x] \`pnpm lint\` 緑
- [x] \`pnpm test\` 緑 — 961 tests (既存 954 + 新規 7)
- [ ] 手動: AI に「○○ カラムを削除して」 → SR で \"AI がカラムを削除しました\" 読み上げ、視覚 spotlight なし
- [ ] 手動: AI に「○○ カラムを最後に移動」 → 移動後タブが朱色グラデで光る
- [ ] 手動: AI に「○○ カラムの名前を変更」 → タブが光る + SR で \"名前を更新しました\"
- [ ] 手動: AI に「通知を既読化して」 → navbar 通知ボタンが朱色グラデで光る + バッジ消失

## Phase 3 への次のステップ (この PR の対象外)

Phase 2b (別 PR) で新 capability + 新 target 規約を整備:
- 新 capability: \`account.switch\` / 全アカウント通知既読化
- 新 target: \`account:<id>\` / \`note:<id>\` / \`window:<id>\` + 各 UI binding
- DEBUG console.log の整理、設定トグル、stagger

それらが揃ったら Phase 3 (AI 案内モード = welcome-tour skill) に進む。Issue #576 で追跡中。

Refs: #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)