### PR TITLE
refactor(spotlight): ハイライト色をテーマ警告色 (--nd-warn) に切替

### DIFF
--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -1556,8 +1556,8 @@ function handlePickerReaction(reaction: string) {
     border-radius: inherit;
     pointer-events: none;
     box-shadow:
-      0 0 0 2px rgba(170, 30, 30, 0.7),
-      0 0 24px 8px rgba(170, 30, 30, 0.4);
+      0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
+      0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
     animation: spotlightNoteAppear 2.4s ease-out 1 forwards;
     z-index: 2;
   }

--- a/src/components/deck/DeckBottomBar.vue
+++ b/src/components/deck/DeckBottomBar.vue
@@ -276,11 +276,11 @@ const {
     border-radius: inherit;
     background: linear-gradient(
       180deg,
-      rgba(170, 30, 30, 0.55) 0%,
-      rgba(200, 55, 45, 0.3) 50%,
-      rgba(220, 90, 80, 0.05) 100%
+      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
+      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
+      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
     );
-    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
     pointer-events: none;
     z-index: 0;
     animation: spotlightFill 2.4s ease-out 1 forwards;

--- a/src/components/deck/DeckMobileNav.vue
+++ b/src/components/deck/DeckMobileNav.vue
@@ -200,11 +200,11 @@ const {
     border-radius: inherit;
     background: linear-gradient(
       180deg,
-      rgba(170, 30, 30, 0.55) 0%,
-      rgba(200, 55, 45, 0.3) 50%,
-      rgba(220, 90, 80, 0.05) 100%
+      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
+      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
+      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
     );
-    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
     pointer-events: none;
     z-index: 0;
     animation: spotlightFill 2.4s ease-out 1 forwards;

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -936,11 +936,11 @@ defineExpose({
     border-radius: inherit;
     background: linear-gradient(
       180deg,
-      rgba(170, 30, 30, 0.55) 0%,
-      rgba(200, 55, 45, 0.3) 50%,
-      rgba(220, 90, 80, 0.05) 100%
+      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
+      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
+      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
     );
-    box-shadow: 0 -1px 8px rgba(170, 30, 30, 0.25);
+    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
     pointer-events: none;
     z-index: 0;
     animation: spotlightFill 2.4s ease-out 1 forwards;
@@ -1040,8 +1040,8 @@ defineExpose({
   border-radius: inherit;
   pointer-events: none;
   box-shadow:
-    0 0 0 2px rgba(170, 30, 30, 0.7),
-    0 0 24px 8px rgba(170, 30, 30, 0.4);
+    0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
+    0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
   animation: spotlightAccountAppear 2.4s ease-out 1 forwards;
   z-index: 2;
 }

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -410,8 +410,8 @@ onBeforeUnmount(() => {
     border-radius: inherit;
     pointer-events: none;
     box-shadow:
-      0 0 0 2px rgba(170, 30, 30, 0.7),
-      0 0 24px 8px rgba(170, 30, 30, 0.4);
+      0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
+      0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
     animation: spotlightWindowAppear 2.4s ease-out 1 forwards;
   }
 

--- a/src/components/guide/GuideOverlay.vue
+++ b/src/components/guide/GuideOverlay.vue
@@ -118,7 +118,7 @@ onUnmounted(() => {
   border-radius: 12px;
   box-shadow:
     0 4px 16px rgba(0, 0, 0, 0.18),
-    0 0 0 1px rgba(170, 30, 30, 0.45);
+    0 0 0 1px color-mix(in srgb, var(--nd-warn) 45%, transparent);
   color: var(--nd-fg);
   font-size: 0.9em;
   animation: guideAppear 0.25s ease-out 1 forwards;


### PR DESCRIPTION
## Summary

これまで spotlight 系 (AI 経由 / ガイド経由ともに) の glow / fill / overlay 装飾は OpenClaw 系朱色 `rgba(170, 30, 30, *)` を hard-coded で使っていたが、テーマ警告色 `var(--nd-warn)` に統一する。

## なぜ変えるか

- **テーマ整合**: ダーク/ライト切替やカスタムテーマでも spotlight 色がアプリ全体と一致するようにする
- **コードベース整合**: 既存コード (DeckColumn / AppToast / SystemIcon 等) は `color-mix(in srgb, var(--nd-warn) X%, transparent)` パターンで警告系を表現済み。spotlight もこれに合わせる
- alpha 値はそのまま保持して視覚的強さは変えていない (= 色相のみ変更)

## 対象ファイル (6 件)

| ファイル | 装飾種別 |
|---|---|
| DeckBottomBar.vue / DeckMobileNav.vue / DeckNavbar.vue | 塗りつぶし系グラデーション (3 ストップ + 落とし影) |
| DeckNavbar.vue (account popup) | popup item の枠 glow |
| DeckWindow.vue / MkNote.vue | ::after 枠 glow |
| GuideOverlay.vue | カード周囲のハイライト |

## 変換例

```scss
/* Before */
0 0 0 2px rgba(170, 30, 30, 0.7),
0 0 24px 8px rgba(170, 30, 30, 0.4);

/* After */
0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
```

## Test plan

- [x] `pnpm typecheck` 緑
- [x] `pnpm lint` 緑
- [x] `pnpm test` 緑 (990 件、変化なし)
- [ ] 手動: AI が capability 実行 → spotlight が `--nd-warn` の色 (amber #ecb637) で光る
- [ ] 手動: テーマ切替で spotlight 色がテーマに追従する
- [ ] 手動: ガイド (/guide) を起動 → カードのハイライト枠も同じ色味になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)