### PR TITLE
Release v1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.6",
+  "version": "1.1.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2746,7 +2746,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.3.1"
-source = "git+https://github.com/hitalin/notecli?rev=5659534b9ca40bf758f22840b887081d6324acee#5659534b9ca40bf758f22840b887081d6324acee"
+source = "git+https://github.com/hitalin/notecli?rev=c9012f2647c503d814b4c666bb15ec05db89c99c#c9012f2647c503d814b4c666bb15ec05db89c99c"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.1.6"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "5659534b9ca40bf758f22840b887081d6324acee", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "c9012f2647c503d814b4c666bb15ec05db89c99c", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.6"
+version = "1.1.7"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -2116,6 +2116,10 @@
           "isFollowing": {
             "type": "boolean"
           },
+          "isLocked": {
+            "type": "boolean",
+            "description": "鍵アカウント (フォローに承認が必要) かどうか"
+          },
           "location": {
             "type": [
               "string",

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.6"
+    "version": "1.1.7"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -280,6 +280,8 @@ export interface NormalizedUserDetail extends NormalizedUser {
   isCat: boolean
   isFollowing: boolean
   isFollowed: boolean
+  /** 鍵アカウント (フォローに承認が必要) かどうか */
+  isLocked?: boolean
   /** 鍵アカウントへフォローリクエスト送信済みで未承認の状態 */
   hasPendingFollowRequestFromYou?: boolean
   createdAt: string

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2485,6 +2485,10 @@ export type NormalizedPollChoice = { text: string; votes?: number; isVoted?: boo
 export type NormalizedUser = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; isBot?: boolean; isCat?: boolean; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; instance?: UserInstance | null }
 export type NormalizedUserDetail = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; bannerUrl: string | null; description: string | null; followersCount?: number; followingCount?: number; notesCount?: number; isBot?: boolean; isCat?: boolean; isFollowing?: boolean; isFollowed?: boolean; 
 /**
+ * 鍵アカウント (フォローに承認が必要) かどうか
+ */
+isLocked?: boolean; 
+/**
  * 鍵アカウントへフォローリクエスト送信済みで未承認の状態
  */
 hasPendingFollowRequestFromYou?: boolean; createdAt?: string; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; roles?: UserRole[]; fields?: UserField[]; url?: string | null; birthday?: string | null; location?: string | null; onlineStatus?: string | null; followingVisibility?: string | null; followersVisibility?: string | null; followedMessage?: string | null; 

--- a/src/utils/toggleFollow.test.ts
+++ b/src/utils/toggleFollow.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NormalizedUserDetail } from '@/adapters/types'
+import { toggleFollow } from './toggleFollow'
+
+vi.mock('@/utils/haptics', () => ({ hapticLight: vi.fn() }))
+
+function makeUser(
+  overrides: Partial<NormalizedUserDetail> = {},
+): NormalizedUserDetail {
+  return {
+    id: 'u1',
+    username: 'alice',
+    host: null,
+    name: 'Alice',
+    avatarUrl: null,
+    isFollowing: false,
+    isFollowed: false,
+    followersCount: 10,
+    ...overrides,
+  } as NormalizedUserDetail
+}
+
+function makeApi() {
+  return {
+    followUser: vi.fn().mockResolvedValue(undefined),
+    unfollowUser: vi.fn().mockResolvedValue(undefined),
+    cancelFollowRequest: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('toggleFollow', () => {
+  let api: ReturnType<typeof makeApi>
+
+  beforeEach(() => {
+    api = makeApi()
+  })
+
+  it('鍵アカウントへの follow は pending にし isFollowing/followersCount を触らない', async () => {
+    const user = makeUser({ isLocked: true })
+    await toggleFollow(api, user)
+
+    expect(api.followUser).toHaveBeenCalledWith('u1')
+    expect(user.hasPendingFollowRequestFromYou).toBe(true)
+    expect(user.isFollowing).toBe(false)
+    expect(user.followersCount).toBe(10)
+  })
+
+  it('鍵アカウント follow 失敗時は pending を戻す', async () => {
+    const user = makeUser({ isLocked: true })
+    api.followUser.mockRejectedValueOnce(new Error('boom'))
+
+    await expect(toggleFollow(api, user)).rejects.toThrow('boom')
+    expect(user.hasPendingFollowRequestFromYou).toBe(false)
+    expect(user.isFollowing).toBe(false)
+    expect(user.followersCount).toBe(10)
+  })
+
+  it('非鍵アカウントへの follow は従来どおり楽観更新する', async () => {
+    const user = makeUser({ isLocked: false })
+    await toggleFollow(api, user)
+
+    expect(api.followUser).toHaveBeenCalledWith('u1')
+    expect(user.isFollowing).toBe(true)
+    expect(user.followersCount).toBe(11)
+    expect(user.hasPendingFollowRequestFromYou).toBeUndefined()
+  })
+
+  it('pending 状態での再押下は cancelFollowRequest を呼ぶ', async () => {
+    const user = makeUser({
+      isLocked: true,
+      hasPendingFollowRequestFromYou: true,
+    })
+    await toggleFollow(api, user)
+
+    expect(api.cancelFollowRequest).toHaveBeenCalledWith('u1')
+    expect(api.followUser).not.toHaveBeenCalled()
+    expect(user.hasPendingFollowRequestFromYou).toBe(false)
+  })
+
+  it('follow 中の unfollow は従来どおり', async () => {
+    const user = makeUser({ isFollowing: true, followersCount: 10 })
+    await toggleFollow(api, user)
+
+    expect(api.unfollowUser).toHaveBeenCalledWith('u1')
+    expect(user.isFollowing).toBe(false)
+    expect(user.followersCount).toBe(9)
+  })
+})

--- a/src/utils/toggleFollow.ts
+++ b/src/utils/toggleFollow.ts
@@ -28,6 +28,19 @@ export async function toggleFollow(
 
   const prev = user.isFollowing
 
+  // 鍵アカウントへのフォローは following/create が承認待ちリクエストを作るため、
+  // isFollowing / followersCount は楽観更新せず pending 状態として扱う
+  if (!prev && user.isLocked) {
+    user.hasPendingFollowRequestFromYou = true
+    try {
+      await api.followUser(user.id)
+    } catch (e) {
+      user.hasPendingFollowRequestFromYou = false
+      throw e
+    }
+    return
+  }
+
   try {
     user.isFollowing = !prev
     if (prev) {


### PR DESCRIPTION
## 変更内容

### Fix
- 鍵アカウントへのフォローを承認待ちとして楽観更新する (#638)
  - 鍵アカウント (locked) への follow が「フォロー中」と誤表示され、フォロワー数も誤って増えていた問題を修正
  - `NormalizedUserDetail` に `isLocked` を追加 (notecli rev `c9012f2`)、follow 時に locked なら `hasPendingFollowRequestFromYou` のみ立てる

Closes #638

## リリース手順
- [x] version bump (package.json / Cargo.toml / tauri.conf.json → 1.1.7)
- [x] Cargo.lock 同期 + openapi.json 再生成
- [ ] CI 通過確認 → マージ → タグ push

🤖 Generated with [Claude Code](https://claude.com/claude-code)