### PR TITLE
Release v0.30.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.30.1",
+  "version": "0.30.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.30.1"
+version = "0.30.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.30.1"
+version = "0.30.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.30.1"
+    "version": "0.30.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -36,7 +36,11 @@ import {
 import { usePrompt } from '@/stores/prompt'
 import { useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
-import { timestampTitle } from '@/utils/aiSessionTitle'
+import {
+  generateSessionTitle,
+  isTimestampTitle,
+  timestampTitle,
+} from '@/utils/aiSessionTitle'
 import { extractErrorMessage } from '@/utils/errors'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { resolveIdentity } from '@/utils/identity'
@@ -374,12 +378,29 @@ async function generateAiTitleAsync(
 ): Promise<void> {
   // 初期プレースホルダー (timestampTitle) は sendMessage 側で既にセット済み。
   // AI 生成に失敗した場合は何もせず、プレースホルダーがそのまま残る。
-  if (providerStatus.value !== 'connected') return
+  // 診断ログ (#484): 日付フォールバックのまま残る原因を特定するため
+  // 各 early return / 失敗パスに warn を出す。
+  if (providerStatus.value !== 'connected') {
+    console.warn(
+      '[ai-title-gen] skip: provider not connected',
+      providerStatus.value,
+    )
+    return
+  }
   const before = sessionsStore.get(sessionId)
-  if (!before) return
+  if (!before) {
+    console.warn('[ai-title-gen] skip: session not found', sessionId)
+    return
+  }
   const titleBefore = before.title
   const resolved = resolveAiConnection(aiConfig.value, vault.connections.value)
-  if (!resolved || !resolved.model) return
+  if (!resolved || !resolved.model) {
+    console.warn('[ai-title-gen] skip: connection/model unresolved', {
+      hasResolved: !!resolved,
+      model: resolved?.model,
+    })
+    return
+  }
 
   // 会話を 1 つの user メッセージに集約する。assistant role を history に
   // 置くと Anthropic 側が「続きを書く」モードになりタイトルが取れない。
@@ -402,12 +423,27 @@ async function generateAiTitleAsync(
       .replace(/^[\s「『"'“”]+|[\s」』"'“”。．、]+$/g, '')
       .trim()
       .slice(0, 40)
-    if (!cleaned) return
+    if (!cleaned) {
+      console.warn('[ai-title-gen] skip: cleaned title is empty', {
+        rawLength: raw.length,
+        rawPreview: raw.slice(0, 80),
+      })
+      return
+    }
     // ユーザーが間に手動 rename していたら触らない
     const cur = sessionsStore.get(sessionId)
-    if (cur && cur.title === titleBefore) {
-      sessionsStore.setTitle(sessionId, cleaned)
+    if (!cur) {
+      console.warn('[ai-title-gen] skip: session lost during generation')
+      return
     }
+    if (cur.title !== titleBefore) {
+      console.warn('[ai-title-gen] skip: title changed by user during gen', {
+        titleBefore,
+        titleNow: cur.title,
+      })
+      return
+    }
+    sessionsStore.setTitle(sessionId, cleaned)
   } catch (e) {
     console.warn('[ai-title-gen] failed:', e)
   }
@@ -711,11 +747,27 @@ async function sendMessage() {
     // 初回 round 完了後にバックグラウンドで AI にタイトルを再生成させる
     if (wasFirstRound && finalAssistantText) {
       void generateAiTitleAsync(sessionId, text, finalAssistantText)
+    } else if (wasFirstRound && !finalAssistantText) {
+      // #484 診断: 初回 round で本文テキストが空 (tool_use のみで完結等) のため
+      // タイトル生成を skip した。日付フォールバックがそのまま残るケース。
+      console.warn(
+        '[ai-title-gen] skip: first round produced no assistant text',
+        { toolRound, sessionId },
+      )
     }
   } catch (e) {
     // 診断: AI ストリーム失敗時の raw error を console に dump。
     // [object Object] 表示の根本原因 (= 想定外の error shape) を追跡しやすくする。
     console.error('[ai-column] stream error raw:', e)
+    // ストリーム例外で抜けた初回 round はタイトル生成も走らないため、
+    // ユーザー入力から決定論的に fallback タイトルを付ける (#484)。
+    // ユーザーが手動 rename している場合 (= timestamp 形式でない) は触らない。
+    if (wasFirstRound) {
+      const cur = sessionsStore.get(sessionId)
+      if (cur && isTimestampTitle(cur.title)) {
+        sessionsStore.setTitle(sessionId, generateSessionTitle(text))
+      }
+    }
     // 任意の error shape (Error / `{code,message}` / 入れ子オブジェクト / 文字列)
     // から表示可能な文字列を取り出す。`[object Object]` 化を防ぐ。
     const message = extractErrorMessage(e)
@@ -792,6 +844,14 @@ async function runSlashAndAppend(text: string): Promise<void> {
     assistantToolUse,
     toolResultMsg,
   ])
+  // Slash 専用セッションには「/<cmd> の実行」形式でタイトルを付ける (#484)。
+  // AI を呼ばないので入力テキスト先頭トークン (= /cmd 部分) から決定論的に命名。
+  // ユーザーが手動 rename している場合 (= timestamp 形式でない) は触らない。
+  const afterRun = sessionsStore.get(sessionId)
+  if (afterRun && isTimestampTitle(afterRun.title)) {
+    const cmdToken = text.split(/\s+/)[0]
+    sessionsStore.setTitle(sessionId, `${cmdToken} の実行`)
+  }
   scrollToBottom()
 }
 

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -171,7 +171,6 @@ interface HistoryEntry {
 }
 
 const historyEntries = shallowRef<HistoryEntry[]>([])
-const loadProgress = ref<{ host: string; done: boolean }[]>([])
 
 // 履歴 view (#483) の絞り込み。AI カラム ([DeckAiColumn.vue]) と同じ
 // header-extra 入力 + 大文字小文字無視の substring match パターン。
@@ -498,11 +497,6 @@ async function connectCrossAccount() {
     return
   }
 
-  loadProgress.value = accounts.map((acc) => ({
-    host: acc.host,
-    done: false,
-  }))
-
   // 1. 全アカウントのキャッシュを並列取得して即時 render (B-2 hydrate)
   const cachedResults = await Promise.all(
     accounts.map(async (acc) => {
@@ -524,47 +518,41 @@ async function connectCrossAccount() {
   // 2. 並行で API fetch して reconcile。ログイン中アカウントは fresh、
   //    ログアウト中は引き続き cache (上の hydrate と同じ結果)、API エラー時は cache fallback。
   const results = await Promise.allSettled(
-    accounts.map(async (acc, i) => {
-      try {
-        if (!acc.hasToken) {
-          const cached = await loadCachedHistory(acc.id)
-          return cached.map((msg) => ({
-            msg,
-            accountId: acc.id,
-            host: acc.host,
-          }))
-        }
+    accounts.map(async (acc) => {
+      if (!acc.hasToken) {
+        const cached = await loadCachedHistory(acc.id)
+        return cached.map((msg) => ({
+          msg,
+          accountId: acc.id,
+          host: acc.host,
+        }))
+      }
 
-        const adapter = await multiAdapters.getOrCreate(acc.id)
-        if (!adapter) return []
+      const adapter = await multiAdapters.getOrCreate(acc.id)
+      if (!adapter) return []
+      try {
+        const userHistory = await adapter.api.getChatHistory()
+        let roomHistory: ChatMessage[] = []
         try {
-          const userHistory = await adapter.api.getChatHistory()
-          let roomHistory: ChatMessage[] = []
-          try {
-            roomHistory = unwrap(
-              await commands.apiGetChatHistory(acc.id, 100, true, null),
-            ) as unknown as ChatMessage[]
-          } catch {
-            // room chat not supported
-          }
-          return [...userHistory, ...roomHistory].map((msg) => ({
-            msg,
-            accountId: acc.id,
-            host: acc.host,
-          }))
+          roomHistory = unwrap(
+            await commands.apiGetChatHistory(acc.id, 100, true, null),
+          ) as unknown as ChatMessage[]
         } catch {
-          // API エラー → キャッシュ fallback (UI 上の indicator は省略)
-          const cached = await loadCachedHistory(acc.id)
-          return cached.map((msg) => ({
-            msg,
-            accountId: acc.id,
-            host: acc.host,
-          }))
+          // room chat not supported
         }
-      } finally {
-        loadProgress.value = loadProgress.value.map((p, j) =>
-          j === i ? { ...p, done: true } : p,
-        )
+        return [...userHistory, ...roomHistory].map((msg) => ({
+          msg,
+          accountId: acc.id,
+          host: acc.host,
+        }))
+      } catch {
+        // API エラー → キャッシュ fallback
+        const cached = await loadCachedHistory(acc.id)
+        return cached.map((msg) => ({
+          msg,
+          accountId: acc.id,
+          host: acc.host,
+        }))
       }
     }),
   )
@@ -577,7 +565,6 @@ async function connectCrossAccount() {
   chatMessageStore.put(allMessages.map((x) => x.msg))
   historyEntries.value = buildCrossAccountHistoryEntries(allMessages)
   isLoading.value = false
-  loadProgress.value = []
 
   // B-6: ログイン中アカウントの thread を裏で prefetch (UI 変更なし)。
   const tokenAccountIds = new Set(
@@ -1286,16 +1273,6 @@ onBeforeUnmount(() => {
       is-error
     />
 
-    <!-- Per-account progress (cross-account) -->
-    <div v-if="isCrossAccount && loadProgress.length > 0" :class="$style.chatProgress">
-      <span
-        v-for="(p, i) in loadProgress"
-        :key="i"
-        :class="[$style.progressDot, { [$style.done]: p.done }]"
-        :title="p.host"
-      />
-    </div>
-
     <!-- History View: Cross-account -->
     <div v-if="isCrossAccount && viewMode === 'history'" :class="$style.chatBody">
       <ColumnEmptyState
@@ -1536,29 +1513,6 @@ onBeforeUnmount(() => {
 
 .chatBody {
   composes: tlBody from './column-common.module.scss';
-}
-
-.chatProgress {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  padding: 6px 12px;
-  flex-shrink: 0;
-}
-
-.progressDot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--nd-fg);
-  opacity: 0.15;
-  transition: opacity var(--nd-duration-slower), background var(--nd-duration-slower);
-
-  &.done {
-    background: var(--nd-accent);
-    opacity: 0.8;
-  }
 }
 
 .searchBar {

--- a/src/utils/aiSessionTitle.ts
+++ b/src/utils/aiSessionTitle.ts
@@ -36,6 +36,15 @@ export function timestampTitle(now: Date, suffix = 'のチャット'): string {
 }
 
 /**
+ * 与えられたタイトルが `timestampTitle()` 由来の自動生成タイトルかを判定する。
+ * Slash / エラー fallback が「ユーザーが手動 rename したタイトル」を
+ * 上書きしてしまわないようガードする用途で使う (#484)。
+ */
+export function isTimestampTitle(title: string): boolean {
+  return /^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \S/.test(title)
+}
+
+/**
  * ユーザー発話を整形してタイトルを返す。整形後 4 文字未満なら日付フォールバック。
  */
 export function generateSessionTitle(

--- a/tests/utils/aiSessionTitle.test.ts
+++ b/tests/utils/aiSessionTitle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { generateSessionTitle, timestampTitle } from '@/utils/aiSessionTitle'
+import {
+  generateSessionTitle,
+  isTimestampTitle,
+  timestampTitle,
+} from '@/utils/aiSessionTitle'
 
 const FROZEN = new Date(2026, 3, 30, 15, 30, 12) // 2026-04-30 local
 
@@ -69,5 +73,28 @@ describe('generateSessionTitle', () => {
     expect(generateSessionTitle('```ts\nconsole.log(1)\n```', FROZEN)).toBe(
       '2026-04-30 15:30 のチャット',
     )
+  })
+})
+
+describe('isTimestampTitle', () => {
+  it('returns true for the default のチャット suffix', () => {
+    expect(isTimestampTitle('2026-05-15 17:52 のチャット')).toBe(true)
+  })
+
+  it('returns true for the HEARTBEAT suffix', () => {
+    expect(isTimestampTitle('2026-05-15 17:52 のHEARTBEAT')).toBe(true)
+  })
+
+  it('returns false for an AI-generated title', () => {
+    expect(isTimestampTitle('通知カラムの追加リクエスト')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isTimestampTitle('')).toBe(false)
+  })
+
+  it('returns false when a suffix is missing', () => {
+    expect(isTimestampTitle('2026-05-15 17:52')).toBe(false)
+    expect(isTimestampTitle('2026-05-15')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- fix(ai-chat): Slash/エラー時もセッションタイトルを自動付与 (#484)
- fix(chat): cross-account 読込時の進捗ドット表示を削除
- chore: bump version to 0.30.2

## Test plan

- [x] check (lint / typecheck / test) が通る
- [ ] build (macOS / Linux / Windows) 成功
- [ ] publish → GitHub Release draft 作成
- [ ] AUR ジョブ成功 (前回は aur.archlinux.org 502 で TLS error → 復旧確認待ち)
- [ ] winget ジョブ成功 (WINGET_TOKEN 貼り直し後の初回テスト)