### PR TITLE
Release v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.0.4"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=9f9ad5388629643318cffe48f67693c1e321df22#9f9ad5388629643318cffe48f67693c1e321df22"
+source = "git+https://github.com/hitalin/notecli?rev=8fb1f2fe62eb2938b9526e45fb22a44c4a9af147#8fb1f2fe62eb2938b9526e45fb22a44c4a9af147"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2736,7 +2736,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=8fb1f2fe62eb2938b9526e45fb22a44c4a9af147#8fb1f2fe62eb2938b9526e45fb22a44c4a9af147"
+source = "git+https://github.com/hitalin/notecli?rev=3aaec69337c1011e221e4a9db54f6a62df89bbbe#3aaec69337c1011e221e4a9db54f6a62df89bbbe"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "9f9ad5388629643318cffe48f67693c1e321df22", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "8fb1f2fe62eb2938b9526e45fb22a44c4a9af147", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.0.4"
+version = "1.1.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "8fb1f2fe62eb2938b9526e45fb22a44c4a9af147", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "3aaec69337c1011e221e4a9db54f6a62df89bbbe", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.0.4"
+    "version": "1.1.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -3,8 +3,8 @@ use tauri::State;
 use notecli::api::SearchUsersOptions;
 use notecli::error::NoteDeckError;
 use notecli::models::{
-    Flash, GalleryPost, NormalizedNote, NormalizedUser, NormalizedUserDetail, Page,
-    TimelineOptions, UserReaction,
+    Flash, GalleryPost, MutedWordsResult, NormalizedNote, NormalizedUser, NormalizedUserDetail,
+    Page, TimelineOptions, UserReaction,
 };
 
 use super::{get_credentials, get_credentials_or_anon, validate_host, AppState, Result};
@@ -366,6 +366,18 @@ pub async fn api_get_muted_users(
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials(&db, &account_id)?;
     client.muted_user_ids(&host, &token).await
+}
+
+/// 自分の mutedWords / hardMutedWords を取得する（#610: 起動時の word mute store hydrate、read のみ）。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_get_muted_words(
+    app_state: State<'_, AppState>,
+    account_id: String,
+) -> Result<MutedWordsResult> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client.muted_words(&host, &token).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -368,7 +368,8 @@ pub async fn api_get_muted_users(
     client.muted_user_ids(&host, &token).await
 }
 
-/// 自分の mutedWords / hardMutedWords を取得する（#610: 起動時の word mute store hydrate、read のみ）。
+/// 自分の mutedWords / hardMutedWords / mutedInstances を取得する
+/// （#610/#613: 起動時の word/instance mute store hydrate、read のみ）。
 #[tauri::command]
 #[specta::specta]
 pub async fn api_get_muted_words(
@@ -378,6 +379,18 @@ pub async fn api_get_muted_words(
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials(&db, &account_id)?;
     client.muted_words(&host, &token).await
+}
+
+/// 自分が renote mute 中のユーザー ID 一覧を取得する（#614: 起動時の renote mute store hydrate）。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_get_renote_muted_users(
+    app_state: State<'_, AppState>,
+    account_id: String,
+) -> Result<Vec<String>> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client.renote_muted_user_ids(&host, &token).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -543,6 +543,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_renote_mute_user,
             commands::api_unrenote_mute_user,
             commands::api_get_muted_users,
+            commands::api_get_muted_words,
             commands::api_block_user,
             commands::api_unblock_user,
             commands::api_report_user,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -544,6 +544,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_unrenote_mute_user,
             commands::api_get_muted_users,
             commands::api_get_muted_words,
+            commands::api_get_renote_muted_users,
             commands::api_block_user,
             commands::api_unblock_user,
             commands::api_report_user,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import { useKeyboard } from '@/composables/useKeyboard'
 import { useMuteSync } from '@/composables/useMuteSync'
 import { listenPipEvents } from '@/composables/usePipWindow'
 import { useTheme } from '@/composables/useTheme'
+import { useWordMuteSync } from '@/composables/useWordMuteSync'
 import { useLogsStore } from '@/stores/logs'
 import { useIsCompactLayout, useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
@@ -173,6 +174,8 @@ onMounted(async () => {
 
   // ミュート一覧を各アカウント分 hydrate（#574: 過去ノートを起動直後から非表示に）
   useMuteSync()
+  // ワードミュート（mutedWords / hardMutedWords）を各アカウント分 hydrate（#610）
+  useWordMuteSync()
 
   if (isTauri) {
     // Set up PiP event listener in main window

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import { useHeartbeatDaemon } from '@/composables/useHeartbeatDaemon'
 import { useKeyboard } from '@/composables/useKeyboard'
 import { useMuteSync } from '@/composables/useMuteSync'
 import { listenPipEvents } from '@/composables/usePipWindow'
+import { useRenoteMuteSync } from '@/composables/useRenoteMuteSync'
 import { useTheme } from '@/composables/useTheme'
 import { useWordMuteSync } from '@/composables/useWordMuteSync'
 import { useLogsStore } from '@/stores/logs'
@@ -174,8 +175,10 @@ onMounted(async () => {
 
   // ミュート一覧を各アカウント分 hydrate（#574: 過去ノートを起動直後から非表示に）
   useMuteSync()
-  // ワードミュート（mutedWords / hardMutedWords）を各アカウント分 hydrate（#610）
+  // ワードミュート（mutedWords / hardMutedWords）+ インスタンスミュート（#610/#613）
   useWordMuteSync()
+  // リノートミュート一覧を各アカウント分 hydrate（#614）
+  useRenoteMuteSync()
 
   if (isTauri) {
     // Set up PiP event listener in main window

--- a/src/adapters/misskey/api.ts
+++ b/src/adapters/misskey/api.ts
@@ -757,6 +757,11 @@ export class MisskeyApi implements ApiAdapter {
     return unwrapAny(await commands.apiGetMutedUsers(this.accountId))
   }
 
+  async getMutedWords() {
+    this.requireAuth()
+    return unwrapAny(await commands.apiGetMutedWords(this.accountId))
+  }
+
   async renoteMuteUser(userId: string): Promise<void> {
     this.requireAuth()
     unwrapAny(await commands.apiRenoteMuteUser(this.accountId, userId))

--- a/src/adapters/misskey/api.ts
+++ b/src/adapters/misskey/api.ts
@@ -762,6 +762,11 @@ export class MisskeyApi implements ApiAdapter {
     return unwrapAny(await commands.apiGetMutedWords(this.accountId))
   }
 
+  async getRenoteMutedUsers(): Promise<string[]> {
+    this.requireAuth()
+    return unwrapAny(await commands.apiGetRenoteMutedUsers(this.accountId))
+  }
+
   async renoteMuteUser(userId: string): Promise<void> {
     this.requireAuth()
     unwrapAny(await commands.apiRenoteMuteUser(this.accountId, userId))

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -435,6 +435,10 @@ export type { FederationInstance }
 import type { Flash, GalleryPost, Page } from '@/bindings'
 export type { Flash, GalleryPost, Page }
 
+// ワードミュート（#610）。mutedWords / hardMutedWords は notecli が `i` から取得。
+import type { MutedWord, MutedWordsResult } from '@/bindings'
+export type { MutedWord, MutedWordsResult }
+
 /** Misskey Pages の取得対象 endpoint (Rust 側で allowlist チェック)。 */
 export type PagesEndpoint = 'pages/featured' | 'i/pages' | 'i/page-likes'
 
@@ -642,6 +646,8 @@ export interface ApiAdapter {
   unmuteUser(userId: string): Promise<void>
   /** 自分がミュート中のユーザー ID 一覧（#574: 起動時の mute store hydrate 用）。 */
   getMutedUsers(): Promise<string[]>
+  /** 自分の mutedWords / hardMutedWords（#610: 起動時の word mute store hydrate 用、read のみ）。 */
+  getMutedWords(): Promise<MutedWordsResult>
   renoteMuteUser(userId: string): Promise<void>
   unrenoteMuteUser(userId: string): Promise<void>
   blockUser(userId: string): Promise<void>

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -646,8 +646,10 @@ export interface ApiAdapter {
   unmuteUser(userId: string): Promise<void>
   /** 自分がミュート中のユーザー ID 一覧（#574: 起動時の mute store hydrate 用）。 */
   getMutedUsers(): Promise<string[]>
-  /** 自分の mutedWords / hardMutedWords（#610: 起動時の word mute store hydrate 用、read のみ）。 */
+  /** 自分の mutedWords / hardMutedWords / mutedInstances（#610/#613: 起動時 hydrate 用、read のみ）。 */
   getMutedWords(): Promise<MutedWordsResult>
+  /** 自分が renote mute 中のユーザー ID 一覧（#614: 起動時の renote mute store hydrate 用）。 */
+  getRenoteMutedUsers(): Promise<string[]>
   renoteMuteUser(userId: string): Promise<void>
   unrenoteMuteUser(userId: string): Promise<void>
   blockUser(userId: string): Promise<void>

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -707,6 +707,17 @@ async apiGetMutedUsers(accountId: string) : Promise<Result<string[], { code: str
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * 自分の mutedWords / hardMutedWords を取得する（#610: 起動時の word mute store hydrate、read のみ）。
+ */
+async apiGetMutedWords(accountId: string) : Promise<Result<MutedWordsResult, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_get_muted_words", { accountId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async apiBlockUser(accountId: string, userId: string) : Promise<Result<null, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_block_user", { accountId, userId }) };
@@ -2416,6 +2427,16 @@ export type GalleryPost = { id: string; createdAt: string; updatedAt: string; ti
 export type HttpFetchRequest = { url: string; method: string | null; headers: Partial<{ [key in string]: string }> | null; body: string | null; timeoutMs: number | null }
 export type HttpFetchResponse = { status: number; headers: Partial<{ [key in string]: string }>; body: string }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
+/**
+ * Misskey の `mutedWords` / `hardMutedWords` の 1 要素。
+ * 文字列配列なら AND 語群（全語含むとマッチ）、文字列なら `/regex/flags` 形式の正規表現。
+ */
+export type MutedWord = string[] | string
+/**
+ * `i`(meDetailed) から取得する word mute 設定（read のみ、#610）。
+ * soft = `mutedWords`（隠して展開可）、hard = `hardMutedWords`（完全非表示）。
+ */
+export type MutedWordsResult = { mutedWords: MutedWord[]; hardMutedWords: MutedWord[] }
 export type NormalizedDriveFile = { id: string; name: string; type: string; url: string; thumbnailUrl: string | null; size?: number; isSensitive?: boolean }
 export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; channel?: Channel | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
 /**

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -708,11 +708,23 @@ async apiGetMutedUsers(accountId: string) : Promise<Result<string[], { code: str
 }
 },
 /**
- * 自分の mutedWords / hardMutedWords を取得する（#610: 起動時の word mute store hydrate、read のみ）。
+ * 自分の mutedWords / hardMutedWords / mutedInstances を取得する
+ * （#610/#613: 起動時の word/instance mute store hydrate、read のみ）。
  */
 async apiGetMutedWords(accountId: string) : Promise<Result<MutedWordsResult, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_get_muted_words", { accountId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * 自分が renote mute 中のユーザー ID 一覧を取得する（#614: 起動時の renote mute store hydrate）。
+ */
+async apiGetRenoteMutedUsers(accountId: string) : Promise<Result<string[], { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_get_renote_muted_users", { accountId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -2436,7 +2448,11 @@ export type MutedWord = string[] | string
  * `i`(meDetailed) から取得する word mute 設定（read のみ、#610）。
  * soft = `mutedWords`（隠して展開可）、hard = `hardMutedWords`（完全非表示）。
  */
-export type MutedWordsResult = { mutedWords: MutedWord[]; hardMutedWords: MutedWord[] }
+export type MutedWordsResult = { mutedWords: MutedWord[]; hardMutedWords: MutedWord[]; 
+/**
+ * インスタンスミュート（#613）。ミュート対象ホスト名の配列。同じ `i` から取得。
+ */
+mutedInstances: string[] }
 export type NormalizedDriveFile = { id: string; name: string; type: string; url: string; thumbnailUrl: string | null; size?: number; isSensitive?: boolean }
 export type NormalizedNote = { id: string; _accountId: string; _serverHost: string; createdAt: string; text: string | null; cw: string | null; user: NormalizedUser; visibility: string; emojis?: Partial<{ [key in string]: string }>; reactionEmojis?: Partial<{ [key in string]: string }>; reactions?: Partial<{ [key in string]: number }>; myReaction: string | null; renoteCount: number; repliesCount: number; files?: NormalizedDriveFile[]; poll?: NormalizedPoll | null; replyId?: string | null; renoteId?: string | null; channelId?: string | null; channel?: Channel | null; reactionAcceptance?: string | null; uri?: string | null; url?: string | null; updatedAt?: string | null; localOnly?: boolean; visibleUserIds?: string[]; isFavorited?: boolean; 
 /**

--- a/src/capabilities/builtins/user.ts
+++ b/src/capabilities/builtins/user.ts
@@ -4,6 +4,7 @@ import type { Command } from '@/commands/registry'
 import { stripCredentials } from '@/composables/useAiSystemContext'
 import { useAccountsStore } from '@/stores/accounts'
 import { useMuteStore } from '@/stores/mutes'
+import { useRenoteMuteStore } from '@/stores/renoteMutes'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /**
@@ -277,8 +278,12 @@ export const userRenoteMuteCapability: Command = {
   visible: false,
   execute: async (params) => {
     const userId = pickUserId(params, 'user.renoteMute')
-    const api = await getApiAdapter(pickAccountId(params))
+    const rawAccountId = pickAccountId(params)
+    const api = await getApiAdapter(rawAccountId)
     await api.renoteMuteUser(userId)
+    // 並んでいるリノートを即時非表示（#614）。
+    const accountId = rawAccountId ?? useAccountsStore().activeAccountId
+    if (accountId) useRenoteMuteStore().mute(accountId, userId)
     return { renoteMuted: true, userId }
   },
 }
@@ -300,8 +305,12 @@ export const userUnrenoteMuteCapability: Command = {
   visible: false,
   execute: async (params) => {
     const userId = pickUserId(params, 'user.unrenoteMute')
-    const api = await getApiAdapter(pickAccountId(params))
+    const rawAccountId = pickAccountId(params)
+    const api = await getApiAdapter(rawAccountId)
     await api.unrenoteMuteUser(userId)
+    // 隠れていたリノートを即時復活（#614）。
+    const accountId = rawAccountId ?? useAccountsStore().activeAccountId
+    if (accountId) useRenoteMuteStore().unmute(accountId, userId)
     return { renoteUnmuted: true, userId }
   },
 }

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -14,6 +14,7 @@ import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useLongPress } from '@/composables/useLongPress'
 import { useNavigation } from '@/composables/useNavigation'
 import { provideNoteAccountId } from '@/composables/useNoteContext'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePortal } from '@/composables/usePortal'
 import { useRippleEffect } from '@/composables/useRippleEffect'
 import { noteTargetId, useSpotlightStore } from '@/composables/useSpotlight'
@@ -270,6 +271,14 @@ async function handleUnrenote() {
 }
 const cwExpanded = ref(false)
 const longTextExpanded = ref(false)
+
+// ワードミュート soft（#610）: mutedWords にマッチしたら本文を折りたたみ、展開可能にする
+const visibility = useNoteVisibility()
+const wordMuteRevealed = ref(false)
+const softMuteCollapsed = computed(
+  () =>
+    visibility.isSoftWordMuted(effectiveNote.value) && !wordMuteRevealed.value,
+)
 
 const LONG_TEXT_THRESHOLD = 500
 const LONG_TEXT_LINES = 8
@@ -670,8 +679,16 @@ function handlePickerReaction(reaction: string) {
           <span :class="$style.instanceName">{{ effectiveNote.user.instance.name || effectiveNote.user.host }}</span>
         </div>
 
+        <!-- Word mute (soft, #610) -->
+        <div v-if="softMuteCollapsed" :class="$style.cw">
+          <p :class="$style.cwText">{{ effectiveNote.user.name || effectiveNote.user.username }}が何かを言いました</p>
+          <button :class="$style.cwToggle" class="_button" @click.stop="wordMuteRevealed = true">
+            もっと見る
+          </button>
+        </div>
+
         <!-- CW -->
-        <div v-if="effectiveNote.cw !== null" :class="$style.cw">
+        <div v-if="effectiveNote.cw !== null && !softMuteCollapsed" :class="$style.cw">
           <p :class="$style.cwText">
             <MkMfm
               v-if="effectiveNote.cw"
@@ -692,7 +709,7 @@ function handlePickerReaction(reaction: string) {
         </div>
 
         <!-- Body -->
-        <div v-show="effectiveNote.cw === null || cwExpanded" :class="$style.body">
+        <div v-show="(effectiveNote.cw === null || cwExpanded) && !softMuteCollapsed" :class="$style.body">
           <div v-if="effectiveNote.text" :class="[$style.textContainer, { [$style.collapsed]: isLongText && !longTextExpanded }]">
             <p :class="$style.text">
               <MkMfm
@@ -745,7 +762,7 @@ function handlePickerReaction(reaction: string) {
         </div>
 
         <!-- Reactions -->
-        <div v-if="sortedReactions.length > 0 && !embedded" ref="reactionsAreaRef" :class="$style.reactionsArea">
+        <div v-if="sortedReactions.length > 0 && !embedded && !softMuteCollapsed" ref="reactionsAreaRef" :class="$style.reactionsArea">
           <div
             v-if="reactionsVisible"
             :class="$style.reactions"

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -29,6 +29,7 @@ import {
   type PrefetchTarget,
   useChatThreadPrefetch,
 } from '@/composables/useChatThreadPrefetch'
+import { useChatVisibility } from '@/composables/useChatVisibility'
 import { useColumnSetup } from '@/composables/useColumnSetup'
 import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
@@ -132,6 +133,9 @@ function handleActionError(e: unknown) {
 
 const chatSound = useNoteSound(() => account.value?.host, 'syuilo/waon')
 
+// ミュートユーザーのチャットを「存在ごと」隠す（#575、本家にない独自仕様）
+const { isPartnerMuted, isMessageHidden } = useChatVisibility()
+
 const viewMode = ref<'history' | 'conversation'>('history')
 // B-5: messages は chatMessageStore からの ID 参照のみで管理する。
 // `messageIds` の真値を持ち、`messages` は store から resolve した derived。
@@ -189,7 +193,11 @@ function matchesSearch(name: string, preview: string | null | undefined) {
 }
 
 const filteredHistoryEntries = computed<HistoryEntry[]>(() =>
-  historyEntries.value.filter((e) => matchesSearch(e.name, e.message.text)),
+  historyEntries.value.filter(
+    (e) =>
+      !(!e.isRoom && isPartnerMuted(e.accountId, e.otherId)) &&
+      matchesSearch(e.name, e.message.text),
+  ),
 )
 
 // 会話 view 内検索 (#483 v1)。トグル式で、有効時は messages を本文 + 送信者名で
@@ -214,9 +222,12 @@ function closeConvSearch() {
 }
 
 const filteredMessages = computed(() => {
+  // ミュート送信者の発言は常に隠す（room 内個別発言にも適用）。検索の前段。
+  const acc = activeAccountId.value
+  const visible = messages.value.filter((m) => !isMessageHidden(acc, m))
   const q = convSearchQuery.value.trim().toLowerCase()
-  if (!q) return messages.value
-  return messages.value.filter((m) => {
+  if (!q) return visible
+  return visible.filter((m) => {
     if (m.text?.toLowerCase().includes(q)) return true
     const u = m.fromUser
     if (u?.name?.toLowerCase().includes(q)) return true
@@ -604,6 +615,7 @@ interface PerAccountHistoryEntry {
   emojis?: Record<string, string>
   avatarUrl?: string
   avatarDecorations?: AvatarDecoration[]
+  otherId?: string
 }
 
 /**
@@ -654,6 +666,7 @@ const perAccountHistoryEntries = computed<PerAccountHistoryEntry[]>(() => {
         emojis: other?.emojis ?? undefined,
         avatarUrl: other?.avatarUrl ?? undefined,
         avatarDecorations: other?.avatarDecorations,
+        otherId,
       })
     }
   }
@@ -662,8 +675,10 @@ const perAccountHistoryEntries = computed<PerAccountHistoryEntry[]>(() => {
 })
 
 const filteredPerAccountEntries = computed<PerAccountHistoryEntry[]>(() =>
-  perAccountHistoryEntries.value.filter((e) =>
-    matchesSearch(e.name, e.message.text),
+  perAccountHistoryEntries.value.filter(
+    (e) =>
+      !(!e.isRoom && isPartnerMuted(props.column.accountId, e.otherId)) &&
+      matchesSearch(e.name, e.message.text),
   ),
 )
 
@@ -839,6 +854,8 @@ async function openConversation(
 
 function onNewMessage(msg: ChatMessage) {
   if (messageIds.value.includes(msg.id)) return
+  // ミュート送信者の着信は存在ごと無視（append もサウンドもしない）
+  if (isMessageHidden(activeAccountId.value, msg)) return
   appendMessage(msg)
   if (!props.column.soundMuted) chatSound.play()
   // 検索中は表示位置を維持する (新着で自動スクロールするとヒット箇所を見失うため)。

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -32,6 +32,7 @@ import { useHoverPopup } from '@/composables/useHoverPopup'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
 import { useNavigation } from '@/composables/useNavigation'
 import { useNoteSound } from '@/composables/useNoteSound'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePortal } from '@/composables/usePortal'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
@@ -310,9 +311,15 @@ function onFilterChange(value: string) {
   activeFilter.value = value as NotifFilterKey
 }
 
+// ミュートした notifier / 削除ノートの通知を表示時に隠す（#606、本家整合）
+const { isNotificationHidden } = useNoteVisibility()
+const visibleNotifications = computed(() =>
+  notifications.value.filter((n) => !isNotificationHidden(n)),
+)
+
 const filteredNotifications = computed(() => {
-  if (activeFilter.value === 'all') return notifications.value
-  return notifications.value.filter(
+  if (activeFilter.value === 'all') return visibleNotifications.value
+  return visibleNotifications.value.filter(
     (n) => baseType(n.type) === activeFilter.value,
   )
 })

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -311,10 +311,23 @@ function onFilterChange(value: string) {
   activeFilter.value = value as NotifFilterKey
 }
 
-// ミュートした notifier / 削除ノートの通知を表示時に隠す（#606、本家整合）
-const { isNotificationHidden } = useNoteVisibility()
+// ミュートした notifier / 削除ノートの通知を表示時に隠す（#606）。
+// grouped 通知はミュート済みリアクター/リノーターを除外し、全員ミュートなら
+// 通知ごと隠す（#575）。一部のみなら当該ユーザーを除いて表示する。
+const { isNotificationHidden, visibleReactions, visibleGroupedUsers } =
+  useNoteVisibility()
 const visibleNotifications = computed(() =>
-  notifications.value.filter((n) => !isNotificationHidden(n)),
+  notifications.value
+    .filter((n) => !isNotificationHidden(n))
+    .map((n) => {
+      if (n.type === 'reaction:grouped' && n.reactions) {
+        return { ...n, reactions: visibleReactions(n) }
+      }
+      if (n.type === 'renote:grouped' && n.users) {
+        return { ...n, users: visibleGroupedUsers(n) }
+      }
+      return n
+    }),
 )
 
 const filteredNotifications = computed(() => {

--- a/src/composables/useChatVisibility.ts
+++ b/src/composables/useChatVisibility.ts
@@ -1,0 +1,38 @@
+import type { ChatMessage } from '@/adapters/types'
+import { useMuteStore } from '@/stores/mutes'
+
+/**
+ * チャットの表示可視性述語。[[useNoteVisibility]] のチャット版。
+ *
+ * 本家 (Misskey/yamisskey) はチャットを block ベースで設計しており muting を
+ * 適用しない（DM/通知は muting するのに非対称）。NoteDeck は「ミュート＝存在を
+ * 無視する」方針を貫くため、チャットでも独自にミュートユーザーを隠す（#575）。
+ *
+ * ChatMessage は `_accountId` を持たないため、判定は account 文脈を持つ
+ * 呼び出し側（DeckChatColumn の per-account / cross-account 履歴）から
+ * accountId を渡す。room の個別発言は isMessageHidden、DM 相手単位の
+ * 履歴除外は isPartnerMuted で扱う。
+ */
+export function useChatVisibility() {
+  const muteStore = useMuteStore()
+
+  /** DM 相手がミュート済みか（room には適用しない＝呼び出し側で !isRoom ガード） */
+  function isPartnerMuted(
+    accountId: string | null | undefined,
+    otherId: string | null | undefined,
+  ): boolean {
+    if (!accountId) return false
+    return muteStore.isMuted(accountId, otherId)
+  }
+
+  /** メッセージ送信者がミュート済みか（room 内の個別発言にも適用） */
+  function isMessageHidden(
+    accountId: string | null | undefined,
+    msg: ChatMessage,
+  ): boolean {
+    if (!accountId) return false
+    return muteStore.isMuted(accountId, msg.fromUserId)
+  }
+
+  return { isPartnerMuted, isMessageHidden }
+}

--- a/src/composables/useCrossAccountNotes.ts
+++ b/src/composables/useCrossAccountNotes.ts
@@ -1,7 +1,8 @@
-import { onMounted, type Ref, shallowRef } from 'vue'
+import { computed, onMounted, type Ref, shallowRef } from 'vue'
 import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
 import { useNoteScrollerRef } from '@/composables/useNoteScrollerRef'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
 import { mapWithConcurrency } from '@/utils/concurrency'
@@ -89,8 +90,11 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
   const accountsStore = useAccountsStore()
   const multiAdapters = useMultiAccountAdapters()
   const noteStore = useNoteStore()
+  const { isHidden } = useNoteVisibility()
 
-  const notes = shallowRef<NormalizedNote[]>([])
+  // 取得した生データ。表示用 notes はミュート/削除を表示時に除外（#606 / #574）
+  const rawNotes = shallowRef<NormalizedNote[]>([])
+  const notes = computed(() => rawNotes.value.filter((n) => !isHidden(n)))
   const { noteScrollerRef } = useNoteScrollerRef(scroller)
 
   function scrollToTop() {
@@ -120,7 +124,7 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
         3,
       )
 
-      notes.value = await dedupAsync(collectFulfilled(results))
+      rawNotes.value = await dedupAsync(collectFulfilled(results))
     } catch (e) {
       error.value = AppError.from(e)
     } finally {
@@ -129,7 +133,7 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
   }
 
   async function loadMoreCrossAccount() {
-    if (isLoading.value || notes.value.length === 0) return
+    if (isLoading.value || rawNotes.value.length === 0) return
     isLoading.value = true
     const accounts = accountsStore.accounts.filter((a) => a.hasToken)
 
@@ -139,7 +143,7 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
         async (acc) => {
           const adapter = await multiAdapters.getOrCreate(acc.id)
           if (!adapter) return []
-          const lastForAccount = [...notes.value]
+          const lastForAccount = [...rawNotes.value]
             .reverse()
             .find((n) => n._accountId === acc.id)
           if (!lastForAccount) return fetchNotes(adapter)
@@ -148,9 +152,9 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
         3,
       )
 
-      const existingIds = new Set(notes.value.map((n) => n.id))
+      const existingIds = new Set(rawNotes.value.map((n) => n.id))
       const newOlder = await dedupAsync(collectFulfilled(results), existingIds)
-      notes.value = [...notes.value, ...newOlder]
+      rawNotes.value = [...rawNotes.value, ...newOlder]
     } catch (e) {
       error.value = AppError.from(e)
     } finally {
@@ -170,7 +174,7 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
     } catch {
       return
     }
-    notes.value = notes.value.filter((n) => n.id !== note.id)
+    rawNotes.value = rawNotes.value.filter((n) => n.id !== note.id)
     noteStore.remove(note.id)
   }
 

--- a/src/composables/useNoteVisibility.ts
+++ b/src/composables/useNoteVisibility.ts
@@ -4,8 +4,10 @@ import type {
   NormalizedUser,
   ReactionInfo,
 } from '@/adapters/types'
+import { useAccountsStore } from '@/stores/accounts'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useWordMuteStore } from '@/stores/wordMutes'
 
 /**
  * ノートの表示可視性述語。
@@ -22,6 +24,20 @@ import { useNoteStore } from '@/stores/notes'
 export function useNoteVisibility() {
   const noteStore = useNoteStore()
   const muteStore = useMuteStore()
+  const wordMuteStore = useWordMuteStore()
+  const accountsStore = useAccountsStore()
+
+  /** ワードミュートのマッチ対象テキスト（本家準拠で cw + text）。 */
+  function noteMatchText(note: NormalizedNote): string {
+    return `${note.cw ?? ''}\n${note.text ?? ''}`
+  }
+
+  /** 自分のノートか（本家準拠でワードミュート対象外にする）。 */
+  function isOwnNote(note: NormalizedNote): boolean {
+    return (
+      accountsStore.accountMap.get(note._accountId)?.userId === note.user.id
+    )
+  }
 
   /**
    * 表示から隠すべきノートか。判定材料:
@@ -35,9 +51,42 @@ export function useNoteVisibility() {
     return (
       muteStore.isMuted(acc, note.user.id) ||
       muteStore.isMuted(acc, note.reply?.user?.id) ||
-      muteStore.isMuted(acc, note.renote?.user?.id)
+      muteStore.isMuted(acc, note.renote?.user?.id) ||
+      isHardWordMuted(note)
     )
     // 将来の OR 合成点: || archiveStore.isArchived(...)  // 魚拓
+  }
+
+  /**
+   * hardMutedWords にマッチするか（#610、完全非表示）。本家準拠で
+   * note 本体 + reply先 + renote元 の cw/text を対象にする。isHidden に合成。
+   */
+  function isHardWordMuted(note: NormalizedNote): boolean {
+    if (isOwnNote(note)) return false
+    const acc = note._accountId
+    return (
+      wordMuteStore.matchesHard(acc, noteMatchText(note)) ||
+      (note.reply != null &&
+        wordMuteStore.matchesHard(acc, noteMatchText(note.reply))) ||
+      (note.renote != null &&
+        wordMuteStore.matchesHard(acc, noteMatchText(note.renote)))
+    )
+  }
+
+  /**
+   * mutedWords にマッチするか（#610、soft = 隠して展開可）。isHidden には
+   * 入れず、MkNote 側で折りたたみ表示の判定に使う。対象は hard と同じ。
+   */
+  function isSoftWordMuted(note: NormalizedNote): boolean {
+    if (isOwnNote(note)) return false
+    const acc = note._accountId
+    return (
+      wordMuteStore.matchesSoft(acc, noteMatchText(note)) ||
+      (note.reply != null &&
+        wordMuteStore.matchesSoft(acc, noteMatchText(note.reply))) ||
+      (note.renote != null &&
+        wordMuteStore.matchesSoft(acc, noteMatchText(note.renote)))
+    )
   }
 
   /** grouped reaction 通知から、ミュート済みリアクターを除いた一覧（#575） */
@@ -80,6 +129,7 @@ export function useNoteVisibility() {
 
   return {
     isHidden,
+    isSoftWordMuted,
     isNotificationHidden,
     visibleReactions,
     visibleGroupedUsers,

--- a/src/composables/useNoteVisibility.ts
+++ b/src/composables/useNoteVisibility.ts
@@ -1,4 +1,4 @@
-import type { NormalizedNote } from '@/adapters/types'
+import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
 
@@ -35,5 +35,20 @@ export function useNoteVisibility() {
     // 将来の OR 合成点: || archiveStore.isArchived(...)  // 魚拓
   }
 
-  return { isHidden }
+  /**
+   * 表示から隠すべき通知か（#606）。本家の read-time フィルタ
+   * （notifierId ベースの NotificationEntityService#filterValidNotifier）と
+   * 同じ挙動: ミュートした notifier の通知を丸ごと隠す。
+   * - notifier（reaction/follow/mention 等の発生元ユーザー）がミュート済み
+   * - 関連ノートが削除 / ミュート投稿者（isHidden 経由）
+   * grouped 通知は単一 notifier を持たず、本家も reactors をフィルタしない
+   * （#575 の保留事項）ため対象外。
+   */
+  function isNotificationHidden(notif: NormalizedNotification): boolean {
+    if (muteStore.isMuted(notif._accountId, notif.user?.id)) return true
+    if (notif.note && isHidden(notif.note)) return true
+    return false
+  }
+
+  return { isHidden, isNotificationHidden }
 }

--- a/src/composables/useNoteVisibility.ts
+++ b/src/composables/useNoteVisibility.ts
@@ -5,8 +5,10 @@ import type {
   ReactionInfo,
 } from '@/adapters/types'
 import { useAccountsStore } from '@/stores/accounts'
+import { useInstanceMuteStore } from '@/stores/instanceMutes'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useRenoteMuteStore } from '@/stores/renoteMutes'
 import { useWordMuteStore } from '@/stores/wordMutes'
 
 /**
@@ -25,6 +27,8 @@ export function useNoteVisibility() {
   const noteStore = useNoteStore()
   const muteStore = useMuteStore()
   const wordMuteStore = useWordMuteStore()
+  const renoteMuteStore = useRenoteMuteStore()
+  const instanceMuteStore = useInstanceMuteStore()
   const accountsStore = useAccountsStore()
 
   /** ワードミュートのマッチ対象テキスト（本家準拠で cw + text）。 */
@@ -52,9 +56,33 @@ export function useNoteVisibility() {
       muteStore.isMuted(acc, note.user.id) ||
       muteStore.isMuted(acc, note.reply?.user?.id) ||
       muteStore.isMuted(acc, note.renote?.user?.id) ||
-      isHardWordMuted(note)
+      isHardWordMuted(note) ||
+      isRenoteMuted(note) ||
+      isInstanceMuted(note)
     )
     // 将来の OR 合成点: || archiveStore.isArchived(...)  // 魚拓
+  }
+
+  /**
+   * リノートミュート（#614）。純粋リノート（`renote && text===null`）の
+   * リノート主（note.user）が renote mute 対象なら隠す。引用（text あり）は対象外。
+   */
+  function isRenoteMuted(note: NormalizedNote): boolean {
+    if (note.renote == null || note.text != null) return false
+    return renoteMuteStore.isMuted(note._accountId, note.user.id)
+  }
+
+  /**
+   * インスタンスミュート（#613）。本家準拠で note / reply先 / renote元 の
+   * 投稿者 host のいずれかが mutedInstances に含まれれば隠す。
+   */
+  function isInstanceMuted(note: NormalizedNote): boolean {
+    const acc = note._accountId
+    return (
+      instanceMuteStore.isMuted(acc, note.user.host) ||
+      instanceMuteStore.isMuted(acc, note.reply?.user?.host) ||
+      instanceMuteStore.isMuted(acc, note.renote?.user?.host)
+    )
   }
 
   /**

--- a/src/composables/useNoteVisibility.ts
+++ b/src/composables/useNoteVisibility.ts
@@ -1,4 +1,9 @@
-import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
+import type {
+  NormalizedNote,
+  NormalizedNotification,
+  NormalizedUser,
+  ReactionInfo,
+} from '@/adapters/types'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
 
@@ -35,20 +40,48 @@ export function useNoteVisibility() {
     // 将来の OR 合成点: || archiveStore.isArchived(...)  // 魚拓
   }
 
+  /** grouped reaction 通知から、ミュート済みリアクターを除いた一覧（#575） */
+  function visibleReactions(notif: NormalizedNotification): ReactionInfo[] {
+    if (!notif.reactions) return []
+    return notif.reactions.filter(
+      (r) => !muteStore.isMuted(notif._accountId, r.user.id),
+    )
+  }
+
+  /** grouped renote 通知から、ミュート済みリノーターを除いた一覧（#575） */
+  function visibleGroupedUsers(
+    notif: NormalizedNotification,
+  ): NormalizedUser[] {
+    if (!notif.users) return []
+    return notif.users.filter((u) => !muteStore.isMuted(notif._accountId, u.id))
+  }
+
   /**
-   * 表示から隠すべき通知か（#606）。本家の read-time フィルタ
-   * （notifierId ベースの NotificationEntityService#filterValidNotifier）と
-   * 同じ挙動: ミュートした notifier の通知を丸ごと隠す。
+   * 表示から隠すべき通知か（#606 / #575）。
    * - notifier（reaction/follow/mention 等の発生元ユーザー）がミュート済み
+   *   = 本家 read-time フィルタ（NotificationEntityService#filterValidNotifier）相当
    * - 関連ノートが削除 / ミュート投稿者（isHidden 経由）
-   * grouped 通知は単一 notifier を持たず、本家も reactors をフィルタしない
-   * （#575 の保留事項）ため対象外。
+   * - grouped 通知でリアクター/リノーターが全員ミュート済み（#575）。
+   *   本家は grouped reactors を貫通させる（漏れ）が、NoteDeck は「存在ごと
+   *   隠す」ため独自に除外する。一部のみミュートなら通知は残し、表示側で
+   *   visibleReactions / visibleGroupedUsers により当該ユーザーを除外する。
    */
   function isNotificationHidden(notif: NormalizedNotification): boolean {
     if (muteStore.isMuted(notif._accountId, notif.user?.id)) return true
     if (notif.note && isHidden(notif.note)) return true
+    if (notif.type === 'reaction:grouped' && notif.reactions?.length) {
+      return visibleReactions(notif).length === 0
+    }
+    if (notif.type === 'renote:grouped' && notif.users?.length) {
+      return visibleGroupedUsers(notif).length === 0
+    }
     return false
   }
 
-  return { isHidden, isNotificationHidden }
+  return {
+    isHidden,
+    isNotificationHidden,
+    visibleReactions,
+    visibleGroupedUsers,
+  }
 }

--- a/src/composables/useRenoteMuteSync.ts
+++ b/src/composables/useRenoteMuteSync.ts
@@ -1,0 +1,40 @@
+import { watch } from 'vue'
+import { initAdapterFor } from '@/adapters/factory'
+import { useAccountsStore } from '@/stores/accounts'
+import { useRenoteMuteStore } from '@/stores/renoteMutes'
+import { catchLog } from '@/utils/logger'
+
+/**
+ * 各アカウントの renote mute 一覧（renote-mute/list）を取得し store を hydrate
+ * する（#614）。`useMuteSync` と同型。起動時 / アカウント追加時に同期する。
+ */
+export function useRenoteMuteSync() {
+  const accountsStore = useAccountsStore()
+  const renoteMuteStore = useRenoteMuteStore()
+  const synced = new Set<string>()
+
+  async function syncAccount(accountId: string, host: string) {
+    if (synced.has(accountId)) return
+    synced.add(accountId)
+    try {
+      const { adapter } = await initAdapterFor(host, accountId)
+      renoteMuteStore.setMuted(
+        accountId,
+        await adapter.api.getRenoteMutedUsers(),
+      )
+    } catch (e) {
+      synced.delete(accountId) // 次の accounts 変化で再試行できるように
+      catchLog('renote-mute-sync')(e)
+    }
+  }
+
+  watch(
+    () => accountsStore.accounts,
+    (accounts) => {
+      for (const acc of accounts) {
+        if (acc.hasToken) void syncAccount(acc.id, acc.host)
+      }
+    },
+    { immediate: true },
+  )
+}

--- a/src/composables/useWordMuteSync.ts
+++ b/src/composables/useWordMuteSync.ts
@@ -1,0 +1,42 @@
+import { watch } from 'vue'
+import { initAdapterFor } from '@/adapters/factory'
+import { useAccountsStore } from '@/stores/accounts'
+import { useWordMuteStore } from '@/stores/wordMutes'
+import { catchLog } from '@/utils/logger'
+
+/**
+ * 各アカウントの mutedWords / hardMutedWords を `i` から取得し word mute store を
+ * hydrate する（#610）。`useMuteSync`（userId ミュート）と同型。read のみ。
+ *
+ * Misskey 側で設定済みの語句を起動時から適用するため、App.vue で 1 回呼び、
+ * accounts の変化を watch して未同期アカウントを埋める。
+ */
+export function useWordMuteSync() {
+  const accountsStore = useAccountsStore()
+  const wordMuteStore = useWordMuteStore()
+  const synced = new Set<string>()
+
+  async function syncAccount(accountId: string, host: string) {
+    if (synced.has(accountId)) return
+    synced.add(accountId)
+    try {
+      const { adapter } = await initAdapterFor(host, accountId)
+      const { mutedWords, hardMutedWords } = await adapter.api.getMutedWords()
+      wordMuteStore.setWords(accountId, mutedWords, hardMutedWords)
+    } catch (e) {
+      synced.delete(accountId) // 次の accounts 変化で再試行できるように
+      catchLog('word-mute-sync')(e)
+    }
+  }
+
+  watch(
+    () => accountsStore.accounts,
+    (accounts) => {
+      for (const acc of accounts) {
+        // 認証済みアカウントのみ（ゲスト/匿名は i を取得できない）
+        if (acc.hasToken) void syncAccount(acc.id, acc.host)
+      }
+    },
+    { immediate: true },
+  )
+}

--- a/src/composables/useWordMuteSync.ts
+++ b/src/composables/useWordMuteSync.ts
@@ -1,19 +1,22 @@
 import { watch } from 'vue'
 import { initAdapterFor } from '@/adapters/factory'
 import { useAccountsStore } from '@/stores/accounts'
+import { useInstanceMuteStore } from '@/stores/instanceMutes'
 import { useWordMuteStore } from '@/stores/wordMutes'
 import { catchLog } from '@/utils/logger'
 
 /**
- * 各アカウントの mutedWords / hardMutedWords を `i` から取得し word mute store を
- * hydrate する（#610）。`useMuteSync`（userId ミュート）と同型。read のみ。
+ * 各アカウントの mutedWords / hardMutedWords / mutedInstances を `i` から取得し
+ * word mute / instance mute store を hydrate する（#610 / #613）。
+ * `useMuteSync`（userId ミュート）と同型。read のみ。`i` 取得は 1 回で両方を満たす。
  *
- * Misskey 側で設定済みの語句を起動時から適用するため、App.vue で 1 回呼び、
- * accounts の変化を watch して未同期アカウントを埋める。
+ * Misskey 側で設定済みの語句/インスタンスを起動時から適用するため、App.vue で
+ * 1 回呼び、accounts の変化を watch して未同期アカウントを埋める。
  */
 export function useWordMuteSync() {
   const accountsStore = useAccountsStore()
   const wordMuteStore = useWordMuteStore()
+  const instanceMuteStore = useInstanceMuteStore()
   const synced = new Set<string>()
 
   async function syncAccount(accountId: string, host: string) {
@@ -21,8 +24,10 @@ export function useWordMuteSync() {
     synced.add(accountId)
     try {
       const { adapter } = await initAdapterFor(host, accountId)
-      const { mutedWords, hardMutedWords } = await adapter.api.getMutedWords()
+      const { mutedWords, hardMutedWords, mutedInstances } =
+        await adapter.api.getMutedWords()
       wordMuteStore.setWords(accountId, mutedWords, hardMutedWords)
+      instanceMuteStore.setMuted(accountId, mutedInstances)
     } catch (e) {
       synced.delete(accountId) // 次の accounts 変化で再試行できるように
       catchLog('word-mute-sync')(e)

--- a/src/stores/instanceMutes.ts
+++ b/src/stores/instanceMutes.ts
@@ -1,0 +1,30 @@
+import { defineStore } from 'pinia'
+import { shallowRef, triggerRef } from 'vue'
+
+/**
+ * インスタンス（サーバー）ミュートの per-account reactive 状態（#613）。
+ *
+ * [[useMuteStore]] と同型だが、ユーザー ID ではなくホスト名（`user.host`）の集合。
+ * `useNoteVisibility().isHidden` が note / reply / renote の投稿者 host が
+ * ここに含まれるかを見て隠す。サーバ（Misskey `i` の mutedInstances）から
+ * read のみで取得し setMuted で hydrate する（NoteDeck からは編集しない）。
+ */
+export const useInstanceMuteStore = defineStore('instanceMutes', () => {
+  const mutedByAccount = shallowRef(new Map<string, Set<string>>())
+
+  function isMuted(
+    accountId: string,
+    host: string | null | undefined,
+  ): boolean {
+    if (!host) return false
+    return mutedByAccount.value.get(accountId)?.has(host) ?? false
+  }
+
+  /** mutedInstances 同期。アカウントのホスト集合を丸ごと置き換える。 */
+  function setMuted(accountId: string, hosts: string[]) {
+    mutedByAccount.value.set(accountId, new Set(hosts))
+    triggerRef(mutedByAccount)
+  }
+
+  return { isMuted, setMuted }
+})

--- a/src/stores/renoteMutes.ts
+++ b/src/stores/renoteMutes.ts
@@ -1,0 +1,45 @@
+import { defineStore } from 'pinia'
+import { shallowRef, triggerRef } from 'vue'
+
+/**
+ * リノートミュート中ユーザーの per-account reactive 状態（#614）。
+ *
+ * [[useMuteStore]] と同型。`useNoteVisibility().isHidden` が「純粋リノート
+ * （renote && text===null）のリノート主」がここに含まれるかを見て隠す。
+ * reactive なので renote mute / 解除で即時に表示反映（リロード不要）。
+ * 起動時は `renote-mute/list` から setMuted で hydrate（#614）。
+ */
+export const useRenoteMuteStore = defineStore('renoteMutes', () => {
+  const mutedByAccount = shallowRef(new Map<string, Set<string>>())
+
+  function isMuted(
+    accountId: string,
+    userId: string | null | undefined,
+  ): boolean {
+    if (!userId) return false
+    return mutedByAccount.value.get(accountId)?.has(userId) ?? false
+  }
+
+  function mute(accountId: string, userId: string) {
+    let set = mutedByAccount.value.get(accountId)
+    if (!set) {
+      set = new Set()
+      mutedByAccount.value.set(accountId, set)
+    }
+    set.add(userId)
+    triggerRef(mutedByAccount)
+  }
+
+  function unmute(accountId: string, userId: string) {
+    mutedByAccount.value.get(accountId)?.delete(userId)
+    triggerRef(mutedByAccount)
+  }
+
+  /** renote-mute/list 同期。アカウントの集合を丸ごと置き換える。 */
+  function setMuted(accountId: string, userIds: string[]) {
+    mutedByAccount.value.set(accountId, new Set(userIds))
+    triggerRef(mutedByAccount)
+  }
+
+  return { isMuted, mute, unmute, setMuted }
+})

--- a/src/stores/wordMutes.ts
+++ b/src/stores/wordMutes.ts
@@ -1,0 +1,50 @@
+/**
+ * ワードミュート（mutedWords / hardMutedWords）の per-account ストア（#610）。
+ *
+ * `stores/mutes.ts`（userId ミュート）と同じ shallowRef + triggerRef パターン。
+ * サーバ（Misskey `i`）から read のみで取得した語句を保持し、解除/変更時は
+ * `setWords` の置き換え + triggerRef で参照側 computed が即再評価される。
+ *
+ * soft = `mutedWords`（隠して展開可）、hard = `hardMutedWords`（完全非表示）。
+ */
+import { defineStore } from 'pinia'
+import { shallowRef, triggerRef } from 'vue'
+import type { MutedWord } from '@/bindings'
+import { matchMutedWords } from '@/utils/wordMuteMatch'
+
+interface AccountWordMutes {
+  soft: MutedWord[]
+  hard: MutedWord[]
+}
+
+export const useWordMuteStore = defineStore('wordMutes', () => {
+  const byAccount = shallowRef(new Map<string, AccountWordMutes>())
+
+  /** `i` から取得した語句で account 分を置き換える（read 同期用）。 */
+  function setWords(accountId: string, soft: MutedWord[], hard: MutedWord[]) {
+    byAccount.value.set(accountId, { soft, hard })
+    triggerRef(byAccount)
+  }
+
+  /** hard ミュート（完全非表示）にマッチするか。 */
+  function matchesHard(
+    accountId: string | null | undefined,
+    text: string | null | undefined,
+  ): boolean {
+    if (!accountId) return false
+    const w = byAccount.value.get(accountId)
+    return w ? matchMutedWords(text, w.hard) : false
+  }
+
+  /** soft ミュート（折りたたみ表示）にマッチするか。 */
+  function matchesSoft(
+    accountId: string | null | undefined,
+    text: string | null | undefined,
+  ): boolean {
+    if (!accountId) return false
+    const w = byAccount.value.get(accountId)
+    return w ? matchMutedWords(text, w.soft) : false
+  }
+
+  return { byAccount, setWords, matchesHard, matchesSoft }
+})

--- a/src/utils/wordMuteMatch.ts
+++ b/src/utils/wordMuteMatch.ts
@@ -1,0 +1,40 @@
+import type { MutedWord } from '@/bindings'
+
+/**
+ * Misskey 本家の `check-word-mute` 準拠のワードミュート判定（#610）。
+ *
+ * フィルタ配列の各要素は:
+ * - `string[]`: その語をすべて含めばマッチ（AND、本家同様 case-sensitive な `includes`）
+ * - `string`: `/pattern/flags` 形式の正規表現としてマッチ（不正形式は無視）
+ *
+ * 要素間は OR（いずれか 1 つがマッチすれば true）。
+ */
+
+/** `/pattern/flags` 形式の文字列を RegExp に。不正なら null。 */
+function buildRegex(pattern: string): RegExp | null {
+  const m = pattern.match(/^\/(.+)\/(.*)$/)
+  if (!m) return null
+  try {
+    return new RegExp(m[1] ?? '', m[2] ?? '')
+  } catch {
+    return null
+  }
+}
+
+function matchesEntry(text: string, entry: MutedWord): boolean {
+  if (Array.isArray(entry)) {
+    if (entry.length === 0) return false
+    return entry.every((kw) => kw.length > 0 && text.includes(kw))
+  }
+  const re = buildRegex(entry)
+  return re ? re.test(text) : false
+}
+
+/** text に対し、words のいずれかのフィルタがマッチすれば true。 */
+export function matchMutedWords(
+  text: string | null | undefined,
+  words: MutedWord[],
+): boolean {
+  if (!text || words.length === 0) return false
+  return words.some((entry) => matchesEntry(text, entry))
+}

--- a/tests/composables/useChatVisibility.test.ts
+++ b/tests/composables/useChatVisibility.test.ts
@@ -1,0 +1,59 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ChatMessage } from '@/adapters/types'
+import { useChatVisibility } from '@/composables/useChatVisibility'
+import { useMuteStore } from '@/stores/mutes'
+
+function makeMessage(fromUserId: string): ChatMessage {
+  return {
+    id: 'm1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    fromUserId,
+    text: 'hi',
+  }
+}
+
+describe('useChatVisibility', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('reports a muted DM partner, restores on unmute', () => {
+    const muteStore = useMuteStore()
+    const { isPartnerMuted } = useChatVisibility()
+    expect(isPartnerMuted('acc1', 'muted-user')).toBe(false)
+
+    muteStore.mute('acc1', 'muted-user')
+    expect(isPartnerMuted('acc1', 'muted-user')).toBe(true)
+
+    muteStore.unmute('acc1', 'muted-user')
+    expect(isPartnerMuted('acc1', 'muted-user')).toBe(false)
+  })
+
+  it('hides a message from a muted sender', () => {
+    const muteStore = useMuteStore()
+    const { isMessageHidden } = useChatVisibility()
+    const msg = makeMessage('muted-user')
+    expect(isMessageHidden('acc1', msg)).toBe(false)
+
+    muteStore.mute('acc1', 'muted-user')
+    expect(isMessageHidden('acc1', msg)).toBe(true)
+  })
+
+  it('scopes mute per account', () => {
+    const muteStore = useMuteStore()
+    const { isPartnerMuted, isMessageHidden } = useChatVisibility()
+    muteStore.mute('acc2', 'u9')
+    expect(isPartnerMuted('acc1', 'u9')).toBe(false)
+    expect(isMessageHidden('acc1', makeMessage('u9'))).toBe(false)
+  })
+
+  it('returns false when account context is missing', () => {
+    const muteStore = useMuteStore()
+    const { isPartnerMuted, isMessageHidden } = useChatVisibility()
+    muteStore.mute('acc1', 'u9')
+    expect(isPartnerMuted(null, 'u9')).toBe(false)
+    expect(isPartnerMuted(undefined, 'u9')).toBe(false)
+    expect(isMessageHidden(null, makeMessage('u9'))).toBe(false)
+  })
+})

--- a/tests/composables/useNoteVisibility.test.ts
+++ b/tests/composables/useNoteVisibility.test.ts
@@ -4,6 +4,7 @@ import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useWordMuteStore } from '@/stores/wordMutes'
 
 function makeNote(
   id: string,
@@ -199,5 +200,55 @@ describe('useNoteVisibility.isNotificationHidden (#606)', () => {
 
     muteStore.mute('acc1', 'other-user')
     expect(isNotificationHidden(notif)).toBe(true)
+  })
+})
+
+describe('useNoteVisibility word mute (#610)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('hides a note matching hardMutedWords, restores when removed', () => {
+    const wordMuteStore = useWordMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = makeNote('1', 'author', { text: 'this is spam content' })
+    expect(isHidden(note)).toBe(false)
+
+    wordMuteStore.setWords('acc1', [], [['spam']])
+    expect(isHidden(note)).toBe(true)
+
+    wordMuteStore.setWords('acc1', [], [])
+    expect(isHidden(note)).toBe(false)
+  })
+
+  it('soft mute does not hide but flags isSoftWordMuted', () => {
+    const wordMuteStore = useWordMuteStore()
+    const { isHidden, isSoftWordMuted } = useNoteVisibility()
+    const note = makeNote('1', 'author', { text: 'mild spoiler here' })
+    wordMuteStore.setWords('acc1', [['spoiler']], [])
+    expect(isHidden(note)).toBe(false)
+    expect(isSoftWordMuted(note)).toBe(true)
+  })
+
+  it('matches against cw text', () => {
+    const wordMuteStore = useWordMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = makeNote('1', 'author', {
+      text: 'body',
+      cw: 'spoiler warning',
+    })
+    wordMuteStore.setWords('acc1', [], [['spoiler']])
+    expect(isHidden(note)).toBe(true)
+  })
+
+  it('matches via renote text (本家 parity)', () => {
+    const wordMuteStore = useWordMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = makeNote('1', 'author', {
+      text: 'clean',
+      renote: makeNote('0', 'other', { text: 'banned word inside' }),
+    })
+    wordMuteStore.setWords('acc1', [], [['banned']])
+    expect(isHidden(note)).toBe(true)
   })
 })

--- a/tests/composables/useNoteVisibility.test.ts
+++ b/tests/composables/useNoteVisibility.test.ts
@@ -1,6 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
-import type { NormalizedNote } from '@/adapters/types'
+import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
@@ -89,5 +89,87 @@ describe('useNoteVisibility', () => {
     const note = makeNote('1', 'u9') // _accountId: 'acc1'
     muteStore.mute('acc2', 'u9')
     expect(isHidden(note)).toBe(false)
+  })
+})
+
+function makeNotif(
+  type: string,
+  extra: Partial<NormalizedNotification> = {},
+): NormalizedNotification {
+  return {
+    id: 'n1',
+    _accountId: 'acc1',
+    _serverHost: 'example.com',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    type,
+    ...extra,
+  } as NormalizedNotification
+}
+
+describe('useNoteVisibility.isNotificationHidden (#606)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('hides a notification from a muted notifier, restores on unmute', () => {
+    const muteStore = useMuteStore()
+    const { isNotificationHidden } = useNoteVisibility()
+    const notif = makeNotif('reaction', {
+      user: { id: 'muted-user', username: 'u', host: null, avatarUrl: null },
+      reaction: '👍',
+    })
+    expect(isNotificationHidden(notif)).toBe(false)
+
+    muteStore.mute('acc1', 'muted-user')
+    expect(isNotificationHidden(notif)).toBe(true)
+
+    muteStore.unmute('acc1', 'muted-user')
+    expect(isNotificationHidden(notif)).toBe(false)
+  })
+
+  it('hides a follow notification (no note) from a muted notifier', () => {
+    const muteStore = useMuteStore()
+    const { isNotificationHidden } = useNoteVisibility()
+    const notif = makeNotif('follow', {
+      user: { id: 'muted-user', username: 'u', host: null, avatarUrl: null },
+    })
+    muteStore.mute('acc1', 'muted-user')
+    expect(isNotificationHidden(notif)).toBe(true)
+  })
+
+  it('hides a notification whose related note is deleted', () => {
+    const noteStore = useNoteStore()
+    const { isNotificationHidden } = useNoteVisibility()
+    const note = makeNote('1')
+    noteStore.put([note])
+    const notif = makeNotif('mention', {
+      user: { id: 'author', username: 'u', host: null, avatarUrl: null },
+      note,
+    })
+    expect(isNotificationHidden(notif)).toBe(false)
+
+    noteStore.remove('1')
+    expect(isNotificationHidden(notif)).toBe(true)
+  })
+
+  it('does not filter grouped reactions (本家 parity)', () => {
+    const muteStore = useMuteStore()
+    const { isNotificationHidden } = useNoteVisibility()
+    const notif = makeNotif('reaction:grouped', {
+      reactions: [
+        {
+          user: {
+            id: 'muted-user',
+            username: 'u',
+            host: null,
+            avatarUrl: null,
+          },
+          reaction: '👍',
+        },
+      ],
+    })
+    muteStore.mute('acc1', 'muted-user')
+    // grouped 通知は単一 notifier を持たず、本家も reactors をフィルタしないため残す
+    expect(isNotificationHidden(notif)).toBe(false)
   })
 })

--- a/tests/composables/useNoteVisibility.test.ts
+++ b/tests/composables/useNoteVisibility.test.ts
@@ -2,8 +2,10 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it } from 'vitest'
 import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
+import { useInstanceMuteStore } from '@/stores/instanceMutes'
 import { useMuteStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useRenoteMuteStore } from '@/stores/renoteMutes'
 import { useWordMuteStore } from '@/stores/wordMutes'
 
 function makeNote(
@@ -249,6 +251,89 @@ describe('useNoteVisibility word mute (#610)', () => {
       renote: makeNote('0', 'other', { text: 'banned word inside' }),
     })
     wordMuteStore.setWords('acc1', [], [['banned']])
+    expect(isHidden(note)).toBe(true)
+  })
+})
+
+describe('useNoteVisibility renote mute (#614)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('hides a pure renote from a renote-muted user, restores on unmute', () => {
+    const renoteMuteStore = useRenoteMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const renote = makeNote('1', 'renoter', {
+      text: null,
+      renote: makeNote('0', 'orig'),
+    })
+    expect(isHidden(renote)).toBe(false)
+
+    renoteMuteStore.mute('acc1', 'renoter')
+    expect(isHidden(renote)).toBe(true)
+
+    renoteMuteStore.unmute('acc1', 'renoter')
+    expect(isHidden(renote)).toBe(false)
+  })
+
+  it('does not hide a quote (text present) from a renote-muted user', () => {
+    const renoteMuteStore = useRenoteMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const quote = makeNote('1', 'renoter', {
+      text: 'my comment',
+      renote: makeNote('0', 'orig'),
+    })
+    renoteMuteStore.mute('acc1', 'renoter')
+    expect(isHidden(quote)).toBe(false)
+  })
+
+  it('does not hide a normal note from a renote-muted user', () => {
+    const renoteMuteStore = useRenoteMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = makeNote('1', 'renoter', { text: 'just posting' })
+    renoteMuteStore.mute('acc1', 'renoter')
+    expect(isHidden(note)).toBe(false)
+  })
+})
+
+describe('useNoteVisibility instance mute (#613)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  function noteFromHost(id: string, host: string | null): NormalizedNote {
+    return makeNote(id, 'u1', {
+      user: { id: 'u1', username: 'u', host, avatarUrl: null },
+    })
+  }
+
+  it('hides a note from a muted instance, restores on unmute', () => {
+    const instanceMuteStore = useInstanceMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = noteFromHost('1', 'bad.example')
+    expect(isHidden(note)).toBe(false)
+
+    instanceMuteStore.setMuted('acc1', ['bad.example'])
+    expect(isHidden(note)).toBe(true)
+
+    instanceMuteStore.setMuted('acc1', [])
+    expect(isHidden(note)).toBe(false)
+  })
+
+  it('does not hide local (host=null) notes', () => {
+    const instanceMuteStore = useInstanceMuteStore()
+    const { isHidden } = useNoteVisibility()
+    instanceMuteStore.setMuted('acc1', ['bad.example'])
+    expect(isHidden(noteFromHost('1', null))).toBe(false)
+  })
+
+  it('hides when the renote target is from a muted instance', () => {
+    const instanceMuteStore = useInstanceMuteStore()
+    const { isHidden } = useNoteVisibility()
+    const note = makeNote('1', 'local', {
+      renote: noteFromHost('0', 'bad.example'),
+    })
+    instanceMuteStore.setMuted('acc1', ['bad.example'])
     expect(isHidden(note)).toBe(true)
   })
 })

--- a/tests/composables/useNoteVisibility.test.ts
+++ b/tests/composables/useNoteVisibility.test.ts
@@ -92,6 +92,10 @@ describe('useNoteVisibility', () => {
   })
 })
 
+function makeUser(id: string) {
+  return { id, username: 'user', host: null, avatarUrl: null }
+}
+
 function makeNotif(
   type: string,
   extra: Partial<NormalizedNotification> = {},
@@ -152,24 +156,48 @@ describe('useNoteVisibility.isNotificationHidden (#606)', () => {
     expect(isNotificationHidden(notif)).toBe(true)
   })
 
-  it('does not filter grouped reactions (本家 parity)', () => {
+  it('hides a grouped reaction when all reactors are muted (#575)', () => {
     const muteStore = useMuteStore()
     const { isNotificationHidden } = useNoteVisibility()
     const notif = makeNotif('reaction:grouped', {
       reactions: [
-        {
-          user: {
-            id: 'muted-user',
-            username: 'u',
-            host: null,
-            avatarUrl: null,
-          },
-          reaction: '👍',
-        },
+        { user: makeUser('muted-user'), reaction: '👍' },
+        { user: makeUser('muted-user'), reaction: '🎉' },
+      ],
+    })
+    expect(isNotificationHidden(notif)).toBe(false)
+
+    muteStore.mute('acc1', 'muted-user')
+    expect(isNotificationHidden(notif)).toBe(true)
+  })
+
+  it('keeps a grouped reaction with a non-muted reactor, filtering the muted one (#575)', () => {
+    const muteStore = useMuteStore()
+    const { isNotificationHidden, visibleReactions } = useNoteVisibility()
+    const notif = makeNotif('reaction:grouped', {
+      reactions: [
+        { user: makeUser('muted-user'), reaction: '👍' },
+        { user: makeUser('other-user'), reaction: '🎉' },
       ],
     })
     muteStore.mute('acc1', 'muted-user')
-    // grouped 通知は単一 notifier を持たず、本家も reactors をフィルタしないため残す
     expect(isNotificationHidden(notif)).toBe(false)
+    const visible = visibleReactions(notif)
+    expect(visible).toHaveLength(1)
+    expect(visible[0].user.id).toBe('other-user')
+  })
+
+  it('hides a grouped renote when all renoters are muted (#575)', () => {
+    const muteStore = useMuteStore()
+    const { isNotificationHidden, visibleGroupedUsers } = useNoteVisibility()
+    const notif = makeNotif('renote:grouped', {
+      users: [makeUser('muted-user'), makeUser('other-user')],
+    })
+    muteStore.mute('acc1', 'muted-user')
+    expect(isNotificationHidden(notif)).toBe(false)
+    expect(visibleGroupedUsers(notif)).toHaveLength(1)
+
+    muteStore.mute('acc1', 'other-user')
+    expect(isNotificationHidden(notif)).toBe(true)
   })
 })

--- a/tests/stores/wordMutes.test.ts
+++ b/tests/stores/wordMutes.test.ts
@@ -1,0 +1,38 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useWordMuteStore } from '@/stores/wordMutes'
+
+describe('useWordMuteStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('matches hard and soft words after sync', () => {
+    const store = useWordMuteStore()
+    store.setWords('acc1', [['spoiler']], [['banned']])
+    expect(store.matchesSoft('acc1', 'a spoiler appears')).toBe(true)
+    expect(store.matchesHard('acc1', 'a spoiler appears')).toBe(false)
+    expect(store.matchesHard('acc1', 'banned content')).toBe(true)
+  })
+
+  it('is scoped per account', () => {
+    const store = useWordMuteStore()
+    store.setWords('acc1', [['x']], [])
+    expect(store.matchesSoft('acc2', 'x here')).toBe(false)
+  })
+
+  it('replaces words on re-sync and reflects removal', () => {
+    const store = useWordMuteStore()
+    store.setWords('acc1', [['old']], [])
+    expect(store.matchesSoft('acc1', 'old word')).toBe(true)
+    store.setWords('acc1', [['new']], [])
+    expect(store.matchesSoft('acc1', 'old word')).toBe(false)
+    expect(store.matchesSoft('acc1', 'new word')).toBe(true)
+  })
+
+  it('returns false when account has no words or is missing', () => {
+    const store = useWordMuteStore()
+    expect(store.matchesSoft('acc1', 'anything')).toBe(false)
+    expect(store.matchesHard(null, 'anything')).toBe(false)
+  })
+})

--- a/tests/utils/wordMuteMatch.test.ts
+++ b/tests/utils/wordMuteMatch.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { matchMutedWords } from '@/utils/wordMuteMatch'
+
+describe('matchMutedWords', () => {
+  it('matches a single keyword group', () => {
+    expect(matchMutedWords('hello world', [['world']])).toBe(true)
+    expect(matchMutedWords('hello there', [['world']])).toBe(false)
+  })
+
+  it('requires all keywords in a group (AND)', () => {
+    expect(matchMutedWords('foo and bar', [['foo', 'bar']])).toBe(true)
+    expect(matchMutedWords('only foo', [['foo', 'bar']])).toBe(false)
+  })
+
+  it('matches if any filter matches (OR across entries)', () => {
+    expect(matchMutedWords('just baz', [['foo'], ['baz']])).toBe(true)
+  })
+
+  it('matches a /regex/flags string entry', () => {
+    expect(matchMutedWords('HELLO', ['/hello/i'])).toBe(true)
+    expect(matchMutedWords('hello', ['/HELLO/'])).toBe(false) // case-sensitive without i
+    expect(matchMutedWords('abc123', ['/\\d+/'])).toBe(true)
+  })
+
+  it('ignores invalid regex entries', () => {
+    expect(matchMutedWords('anything', ['/(/'])).toBe(false)
+    expect(matchMutedWords('anything', ['not-a-regex'])).toBe(false)
+  })
+
+  it('returns false for empty text or empty filters', () => {
+    expect(matchMutedWords(null, [['x']])).toBe(false)
+    expect(matchMutedWords('', [['x']])).toBe(false)
+    expect(matchMutedWords('text', [])).toBe(false)
+    expect(matchMutedWords('text', [[]])).toBe(false)
+  })
+})


### PR DESCRIPTION
## Release v1.1.0 — ミュート完備リリース

「ミュート＝存在を無視する」を各表示面で徹底する機能群。すべて可視性述語 `useNoteVisibility`（データ層は触らず表示時に判定、変更/解除で即時反映）に乗せた。

### 新機能（feat）

- **通知 / cross-account への可視性述語適用 (#606)** — ミュートした notifier の通知を即時非表示（本家 read-time フィルタ整合）。cross-account mentions/DM もミュート/削除を反映。
- **grouped 通知のミュート除外 (#609 / #575 通知側)** — `reaction:grouped` / `renote:grouped` のミュート済みリアクター・リノーターを除外、全員ミュートなら通知ごと非表示。
- **チャットミュート (#611)** — ミュートユーザーの DM・ルーム発言・着信サウンドを非表示（本家は chat を block ベースで muting 非適用 → NoteDeck 独自仕様）。
- **ワードミュート (#610)** — `mutedWords`(soft=折りたたみ展開可) / `hardMutedWords`(hard=完全非表示) をサーバから read のみ取得して適用。`(string[]|string)[]`（AND 語群 / OR / `/regex/flags`）対応、自分のノート除外。
- **リノートミュート表示反映 (#614)** — 既存の renote mute 操作に表示フィルタを追加。純粋リノート（引用でない renote）のみ非表示、引用・通常ノートは表示。
- **サーバー（インスタンス）ミュート (#613)** — `mutedInstances` を read 取得し、note/reply/renote の投稿者 host で非表示。

### 依存

- notecli を rev `3aaec69` に更新（`i` から mutedWords/hardMutedWords/mutedInstances 取得、`renote-mute/list` 読取）。bindings/openapi 再生成済み。

### テスト

- フロント 1084 テスト全パス（ミュート述語・util・store の新規テスト含む）、typecheck / lint / bindings・openapi snapshot OK。

---

Closes #609
Closes #610
Closes #611
Closes #613
Closes #614

Refs #606（item 3 = 詳細ウィンドウのスレッド ancestors/children は意図的にスコープ外）
Refs #575（通知/grouped/チャットは対応済み。ノート本体の reactions カウント除外は API N+1 のためスコープ外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
