### PR TITLE
Release v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "0.31.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "0.31.0"
+version = "1.0.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "0.31.0"
+version = "1.0.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "0.31.0"
+    "version": "1.0.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "0.31.0",
+  "version": "1.0.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Release v1.0.0 — 正式版リリース

NoteDeck の最初の正式バージョンです。機能・バグ修正は含まれず、コード変更は version bump のみ (v0.31.0 と同等のバイナリ)。

[ROADMAP.md L64-66](https://github.com/hitalin/notedeck/blob/main/ROADMAP.md#L64-L66) の v1.0.0 条件 (Layer 0〜2 完成 + Layer 3 検索) 達成、デスクトップ 3 OS (macOS / Linux / Windows) を正式対応プラットフォームとして宣言します。

### 含まれる変更

- chore: bump version to 1.0.0
- chore: regenerate openapi.json for 1.0.0

### 対応プラットフォーム

| プラットフォーム | ステージ |
|---|---|
| macOS / Linux / Windows | **正式版** |
| Android | β継続 (Play Store 未認証) |

### winget CI

直前まで継続失敗していた winget CI (#380) は fork sync で解決済み。v0.31.0 で winget-pkgs に submit 成功を実証済み。