### PR TITLE
feat(ai): Spotlight Phase 2b.1 — Window spotlight

### DIFF
--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -701,4 +701,84 @@ describe('dispatchCapability spotlight emission', () => {
     await flushNextTick()
     expect(store.isActive('navbar:notifications:null')).toBe(true)
   })
+
+  it('windows.open 成功時に window:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'windows.open',
+        execute: () => ({ id: 'win-1' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'windows.open',
+      { type: 'note-detail' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('window:win-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain('ノート')
+  })
+
+  it('windows.focus 成功時に window:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'windows.focus',
+        execute: () => ({ focused: true, id: 'win-2' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'windows.focus',
+      { id: 'win-2' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('window:win-2')).toBe(true)
+    expect(store.lastAnnouncement).toContain('前面')
+  })
+
+  it('windows.close 成功時は announce のみ (視覚 spotlight なし)', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'windows.close',
+        execute: () => ({ closed: true, id: 'win-3' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'windows.close',
+      { id: 'win-3' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+    expect(store.lastAnnouncement).toContain('閉じ')
+  })
+
+  it('windows.closeAll 成功時も announce のみ', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'windows.closeAll',
+        execute: () => ({ closedAll: true }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'windows.closeAll',
+      undefined,
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+    expect(store.lastAnnouncement).toContain('全ウィンドウ')
+  })
 })

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -13,6 +13,7 @@
 import { nextTick } from 'vue'
 import { COLUMN_LABELS } from '@/columns/registry'
 import type { Command } from '@/commands/registry'
+import { WINDOW_LABELS } from '@/components/deck/windowLabels'
 import {
   type AiConfig,
   type PermissionKey,
@@ -22,6 +23,7 @@ import {
   columnTargetId,
   navbarTargetId,
   useSpotlightStore,
+  windowTargetId,
 } from '@/composables/useSpotlight'
 import {
   type ConfirmDecision,
@@ -29,6 +31,7 @@ import {
   useConfirm,
 } from '@/stores/confirm'
 import { useDeckStore } from '@/stores/deck'
+import { useWindowsStore } from '@/stores/windows'
 import { sanitizeToolName } from './identifier'
 import { getCapability, listCapabilities } from './registry'
 
@@ -224,6 +227,35 @@ function emitSpotlightFromCapability(
     useSpotlightStore().highlight(targetId, {
       label: 'AI が通知を既読化しました',
     })
+  } else if (capId === 'windows.open') {
+    // 新規 or 既存 focus されたウィンドウを朱色 glow で枠を光らせる
+    const r = result as { id?: string } | null
+    const type = params?.type as string | undefined
+    if (r?.id) {
+      const label = type ? (WINDOW_LABELS[type] ?? type) : 'ウィンドウ'
+      const targetId = windowTargetId(r.id)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}ウィンドウを開きました`,
+      })
+    }
+  } else if (capId === 'windows.focus') {
+    // 既存ウィンドウを最前面に → 同じ window:${id} を再点灯
+    const r = result as { id?: string } | null
+    if (r?.id) {
+      const win = useWindowsStore().windows.find((w) => w.id === r.id)
+      const label = win ? (WINDOW_LABELS[win.type] ?? win.type) : 'ウィンドウ'
+      const targetId = windowTargetId(r.id)
+      console.debug('[spotlight] highlight target:', targetId, 'label:', label)
+      useSpotlightStore().highlight(targetId, {
+        label: `AI が${label}ウィンドウを前面に出しました`,
+      })
+    }
+  } else if (capId === 'windows.close') {
+    // 閉じた window の DOM は消えているので announce のみ
+    useSpotlightStore().announce('AI がウィンドウを閉じました')
+  } else if (capId === 'windows.closeAll') {
+    useSpotlightStore().announce('AI が全ウィンドウを閉じました')
   }
 }
 

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from 'vue'
+import { useSpotlightStore, windowTargetId } from '@/composables/useSpotlight'
 import { provideWindowEditAction } from '@/composables/useWindowEditAction'
 import { provideWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { provideWindowExternalLink } from '@/composables/useWindowExternalLink'
@@ -11,6 +12,7 @@ import {
   WINDOW_SIZES,
 } from '@/stores/windows'
 import { isTauri, openSettingsFileInEditor } from '@/utils/settingsFs'
+import { WINDOW_LABELS } from './windowLabels'
 
 const props = defineProps<{
   window: DeckWindow
@@ -20,6 +22,11 @@ const props = defineProps<{
 const emit = defineEmits<{ close: [] }>()
 
 const windowsStore = useWindowsStore()
+const spotlightStore = useSpotlightStore()
+
+const isSpotlighted = computed(() =>
+  spotlightStore.spotlights.has(windowTargetId(props.window.id)),
+)
 const isCompact = useIsCompactLayout()
 const baseSize = computed(() => WINDOW_SIZES[props.window.type])
 
@@ -60,48 +67,8 @@ function runEditAction() {
   }
 }
 
-const BASE_TITLES: Record<string, string> = {
-  'note-detail': 'ノート',
-  'note-inspector': 'ノートインスペクタ',
-  'notification-inspector': '通知インスペクタ',
-  'user-profile': 'プロフィール',
-  'federation-instance': 'サーバー',
-  'follow-list': 'フォロー / フォロワー',
-  login: 'アカウント追加',
-  search: '検索',
-  notifications: '通知',
-  plugins: 'プラグイン',
-  keybinds: 'キーバインド',
-  cssEditor: 'カスタムCSS',
-  themeEditor: 'テーマ',
-  profileEditor: 'プロファイルエディタ',
-  ai: 'AI アシスタント',
-  aiSettings: 'AI 設定',
-  chat: 'チャット',
-  about: 'NoteDeck について',
-  navEditor: 'ナビバー',
-  performanceEditor: 'パフォーマンス',
-  appearanceEditor: 'アピアランス',
-  backup: 'バックアップ',
-  cacheEditor: 'キャッシュ',
-  tasksEditor: 'タスク設定',
-  snippetsEditor: 'スニペット',
-  memoEditor: 'メモ',
-  'page-detail': 'ページ',
-  'play-detail': 'Play',
-  'gallery-detail': 'ギャラリー',
-  'list-detail': 'リスト',
-  'clip-detail': 'クリップ',
-  'page-edit': 'ページを編集',
-  'play-edit': 'Play を編集',
-  'widget-edit': 'ウィジット編集',
-  'skill-edit': 'スキル編集',
-  connections: '接続',
-  connectionEdit: '接続を編集',
-}
-
 const windowTitle = computed(() => {
-  const base = BASE_TITLES[props.window.type] ?? ''
+  const base = WINDOW_LABELS[props.window.type] ?? ''
   if (props.window.type === 'follow-list' && props.window.props.username) {
     return `@${props.window.props.username} のフォロー / フォロワー`
   }
@@ -325,6 +292,8 @@ function onResizePointerUp() {
 }
 
 function onWindowMouseDown() {
+  // spotlight 中なら認識した = 即解除
+  spotlightStore.clear(windowTargetId(props.window.id))
   windowsStore.bringToFront(props.window.id)
 }
 
@@ -336,7 +305,7 @@ onBeforeUnmount(() => {
 
 <template>
   <div
-    :class="[$style.deckWindow, { [$style.dragging]: isDragging, [$style.resizing]: isResizing, [$style.userSized]: isUserSized, [$style.minimized]: isMinimized, [$style.maximized]: isMaximized, [$style.mobile]: isCompact }]"
+    :class="[$style.deckWindow, { [$style.dragging]: isDragging, [$style.resizing]: isResizing, [$style.userSized]: isUserSized, [$style.minimized]: isMinimized, [$style.maximized]: isMaximized, [$style.mobile]: isCompact, [$style.spotlighted]: isSpotlighted }]"
     :style="windowStyle"
     @mousedown="onWindowMouseDown"
   >
@@ -428,6 +397,37 @@ onBeforeUnmount(() => {
 .dragging {
   opacity: 0.92;
   will-change: translate;
+}
+
+// AI 操作の可視化 (Spotlight): dispatcher が windows.open / windows.focus
+// 成功時に光らせる。塗りつぶしだとウィンドウ内容が読めなくなるので、
+// 外周の朱色 glow で「この window が AI 由来で操作された」ことだけ示す。
+.spotlighted {
+  &::after {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow:
+      0 0 0 2px rgba(170, 30, 30, 0.7),
+      0 0 24px 8px rgba(170, 30, 30, 0.4);
+    animation: spotlightWindowAppear 2.4s ease-out 1 forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}
+
+@keyframes spotlightWindowAppear {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .resizing {

--- a/src/components/deck/windowLabels.ts
+++ b/src/components/deck/windowLabels.ts
@@ -1,0 +1,46 @@
+/**
+ * DeckWindow の type → 日本語表示名のマップ。
+ *
+ * 元は DeckWindow.vue 内 `BASE_TITLES` だったが、AI Spotlight の SR
+ * (aria-live) テキスト用に dispatcher 側からも参照したいため切り出した。
+ * 「ウィンドウタイプの名前を変えたい」とき 1 箇所修正で済む。
+ */
+export const WINDOW_LABELS: Record<string, string> = {
+  'note-detail': 'ノート',
+  'note-inspector': 'ノートインスペクタ',
+  'notification-inspector': '通知インスペクタ',
+  'user-profile': 'プロフィール',
+  'federation-instance': 'サーバー',
+  'follow-list': 'フォロー / フォロワー',
+  login: 'アカウント追加',
+  search: '検索',
+  notifications: '通知',
+  plugins: 'プラグイン',
+  keybinds: 'キーバインド',
+  cssEditor: 'カスタムCSS',
+  themeEditor: 'テーマ',
+  profileEditor: 'プロファイルエディタ',
+  ai: 'AI アシスタント',
+  aiSettings: 'AI 設定',
+  chat: 'チャット',
+  about: 'NoteDeck について',
+  navEditor: 'ナビバー',
+  performanceEditor: 'パフォーマンス',
+  appearanceEditor: 'アピアランス',
+  backup: 'バックアップ',
+  cacheEditor: 'キャッシュ',
+  tasksEditor: 'タスク設定',
+  snippetsEditor: 'スニペット',
+  memoEditor: 'メモ',
+  'page-detail': 'ページ',
+  'play-detail': 'Play',
+  'gallery-detail': 'ギャラリー',
+  'list-detail': 'リスト',
+  'clip-detail': 'クリップ',
+  'page-edit': 'ページを編集',
+  'play-edit': 'Play を編集',
+  'widget-edit': 'ウィジット編集',
+  'skill-edit': 'スキル編集',
+  connections: '接続',
+  connectionEdit: '接続を編集',
+}

--- a/src/composables/useSpotlight.test.ts
+++ b/src/composables/useSpotlight.test.ts
@@ -5,6 +5,7 @@ import {
   columnTargetId,
   navbarTargetId,
   useSpotlightStore,
+  windowTargetId,
 } from './useSpotlight'
 
 describe('useSpotlightStore', () => {
@@ -149,5 +150,11 @@ describe('navbarTargetId', () => {
 
   it('accountId が文字列のときそれを埋め込む', () => {
     expect(navbarTargetId('chat', 'abc123')).toBe('navbar:chat:abc123')
+  })
+})
+
+describe('windowTargetId', () => {
+  it('window id を window:<id> 形式で組み立てる', () => {
+    expect(windowTargetId('win-abc')).toBe('window:win-abc')
   })
 })

--- a/src/composables/useSpotlight.ts
+++ b/src/composables/useSpotlight.ts
@@ -106,3 +106,8 @@ export function columnTargetId(columnId: string): string {
 export function navbarTargetId(type: string, accountId: string | null): string {
   return `navbar:${type}:${accountId ?? 'null'}`
 }
+
+/** DeckWindow を一意に指す target ID (windows store の id ベース) */
+export function windowTargetId(windowId: string): string {
+  return `window:${windowId}`
+}


### PR DESCRIPTION
## Summary

AI Spotlight の Phase 2b.1。`windows.*` capability を AI が呼んだとき、対応する DeckWindow を朱色の枠 glow で光らせる。

- `windows.open` / `windows.focus` → `window:<id>` を spotlight (朱色枠 glow + SR テキスト)
- `windows.close` / `windows.closeAll` → DOM が消えるので announce のみ
- DeckWindow.vue の `BASE_TITLES` を `windowLabels.ts` に切り出し、dispatcher と共有

## 設計判断

navbar / bottombar / mobile-nav は塗りつぶしグラデで「アイテム全体を覆う」が、**ウィンドウは大きく内容を読みづらくなる**ので不向き。代わりに `::after` で外周に**朱色 glow**を出して、内容を阻害せずに「この window が AI 経由で操作された」シグナルだけ送る。色系統 (OpenClaw 系 `rgba(170,30,30,*)`) は他 spotlight と統一。

target ID 新規規約: `window:<id>` (`windowTargetId(id)` ヘルパー)。

## Test plan

- [x] `pnpm typecheck` 緑
- [x] `pnpm lint` 緑
- [x] `pnpm test` 緑 (966 件)
- [ ] 手動: AI に「ユーザープロフィールを開いて」→ user-profile window が朱色 glow
- [ ] 手動: AI に「AI 設定を開いて」→ aiSettings window が朱色 glow
- [ ] 手動: AI に「ウィンドウ閉じて」→ SR で "AI がウィンドウを閉じました"
- [ ] 手動: ユーザー手動 mousedown → spotlight 即解除
- [ ] 手動: `prefers-reduced-motion` 有効で animation なし、静的 glow

## 次の PR

- Phase 2b.2: Note spotlight (`note:<id>` + MkNote binding + notes.* emit)
- Phase 2b.3: Account switch (`account:<id>` + NavAccountMenu + 新 `account.switch` capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)