### PR TITLE
Release v1.0.1

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,99 @@
+# Privacy Policy
+
+NoteDeck は Misskey を中心とした分散型 SNS のためのデスクトップ統合環境 (IDE) です。本ドキュメントは NoteDeck がユーザーデータをどう扱うかを明示します。
+
+## 基本方針
+
+NoteDeck の開発者はサーバーを一切運営していません。ユーザーデータは原則としてローカルマシン上にのみ保存され、外部に送信されるのは以下の場合だけです：
+
+- ユーザーが接続を設定した **Misskey サーバー**
+- ユーザーが接続を設定した **AI プロバイダー** (Anthropic / OpenAI / OpenAI 互換 API 等)
+- ユーザーが明示的に開いた **外部 URL** (ノートリンク、OGP 取得対象等)
+- **アップデートチェック** (GitHub Releases へのリクエストのみ)
+
+開発者は上記のいずれを経由してもユーザーデータを受け取りません。
+
+## OS キーチェーンに格納される機密情報
+
+機密性の高い認証情報は OS のキーチェーンに格納されます。設定ファイルや SQLite データベースには保存されません。
+
+- **Misskey アクセストークン** (各サーバー / 各アカウントごと)
+- **AI プロバイダーの API キー** (Secret Vault 経由、接続単位で格納)
+- **WebPush 通知用 VAPID キー** (Push 通知有効時のみ)
+
+格納先:
+
+| OS | バックエンド |
+|---|---|
+| macOS | Keychain Access |
+| Linux | Secret Service (gnome-keyring / KWallet 等) |
+| Windows | Credential Manager |
+
+## ローカルに保存されるデータ
+
+設定フォルダ (`$APP_DATA_DIR/notedeck/`) 配下に以下が保存されます。「ファイル → 設定フォルダを開く」から場所を確認できます。
+
+| ファイル / フォルダ | 内容 |
+|---|---|
+| `notecli.db` (SQLite) | ノート・通知・ユーザー情報のキャッシュ、FTS5 全文検索インデックス、チャットキャッシュ |
+| `settings.json` | テーマ・キーバインド・カラム構成・AI 設定 (機密以外) |
+| `accounts.json5` | 接続中アカウント一覧 (トークン本体はキーチェーン) |
+| `profiles/` | デッキプロファイル (カラム配置等) |
+| `themes/` | ユーザー作成テーマ |
+| `plugins/` | プラグイン本体・設定 |
+| `widgets/` | ウィジェット |
+| `snippets/` | スニペット |
+| `memos/` | AI メモ |
+| `sessions/` | AI チャットセッション履歴 |
+| `image-cache/` | 表示画像のキャッシュ |
+
+これらはすべてユーザーマシン上に留まり、NoteDeck 開発者がアクセスする手段はありません。
+
+## ネットワーク通信
+
+NoteDeck が行う外部通信は以下に限定されます：
+
+1. **Misskey サーバー** — REST / WebSocket ストリーミング、画像取得
+2. **AI プロバイダー** — AI チャット使用時のみ。Anthropic Messages API / OpenAI Chat Completions API 互換
+3. **WebPush エンドポイント** — Push 通知有効化時のみ
+4. **アップデートチェック** — `https://github.com/hitalin/notedeck/releases/latest` (Tauri Updater)
+5. **OGP 取得** — ノート内 URL の OGP 情報取得 (設定で無効化可能)
+
+### NoteDeck が行わない通信
+
+- ❌ テレメトリー / 利用統計の送信
+- ❌ クラッシュレポートの自動送信
+- ❌ 広告配信
+- ❌ サードパーティ analytics (Google Analytics 等)
+- ❌ 開発者へのユーザーデータ送信
+
+## AI チャット機能のデータ取り扱い
+
+AI チャット機能を使用すると、入力したメッセージと、ユーザーが capability で許可したコンテキスト情報が、選択した AI プロバイダーに送信されます。
+
+- **送信先**: ユーザーが Vault に登録した AI プロバイダー
+- **データ保管**: AI プロバイダーのプライバシーポリシーに従います (NoteDeck 開発者は記録しません)
+- **HEARTBEAT デーモン使用時**: 設定された skill の内容に従い、AI プロバイダーへ定期送信されます (デフォルトは無効)
+- **AI セッション履歴**: `sessions/` フォルダにローカル保存されます
+
+## データの削除
+
+- **アカウント単位**: アカウントメニュー → ログアウト → 「すべて削除」でキャッシュ・トークン・関連データを削除
+- **完全削除**: 設定フォルダを丸ごと削除
+- **アンインストール**: OS のアプリ削除手順に従う (設定フォルダはユーザー判断で別途削除)
+
+## 第三者への提供
+
+NoteDeck 開発者は、ユーザーデータを第三者に提供しません。そもそも開発者の手元にユーザーデータは存在しません。
+
+## オープンソース
+
+NoteDeck は AGPL-3.0 ライセンスで公開されています。ソースコードは [https://github.com/hitalin/notedeck](https://github.com/hitalin/notedeck) で確認できます。
+
+## お問い合わせ
+
+プライバシーに関する質問は GitHub Issues でお願いします: [https://github.com/hitalin/notedeck/issues](https://github.com/hitalin/notedeck/issues)
+
+## 更新履歴
+
+- 2026-05-17: 初版作成 (v1.0.0 リリースに合わせて)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=59b39c2288b608cc81c434545eb1b3bdd757ba64#59b39c2288b608cc81c434545eb1b3bdd757ba64"
+source = "git+https://github.com/hitalin/notecli?rev=0040cb6e9cc5bcd64f580dde2a9b935f72da8e21#0040cb6e9cc5bcd64f580dde2a9b935f72da8e21"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.0.0"
+version = "1.0.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "59b39c2288b608cc81c434545eb1b3bdd757ba64", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "0040cb6e9cc5bcd64f580dde2a9b935f72da8e21", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2186,7 +2186,7 @@ export type ChatMessage = { id: string; createdAt: string; fromUserId: string; f
 export type ChatMessageReaction = { user: ChatReactionUser | null; reaction: string }
 export type ChatReactionUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null }
 export type ChatRoom = { id: string; name: string | null; description: string | null }
-export type ChatUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null; emojis?: Partial<{ [key in string]: string }> }
+export type ChatUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null; emojis?: Partial<{ [key in string]: string }>; avatarDecorations?: AvatarDecoration[] }
 /**
  * Metadata for a single CLI argument.
  */

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   myUserId?: string
   accountId?: string
   serverHost?: string
+  myAvatarUrl?: string
   otherAvatarUrl?: string
 }>()
 
@@ -93,9 +94,17 @@ const groupedReactions = computed(() => {
       userName = r.user.name || r.user.username
       avatarUrl = r.user.avatarUrl
       isMe = r.user.id === props.myUserId
-    } else if (props.otherAvatarUrl) {
-      // 1-on-1: no user in reaction = the other participant reacted
-      avatarUrl = props.otherAvatarUrl
+    } else {
+      // 1on1 (packMessageLiteFor1on1) はリアクションから reactor を削除する。
+      // Misskey 本家 (room.vue normalizeMessage) と同じく、メッセージ送信者から
+      // 逆算する: 自分のメッセージへのリアクション = 相手、相手のメッセージ = 自分。
+      // (自分のメッセージに自分でリアクションした場合は相手扱いになる本家と同じ制約)
+      if (isMine.value) {
+        avatarUrl = props.otherAvatarUrl
+      } else {
+        avatarUrl = props.myAvatarUrl
+        isMe = true
+      }
     }
 
     const existing = map.get(r.reaction)

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -181,11 +181,11 @@ usePortal(lightboxPortalRef)
 <template>
   <div :class="[$style.chatMsg, { [$style.mine]: isMine }]">
     <MkAvatar
-      v-if="!isMine && displayUser"
+      v-if="displayUser"
       :class="$style.chatAvatar"
       :avatar-url="displayUser.avatarUrl"
       :decorations="displayUser.avatarDecorations"
-      :size="32"
+      :size="42"
       :is-cat="displayUser.isCat"
     />
     <div :class="$style.chatBubbleWrapper">
@@ -218,7 +218,16 @@ usePortal(lightboxPortalRef)
             {{ message.file.name }}
           </a>
         </div>
-        <div :class="$style.chatTime">{{ timeStr }}</div>
+      </div>
+      <div :class="$style.chatMeta">
+        <button
+          :class="$style.chatMoreBtn"
+          title="メニュー"
+          @click.stop="moreMenuRef?.open($event)"
+        >
+          <i class="ti ti-dots" />
+        </button>
+        <span :class="$style.chatTime">{{ timeStr }}</span>
       </div>
 
       <!-- Reactions -->
@@ -258,15 +267,6 @@ usePortal(lightboxPortalRef)
           <span v-if="r.count > 1" :class="$style.reactionCount">{{ r.count }}</span>
         </button>
       </div>
-
-      <!-- Add reaction button -->
-      <button
-        :class="$style.chatAddReaction"
-        title="リアクション"
-        @click.stop="emit('react', message.id, '')"
-      >
-        <i class="ti ti-mood-plus" />
-      </button>
     </div>
   </div>
 
@@ -274,6 +274,8 @@ usePortal(lightboxPortalRef)
     ref="moreMenuRef"
     :message="message"
     :is-mine="!!isMine"
+    :account-id="accountId"
+    @react="emit('react', $event, '')"
     @delete="emit('delete', $event)"
   />
 
@@ -319,26 +321,18 @@ usePortal(lightboxPortalRef)
     .chatReactions {
       justify-content: flex-end;
     }
-
-    .chatAddReaction {
-      left: -28px;
-    }
   }
 
   &:not(.mine) {
     .chatBubble {
       border-bottom-left-radius: 4px;
     }
-
-    .chatAddReaction {
-      right: -28px;
-    }
   }
 }
 
 .chatAvatar {
-  width: 32px;
-  height: 32px;
+  width: 42px;
+  height: 42px;
   flex-shrink: 0;
   margin-top: 4px;
 }
@@ -346,10 +340,6 @@ usePortal(lightboxPortalRef)
 .chatBubbleWrapper {
   max-width: 75%;
   position: relative;
-
-  &:hover .chatAddReaction {
-    opacity: 1;
-  }
 }
 
 .chatBubble {
@@ -384,11 +374,42 @@ usePortal(lightboxPortalRef)
   cursor: pointer;
 }
 
+.chatMeta {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+  padding: 0 2px;
+}
+
+.mine .chatMeta {
+  flex-direction: row-reverse;
+}
+
 .chatTime {
   font-size: 0.7em;
   opacity: 0.5;
-  text-align: right;
-  margin-top: 2px;
+}
+
+.chatMoreBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 50%;
+  background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.08));
+  color: var(--nd-fg);
+  opacity: 0.5;
+  cursor: pointer;
+  font-size: 0.8em;
+  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg, rgba(255, 255, 255, 0.15));
+  }
 }
 
 /* Reactions */
@@ -463,28 +484,6 @@ usePortal(lightboxPortalRef)
 }
 
 /* Add reaction button */
-.chatAddReaction {
-  position: absolute;
-  top: 2px;
-  border: none;
-  background: var(--nd-panelHighlight, rgba(255, 255, 255, 0.08));
-  color: var(--nd-fg);
-  opacity: 0;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  font-size: 0.85em;
-  transition: opacity var(--nd-duration-base);
-
-  &:hover {
-    background: var(--nd-buttonHoverBg, rgba(255, 255, 255, 0.15));
-  }
-}
-
 /* Lightbox */
 .lightboxOverlay {
   position: fixed;

--- a/src/components/common/MkChatMessageMoreMenu.vue
+++ b/src/components/common/MkChatMessageMoreMenu.vue
@@ -1,19 +1,29 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import type { ChatMessage } from '@/adapters/types'
+import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
+import { useToast } from '@/stores/toast'
+import { AppError } from '@/utils/errors'
 import PopupMenu from './PopupMenu.vue'
 
 const props = defineProps<{
   message: ChatMessage
   isMine: boolean
+  accountId?: string
 }>()
 
 const emit = defineEmits<{
   delete: [messageId: string]
+  react: [messageId: string]
 }>()
+
+const toast = useToast()
+const { getOrCreate } = useMultiAccountAdapters()
 
 const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
 const showDeleteConfirm = ref(false)
+const showReportForm = ref(false)
+const reportComment = ref('')
 
 function open(e: MouseEvent) {
   popupMenuRef.value?.open(e)
@@ -25,6 +35,8 @@ function close() {
 
 function resetSubViews() {
   showDeleteConfirm.value = false
+  showReportForm.value = false
+  reportComment.value = ''
 }
 
 async function copyAndClose(text: string) {
@@ -42,9 +54,29 @@ async function copyAndClose(text: string) {
   close()
 }
 
+function reactAndClose() {
+  emit('react', props.message.id)
+  close()
+}
+
 function confirmDelete() {
   emit('delete', props.message.id)
   close()
+}
+
+async function submitReport() {
+  if (!reportComment.value.trim() || !props.accountId) return
+  try {
+    const adapter = await getOrCreate(props.accountId)
+    if (!adapter) return
+    await adapter.api.reportUser(props.message.fromUserId, reportComment.value)
+    toast.show('通報しました')
+    close()
+  } catch (e) {
+    const err = AppError.from(e)
+    console.error('[chat:report]', err.code, err.message)
+    toast.show(`通報に失敗しました（${err.displayCode}）`, 'error')
+  }
 }
 
 defineExpose({ open })
@@ -65,8 +97,37 @@ defineExpose({ open })
       </button>
     </template>
 
+    <!-- Report form -->
+    <template v-else-if="showReportForm">
+      <div class="_popupConfirmText">@{{ message.fromUser?.username }} を通報</div>
+      <div class="_popupReportInputWrap">
+        <textarea
+          v-model="reportComment"
+          class="_popupReportInput"
+          placeholder="通報理由を入力..."
+          rows="3"
+        />
+      </div>
+      <button
+        class="_popupItem _popupItemDanger"
+        :disabled="!reportComment.trim()"
+        @click="submitReport"
+      >
+        <i class="ti ti-alert-triangle" />
+        送信
+      </button>
+      <button class="_popupItem" @click="showReportForm = false">
+        <i class="ti ti-x" />
+        キャンセル
+      </button>
+    </template>
+
     <!-- Main menu -->
     <template v-else>
+      <button class="_popupItem" @click.stop="reactAndClose">
+        <i class="ti ti-mood-plus" />
+        リアクション
+      </button>
       <button v-if="message.text" class="_popupItem" @click="copyAndClose(message.text!)">
         <i class="ti ti-copy" />
         内容をコピー
@@ -76,6 +137,13 @@ defineExpose({ open })
         <button class="_popupItem _popupItemDanger" @click="showDeleteConfirm = true">
           <i class="ti ti-trash" />
           削除
+        </button>
+      </template>
+      <template v-else>
+        <div class="_popupDivider" />
+        <button class="_popupItem _popupItemDanger" @click="showReportForm = true">
+          <i class="ti ti-flag" />
+          通報
         </button>
       </template>
     </template>

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -248,6 +248,14 @@ const myUserId = computed(() => {
   return account.value.userId
 })
 
+// 1on1 リアクションの reactor 逆算 (本家準拠) 用の自分のアバター。
+const myAvatarUrl = computed(() => {
+  const acc = isCrossAccount.value
+    ? accountsStore.accounts.find((a) => a.id === conversationAccountId.value)
+    : account.value
+  return acc?.avatarUrl ?? null
+})
+
 // --- Active account for conversation (cross-account or per-account) ---
 const activeAccountId = computed(() =>
   isCrossAccount.value ? conversationAccountId.value : props.column.accountId,
@@ -1416,6 +1424,7 @@ onBeforeUnmount(() => {
               :my-user-id="myUserId"
               :account-id="activeAccountId ?? undefined"
               :server-host="activeServerHost ?? undefined"
+              :my-avatar-url="currentRoomId ? undefined : myAvatarUrl ?? undefined"
               :other-avatar-url="currentRoomId ? undefined : conversationOtherAvatarUrl ?? undefined"
               @react="handleReact"
               @unreact="handleUnreact"


### PR DESCRIPTION
## Release v1.0.1

### 🐛 Bug Fixes

- **fix(chat): チャットのアバターデコ表示を修正** (Closes #598)
  - notecli の hydration が `fromUser=null` のときだけ補完していたため、`fromUser` を埋め込む room (group chat) でアバターデコが出なかった。デコ欠落時も `users/show` で補完し、`create` レスポンスも hydrate するよう notecli を更新 (rev `0040cb6`)
- **fix(chat): 1on1 リアクションの reactor を本家準拠で逆算**
  - `packMessageLiteFor1on1` がリアクションから reactor を削除するため、自分がしたリアクションが相手のアイコンで表示されていた。Misskey 本家と同じくメッセージ送信者から逆算する heuristic に修正

### ✨ Features

- **feat(chat): メッセージ UI 刷新**
  - 自分のメッセージにもアバターを表示
  - アバターサイズを通知カラムと統一 (32 → 42)
  - 時刻をバブルの外に移動
  - ホバーのリアクションボタンを廃止し、右クリック /「…」ボタンのメニューに「リアクション」を追加
  - 時刻の横に「…」ボタンを追加 (押した位置からメニュー)
  - 自分以外のメッセージのメニューに「通報」を追加
  - リアクションピッカーが開いて即閉じる不具合を修正

### 📝 Docs

- docs: プライバシーポリシー (PRIVACY.md) を追加
