### PR TITLE
Release v1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.1"
+version = "1.1.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.1"
+    "version": "1.1.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -2,6 +2,7 @@
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, useCssModule } from 'vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
+import { useNavigation } from '@/composables/useNavigation'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyUrl } from '@/utils/imageProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
@@ -33,6 +34,7 @@ const emit = defineEmits<{
 }>()
 
 const { resolveEmoji: resolveEmojiRaw } = useEmojiResolver()
+const { navigateToHashtag } = useNavigation()
 const style = useCssModule()
 
 function isMentionMe(username: string, host: string | null): boolean {
@@ -421,7 +423,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- URL --><a v-if="token.type === 'url'" :href="isSafeUrl(token.value) ? token.value : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.value)">{{ token.value }}</a><!--
     --><!-- Link --><a v-else-if="token.type === 'link'" :href="isSafeUrl(token.url) ? token.url : '#'" :class="$style.mfmUrl" target="_blank" rel="noopener noreferrer" @click.stop="handleLinkClick($event, token.url)"><MkMfm :tokens="token.label" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></a><!--
     --><!-- Mention --><span v-else-if="token.type === 'mention'" :class="isMentionMe(token.username, token.host) ? $style.mfmMentionMe : $style.mfmMention" @click.stop="emit('mentionClick', token.username, token.host)" @mouseenter="emit('mentionHover', $event, token.username, token.host)" @mouseleave="emit('mentionLeave')">{{ token.acct }}</span><!--
-    --><!-- Hashtag --><span v-else-if="token.type === 'hashtag'" :class="$style.mfmHashtag" @click.stop>#{{ token.value }}</span><!--
+    --><!-- Hashtag --><span v-else-if="token.type === 'hashtag'" :class="$style.mfmHashtag" @click.stop="navigateToHashtag(token.value)">#{{ token.value }}</span><!--
     --><!-- Bold --><b v-else-if="token.type === 'bold'"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></b><!--
     --><!-- Italic --><i v-else-if="token.type === 'italic'"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></i><!--
     --><!-- Strike --><s v-else-if="token.type === 'strike'"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></s><!--

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -290,8 +290,12 @@ watch(searchQuery, (val) => {
 watch(
   () => props.column.query,
   (q) => {
-    if (!q || q === searchQuery.value) return
+    if (!q || q === confirmedQuery.value) return
     searchQuery.value = q
+    // 手入力フローと違いプレビュー検索を経ないため、前クエリの結果に
+    // server 結果が merge されないようリセットしてから検索する
+    notes.value = []
+    hasLocalResults.value = false
     performSearch()
   },
 )

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -179,6 +179,23 @@ function getSearchHint(q: string): string {
   return extractLiterals(q)
 }
 
+// サーバー検索はバックエンド (Meilisearch 等) がトークナイズで `#` 等の記号を
+// 落とし曖昧マッチを返すことがある。ローカル DB 検索 (trigram FTS) のリテラル
+// 一致と意味論を揃えるため、単一語クエリはリテラル含有でフィルタする。
+// 複数語 (空白区切り AND) はサーバーの挙動を尊重してそのまま通す。
+function filterServerNotes(
+  results: NormalizedNote[],
+  q: string,
+): NormalizedNote[] {
+  if (regexMode.value || /\s/.test(q)) return results
+  const needle = q.toLowerCase()
+  return results.filter(
+    (n) =>
+      n.text?.toLowerCase().includes(needle) ||
+      n.cw?.toLowerCase().includes(needle),
+  )
+}
+
 function mergeNotes(
   existing: NormalizedNote[],
   incoming: NormalizedNote[],
@@ -375,6 +392,7 @@ async function performSearchPerAccount(q: string, hint: string) {
           untilDate: getUntilDateMs(),
           userId: props.column.userId,
         })
+        results = filterServerNotes(results, q)
         if (regexMode.value) {
           results = await filterNotesByRegexAsync(results, q)
         }
@@ -437,7 +455,7 @@ async function performSearchCrossAccount(q: string, hint: string) {
           })
         }),
       )
-      let merged = collectFulfilled(serverResults)
+      let merged = filterServerNotes(collectFulfilled(serverResults), q)
       if (regexMode.value) {
         merged = await filterNotesByRegexAsync(merged, q)
       }
@@ -476,6 +494,7 @@ async function loadMorePerAccount() {
       untilDate: getUntilDateMs(),
       userId: props.column.userId,
     })
+    older = filterServerNotes(older, q)
     if (regexMode.value) {
       older = await filterNotesByRegexAsync(older, q)
     }
@@ -514,7 +533,7 @@ async function loadMoreCrossAccount() {
       }),
     )
 
-    let older = collectFulfilled(results)
+    let older = filterServerNotes(collectFulfilled(results), q)
     if (regexMode.value) {
       older = await filterNotesByRegexAsync(older, q)
     }

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -286,6 +286,16 @@ watch(searchQuery, (val) => {
   debounceTimer = setTimeout(() => searchLocal(q), 200)
 })
 
+// ハッシュタグクリック等で外部から query が差し替えられたとき (deck.openSearchWith)
+watch(
+  () => props.column.query,
+  (q) => {
+    if (!q || q === searchQuery.value) return
+    searchQuery.value = q
+    performSearch()
+  },
+)
+
 // Re-search when date filters or sort order change (debounced)
 let filterTimer: ReturnType<typeof setTimeout> | null = null
 watch([sinceDate, untilDate, ascending], () => {

--- a/src/composables/useNavigation.ts
+++ b/src/composables/useNavigation.ts
@@ -81,6 +81,14 @@ export function useNavigation() {
     toggleOrOpenColumn('search')
   }
 
+  /** ハッシュタグクリックから検索カラムを `#tag` クエリ付きで開く。 */
+  function navigateToHashtag(tag: string) {
+    if (!isDeckActive()) {
+      router.push('/deck')
+    }
+    deckStore.openSearchWith(`#${tag}`)
+  }
+
   function navigateToNotifications() {
     toggleOrOpenColumn('notifications')
   }
@@ -99,6 +107,7 @@ export function useNavigation() {
     navigateToChannel,
     navigateToLogin,
     navigateToSearch,
+    navigateToHashtag,
     navigateToNotifications,
     navigateToAi,
     navigateToChat,

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -408,6 +408,39 @@ export const useDeckStore = defineStore('deck', () => {
     }
   }
 
+  /** ハッシュタグクリック等から検索カラムをクエリ付きで開く。 */
+  function openSearchWith(query: string) {
+    const existing = columns.value.find((c) => c.sidebar)
+    if (existing && existing.type === 'search') {
+      // 既に開いている → query を差し替え (DeckSearchColumn 側の watch が再検索する)
+      updateColumn(existing.id, { query })
+      activeColumnId.value = null
+      nextTick(() => {
+        activeColumnId.value = existing.id
+      })
+    } else if (existing) {
+      updateColumn(existing.id, {
+        type: 'search',
+        accountId: null,
+        name: null,
+        query,
+      })
+      activeColumnId.value = null
+      nextTick(() => {
+        activeColumnId.value = existing.id
+      })
+    } else {
+      addColumnAt(0, {
+        type: 'search',
+        name: null,
+        width: 360,
+        accountId: null,
+        sidebar: true,
+        query,
+      })
+    }
+  }
+
   /** sidebar チャットカラムが会話ターゲットを取り出して消費する。 */
   function consumePendingChatTarget(): ChatConversationTarget | null {
     const t = pendingChatTarget.value
@@ -774,6 +807,7 @@ export const useDeckStore = defineStore('deck', () => {
     toggleSidebarColumn,
     pendingChatTarget,
     openChatWith,
+    openSearchWith,
     consumePendingChatTarget,
     updateColumn,
     swapColumns,


### PR DESCRIPTION
## Changelog

- fix: ハッシュタグクリックで検索カラムを開いて検索する
- fix: ハッシュタグ再クリック時に検索結果が前クエリのまま残る問題を修正
- fix: サーバー検索結果を単一語クエリでリテラル一致にフィルタ
- chore: bump version to 1.1.2
- chore: regenerate openapi.json for 1.1.2

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)