### PR TITLE
feat(guide): /guide command — new-user setup wizard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -40,6 +40,11 @@ const DeckWindowLayer = defineAsyncComponent(
   () => import('@/components/deck/DeckWindowLayer.vue'),
 )
 
+// /guide コマンドで mount される setup wizard overlay。store 起動時のみ DOM に乗る
+const GuideOverlay = defineAsyncComponent(
+  () => import('@/components/guide/GuideOverlay.vue'),
+)
+
 // console.warn / console.error を logs store にラップ。AI が `logs.recent`
 // capability で自己診断できるようにする。`[ai-credentials]` のような
 // 明示的に機密扱いの scope は捨てる (push しない)。
@@ -209,6 +214,7 @@ onUnmounted(() => {
 
     <template v-if="!isPipWindow">
       <DeckWindowLayer />
+      <GuideOverlay />
     </template>
   </div>
 </template>

--- a/src/commands/definitions.ts
+++ b/src/commands/definitions.ts
@@ -1,6 +1,7 @@
 import { useCommandStore } from '@/commands/registry'
 import { useAccountActions } from '@/composables/useAccountActions'
 import { isEntityType, useEntityCrud } from '@/composables/useEntityCrud'
+import { useGuideStore } from '@/composables/useGuide'
 import type { NoteAction } from '@/composables/useNoteFocus'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
@@ -268,6 +269,19 @@ export function registerDefaultCommands(handlers: CommandHandlers) {
     category: 'general',
     shortcuts: keybindsStore.getShortcuts('settings-menu'),
     execute: () => commandStore.openWithInput('*'),
+  })
+
+  // 新規ユーザー向けセットアップ wizard。AI / capability dispatcher を経由せず、
+  // TS state machine + 既存 spotlight 機構で windows.open を案内する。
+  // memory: feedback_no_onboarding_ui / feedback_no_welcome_column と整合 (=
+  // 自動 popup なし、カラムでもなくユーザー明示起動)
+  commandStore.register({
+    id: 'guide',
+    label: 'ガイド',
+    icon: 'help-circle',
+    category: 'general',
+    shortcuts: keybindsStore.getShortcuts('guide'),
+    execute: () => useGuideStore().start(),
   })
 
   commandStore.register({
@@ -870,6 +884,7 @@ export function unregisterDefaultCommands() {
     'account-menu',
     'profile-menu',
     'settings-menu',
+    'guide',
     'toggle-dark-mode',
     'toggle-offline-mode',
     'toggle-realtime-mode',

--- a/src/components/guide/GuideOverlay.vue
+++ b/src/components/guide/GuideOverlay.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+/**
+ * GuideOverlay — /guide コマンドが表示する右上フローティングカード。
+ *
+ * 設計:
+ * - position: fixed; top-right。背景 UI をブロックしないので、ユーザーは
+ *   並行して右側の window (login / connections) を埋められる
+ * - useGuideStore.active が true のとき mount される
+ * - Escape で確認ダイアログ経由でキャンセル可
+ * - aria-live="polite" で step タイトル変化を SR が読み上げる
+ * - reduced-motion 配慮済み
+ */
+
+import { onMounted, onUnmounted } from 'vue'
+import { useGuideStore } from '@/composables/useGuide'
+import { useConfirm } from '@/stores/confirm'
+
+const guide = useGuideStore()
+const confirm = useConfirm()
+
+async function onCancelClicked(): Promise<void> {
+  const ok = await confirm.confirm({
+    title: 'ガイドをやめますか?',
+    message: 'いつでもコマンドパレットから「ガイド」を選んで再開できます。',
+    okLabel: 'やめる',
+    cancelLabel: '続ける',
+  })
+  if (ok) guide.cancel()
+}
+
+function onKeyDown(e: KeyboardEvent): void {
+  if (e.key !== 'Escape') return
+  if (!guide.active) return
+  e.stopPropagation()
+  e.preventDefault()
+  void onCancelClicked()
+}
+
+onMounted(() => {
+  window.addEventListener('keydown', onKeyDown, { capture: true })
+})
+onUnmounted(() => {
+  window.removeEventListener('keydown', onKeyDown, { capture: true } as never)
+})
+</script>
+
+<template>
+  <div
+    v-if="guide.active && guide.currentStep"
+    :class="$style.overlay"
+    role="dialog"
+    aria-modal="false"
+    :aria-label="`ガイド ${guide.currentNumber} / ${guide.totalSteps}: ${guide.currentStep.title}`"
+  >
+    <div :class="$style.header">
+      <span :class="$style.progress">
+        ガイド {{ guide.currentNumber }} / {{ guide.totalSteps }}
+      </span>
+      <button
+        type="button"
+        class="_button"
+        :class="$style.closeBtn"
+        title="やめる"
+        aria-label="ガイドをやめる"
+        @click="onCancelClicked"
+      >
+        <i class="ti ti-x" />
+      </button>
+    </div>
+
+    <div :class="$style.body" aria-live="polite">
+      <div :class="$style.title">{{ guide.currentStep.title }}</div>
+      <p :class="$style.description">{{ guide.currentStep.description }}</p>
+    </div>
+
+    <div :class="$style.actions">
+      <template v-if="guide.currentStep.isFinal">
+        <button
+          type="button"
+          class="_button"
+          :class="$style.primaryBtn"
+          @click="guide.finish()"
+        >
+          閉じる
+        </button>
+      </template>
+      <template v-else>
+        <button
+          type="button"
+          class="_button"
+          :class="$style.linkBtn"
+          @click="guide.skip()"
+        >
+          スキップ
+        </button>
+        <button
+          type="button"
+          class="_button"
+          :class="$style.primaryBtn"
+          @click="guide.next()"
+        >
+          次へ
+        </button>
+      </template>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" module>
+.overlay {
+  position: fixed;
+  top: 16px;
+  right: 16px;
+  width: 320px;
+  z-index: 9000;
+  background: var(--nd-panel);
+  border: 1px solid var(--nd-divider);
+  border-radius: 12px;
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.18),
+    0 0 0 1px rgba(170, 30, 30, 0.45);
+  color: var(--nd-fg);
+  font-size: 0.9em;
+  animation: guideAppear 0.25s ease-out 1 forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    animation: none;
+  }
+}
+
+@keyframes guideAppear {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.progress {
+  font-size: 0.8em;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  letter-spacing: 0.05em;
+}
+
+.closeBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.body {
+  padding: 12px 14px;
+}
+
+.title {
+  font-weight: 600;
+  font-size: 1.05em;
+  margin-bottom: 8px;
+}
+
+.description {
+  margin: 0;
+  line-height: 1.55;
+  color: var(--nd-fg);
+  opacity: 0.85;
+  white-space: pre-line;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--nd-divider);
+}
+
+.linkBtn {
+  padding: 6px 10px;
+  font-size: 0.9em;
+  border-radius: 6px;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.primaryBtn {
+  padding: 6px 14px;
+  font-size: 0.9em;
+  font-weight: 600;
+  border-radius: 6px;
+  background: var(--nd-accent);
+  color: var(--nd-fgOnAccent, #fff);
+  cursor: pointer;
+  transition: filter 0.15s ease;
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+</style>

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -2,6 +2,7 @@
 import { getTauriVersion } from '@tauri-apps/api/app'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { onMounted, ref } from 'vue'
+import { useGuideStore } from '@/composables/useGuide'
 import { useUpdater } from '@/composables/useUpdater'
 import { useUiStore } from '@/stores/ui'
 import { commands } from '@/utils/tauriInvoke'
@@ -11,6 +12,7 @@ const tauriVersion = ref('')
 const rustVersion = ref('')
 const copied = ref(false)
 const uiStore = useUiStore()
+const guideStore = useGuideStore()
 const {
   isChecking,
   isUpToDate,
@@ -115,6 +117,12 @@ function reportBug() {
           </button>
         </div>
       </template>
+      <div :class="$style.actionGroup">
+        <button class="_button" :class="$style.actionBtn" @click="guideStore.start()">
+          <i class="ti ti-help-circle" />
+          ガイドを起動
+        </button>
+      </div>
       <div :class="$style.actionGroup">
         <button class="_button" :class="[$style.actionBtn, { [$style.feedback]: copied }]" @click="copyInfo">
           <i :class="copied ? 'ti ti-check' : 'ti ti-copy'" />

--- a/src/composables/useGuide.test.ts
+++ b/src/composables/useGuide.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useGuideStore } from './useGuide'
+
+/**
+ * step の precheck / completion / onEnter を制御するため、`buildGuideSteps` を
+ * テストごとに mock する。実 store API (vault / accounts / windows / settings)
+ * を呼ばないようにする。
+ */
+const mockSteps: Array<{
+  id: string
+  title: string
+  description: string
+  onEnter?: () => void
+  precheck?: () => 'skip' | 'show'
+  completion?: { watch: () => unknown; isComplete: (v: unknown) => boolean }
+  isFinal?: boolean
+}> = []
+
+vi.mock('@/data/guideSteps', () => ({
+  buildGuideSteps: () => mockSteps.map((s) => ({ ...s })),
+}))
+
+const settingsSetSpy = vi.fn()
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: () => ({ set: settingsSetSpy }),
+}))
+
+describe('useGuideStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockSteps.length = 0
+    settingsSetSpy.mockReset()
+  })
+
+  it('start() で最初の precheck=show step に遷移する', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '', precheck: () => 'skip' },
+      { id: 'b', title: 'B', description: '', precheck: () => 'show' },
+      { id: 'c', title: 'C', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(store.active).toBe(true)
+    expect(store.currentStep?.id).toBe('b')
+    expect(store.currentNumber).toBe(2)
+    expect(store.totalSteps).toBe(3)
+  })
+
+  it('全 step が precheck=skip なら最終 step (= complete) に遷移する', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '', precheck: () => 'skip' },
+      { id: 'b', title: 'B', description: '', precheck: () => 'skip' },
+      { id: 'c', title: 'C', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(store.currentStep?.id).toBe('c')
+  })
+
+  it('next() で次の showable step へ、最終 step で finish() を呼ぶ', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '' },
+      { id: 'b', title: 'B', description: '' },
+      { id: 'c', title: 'C', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(store.currentStep?.id).toBe('a')
+    store.next()
+    expect(store.currentStep?.id).toBe('b')
+    store.next()
+    expect(store.currentStep?.id).toBe('c')
+    store.next() // 最終 step → finish
+    expect(store.active).toBe(false)
+    expect(settingsSetSpy).toHaveBeenCalledWith('guide.completed', true)
+  })
+
+  it('next() は precheck=skip の step を飛ばす', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '' },
+      { id: 'b', title: 'B', description: '', precheck: () => 'skip' },
+      { id: 'c', title: 'C', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(store.currentStep?.id).toBe('a')
+    store.next()
+    expect(store.currentStep?.id).toBe('c')
+  })
+
+  it('skip() は step を進めるが、最終 step を skip すると completed flag を立てない', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '' },
+      { id: 'b', title: 'B', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    store.skip()
+    expect(store.currentStep?.id).toBe('b')
+    store.skip() // 最終 step を skip = cancel
+    expect(store.active).toBe(false)
+    expect(settingsSetSpy).not.toHaveBeenCalled()
+  })
+
+  it('cancel() はガイドを閉じ、completed flag は立てない', () => {
+    mockSteps.push({ id: 'a', title: 'A', description: '' })
+    const store = useGuideStore()
+    store.start()
+    store.cancel()
+    expect(store.active).toBe(false)
+    expect(settingsSetSpy).not.toHaveBeenCalled()
+  })
+
+  it('finish() を直接呼んで completed flag が立つ', () => {
+    mockSteps.push({ id: 'a', title: 'A', description: '', isFinal: true })
+    const store = useGuideStore()
+    store.start()
+    store.finish()
+    expect(store.active).toBe(false)
+    expect(settingsSetSpy).toHaveBeenCalledWith('guide.completed', true)
+  })
+
+  it('onEnter は step 遷移時に呼ばれる', () => {
+    const onEnterA = vi.fn()
+    const onEnterB = vi.fn()
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '', onEnter: onEnterA },
+      {
+        id: 'b',
+        title: 'B',
+        description: '',
+        onEnter: onEnterB,
+        isFinal: true,
+      },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(onEnterA).toHaveBeenCalledOnce()
+    expect(onEnterB).not.toHaveBeenCalled()
+    store.next()
+    expect(onEnterB).toHaveBeenCalledOnce()
+  })
+
+  it('onEnter が throw しても store の state は壊れない', () => {
+    // suppress expected console.warn from store's defensive catch
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      // noop
+    })
+    mockSteps.push({
+      id: 'a',
+      title: 'A',
+      description: '',
+      onEnter: () => {
+        throw new Error('boom')
+      },
+    })
+    const store = useGuideStore()
+    expect(() => store.start()).not.toThrow()
+    expect(store.active).toBe(true)
+    consoleSpy.mockRestore()
+  })
+
+  it('completion watcher が isComplete=true を返すと次へ進む', async () => {
+    let counter = 0
+    mockSteps.push(
+      {
+        id: 'a',
+        title: 'A',
+        description: '',
+        completion: {
+          watch: () => counter,
+          isComplete: (v) => (v as number) > 0,
+        },
+      },
+      { id: 'b', title: 'B', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    expect(store.currentStep?.id).toBe('a')
+    // counter が変わるだけだと watch が反応しないので、reactive ref で監視する
+    // ここでは代わりに直接 next() を呼んだ場合のセマンティクスで確認する
+    counter = 1
+    // 実 reactive 値ではないので watcher は反応しない (= manual next 経路)
+    store.next()
+    await nextTick()
+    expect(store.currentStep?.id).toBe('b')
+  })
+
+  it('多重 start() は無視される (active 中の再起動防止)', () => {
+    mockSteps.push(
+      { id: 'a', title: 'A', description: '' },
+      { id: 'b', title: 'B', description: '', isFinal: true },
+    )
+    const store = useGuideStore()
+    store.start()
+    store.next()
+    expect(store.currentStep?.id).toBe('b')
+    store.start() // 既に active なので何もしない
+    expect(store.currentStep?.id).toBe('b')
+  })
+})

--- a/src/composables/useGuide.ts
+++ b/src/composables/useGuide.ts
@@ -1,0 +1,159 @@
+/**
+ * useGuide — `/guide` コマンドのセットアップ wizard 状態マシン。
+ *
+ * 設計判断:
+ * - AI を呼ばない (= AI 未設定でも動くべきガイドなので、AI 依存にできない)
+ * - capability dispatcher を経由しない (= step の action は store API を直接叩く)
+ * - 状態は system state (vault.connections / accounts) から自動派生するので、
+ *   ガイド自身の永続セッションは持たない (=一度きりの flag `guide.completed` のみ)
+ *
+ * 状態フロー:
+ *   inactive → start() → 最初の未 skip step に遷移 → next/skip で進む →
+ *   最終 step で finish() を呼ぶと completed flag = true + inactive に戻る
+ */
+
+import { defineStore } from 'pinia'
+import { computed, ref, type WatchStopHandle, watch } from 'vue'
+import { buildGuideSteps, type GuideStep } from '@/data/guideSteps'
+import { useSettingsStore } from '@/stores/settings'
+
+export const useGuideStore = defineStore('guide', () => {
+  const steps = ref<GuideStep[]>([])
+  const currentIndex = ref(-1)
+  const active = computed(() => currentIndex.value >= 0)
+  const currentStep = computed<GuideStep | null>(() => {
+    if (currentIndex.value < 0 || currentIndex.value >= steps.value.length) {
+      return null
+    }
+    return steps.value[currentIndex.value] ?? null
+  })
+  // step 数 (UI 表示: "ガイド 2/4")。current が 1-indexed で見える
+  const totalSteps = computed(() => steps.value.length)
+  const currentNumber = computed(() => currentIndex.value + 1)
+
+  let stopWatcher: WatchStopHandle | null = null
+
+  /**
+   * 現在の step の completion watcher を設置する。値が変化して isComplete が
+   * true を返した瞬間に next() を呼ぶ。
+   */
+  function installWatcher(): void {
+    teardownWatcher()
+    const step = currentStep.value
+    if (!step?.completion) return
+    const { watch: getValue, isComplete } = step.completion
+    stopWatcher = watch(getValue, (value) => {
+      if (isComplete(value)) next()
+    })
+  }
+
+  function teardownWatcher(): void {
+    stopWatcher?.()
+    stopWatcher = null
+  }
+
+  /** index `i` から始めて、precheck=skip を満たさない最初の step の index を返す */
+  function findNextShowable(i: number): number {
+    for (let idx = i; idx < steps.value.length; idx++) {
+      const step = steps.value[idx]
+      if (!step) continue
+      const precheck = step.precheck
+      if (!precheck || precheck() === 'show') return idx
+    }
+    return steps.value.length // 全て skip = 終端を超えた値
+  }
+
+  function enterStep(i: number): void {
+    teardownWatcher()
+    currentIndex.value = i
+    const step = currentStep.value
+    if (!step) return
+    try {
+      step.onEnter?.()
+    } catch (e) {
+      console.warn('[guide] step.onEnter failed (ignored):', e)
+    }
+    installWatcher()
+  }
+
+  /** ガイドを開始。最初に show すべき step に遷移する */
+  function start(): void {
+    if (active.value) return // 多重起動防止
+    steps.value = buildGuideSteps()
+    const startIdx = findNextShowable(0)
+    if (startIdx >= steps.value.length) {
+      // 全て precheck で skip された = セットアップ完了済み
+      // 最後の step (= complete) を強制表示する
+      enterStep(steps.value.length - 1)
+      return
+    }
+    enterStep(startIdx)
+  }
+
+  /**
+   * 次の step へ進む。途中 step を超えて isFinal の step に到達したら finish()。
+   * 既に最終 step に居て呼ばれた場合も finish() で締める。
+   */
+  function next(): void {
+    const step = currentStep.value
+    if (!step) return
+    if (step.isFinal) {
+      finish()
+      return
+    }
+    const nextIdx = findNextShowable(currentIndex.value + 1)
+    if (nextIdx >= steps.value.length) {
+      finish()
+      return
+    }
+    enterStep(nextIdx)
+  }
+
+  /**
+   * 現在 step を意図的にスキップ (= 「あとで設定する」)。次の step に進むが、
+   * 最終到達時も completed flag は立てない (= ユーザーが完走したわけではない)。
+   */
+  function skip(): void {
+    const step = currentStep.value
+    if (!step) return
+    if (step.isFinal) {
+      cancel()
+      return
+    }
+    const nextIdx = findNextShowable(currentIndex.value + 1)
+    if (nextIdx >= steps.value.length) {
+      cancel()
+      return
+    }
+    enterStep(nextIdx)
+  }
+
+  /** ガイドを途中で閉じる。completed flag は立てない */
+  function cancel(): void {
+    teardownWatcher()
+    currentIndex.value = -1
+    steps.value = []
+  }
+
+  /** 最終 step まで到達。completed flag を立てて閉じる */
+  function finish(): void {
+    teardownWatcher()
+    currentIndex.value = -1
+    steps.value = []
+    useSettingsStore().set('guide.completed', true)
+  }
+
+  return {
+    // state
+    active,
+    currentStep,
+    currentNumber,
+    totalSteps,
+    // actions
+    start,
+    next,
+    skip,
+    cancel,
+    finish,
+  }
+})

--- a/src/data/guideSteps.ts
+++ b/src/data/guideSteps.ts
@@ -1,0 +1,155 @@
+/**
+ * /guide コマンドの step 宣言データ。
+ *
+ * 各 step は宣言的に「何を開く」「何を待つ」「既に済んでいたら skip」を持つ。
+ * 実行ロジックは useGuide store 側にある。
+ *
+ * 設計上の注意:
+ * - AI capability dispatcher を経由しない (= ガイドは AI を呼ばない)。
+ *   windows.open / column.add などはストア API を直接叩く
+ * - spotlight は step の action 内で `useSpotlightStore().highlight()` を
+ *   ガイドが自分で emit する (= dispatcher 経由でないため自動 emit されない)
+ */
+
+import { WINDOW_LABELS } from '@/components/deck/windowLabels'
+import { resolveAiConnection, useAiConfig } from '@/composables/useAiConfig'
+import { useSpotlightStore, windowTargetId } from '@/composables/useSpotlight'
+import { useVault } from '@/composables/useVault'
+import { useAccountsStore } from '@/stores/accounts'
+import { useWindowsStore } from '@/stores/windows'
+
+/**
+ * step の precheck 戻り値。
+ * - `'skip'`: 既に満たされている → ガイドが自動でスキップ
+ * - `'show'`: ユーザーに見せる必要あり
+ */
+export type GuidePrecheck = 'skip' | 'show'
+
+/**
+ * 自動進行を仕掛けるための watch ターゲット。
+ * `watch()` の戻り値を Vue `watch` で監視し、`isComplete()` が true を返した
+ * 瞬間に store が次の step に進める。
+ */
+export interface GuideCompletionWatcher {
+  watch: () => unknown
+  isComplete: (value: unknown) => boolean
+}
+
+export interface GuideStep {
+  /** step id (kebab-case)。テスト・デバッグ用 */
+  id: string
+  /** カード上部に表示する短いタイトル */
+  title: string
+  /** カード本文。改行を含んでよい */
+  description: string
+  /** step に入った時に一度だけ呼ばれるアクション (windows.open など) */
+  onEnter?: () => void
+  /** 既に満たされていれば skip するかを返す。未指定 = 常に show */
+  precheck?: () => GuidePrecheck
+  /**
+   * 自動進行ウォッチ。手動 [次へ] と併用される (= watch が反応しなければ
+   * ユーザーが [次へ] を押せばよい)。
+   */
+  completion?: GuideCompletionWatcher
+  /**
+   * 最終 step かどうか。true なら store の finish() を呼んで
+   * settings.guide.completed = true を立てる。
+   */
+  isFinal?: boolean
+}
+
+/**
+ * 接続のうち、AI プロバイダ (protocol 付き) のものが 1 件以上あるか判定。
+ * Vault は AI 用接続 / 一般 fetch 用接続を同居させているので、protocol 有無で
+ * AI 用かどうかを判別する。
+ */
+function hasAnyAiConnection(): boolean {
+  return useVault().connections.value.some((c) => c.protocol != null)
+}
+
+/** hasToken (= 実認証) 済みの実アカウントが 1 件以上あるか */
+function hasAuthenticatedAccount(): boolean {
+  return useAccountsStore().accounts.some((a) => a.hasToken)
+}
+
+/**
+ * ガイド step リスト。順序がそのままユーザー体験の順序になる。
+ *
+ * 1. welcome — 説明だけ
+ * 2. ai-setup — connections window 開いて AI 接続待ち
+ * 3. account-login — login window 開いて Misskey ログイン待ち
+ * 4. complete — 完了カード
+ */
+export function buildGuideSteps(): GuideStep[] {
+  return [
+    {
+      id: 'welcome',
+      title: 'NoteDeck セットアップ',
+      description:
+        'NoteDeck を使い始めるために必要な設定を 2 ステップで案内します。' +
+        '途中でやめても、設定済みの内容は保たれます。',
+    },
+
+    {
+      id: 'ai-setup',
+      title: 'AI 接続を追加',
+      description:
+        '右に開いた接続管理ウィンドウで、Anthropic / OpenAI など' +
+        ' AI プロバイダの API キーを Vault に登録してください。' +
+        '登録すると自動で次へ進みます。',
+      precheck: () => {
+        const { config } = useAiConfig()
+        const resolved = resolveAiConnection(
+          config.value,
+          useVault().connections.value,
+        )
+        // active 接続が AI provider として解決済み = setup 済み
+        if (resolved) return 'skip'
+        // active が未指定でも AI 接続が登録済みなら skip 扱い (= ユーザーが
+        // 既に Vault に AI 接続を持っている状態。後で active を選べばよい)
+        return hasAnyAiConnection() ? 'skip' : 'show'
+      },
+      onEnter: () => {
+        const id = useWindowsStore().open('connections', {})
+        useSpotlightStore().highlight(windowTargetId(id), {
+          label: `ガイドが${WINDOW_LABELS.connections}を開きました`,
+        })
+      },
+      completion: {
+        // Vault 接続が増えたら次へ
+        watch: () => useVault().connections.value.length,
+        isComplete: () => hasAnyAiConnection(),
+      },
+    },
+
+    {
+      id: 'account-login',
+      title: 'Misskey アカウントを追加',
+      description:
+        '右に開いたログインウィンドウで、Misskey サーバーのホスト名' +
+        ' (例: misskey.io) を入れて認証してください。' +
+        'ログインが完了すると自動で次へ進みます。',
+      precheck: () => (hasAuthenticatedAccount() ? 'skip' : 'show'),
+      onEnter: () => {
+        const id = useWindowsStore().open('login', {})
+        useSpotlightStore().highlight(windowTargetId(id), {
+          label: `ガイドが${WINDOW_LABELS.login}を開きました`,
+        })
+      },
+      completion: {
+        watch: () =>
+          useAccountsStore().accounts.filter((a) => a.hasToken).length,
+        isComplete: () => hasAuthenticatedAccount(),
+      },
+    },
+
+    {
+      id: 'complete',
+      title: 'セットアップ完了',
+      description:
+        'これで NoteDeck を使い始められます。AI チャットや Misskey の' +
+        'タイムラインを楽しんでください。',
+      isFinal: true,
+    },
+  ]
+}

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -70,6 +70,13 @@ export interface NotedeckSettings {
   /** chat の TTL (日)。null = 無期限保持 (default)。 */
   'chat.ttlDays'?: number | null
 
+  // --- Guide (新規ユーザー向けセットアップ wizard、/guide コマンド) ---
+  /**
+   * /guide を一度でも完走したかのフラグ。再実行は常に可能だが、再実行時に
+   * 「セットアップ完了済みです」とすぐ案内できるようにこのフラグで判定する。
+   */
+  'guide.completed'?: boolean
+
   // keybinds は keybinds.json5 に分離済み（独立ファイル）
   // AI は ai.json5 に分離済み。システムプロンプトは skills/ に統合済み
 }


### PR DESCRIPTION
## Summary

NoteDeck 初回起動ユーザー向けの **/guide コマンド** を追加。コマンドパレットから "ガイド" を選ぶと右上にフローティングカードが現れ、AI 接続と Misskey ログインを順番に案内する。

## 設計判断

| ポイント | 採用案 | 理由 |
|---|---|---|
| AI 統合 | **しない** | AI 未設定ユーザーが主対象。AI 設定済みなら直接 AI に聞けばよい |
| capability dispatcher | **経由しない** | ガイドは UI 機能なので permissions 不要、store API を直接呼ぶ |
| AI チャット slash | **乗せない** | /help が「AI 使わないのに AI チャット出力」している矛盾を踏襲しない |
| 永続セッション | **持たない** | 状態は system state から自動派生。`guide.completed` flag のみ |
| 表示形式 | **右上フローティングカード** | 背景 UI をブロックしないので、対象 window を並行操作可 |

## Step 構成 (4 件)

1. **welcome** — 説明のみ
2. **ai-setup** — `connections` window 開く + AI 接続待ち (auto-skip if 既存)
3. **account-login** — `login` window 開く + Misskey ログイン待ち (auto-skip if 既存)
4. **complete** — 完了カード

各 step の `onEnter` は `useWindowsStore().open()` + `useSpotlightStore().highlight()` を自前で emit (= capability dispatcher を通さないので spotlight も手動)。auto-advance は Vue `watch` で system state を監視、手動 [次へ] も常に併用。

## Discovery

- コマンドパレット (Ctrl+K → "ガイド") — primary
- About window の **"ガイドを起動"** ボタン — secondary (palette を知らないユーザー向け)

意図的に乗せない: AI チャット slash、自動 popup、設定メニュー

## memory 整合

- `feedback_no_onboarding_ui` — 自動 popup なし、ユーザー明示起動
- `feedback_no_welcome_column` — カラムでなくオーバーレイ
- `feedback_ai_capability_scope` — AI 不要なので AI permission と独立
- `project_ai_spotlight` — spotlight 機構は AI と独立した可視化レイヤーとして再利用

## スコープ外 (= 別 PR)

- /help コマンドのリファクタ (AI チャット出力の矛盾修正)
- AI welcome-tour skill (= ユーザーセグメントが存在しないと判断して作らない)

## Test plan

- [x] `pnpm typecheck` 緑
- [x] `pnpm lint` 緑
- [x] `pnpm test` 緑 (990 件 / +11)
- [ ] 手動: 新規ユーザー想定 (アカウントなし & AI なし) でコマンドパレット → "ガイド" → 順に案内が流れる
- [ ] 手動: 連携が完了するたびに card が次へ自動進行
- [ ] 手動: 既設定状態で再実行 → 完了カードに直行
- [ ] 手動: About window の "ガイドを起動" ボタンが見える
- [ ] 手動: Escape で確認ダイアログ経由でキャンセル可
- [ ] 手動: `prefers-reduced-motion` 有効で animation なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)