### PR TITLE
Release v0.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.30.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.30.0"
+version = "0.30.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.30.0"
+    "version": "0.30.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/window/SkillEditContent.vue
+++ b/src/components/window/SkillEditContent.vue
@@ -233,7 +233,6 @@ const statusText = computed(() => {
           v-model="body"
           :language="lang"
           :class="$style.editor"
-          auto-height
         />
       </div>
 
@@ -392,9 +391,8 @@ const statusText = computed(() => {
 }
 
 .editor {
-  border: 1px solid var(--nd-divider);
-  border-radius: 3px;
-  overflow: hidden;
+  flex: 1;
+  min-width: 0;
 }
 
 .status {


### PR DESCRIPTION
## Summary

v0.30.1 patch release.

## Changes

- fix(skill-edit): コードタブで縦スクロールが効かない問題を修正 (#591)
- chore: bump version to 0.30.1

## Test plan

- [x] typecheck (lefthook pre-commit)
- [x] cargo check (Cargo.lock 同期)
- [ ] CI (lint, typecheck, test) パス