### PR TITLE
docs(site): プラットフォーム3カードの文章量を均し Vault と AI エージェント連携を追記

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -149,7 +149,7 @@
           </div>
           <h3>自己拡張する IDE</h3>
           <p class="pillar-lead">デッキの挙動も、<strong>世界の情報も、取り込む。</strong></p>
-          <p>検索・投稿・カラム操作・通知・メモなど NoteDeck の全機能に加え、翻訳・天気・GitHub など <strong>Web UI が CORS で触れない任意の外部 API</strong> までを AiScript・AI から直接叩ける (ネイティブアプリだけの特権)。新コマンドを書けばコマンドパレットに即登録、AI ツールとしても自動公開。</p>
+          <p>検索・投稿・カラム操作・通知・メモなど NoteDeck の全機能に加え、翻訳・天気・GitHub など <strong>Web UI が CORS で触れない任意の外部 API</strong> までを AiScript・AI から直接叩ける (ネイティブアプリだけの特権)。認証が要る API も内蔵 Vault に「接続」として登録するだけ — シークレットは OS キーチェーンに収まり、AI の目には触れない。新コマンドを書けば、その瞬間コマンドパレットに登録され、AI ツールとしても自動公開される。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
@@ -157,7 +157,7 @@
           </div>
           <h3>AI と一緒に育つ IDE</h3>
           <p class="pillar-lead">使うほど、<strong>自分専用の道具に育っていく。</strong></p>
-          <p>AI 自身が CSS・キーバインド・navbar から、プラグイン・テーマ・ウィジット・AI 自身のペルソナまで直接編集できる。さらにカラム追加・サイドバー切替・アカウント切替などの UI 操作も会話から代行 (操作箇所はテーマカラーで光って可視化)。MisStore からの導入も削除も会話で完結し、観察したことは永続記憶として次のセッションへ引き継がれる。出荷時の機能で固定されない、人間と AI が一緒に手を入れていく IDE。</p>
+          <p>AI 自身が CSS・キーバインド・navbar から、プラグイン・テーマ・ウィジット・<strong>AI 自身のペルソナ</strong>まで直接編集できる。カラム追加・サイドバー切替・アカウント切替などの UI 操作も会話から代行 (操作箇所はテーマカラーで光って可視化)。MisStore からの導入も削除も会話で完結し、観察したことは永続記憶として次のセッションへ。出荷時の機能で固定されない、人間と AI が一緒に手を入れていく IDE。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
@@ -165,7 +165,7 @@
           </div>
           <h3>外部から駆動できる</h3>
           <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
-          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークン渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも、<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck・自作ボット、一度書けば全経路から呼べる。</p>
+          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークンを渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck から、OpenClaw・Hermes Agent・Claude Cowork といった AI エージェントの手足まで、一度書けば全経路から呼べる。</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 概要

ランディングページ「プラットフォームとして」セクションの3カードを刷新。

- **自己拡張する IDE**: 内蔵 Vault の「接続」で認証付き外部 API も叩ける点をアピール強化（シークレットは OS キーチェーン保管、AI には見えない）
- **AI と一緒に育つ IDE**: 情報量は維持しつつ文章を引き締め、`<strong>` の使い方を他カードと統一
- **外部から駆動できる**: OpenClaw・Hermes Agent・Claude Cowork といった AI エージェントとの連携に言及
- 3カードの本文を 208〜239 文字に揃え、情報量と文章量のバランスを統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)