### PR TITLE
feat(ai): Spotlight Phase 2b.2 — Note spotlight

### DIFF
--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -781,4 +781,128 @@ describe('dispatchCapability spotlight emission', () => {
     expect(store.spotlights.size).toBe(0)
     expect(store.lastAnnouncement).toContain('全ウィンドウ')
   })
+
+  it('notes.react 成功時に note:<id> を spotlight + reaction 名を含む announcement', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.react',
+        execute: () => ({ noteId: 'note-1', ok: true, reaction: ':smile:' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.react',
+      { noteId: 'note-1', reaction: ':smile:' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('note:note-1')).toBe(true)
+    expect(store.lastAnnouncement).toContain(':smile:')
+  })
+
+  it('notes.unreact 成功時に note:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.unreact',
+        execute: () => ({ noteId: 'note-2', ok: true }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.unreact',
+      { noteId: 'note-2' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('note:note-2')).toBe(true)
+    expect(store.lastAnnouncement).toContain('取り消し')
+  })
+
+  it('notes.pin 成功時に note:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.pin',
+        execute: () => ({ noteId: 'note-3', pinned: true }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.pin',
+      { noteId: 'note-3' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('note:note-3')).toBe(true)
+    expect(store.lastAnnouncement).toContain('ピン留め')
+  })
+
+  it('notes.unpin 成功時に note:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.unpin',
+        execute: () => ({ noteId: 'note-4', unpinned: true }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.unpin',
+      { noteId: 'note-4' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('note:note-4')).toBe(true)
+    expect(store.lastAnnouncement).toContain('外し')
+  })
+
+  it('notes.create 成功時に result.id を note:<id> として spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.create',
+        execute: () => ({
+          createdAt: '2026-05-15T00:00:00Z',
+          id: 'note-new',
+          text: 'hello',
+        }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.create',
+      { text: 'hello' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('note:note-new')).toBe(true)
+    expect(store.lastAnnouncement).toContain('投稿')
+  })
+
+  it('notes.delete 成功時は announce のみ (視覚 spotlight なし)', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'notes.delete',
+        execute: () => ({ deleted: true, noteId: 'note-5' }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'notes.delete',
+      { noteId: 'note-5' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.spotlights.size).toBe(0)
+    expect(store.lastAnnouncement).toContain('削除')
+  })
 })

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -22,6 +22,7 @@ import {
 import {
   columnTargetId,
   navbarTargetId,
+  noteTargetId,
   useSpotlightStore,
   windowTargetId,
 } from '@/composables/useSpotlight'
@@ -256,6 +257,50 @@ function emitSpotlightFromCapability(
     useSpotlightStore().announce('AI がウィンドウを閉じました')
   } else if (capId === 'windows.closeAll') {
     useSpotlightStore().announce('AI が全ウィンドウを閉じました')
+  } else if (capId === 'notes.react') {
+    // リアクション付与: 戻り値 { ok, noteId, reaction } から noteId と
+    // reaction を取り、対応する note 本体を spotlight する。
+    const r = result as { noteId?: string; reaction?: string } | null
+    if (r?.noteId) {
+      useSpotlightStore().highlight(noteTargetId(r.noteId), {
+        label: r.reaction
+          ? `AI がノートに ${r.reaction} でリアクションしました`
+          : 'AI がノートにリアクションしました',
+      })
+    }
+  } else if (capId === 'notes.unreact') {
+    const r = result as { noteId?: string } | null
+    if (r?.noteId) {
+      useSpotlightStore().highlight(noteTargetId(r.noteId), {
+        label: 'AI がノートのリアクションを取り消しました',
+      })
+    }
+  } else if (capId === 'notes.pin') {
+    const r = result as { noteId?: string } | null
+    if (r?.noteId) {
+      useSpotlightStore().highlight(noteTargetId(r.noteId), {
+        label: 'AI がノートをピン留めしました',
+      })
+    }
+  } else if (capId === 'notes.unpin') {
+    const r = result as { noteId?: string } | null
+    if (r?.noteId) {
+      useSpotlightStore().highlight(noteTargetId(r.noteId), {
+        label: 'AI がノートのピン留めを外しました',
+      })
+    }
+  } else if (capId === 'notes.create') {
+    // 投稿成功: 戻り値 { id, ... } の id がそのまま新規 note id。
+    // Timeline reactivity で DOM に出れば光る (出てなければ noop)。
+    const r = result as { id?: string } | null
+    if (r?.id) {
+      useSpotlightStore().highlight(noteTargetId(r.id), {
+        label: 'AI がノートを投稿しました',
+      })
+    }
+  } else if (capId === 'notes.delete') {
+    // 削除は対象 DOM が消えるので視覚 spotlight 無し。SR テキストのみ。
+    useSpotlightStore().announce('AI がノートを削除しました')
   }
 }
 

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -16,6 +16,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { provideNoteAccountId } from '@/composables/useNoteContext'
 import { usePortal } from '@/composables/usePortal'
 import { useRippleEffect } from '@/composables/useRippleEffect'
+import { noteTargetId, useSpotlightStore } from '@/composables/useSpotlight'
 import {
   useVaporTransition,
   useVaporTransitionGroup,
@@ -92,6 +93,16 @@ const extractedUrls = computed<string[]>(() => {
 })
 
 provideNoteAccountId(props.note._accountId)
+
+// AI Spotlight: capability dispatcher が note:<id> を highlight している間だけ
+// 朱色 glow を出す。複数カラムで同じ note が表示されていれば全箇所で光る。
+const spotlightStore = useSpotlightStore()
+const isSpotlighted = computed(() =>
+  spotlightStore.spotlights.has(noteTargetId(props.note.id)),
+)
+function clearSpotlight(): void {
+  spotlightStore.clear(noteTargetId(props.note.id))
+}
 
 const { canInteract, isGuest } = useAccountMode(() => props.note._accountId)
 const { spawn: spawnRipple } = useRippleEffect()
@@ -500,10 +511,12 @@ function handlePickerReaction(reaction: string) {
         [$style.detailed]: detailed,
         [$style.focused]: focused,
         [$style.hasChannel]: showChannelInfo,
+        [$style.spotlighted]: isSpotlighted,
       },
     ]"
     :style="channelInfo && showChannelInfo ? { '--nd-channel-color': channelInfo.color } : undefined"
     tabindex="0"
+    @mousedown="clearSpotlight"
     @contextmenu.prevent.stop="moreMenuRef?.open($event)"
   >
     <!-- Pinned indicator -->
@@ -1532,6 +1545,36 @@ function handlePickerReaction(reaction: string) {
 /* Divider between notes */
 .noteRoot + .noteRoot {
   border-top: 0.5px solid var(--nd-divider);
+}
+
+/* AI Spotlight: note 本体を朱色 glow で囲む (内容を阻害しないよう枠 only) */
+.spotlighted {
+  &::after {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    border-radius: inherit;
+    pointer-events: none;
+    box-shadow:
+      0 0 0 2px rgba(170, 30, 30, 0.7),
+      0 0 24px 8px rgba(170, 30, 30, 0.4);
+    animation: spotlightNoteAppear 2.4s ease-out 1 forwards;
+    z-index: 2;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}
+
+@keyframes spotlightNoteAppear {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 /* Container query responsive breakpoints */

--- a/src/composables/useSpotlight.test.ts
+++ b/src/composables/useSpotlight.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   columnTargetId,
   navbarTargetId,
+  noteTargetId,
   useSpotlightStore,
   windowTargetId,
 } from './useSpotlight'
@@ -156,5 +157,11 @@ describe('navbarTargetId', () => {
 describe('windowTargetId', () => {
   it('window id を window:<id> 形式で組み立てる', () => {
     expect(windowTargetId('win-abc')).toBe('window:win-abc')
+  })
+})
+
+describe('noteTargetId', () => {
+  it('note id を note:<id> 形式で組み立てる', () => {
+    expect(noteTargetId('9abc123')).toBe('note:9abc123')
   })
 })

--- a/src/composables/useSpotlight.ts
+++ b/src/composables/useSpotlight.ts
@@ -111,3 +111,11 @@ export function navbarTargetId(type: string, accountId: string | null): string {
 export function windowTargetId(windowId: string): string {
   return `window:${windowId}`
 }
+
+/**
+ * MkNote の note 本体を指す target ID (Misskey note id ベース)。
+ * 同じ note が複数カラムで表示されている場合は全ての表示インスタンスが反応する。
+ */
+export function noteTargetId(noteId: string): string {
+  return `note:${noteId}`
+}


### PR DESCRIPTION
## Summary

AI Spotlight の Phase 2b.2。`notes.*` capability を AI が呼んだとき、対応する MkNote を朱色枠 glow で光らせる。

| capability | 動作 | spotlight |
|---|---|---|
| `notes.react` | リアクション付与 | `note:<id>` highlight + reaction 名 SR |
| `notes.unreact` | リアクション取り消し | `note:<id>` highlight + 「取り消し」SR |
| `notes.pin` / `notes.unpin` | ピン留め / 解除 | `note:<id>` highlight |
| `notes.create` | 投稿 | 戻り値 `id` を `note:<id>` highlight (TL reactivity 次第で DOM に出る) |
| `notes.delete` | 削除 | DOM が消えるので announce のみ |
| `notes.show` / `search` / `timeline` / `user` / `children` | read-only | emit しない (対象が曖昧) |

## 設計判断

- target ID 新規規約 `note:<noteId>` (`noteTargetId(id)` ヘルパー)。同じ note が複数カラムで表示されていれば**全箇所が同時に光る** (target ID ベース設計の自然な振る舞い、Phase 2b.1 までの DeckWindow と同形)
- MkNote の root に `::after` 枠 glow を追加 — テキスト本体を阻害しない
- 色系統と animation は DeckWindow と統一 (OpenClaw 系 `rgba(170,30,30,*)`)
- mousedown で spotlight 即解除 (認識したシグナル)

## Test plan

- [x] `pnpm typecheck` 緑
- [x] `pnpm lint` 緑
- [x] `pnpm test` 緑 (973 件 / +7)
- [ ] 手動: AI に「このノートに👍リアクションして」→ 該当 MkNote が朱色 glow + SR で reaction 名読み上げ
- [ ] 手動: AI に「ノート投稿して」→ TL 反映後に新規 note が朱色 glow
- [ ] 手動: AI に「このノート削除して」→ SR で「AI がノートを削除しました」
- [ ] 手動: ユーザー手動 mousedown → spotlight 即解除
- [ ] 手動: `prefers-reduced-motion` 有効で animation なし、静的 glow

## 次の PR

- Phase 2b.3: Account switch (`account:<id>` + NavAccountMenu + 新 `account.switch` capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)