### PR TITLE
Release v1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -684,6 +684,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,13 +2745,14 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "notecli"
-version = "0.2.0"
-source = "git+https://github.com/hitalin/notecli?rev=3aaec69337c1011e221e4a9db54f6a62df89bbbe#3aaec69337c1011e221e4a9db54f6a62df89bbbe"
+version = "0.3.1"
+source = "git+https://github.com/hitalin/notecli?rev=5659534b9ca40bf758f22840b887081d6324acee#5659534b9ca40bf758f22840b887081d6324acee"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
  "axum",
  "clap",
+ "colored",
  "dirs 6.0.0",
  "futures-util",
  "keyring-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.5"
+version = "1.1.6"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.1.5"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "3aaec69337c1011e221e4a9db54f6a62df89bbbe", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "5659534b9ca40bf758f22840b887081d6324acee", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -2091,6 +2091,10 @@
               "null"
             ]
           },
+          "hasPendingFollowRequestFromYou": {
+            "type": "boolean",
+            "description": "鍵アカウントへフォローリクエスト送信済みで未承認の状態"
+          },
           "host": {
             "type": [
               "string",

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.5"
+    "version": "1.1.6"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -234,6 +234,19 @@ pub async fn api_reject_follow_request(
     client.reject_follow_request(&host, &token, &user_id).await
 }
 
+/// 自分が送ったフォローリクエストを取り消す (following/requests/cancel)。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_cancel_follow_request(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    user_id: String,
+) -> Result<()> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client.cancel_follow_request(&host, &token, &user_id).await
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn api_get_follow_requests(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -516,6 +516,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_update_user_memo,
             commands::api_accept_follow_request,
             commands::api_reject_follow_request,
+            commands::api_cancel_follow_request,
             commands::api_get_user,
             commands::api_get_user_detail,
             commands::api_get_user_notes,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/api.ts
+++ b/src/adapters/misskey/api.ts
@@ -528,6 +528,11 @@ export class MisskeyApi implements ApiAdapter {
     unwrapAny(await commands.apiRejectFollowRequest(this.accountId, userId))
   }
 
+  async cancelFollowRequest(userId: string): Promise<void> {
+    this.requireAuth()
+    unwrapAny(await commands.apiCancelFollowRequest(this.accountId, userId))
+  }
+
   async getUserLists(): Promise<UserList[]> {
     return unwrapAny(await commands.apiGetUserLists(this.accountId))
   }

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -280,6 +280,8 @@ export interface NormalizedUserDetail extends NormalizedUser {
   isCat: boolean
   isFollowing: boolean
   isFollowed: boolean
+  /** 鍵アカウントへフォローリクエスト送信済みで未承認の状態 */
+  hasPendingFollowRequestFromYou?: boolean
   createdAt: string
   roles: UserRole[]
   fields: UserField[]
@@ -599,6 +601,8 @@ export interface ApiAdapter {
   updateUserMemo(userId: string, memo: string): Promise<void>
   acceptFollowRequest(userId: string): Promise<void>
   rejectFollowRequest(userId: string): Promise<void>
+  /** 自分が送ったフォローリクエストを取り消す (following/requests/cancel) */
+  cancelFollowRequest(userId: string): Promise<void>
   getUserLists(): Promise<UserList[]>
   getAntennas(): Promise<Antenna[]>
   /** 単一アンテナの設定を取得する (antennas/show) */

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -483,6 +483,17 @@ async apiRejectFollowRequest(accountId: string, userId: string) : Promise<Result
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * 自分が送ったフォローリクエストを取り消す (following/requests/cancel)。
+ */
+async apiCancelFollowRequest(accountId: string, userId: string) : Promise<Result<null, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_cancel_follow_request", { accountId, userId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async apiGetUser(accountId: string, userId: string) : Promise<Result<NormalizedUser, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_get_user", { accountId, userId }) };
@@ -2472,7 +2483,11 @@ users?: NormalizedUser[] | null }
 export type NormalizedPoll = { choices: NormalizedPollChoice[]; multiple?: boolean; expiresAt: string | null }
 export type NormalizedPollChoice = { text: string; votes?: number; isVoted?: boolean }
 export type NormalizedUser = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; isBot?: boolean; isCat?: boolean; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; instance?: UserInstance | null }
-export type NormalizedUserDetail = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; bannerUrl: string | null; description: string | null; followersCount?: number; followingCount?: number; notesCount?: number; isBot?: boolean; isCat?: boolean; isFollowing?: boolean; isFollowed?: boolean; createdAt?: string; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; roles?: UserRole[]; fields?: UserField[]; url?: string | null; birthday?: string | null; location?: string | null; onlineStatus?: string | null; followingVisibility?: string | null; followersVisibility?: string | null; followedMessage?: string | null; 
+export type NormalizedUserDetail = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; bannerUrl: string | null; description: string | null; followersCount?: number; followingCount?: number; notesCount?: number; isBot?: boolean; isCat?: boolean; isFollowing?: boolean; isFollowed?: boolean; 
+/**
+ * 鍵アカウントへフォローリクエスト送信済みで未承認の状態
+ */
+hasPendingFollowRequestFromYou?: boolean; createdAt?: string; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; roles?: UserRole[]; fields?: UserField[]; url?: string | null; birthday?: string | null; location?: string | null; onlineStatus?: string | null; followingVisibility?: string | null; followersVisibility?: string | null; followedMessage?: string | null; 
 /**
  * このユーザーに対する自分用メモ (users/update-memo)
  */

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -35,14 +35,11 @@ const props = withDefaults(
     noteColumnConfig: NoteColumnConfig
     /** 空状態のメッセージ（デフォルト: まだノートがありません） */
     emptyMessage?: string
-    /** 空状態に「ノートを書く」CTA を表示するか */
-    showEmptyCta?: boolean
     /** チャンネルカラム等、自明な文脈ではノートのチャンネルバッジを非表示にする */
     hideChannelBadge?: boolean
   }>(),
   {
     emptyMessage: 'まだノートがありません',
-    showEmptyCta: false,
   },
 )
 
@@ -181,9 +178,6 @@ defineExpose({
         v-if="!isLoading && notes.length === 0"
         :message="emptyMessage"
         :image-url="serverInfoImageUrl"
-        :cta-label="showEmptyCta && account?.hasToken ? 'ノートを書く' : undefined"
-        cta-icon="ti-pencil"
-        @cta="postForm.show.value = true"
       />
 
       <template v-if="!(isLoading && notes.length === 0) && notes.length > 0">

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -435,7 +435,6 @@ onMounted(async () => {
     title="タイムライン"
     icon="ti-home"
     sound-enabled
-    show-empty-cta
     :note-column-config="noteColumnConfig"
   >
     <template #header-icon>

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -102,6 +102,13 @@ const account = computed(() =>
 )
 const isOwnProfile = computed(() => account.value?.userId === props.userId)
 
+const followButtonLabel = computed(() => {
+  const u = user.value
+  if (u?.isFollowing) return 'フォロー中'
+  if (u?.hasPendingFollowRequestFromYou) return 'フォロー許可待ち'
+  return 'フォロー'
+})
+
 type ProfileTab = 'highlight' | 'notes' | 'all' | 'files'
 const PROFILE_TABS: { key: ProfileTab; label: string; icon: string }[] = [
   { key: 'highlight', label: 'ハイライト', icon: 'ti ti-bolt' },
@@ -1479,11 +1486,17 @@ async function handlePosted(editedNoteId?: string) {
             <button
               v-if="!isOwnProfile"
               class="_button"
-              :class="[$style.bannerFollowBtn, { [$style.following]: user.isFollowing }]"
+              :class="[
+                $style.bannerFollowBtn,
+                {
+                  [$style.following]:
+                    user.isFollowing || user.hasPendingFollowRequestFromYou,
+                },
+              ]"
               :disabled="isFollowLoading"
               @click="handleToggleFollow"
             >
-              {{ user.isFollowing ? 'フォロー中' : 'フォロー' }}
+              {{ followButtonLabel }}
             </button>
             <button class="_button" :class="$style.bannerActionBtn" title="QRコード" @click="openQrCode">
               <i class="ti ti-qrcode" />

--- a/src/utils/toggleFollow.ts
+++ b/src/utils/toggleFollow.ts
@@ -4,6 +4,7 @@ import { hapticLight } from '@/utils/haptics'
 interface FollowApi {
   followUser(userId: string): Promise<void>
   unfollowUser(userId: string): Promise<void>
+  cancelFollowRequest(userId: string): Promise<void>
 }
 
 export async function toggleFollow(
@@ -11,6 +12,20 @@ export async function toggleFollow(
   user: NormalizedUserDetail,
 ): Promise<void> {
   hapticLight()
+
+  // 鍵アカウントへの未承認フォローリクエストはキャンセルする
+  // (following/delete は notFollowing エラーになるため別エンドポイント)
+  if (user.hasPendingFollowRequestFromYou) {
+    user.hasPendingFollowRequestFromYou = false
+    try {
+      await api.cancelFollowRequest(user.id)
+    } catch (e) {
+      user.hasPendingFollowRequestFromYou = true
+      throw e
+    }
+    return
+  }
+
   const prev = user.isFollowing
 
   try {


### PR DESCRIPTION
## 変更点

- feat: 鍵アカウントへのフォローリクエストを取り消せるようにする
- fix: 空ノートリストの「ノートを書く」CTAボタンを削除 (#636)

## リリース作業

- バージョンを 1.1.6 に bump（package.json / Cargo.toml / tauri.conf.json / Cargo.lock）
- openapi.json 再生成
- notecli rev を `5659534`（cancel_follow_request 対応）に更新

## 確認

- [x] lint (biome) green
- [x] typecheck (vue-tsc) green
- [x] test (vitest 1120 passed) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)