### PR TITLE
Release v1.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.7",
+  "version": "1.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2746,7 +2746,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.3.1"
-source = "git+https://github.com/hitalin/notecli?rev=c9012f2647c503d814b4c666bb15ec05db89c99c#c9012f2647c503d814b4c666bb15ec05db89c99c"
+source = "git+https://github.com/hitalin/notecli?rev=a04ea9eeae256e503925eb2887058eaccc60a828#a04ea9eeae256e503925eb2887058eaccc60a828"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.7"
+version = "1.1.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.7"
+version = "1.1.8"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.1.7"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "c9012f2647c503d814b4c666bb15ec05db89c99c", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "a04ea9eeae256e503925eb2887058eaccc60a828", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.7"
+    "version": "1.1.8"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/ai_chat.rs
+++ b/src-tauri/src/commands/ai_chat.rs
@@ -114,7 +114,12 @@ pub struct AiChatEvent {
 
 const EVENT_NAME: &str = "nd:ai-chat-event";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(180);
+/// Time allowed to establish the TCP+TLS connection.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Per-read idle timeout for the SSE body. Unlike a total timeout this does NOT
+/// kill a healthy long generation — it only fires when no bytes arrive for this
+/// long, so a silently-dropped mid-stream connection is still bounded.
+const READ_TIMEOUT: Duration = Duration::from_secs(120);
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 /// Hard cap on the total bytes (system + all message contents) sent in one
 /// chat request. Prevents accidental paste-of-a-huge-file and runaway costs.
@@ -124,13 +129,17 @@ const MAX_REQUEST_BYTES: usize = 256 * 1024;
 ///
 /// 共有 `reqwest::Client` (lib.rs の `shared_http`) を使うと、HTTP/2 の
 /// RST_STREAM や connection pool の半閉じ接続再利用が原因で
-/// "error decoding response body" になるケースが発生する (大きい tool_result
-/// を AI が処理した後の長いレスポンス中に多い)。それを避けるため:
+/// "error decoding response body" / "os error 103" になるケースが発生する
+/// (大きい tool_result を AI が処理した後の長いレスポンス中に多い)。それを避けるため:
 ///
 /// - `http1_only()` で HTTP/2 を無効化 (SSE は HTTP/1.1 chunked が安定)
-/// - pool は default のまま (= ストリーム終了後は idle 接続として残るが、
-///   AI 用途では request 頻度が低いので問題にならない)
-/// - timeout は per-request の `REQUEST_TIMEOUT` で 180s
+/// - `pool_max_idle_per_host(0)` で idle 接続を保持しない。AI は低頻度なので毎回
+///   新規接続のコストは無視でき、モバイルで NAT が切った半閉じ接続を次リクエストで
+///   掴む事故 (#508 の os error 103 の一因) を防げる
+/// - total timeout は持たない。代わりに `connect_timeout` (接続確立) と
+///   `read_timeout` (チャンク間 idle) を使う。total timeout だと健全な長文生成が
+///   180s で問答無用に切られていた (#508 の「長文応答で切れる」直因)。read_timeout
+///   は無音が続いたときだけ発火するので長文生成自体は切らない
 ///
 /// `OnceLock` でプロセス生存期間 1 回だけ構築。
 static STREAMING_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
@@ -139,7 +148,9 @@ fn streaming_client() -> &'static reqwest::Client {
     STREAMING_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
             .http1_only()
-            .timeout(REQUEST_TIMEOUT)
+            .pool_max_idle_per_host(0)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .read_timeout(READ_TIMEOUT)
             .user_agent("notedeck-ai-streaming")
             .build()
             .expect("failed to build AI streaming client")
@@ -461,7 +472,6 @@ async fn run_anthropic(
         .header("x-api-key", api_key)
         .header("anthropic-version", ANTHROPIC_VERSION)
         .header("content-type", "application/json")
-        .timeout(REQUEST_TIMEOUT)
         .json(&body)
         .send()
         .await
@@ -618,7 +628,6 @@ async fn run_openai_compat(
     let mut request = streaming_client()
         .post(&url)
         .header("content-type", "application/json")
-        .timeout(REQUEST_TIMEOUT)
         .json(&body);
     if !api_key.is_empty() {
         request = request.header("authorization", format!("Bearer {api_key}"));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/streaming.test.ts
+++ b/src/adapters/misskey/streaming.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StreamConnectionState } from '../types'
+import { MisskeyStream } from './streaming'
+
+// setStatus is the private funnel that all connection-status transitions go
+// through. Driving it directly (with fake timers) verifies the #507 offline
+// debounce without mocking the whole Tauri boundary.
+type StatusDriver = { setStatus(s: StreamConnectionState): void }
+const drive = (s: MisskeyStream, state: StreamConnectionState) =>
+  (s as unknown as StatusDriver).setStatus(state)
+
+const GRACE_MS = 5000
+
+describe('MisskeyStream offline debounce (#507)', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  function makeStream() {
+    const stream = new MisskeyStream('acct')
+    const counts = { connected: 0, reconnecting: 0, disconnected: 0 }
+    stream.on('connected', () => counts.connected++)
+    stream.on('reconnecting', () => counts.reconnecting++)
+    stream.on('disconnected', () => counts.disconnected++)
+    return { stream, counts }
+  }
+
+  it('surfaces recovery to connected immediately', () => {
+    const { stream, counts } = makeStream()
+    drive(stream, 'connected')
+    expect(counts.connected).toBe(1)
+  })
+
+  it('debounces a live connection drop by the grace window', () => {
+    const { stream, counts } = makeStream()
+    drive(stream, 'connected')
+    drive(stream, 'reconnecting')
+
+    // Nothing offline-facing yet — within the grace window the badge stays put.
+    expect(counts.reconnecting).toBe(0)
+    vi.advanceTimersByTime(GRACE_MS - 1)
+    expect(counts.reconnecting).toBe(0)
+
+    vi.advanceTimersByTime(1)
+    expect(counts.reconnecting).toBe(1)
+  })
+
+  it('cancels the offline transition if reconnect succeeds within grace', () => {
+    const { stream, counts } = makeStream()
+    drive(stream, 'connected')
+    drive(stream, 'reconnecting')
+
+    vi.advanceTimersByTime(GRACE_MS - 1)
+    drive(stream, 'connected') // recovered before grace elapsed
+    vi.advanceTimersByTime(GRACE_MS)
+
+    expect(counts.reconnecting).toBe(0)
+    expect(counts.disconnected).toBe(0)
+    expect(counts.connected).toBe(2)
+  })
+
+  it('does not restart the timer on repeated reconnecting (falls offline once)', () => {
+    const { stream, counts } = makeStream()
+    drive(stream, 'connected')
+    drive(stream, 'reconnecting')
+    vi.advanceTimersByTime(GRACE_MS - 1)
+    drive(stream, 'reconnecting') // repeat must not defer the deadline
+    vi.advanceTimersByTime(1)
+
+    expect(counts.reconnecting).toBe(1)
+  })
+
+  it('surfaces the initial connection failure immediately (no grace)', () => {
+    const { stream, counts } = makeStream()
+    // Never connected yet: a drop is the initializing failure, shown at once.
+    drive(stream, 'disconnected')
+    expect(counts.disconnected).toBe(1)
+  })
+})

--- a/src/adapters/misskey/streaming.ts
+++ b/src/adapters/misskey/streaming.ts
@@ -13,6 +13,12 @@ export class MisskeyStream implements StreamAdapter {
   private _state: StreamConnectionState = 'initializing'
   private eventHandlers = new Map<string, Set<() => void>>()
 
+  /** Online→offline debounce so brief reconnects don't flicker the badge (#507). */
+  private static readonly OFFLINE_GRACE_MS = 5000
+  private graceTimer: ReturnType<typeof setTimeout> | null = null
+  /** Whether we've ever reached 'connected'. Before that, drops surface immediately. */
+  private hasConnected = false
+
   // Centralized listeners (registered once in connect(), cleaned up in disconnect())
   private unlistenFns: (() => void)[] = []
   /** Incremented on each registerListeners() call; stale listeners check this to self-discard. */
@@ -41,13 +47,11 @@ export class MisskeyStream implements StreamAdapter {
       .streamConnect(this.accountId)
       .then((result) => {
         unwrap(result)
-        this._state = 'connected'
-        this.emit('connected')
+        this.setStatus('connected')
       })
       .catch((e) => {
         console.error('[stream] connect failed:', e)
-        this._state = 'disconnected'
-        this.emit('disconnected')
+        this.setStatus('disconnected')
       })
   }
 
@@ -64,8 +68,7 @@ export class MisskeyStream implements StreamAdapter {
       .streamConnect(this.accountId)
       .then((result) => {
         unwrap(result)
-        this._state = 'connected'
-        this.emit('connected')
+        this.setStatus('connected')
       })
       .catch((e) => {
         // Connection might be reconnecting on Rust side — that's fine
@@ -96,8 +99,7 @@ export class MisskeyStream implements StreamAdapter {
       switch (kind) {
         case 'stream-status':
           if (p.state) {
-            this._state = p.state
-            this.emit(p.state)
+            this.setStatus(p.state)
           }
           break
         // 旧来の note / mention / notification / main / chat / note-update /
@@ -149,6 +151,8 @@ export class MisskeyStream implements StreamAdapter {
     this.unlistenFns = []
     this.noteCaptureHandlers.clear()
     this.eventHandlers.clear()
+    this.clearGraceTimer()
+    this.hasConnected = false
     this._state = 'disconnected'
   }
 
@@ -193,6 +197,49 @@ export class MisskeyStream implements StreamAdapter {
 
   offRawEvent(handler: (event: RawStreamEvent) => void): void {
     this.rawEventHandlers.delete(handler)
+  }
+
+  private clearGraceTimer(): void {
+    if (this.graceTimer !== null) {
+      clearTimeout(this.graceTimer)
+      this.graceTimer = null
+    }
+  }
+
+  /**
+   * Single funnel for connection-status transitions. Recovery to 'connected'
+   * is surfaced immediately; an online→offline transition is debounced by
+   * OFFLINE_GRACE_MS so brief reconnects (mobile handoff, app resume, the
+   * notecli read-idle watchdog's reconnect cycle) don't flicker the offline
+   * badge (#507). Centralizing here means all columns sharing this per-account
+   * adapter benefit without each holding its own timer.
+   */
+  private setStatus(state: StreamConnectionState): void {
+    if (state === 'connected') {
+      this.hasConnected = true
+      this.clearGraceTimer()
+      this._state = 'connected'
+      this.emit('connected')
+      return
+    }
+
+    // Initial connection failure (never connected): surface immediately —
+    // there is no live state to protect from flicker.
+    if (!this.hasConnected) {
+      this._state = state
+      this.emit(state)
+      return
+    }
+
+    // A live connection dropped. Debounce the offline transition. Don't restart
+    // the timer on repeated 'reconnecting', so a persistent outage still falls
+    // to offline after the grace window instead of being deferred forever.
+    if (this.graceTimer !== null) return
+    this.graceTimer = setTimeout(() => {
+      this.graceTimer = null
+      this._state = state
+      this.emit(state)
+    }, MisskeyStream.OFFLINE_GRACE_MS)
   }
 
   private emit(event: string): void {


### PR DESCRIPTION
## Changelog

- fix: debounce offline badge, adopt WS half-open watchdog (#506/#507)
- fix(ai): drop total timeout for streaming, disable idle pool (#508)
- chore: bump version to 1.1.8

## 内容

Android で WebSocket 常時接続が切れる問題群への対応（設計: #640）。

### #506 / #507 — WS 半開接続の検知とオフライン表示の安定化
- **notecli** ([hitalin/notecli#22](https://github.com/hitalin/notecli/pull/22), rev `a04ea9e`): read-idle watchdog で半開（ゾンビ）接続を 90s で検知し再接続。あらゆる inbound フレーム（Pong 含む）で締切リセット。再接続バックオフに Equal Jitter。
- **frontend**: `MisskeyStream` の接続状態を単一 `setStatus` seam に集約。online 復帰は即時、online→offline は 5s grace で debounce → reconnecting 連発によるオフラインバッジ点滅を抑制（#507）。初回接続失敗は即時表示、teardown でタイマー解放。

### #508 — AI ストリーミングの接続層改善（部分対応・close しない）
2 つの実バグを潰すが、#508 の症状そのものを完全には解消しないため close しない:
- **180s total request timeout を撤去**し `connect_timeout` + `read_timeout`（チャンク間 idle）に置換 → 健全な長文生成が 180s で問答無用に kill されるバグを解消（これは厳密には `TimedOut` で現れる症状）。
- **`pool_max_idle_per_host(0)`** → モバイル NAT が切った半閉じ idle 接続を**リクエスト開始時**に掴む start-staleness 型の `ECONNABORTED` を回避。
- ⚠️ **`os error 103 (ECONNABORTED)` が真の mid-stream ネットワーク abort の場合は本修正では直らない**（timeout でも pool でもなく、retry/resume が必要）。SSE に再開トークンが無く、retry は「途中まで出した応答を捨てて再生成」になり `onToolUse` 即実行（`useAiChat.ts:207`）と組み合わさると write capability の二重実行を招くため、冪等性ガードの設計が要る別タスク。→ 本リリース後に実機で os error 103 が解消するか観察し、残れば retry/resume を別途実装する。

## 検証
- notecli: CI green（build/clippy `-D warnings`/test、新規テスト 2 本）。
- notedeck: `cargo clippy --all-targets -D warnings` ✓ / `cargo test`（snapshot ゲート含む）✓ / 全 1130 frontend テスト ✓ / typecheck ✓ / biome ✓ / openapi・bindings 再生成 no-op ✓。
- ⚠️ 半開接続の**ランタイム再現**（機内モード/NIC down）と**実機 Android（Doze）**は未検証。机上では「検知機構が入った」までを担保。

Closes #506
Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)