### PR TITLE
Release v0.31.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,15 +72,20 @@ pnpm typecheck    # vue-tsc -b --noEmit
 ```bash
 # Cargo.lock も同期
 cd src-tauri && cargo check && cd ..
+
+# openapi.json もバージョン番号を埋め込んでいるため再生成
+# (忘れると CI の openapi_snapshot_is_current テストが落ちる)
+cd src-tauri && cargo run --example gen_openapi && cd ..
 ```
 
-コミット: `chore: bump version to X.Y.Z`
+コミット例: `chore: bump version to X.Y.Z` + `chore: regenerate openapi.json for X.Y.Z`
+(1 コミットにまとめても 2 コミットに分けても可。過去ログは分けるパターンが多い)
 
 ### 2. PR 作成・マージ
 
 - develop → main の PR を作成（タイトル例: `Release vX.Y.Z`）
 - `pnpm changelog` で変更一覧を PR 本文に記載
-- CI（lint, typecheck, test）が通ることを確認
+- CI（lint, typecheck, test, openapi_snapshot）が通ることを確認
 - マージ
 
 ### 3. タグ作成・プッシュ（CI トリガー）

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.30.2",
+  "version": "0.31.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.30.2"
+version = "0.31.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.30.2"
+version = "0.31.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.30.2"
+    "version": "0.31.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.30.2",
+  "version": "0.31.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -168,6 +168,13 @@ const autoSaveLabel = computed(() =>
   props.memoMode ? 'メモを自動保存' : '下書きを自動保存',
 )
 
+const rememberVisibilityEnabled = computed<boolean>({
+  get: () => settingsStore.get('postForm.rememberVisibility') ?? false,
+  set: (v) => {
+    settingsStore.set('postForm.rememberVisibility', v)
+  },
+})
+
 // --- Popup exclusive control ---
 // ピッカー系 (emoji / drive / memo) はシングルトン: 同時に1つだけ開く
 const popups = usePopupControl()
@@ -595,6 +602,24 @@ function onKeydown(e: KeyboardEvent) {
                 <span
                   class="nd-toggle-switch"
                   :class="{ on: autoSaveEnabled }"
+                  :style="{ marginLeft: 'auto' }"
+                  aria-hidden="true"
+                >
+                  <span class="nd-toggle-switch-knob" />
+                </span>
+              </div>
+              <!-- Remember visibility toggle -->
+              <div
+                :class="$style.moreMenuItem"
+                role="switch"
+                :aria-checked="rememberVisibilityEnabled"
+                @click="rememberVisibilityEnabled = !rememberVisibilityEnabled"
+              >
+                <i class="ti ti-bookmark" />
+                公開範囲を記憶
+                <span
+                  class="nd-toggle-switch"
+                  :class="{ on: rememberVisibilityEnabled }"
                   :style="{ marginLeft: 'auto' }"
                   aria-hidden="true"
                 >

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -218,14 +218,19 @@ export function usePostFormState(
 
     // rememberVisibility: 最後に使った値で上書き。
     // 返信・編集・メモ・チャネルは visibility が文脈で決まるため対象外。
+    // 記憶値はアカウントごとに保持。
     const isContextual =
       props.replyTo || props.editNote || memoMode || props.channelId
     if (!isContextual && settingsStore.get('postForm.rememberVisibility')) {
-      const last = settingsStore.get('postForm.lastUsedVisibility')
+      const lastMap = settingsStore.get('postForm.lastUsedVisibilityByAccount')
+      const last = lastMap?.[activeAccountId.value]
       if (last && visibilityOptions.some((o) => o.value === last)) {
         visibility.value = last as NoteVisibility
       }
-      const lastLocal = settingsStore.get('postForm.lastUsedLocalOnly')
+      const lastLocalMap = settingsStore.get(
+        'postForm.lastUsedLocalOnlyByAccount',
+      )
+      const lastLocal = lastLocalMap?.[activeAccountId.value]
       if (typeof lastLocal === 'boolean') {
         localOnly.value = lastLocal
       }
@@ -345,14 +350,25 @@ export function usePostFormState(
       activeAccountId.value,
     )
 
-    // rememberVisibility ON のときは送信した visibility を記憶
+    // rememberVisibility ON のときは送信した visibility を記憶 (per-account)
     if (
       !props.replyTo &&
       !props.channelId &&
       settingsStore.get('postForm.rememberVisibility')
     ) {
-      settingsStore.set('postForm.lastUsedVisibility', visibility.value)
-      settingsStore.set('postForm.lastUsedLocalOnly', localOnly.value)
+      const accId = activeAccountId.value
+      const prevVis =
+        settingsStore.get('postForm.lastUsedVisibilityByAccount') ?? {}
+      settingsStore.set('postForm.lastUsedVisibilityByAccount', {
+        ...prevVis,
+        [accId]: visibility.value,
+      })
+      const prevLocal =
+        settingsStore.get('postForm.lastUsedLocalOnlyByAccount') ?? {}
+      settingsStore.set('postForm.lastUsedLocalOnlyByAccount', {
+        ...prevLocal,
+        [accId]: localOnly.value,
+      })
     }
 
     // Close form optimistically before awaiting API

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -216,6 +216,21 @@ export function usePostFormState(
       }
     }
 
+    // rememberVisibility: 最後に使った値で上書き。
+    // 返信・編集・メモ・チャネルは visibility が文脈で決まるため対象外。
+    const isContextual =
+      props.replyTo || props.editNote || memoMode || props.channelId
+    if (!isContextual && settingsStore.get('postForm.rememberVisibility')) {
+      const last = settingsStore.get('postForm.lastUsedVisibility')
+      if (last && visibilityOptions.some((o) => o.value === last)) {
+        visibility.value = last as NoteVisibility
+      }
+      const lastLocal = settingsStore.get('postForm.lastUsedLocalOnly')
+      if (typeof lastLocal === 'boolean') {
+        localOnly.value = lastLocal
+      }
+    }
+
     // Auto-correct if current visibility is disabled
     if (disabled.has(visibility.value)) {
       const first = visibilityOptions.find((o) => !disabled.has(o.value))
@@ -329,6 +344,16 @@ export function usePostFormState(
       },
       activeAccountId.value,
     )
+
+    // rememberVisibility ON のときは送信した visibility を記憶
+    if (
+      !props.replyTo &&
+      !props.channelId &&
+      settingsStore.get('postForm.rememberVisibility')
+    ) {
+      settingsStore.set('postForm.lastUsedVisibility', visibility.value)
+      settingsStore.set('postForm.lastUsedLocalOnly', localOnly.value)
+    }
 
     // Close form optimistically before awaiting API
     posted.value = true

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -30,6 +30,14 @@ export interface NotedeckSettings {
   'postForm.preview'?: boolean
   'postForm.autoSaveDraft'?: boolean
   'postForm.autoSaveMemo'?: boolean
+  /**
+   * ON のとき、最後に投稿した visibility / localOnly を次回の投稿フォーム
+   * 初期値として使う。OFF (デフォルト) はサーバーの defaultNoteVisibility に従う。
+   * 返信・編集・メモ・チャネル投稿は文脈で visibility が決まるため対象外。
+   */
+  'postForm.rememberVisibility'?: boolean
+  'postForm.lastUsedVisibility'?: 'public' | 'home' | 'followers' | 'specified'
+  'postForm.lastUsedLocalOnly'?: boolean
 
   // --- Lists ---
   /**

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -34,10 +34,15 @@ export interface NotedeckSettings {
    * ON のとき、最後に投稿した visibility / localOnly を次回の投稿フォーム
    * 初期値として使う。OFF (デフォルト) はサーバーの defaultNoteVisibility に従う。
    * 返信・編集・メモ・チャネル投稿は文脈で visibility が決まるため対象外。
+   * 記憶値はアカウントごとに保持 (サーバーの defaultNoteVisibility が per-account
+   * なので、記憶も per-account でないとアカウント切替時に意図しない値が適用される)。
    */
   'postForm.rememberVisibility'?: boolean
-  'postForm.lastUsedVisibility'?: 'public' | 'home' | 'followers' | 'specified'
-  'postForm.lastUsedLocalOnly'?: boolean
+  'postForm.lastUsedVisibilityByAccount'?: Record<
+    string,
+    'public' | 'home' | 'followers' | 'specified'
+  >
+  'postForm.lastUsedLocalOnlyByAccount'?: Record<string, boolean>
 
   // --- Lists ---
   /**


### PR DESCRIPTION
## Summary

- **feat(post-form):** 公開範囲を記憶するトグルを追加 (#454)
  - 投稿フォームの「…」メニューにトグル「公開範囲を記憶」を追加。ON のとき、最後に投稿した visibility / localOnly を次回フォームの初期値として使う。OFF (デフォルト) はサーバーの `defaultNoteVisibility` に従う。返信・編集・メモ・チャネル投稿は対象外。
  - 記憶値はアカウントごとに保持 (`postForm.lastUsedVisibilityByAccount` / `lastUsedLocalOnlyByAccount`)。サーバーの `defaultNoteVisibility` が per-account なため、記憶も per-account でないとアカウント切替時に意図しない visibility が適用される。

## Commits

- `feat(post-form): 公開範囲を記憶するトグルを追加 (#454)` (489912bd)
- `fix(post-form): 記憶する公開範囲をアカウント別に分離` (3cf70cb9)
- `chore: bump version to 0.31.0` (3ad3f8ed)

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` 通過
- [x] 投稿フォームの「…」メニューに「公開範囲を記憶」が表示される
- [x] トグル ON で投稿した visibility が次回フォームの初期値になる
- [x] 返信/編集フォームでは記憶値が適用されない
- [x] アカウント切替時はそのアカウントで記憶した値が適用される
- [ ] CI (lint / typecheck / test) 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)