### PR TITLE
feat(ai): Spotlight Phase 2b.3 — account.switch + spotlight

### DIFF
--- a/src/capabilities/builtins/account.test.ts
+++ b/src/capabilities/builtins/account.test.ts
@@ -6,6 +6,7 @@ import {
   ACCOUNT_BUILTIN_CAPABILITIES,
   accountCurrentCapability,
   accountListCapability,
+  accountSwitchCapability,
 } from './account'
 
 const SAMPLE: Account = {
@@ -71,9 +72,51 @@ describe('account.list capability', () => {
   })
 })
 
+describe('account.switch capability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('declares account.write permission and aiTool: true', () => {
+    expect(accountSwitchCapability.permissions).toEqual(['account.write'])
+    expect(accountSwitchCapability.aiTool).toBe(true)
+  })
+
+  it('preflight rejects missing or non-string id', async () => {
+    expect(await accountSwitchCapability.preflight?.({})).toMatchObject({
+      error: expect.stringContaining('id'),
+    })
+    expect(
+      await accountSwitchCapability.preflight?.({ id: 123 }),
+    ).toMatchObject({
+      error: expect.stringContaining('id'),
+    })
+  })
+
+  it('preflight rejects id that is not logged in', async () => {
+    const store = useAccountsStore()
+    store.accounts = [SAMPLE]
+    expect(
+      await accountSwitchCapability.preflight?.({ id: 'acc-missing' }),
+    ).toMatchObject({
+      error: expect.stringContaining('not logged in'),
+    })
+  })
+
+  it('switches active account and returns { ok: true, id }', () => {
+    const store = useAccountsStore()
+    store.accounts = [SAMPLE, { ...SAMPLE, id: 'acc-2', username: 'taka2' }]
+    store.activeAccountId = 'acc-1'
+    const result = accountSwitchCapability.execute({ id: 'acc-2' })
+    expect(result).toEqual({ ok: true, id: 'acc-2' })
+    expect(store.activeAccountId).toBe('acc-2')
+  })
+})
+
 describe('ACCOUNT_BUILTIN_CAPABILITIES', () => {
-  it('contains both capabilities', () => {
+  it('contains all three capabilities', () => {
     expect(ACCOUNT_BUILTIN_CAPABILITIES).toContain(accountCurrentCapability)
     expect(ACCOUNT_BUILTIN_CAPABILITIES).toContain(accountListCapability)
+    expect(ACCOUNT_BUILTIN_CAPABILITIES).toContain(accountSwitchCapability)
   })
 })

--- a/src/capabilities/builtins/account.ts
+++ b/src/capabilities/builtins/account.ts
@@ -69,7 +69,63 @@ export const accountListCapability: Command = {
   },
 }
 
+/**
+ * `account.switch` — グローバルなアクティブアカウントを切り替える write 系。
+ *
+ * 「メインアカウントを別の人格に切り替えて」というユーザー指示を AI が代行
+ * する想定。可逆 / 対外性なし / 破壊的でないため塞ぐリスト外 (memory:
+ * feedback_ai_capability_scope)。auth_start / logout_account / delete_account
+ * とは性質が異なる。
+ *
+ * permissions: `account.write` を要求する。default プリセット (`safe` /
+ * `readonly`) では拒否され、`full` (= user explicit) のみ通る。
+ */
+export const accountSwitchCapability: Command = {
+  id: 'account.switch',
+  label: 'アクティブアカウント切替',
+  icon: 'ti-switch-horizontal',
+  category: 'account',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['account.write'],
+  signature: {
+    description:
+      'グローバルなアクティブアカウントを切り替える。新規カラム追加や' +
+      ' AI チャット送信時のデフォルト送信元が変わる。可逆 (元のアカウントに' +
+      ' 戻せる)、ログアウト・アカウント削除はしない。',
+    params: {
+      id: {
+        type: 'string',
+        description:
+          'account.list で得られるアカウント ID。存在しない ID は失敗する。',
+      },
+    },
+    returns: {
+      type: 'object',
+      description: '`{ ok: true, id }` (切替後の active account id)',
+    },
+    cheap: true,
+  },
+  visible: false,
+  preflight: (params) => {
+    const id = (params as { id?: unknown } | undefined)?.id
+    if (typeof id !== 'string' || id.length === 0) {
+      return { error: 'id (string) is required' }
+    }
+    if (!useAccountsStore().accounts.some((a) => a.id === id)) {
+      return { error: `account "${id}" is not logged in` }
+    }
+    return null
+  },
+  execute: (params) => {
+    const id = (params as { id: string }).id
+    useAccountsStore().switchAccount(id)
+    return { ok: true, id }
+  },
+}
+
 export const ACCOUNT_BUILTIN_CAPABILITIES: readonly Command[] = [
   accountCurrentCapability,
   accountListCapability,
+  accountSwitchCapability,
 ]

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -8,6 +8,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
       [
         'account.current',
         'account.list',
+        'account.switch',
         'ai.chat',
         'ai.listPersonas',
         'ai.sessions.list',

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -905,4 +905,24 @@ describe('dispatchCapability spotlight emission', () => {
     expect(store.spotlights.size).toBe(0)
     expect(store.lastAnnouncement).toContain('削除')
   })
+
+  it('account.switch 成功時に account:<id> を spotlight する', async () => {
+    registerCapability(
+      makeCapability({
+        id: 'account.switch',
+        execute: () => ({ id: 'acc-2', ok: true }),
+      }),
+    )
+
+    const store = useSpotlightStore()
+    await dispatchCapability(
+      'account.switch',
+      { id: 'acc-2' },
+      configWithPreset('full'),
+    )
+
+    await flushNextTick()
+    expect(store.isActive('account:acc-2')).toBe(true)
+    expect(store.lastAnnouncement).toContain('切り替え')
+  })
 })

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -20,12 +20,14 @@ import {
   resolvePermissions,
 } from '@/composables/useAiConfig'
 import {
+  accountTargetId,
   columnTargetId,
   navbarTargetId,
   noteTargetId,
   useSpotlightStore,
   windowTargetId,
 } from '@/composables/useSpotlight'
+import { getAccountLabel, useAccountsStore } from '@/stores/accounts'
 import {
   type ConfirmDecision,
   type ConfirmOptions,
@@ -301,6 +303,17 @@ function emitSpotlightFromCapability(
   } else if (capId === 'notes.delete') {
     // 削除は対象 DOM が消えるので視覚 spotlight 無し。SR テキストのみ。
     useSpotlightStore().announce('AI がノートを削除しました')
+  } else if (capId === 'account.switch') {
+    // アクティブアカウント切替: navbar popup が開いていれば該当行が朱色 glow。
+    // 閉じていれば視覚効果は無いが SR で読み上げ。
+    const r = result as { id?: string } | null
+    if (r?.id) {
+      const acc = useAccountsStore().accounts.find((a) => a.id === r.id)
+      const label = acc ? getAccountLabel(acc) : r.id
+      useSpotlightStore().highlight(accountTargetId(r.id), {
+        label: `AI がアクティブアカウントを ${label} に切り替えました`,
+      })
+    }
   }
 }
 

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -15,7 +15,11 @@ import { useColumnBadge } from '@/composables/useColumnBadge'
 import { COLUMN_ICONS, COLUMN_LABELS } from '@/composables/useColumnTabs'
 import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNavigation } from '@/composables/useNavigation'
-import { navbarTargetId, useSpotlightStore } from '@/composables/useSpotlight'
+import {
+  accountTargetId,
+  navbarTargetId,
+  useSpotlightStore,
+} from '@/composables/useSpotlight'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import {
   type Account,
@@ -77,6 +81,13 @@ function isNavSpotlighted(item: NavItem): boolean {
   return spotlightStore.spotlights.has(
     navbarTargetId(item.type, item.accountId),
   )
+}
+
+function isAccountSpotlighted(id: string): boolean {
+  return spotlightStore.spotlights.has(accountTargetId(id))
+}
+function clearAccountSpotlight(id: string): void {
+  spotlightStore.clear(accountTargetId(id))
 }
 
 const accountAttentionCount = computed(
@@ -641,7 +652,8 @@ defineExpose({
                 <div
                   v-for="acc in accountsStore.accounts"
                   :key="acc.id"
-                  :class="$style.accountPopupItem"
+                  :class="[$style.accountPopupItem, { [$style.spotlighted]: isAccountSpotlighted(acc.id) }]"
+                  @mousedown="clearAccountSpotlight(acc.id)"
                   @click.stop="toggleAccountMenu(acc.id)"
                 >
                   <div
@@ -1018,6 +1030,32 @@ defineExpose({
 
 .accountPopupItem {
   position: relative;
+}
+
+/* AI Spotlight: account.switch でこの行を朱色 glow で囲む */
+.accountPopupItem.spotlighted::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  pointer-events: none;
+  box-shadow:
+    0 0 0 2px rgba(170, 30, 30, 0.7),
+    0 0 24px 8px rgba(170, 30, 30, 0.4);
+  animation: spotlightAccountAppear 2.4s ease-out 1 forwards;
+  z-index: 2;
+}
+@media (prefers-reduced-motion: reduce) {
+  .accountPopupItem.spotlighted::after {
+    animation: none;
+    opacity: 1;
+  }
+}
+@keyframes spotlightAccountAppear {
+  0%   { opacity: 0; }
+  10%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 .accountPopupBtn {

--- a/src/composables/useSpotlight.test.ts
+++ b/src/composables/useSpotlight.test.ts
@@ -2,6 +2,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  accountTargetId,
   columnTargetId,
   navbarTargetId,
   noteTargetId,
@@ -163,5 +164,11 @@ describe('windowTargetId', () => {
 describe('noteTargetId', () => {
   it('note id を note:<id> 形式で組み立てる', () => {
     expect(noteTargetId('9abc123')).toBe('note:9abc123')
+  })
+})
+
+describe('accountTargetId', () => {
+  it('account id を account:<id> 形式で組み立てる', () => {
+    expect(accountTargetId('acc-1')).toBe('account:acc-1')
   })
 })

--- a/src/composables/useSpotlight.ts
+++ b/src/composables/useSpotlight.ts
@@ -119,3 +119,11 @@ export function windowTargetId(windowId: string): string {
 export function noteTargetId(noteId: string): string {
   return `note:${noteId}`
 }
+
+/**
+ * アカウント切替 UI のアバター/アイテムを指す target ID。
+ * NoteDeck のアカウント popup 内 item を光らせるのに使う。
+ */
+export function accountTargetId(accountId: string): string {
+  return `account:${accountId}`
+}


### PR DESCRIPTION
## Summary

AI Spotlight の Phase 2b 最終回。新規 capability `account.switch` を追加し、AI が「メインアカウントを X に切り替えて」と頼まれたときに切り替えられるようにする。同時にアカウント popup item を朱色枠 glow で spotlight する。

### account.switch capability
- グローバルな `activeAccountId` を切り替える (= 画面右下のアカウントアバターをクリックして popup から選ぶのと同等)
- 影響範囲: 新規カラム追加・AI チャット送信時のデフォルト送信元、各種「自分」判定 UI
- **可逆 / 対外性なし / 破壊しない** → memory `feedback_ai_capability_scope` の塞ぐリスト外
- permission: `account.write` (default `safe`/`readonly` プリセットでは拒否、`full` のみ通る)
- preflight で id 形式 + 「未ログイン id」を弾く

### Spotlight
- target ID 新規規約 `account:<accountId>` (`accountTargetId(id)` ヘルパー)
- DeckNavbar のアカウント popup item に `::after` 朱色枠 glow を追加
- popup が閉じている時は視覚効果なし、SR で `AI がアクティブアカウントを @user@host に切り替えました` を読み上げ
- mousedown で spotlight 即解除

### memory 更新
- `feedback_ai_capability_scope`: account.switch は user 操作系 OK / 塞ぐリストは破壊的なもの (auth_start/logout/delete) に限定と明文化

## Test plan

- [x] `pnpm typecheck` 緑
- [x] `pnpm lint` 緑
- [x] `pnpm test` 緑 (979 件 / +6)
- [ ] 手動: 2 アカウント以上ログインした状態で AI に「もう片方のアカウントに切り替えて」 → activeAccountId が変わり、popup を開くと該当行が朱色 glow + SR で読み上げ
- [ ] 手動: 未ログインの id を指定 → preflight で弾かれ permission_denied ではなく preflight_failed
- [ ] 手動: `prefers-reduced-motion` 有効で animation なし、静的 glow

## Phase 2b 全体まとめ

| PR | 対象 | 状態 |
|---|---|---|
| #579 (2b.1) | windows.* | merged |
| #580 (2b.2) | notes.* | merged |
| #581 (2b.3) | account.switch + spotlight | このPR |

これで AI Spotlight Phase 2 系列は一旦完了。次は Phase 3 (AI guide mode / Kifi 風スクリプテッドデモ) に進める。

🤖 Generated with [Claude Code](https://claude.com/claude-code)