### PR TITLE
docs(site): ランディングページの柱の順序を入れ替え

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -87,11 +87,11 @@
       <div class="pillars-grid">
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
           </div>
-          <h3>ネイティブの速さ</h3>
-          <p class="pillar-lead">ブラウザや VM のオーバーヘッドなし。<strong>圧倒的に軽量。</strong></p>
-          <p>Tauri v2 + Rust バックエンドによるネイティブバイナリ。ブラウザタブや Flutter ランタイムの重さとは無縁。起動も一瞬、バッテリーにも優しい。</p>
+          <h3>全鯖をひとつのデッキで</h3>
+          <p class="pillar-lead">複数サーバーの通知・TL・検索を<strong>クロスアカウントで統合表示。</strong></p>
+          <p>misskey.io、にじみす、すしすきー — 何鯖使っていても、ひとつのデッキにまとめて把握。アカウントごとにブラウザのタブを開く時代は終わり。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
@@ -103,11 +103,11 @@
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
           </div>
-          <h3>全鯖をひとつのデッキで</h3>
-          <p class="pillar-lead">複数サーバーの通知・TL・検索を<strong>クロスアカウントで統合表示。</strong></p>
-          <p>misskey.io、にじみす、すしすきー — 何鯖使っていても、ひとつのデッキにまとめて把握。アカウントごとにブラウザのタブを開く時代は終わり。</p>
+          <h3>ネイティブの速さ</h3>
+          <p class="pillar-lead">ブラウザや VM のオーバーヘッドなし。<strong>圧倒的に軽量。</strong></p>
+          <p>Tauri v2 + Rust バックエンドによるネイティブバイナリ。ブラウザタブや Flutter ランタイムの重さとは無縁。起動も一瞬、バッテリーにも優しい。</p>
         </div>
       </div>
 

--- a/site/index.html
+++ b/site/index.html
@@ -153,19 +153,19 @@
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-          </div>
-          <h3>外部から駆動できる</h3>
-          <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
-          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークン渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも、<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck・自作ボット、一度書けば全経路から呼べる。</p>
-        </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 20h10"/><path d="M10 20c5.5-2.5.8-6.4 3-10"/><path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/><path d="M14.1 6a7 7 0 0 1-1.1 4c1.9-.6 3-1.5 3.6-2.6.6-1.2.6-2.5-.1-4.6-2.1.8-3 1.5-3.5 2.7-.2.5-.4 1.2-.4 1.8 0 0 0 0 0 0z"/></svg>
           </div>
           <h3>AI と一緒に育つ IDE</h3>
           <p class="pillar-lead">使うほど、<strong>自分専用の道具に育っていく。</strong></p>
           <p>AI 自身が CSS・キーバインド・navbar・skill を編集して、見た目も操作も提案そのまま反映。会話で観察したことは永続記憶として次のセッションへ引き継がれ、ストアからのテーマ・プラグイン導入も会話で完結する。出荷時の機能で固定されない、人間と AI が一緒に手を入れていく IDE。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+          </div>
+          <h3>外部から駆動できる</h3>
+          <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
+          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークン渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも、<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck・自作ボット、一度書けば全経路から呼べる。</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 「なぜ NoteDeck？」の 3 本柱を 全鯖をひとつのデッキで → オフラインファースト → ネイティブの速さ の順に変更
- 「プラットフォームとして」の 3 本柱を 自己拡張する IDE → AI と一緒に育つ IDE → 外部から駆動できる の順に変更

差別化される価値 (デッキ統合 / AI と一緒に育つ) を中央〜先頭に据え、視線の中心に置く並びへ。

## Test plan
- [ ] site/index.html を開いて柱の並びが意図通りか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)