### PR TITLE
Release v1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.3"
+version = "1.1.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.3"
+    "version": "1.1.4"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -46,7 +46,10 @@ import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
 import { AppError, AUTH_ERROR_MESSAGE } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { proxyUrl } from '@/utils/imageProxy'
-import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
+import {
+  loadNotificationCache,
+  saveNotificationCache,
+} from '@/utils/notificationCache'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { char2twemojiUrl } from '@/utils/twemoji'
 import type { ColumnTabDef } from './ColumnTabs.vue'
@@ -278,11 +281,11 @@ function flushCache() {
     clearTimeout(saveCacheTimer)
     saveCacheTimer = null
   }
-  setStorageJson(getCacheKey(), notifications.value)
+  saveNotificationCache(cacheAccountKey(), notifications.value)
 }
 
 function loadCache(): NormalizedNotification[] {
-  return getStorageJson<NormalizedNotification[]>(getCacheKey(), [])
+  return loadNotificationCache(cacheAccountKey())
 }
 
 const NOTIFICATION_FILTERS = [
@@ -521,10 +524,8 @@ function notificationLabel(type: string): string {
   return NOTIFICATION_LABELS[baseType(type)] || type
 }
 
-function getCacheKey() {
-  return STORAGE_KEYS.notificationCache(
-    props.column.accountId ?? 'cross-account',
-  )
+function cacheAccountKey() {
+  return props.column.accountId ?? 'cross-account'
 }
 
 // When account loses token (logout with keep-data), switch to cache display

--- a/src/utils/notificationCache.ts
+++ b/src/utils/notificationCache.ts
@@ -1,0 +1,68 @@
+import type { NormalizedNotification } from '@/adapters/types'
+import {
+  getStorageJson,
+  removeStorage,
+  STORAGE_KEYS,
+  setStorageJson,
+} from './storage'
+
+// 形式変更時にバンプすると旧 entry は破棄され、通常フェッチで再構築される (#407)
+const NOTIFICATION_CACHE_VERSION = 1
+
+interface CacheEnvelope {
+  _v: number
+  items: NormalizedNotification[]
+}
+
+function isValidNotification(v: unknown): v is NormalizedNotification {
+  if (typeof v !== 'object' || v === null) return false
+  const n = v as Record<string, unknown>
+  if (
+    typeof n.id !== 'string' ||
+    typeof n._accountId !== 'string' ||
+    typeof n._serverHost !== 'string' ||
+    typeof n.createdAt !== 'string' ||
+    typeof n.type !== 'string'
+  ) {
+    return false
+  }
+  // grouped 通知の表示パスは配列前提で .filter する (visibleReactions 等)
+  if (n.reactions !== undefined && !Array.isArray(n.reactions)) return false
+  if (n.users !== undefined && !Array.isArray(n.users)) return false
+  return true
+}
+
+/**
+ * 通知キャッシュを読み込む。バージョン不一致・形式不整合は全破棄して
+ * 空配列を返し、通常フェッチに委ねる (#407)。
+ */
+export function loadNotificationCache(
+  accountKey: string,
+): NormalizedNotification[] {
+  const key = STORAGE_KEYS.notificationCache(accountKey)
+  const raw = getStorageJson<unknown>(key, null)
+  if (raw === null) return []
+  const envelope = raw as Partial<CacheEnvelope>
+  if (
+    typeof raw === 'object' &&
+    !Array.isArray(raw) &&
+    envelope._v === NOTIFICATION_CACHE_VERSION &&
+    Array.isArray(envelope.items) &&
+    envelope.items.every(isValidNotification)
+  ) {
+    return envelope.items
+  }
+  removeStorage(key)
+  return []
+}
+
+/** 通知キャッシュをバージョン付き envelope で保存する。 */
+export function saveNotificationCache(
+  accountKey: string,
+  items: NormalizedNotification[],
+): void {
+  setStorageJson(STORAGE_KEYS.notificationCache(accountKey), {
+    _v: NOTIFICATION_CACHE_VERSION,
+    items,
+  } satisfies CacheEnvelope)
+}

--- a/tests/utils/notificationCache.test.ts
+++ b/tests/utils/notificationCache.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { NormalizedNotification } from '@/adapters/types'
+import {
+  loadNotificationCache,
+  saveNotificationCache,
+} from '@/utils/notificationCache'
+import { STORAGE_KEYS } from '@/utils/storage'
+
+const ACCOUNT_KEY = 'test-account'
+const KEY = STORAGE_KEYS.notificationCache(ACCOUNT_KEY)
+
+function makeNotification(
+  overrides: Partial<NormalizedNotification> = {},
+): NormalizedNotification {
+  return {
+    id: 'n1',
+    _accountId: 'test-account',
+    _serverHost: 'misskey.example.com',
+    createdAt: '2026-06-11T00:00:00.000Z',
+    type: 'reaction',
+    ...overrides,
+  }
+}
+
+describe('notificationCache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('save した通知一覧を load すると同じ配列が返る (optional フィールドも保持)', () => {
+    const items = [
+      makeNotification(),
+      makeNotification({
+        id: 'n2',
+        type: 'reaction:grouped',
+        reactions: [],
+        reaction: '👍',
+      }),
+    ]
+    saveNotificationCache(ACCOUNT_KEY, items)
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual(items)
+  })
+
+  it('旧形式の plain array は破棄され、キーも削除される', () => {
+    localStorage.setItem(KEY, JSON.stringify([makeNotification()]))
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('version が不一致の envelope は破棄される', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ _v: 999, items: [makeNotification()] }),
+    )
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('必須フィールド欠落 item が 1 件でも混入していると全破棄される', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ _v: 1, items: [makeNotification(), { id: 'x' }] }),
+    )
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+    expect(localStorage.getItem(KEY)).toBeNull()
+  })
+
+  it('必須フィールドが string 以外の item が混入していると全破棄される', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        _v: 1,
+        items: [makeNotification({ createdAt: 123 as unknown as string })],
+      }),
+    )
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+
+  it('reactions が配列でない item が混入していると全破棄される', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        _v: 1,
+        items: [makeNotification({ reactions: {} as unknown as [] })],
+      }),
+    )
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+
+  it('users が配列でない item が混入していると全破棄される', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        _v: 1,
+        items: [makeNotification({ users: 'broken' as unknown as [] })],
+      }),
+    )
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+
+  it('JSON として壊れたデータは空配列にフォールバックする', () => {
+    localStorage.setItem(KEY, '{broken')
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+
+  it('キーが存在しないとき load は空配列を返す', () => {
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+
+  it('item が null のとき全破棄される', () => {
+    localStorage.setItem(KEY, JSON.stringify({ _v: 1, items: [null] }))
+    expect(loadNotificationCache(ACCOUNT_KEY)).toEqual([])
+  })
+})


### PR DESCRIPTION
## v1.1.4

通知カラムの修正リリース。

### Fixes

- fix: 通知キャッシュをバージョン付き envelope 化し不正データを破棄 (#407)
  - localStorage の通知キャッシュを `{ _v, items }` envelope で保存し、読込時に version + 必須フィールド + `reactions`/`users` 配列を検証。不正データは全破棄して再フェッチに委ねる
  - 旧 plain-array 形式は自動破棄（マイグレーションなし）

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)