### PR TITLE
Release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.1.8",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.1.8"
+version = "1.2.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.1.8"
+version = "1.2.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.1.8"
+    "version": "1.2.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/query.ts
+++ b/src/adapters/misskey/query.ts
@@ -44,6 +44,13 @@ export function createQuerySubscription(
   let runtimeState: SubscriptionRuntimeState = 'live'
   let unlistenDelta: (() => void) | null = null
   let lastRevision = 0
+  // 下流の channel subscription id (= stream event payload.subscriptionId)。
+  // open 解決まで null。Stream Inspector のカラム別フィルタで使う。
+  let sourceSubscriptionId: string | null = null
+  let resolveReady!: () => void
+  const ready = new Promise<void>((r) => {
+    resolveReady = r
+  })
 
   ;(async () => {
     let snap: QuerySnapshot
@@ -51,6 +58,7 @@ export function createQuerySubscription(
       snap = await opts.open()
     } catch (e) {
       console.error('[query-subscription] open failed:', e)
+      resolveReady()
       return
     }
     if (disposed) {
@@ -58,10 +66,13 @@ export function createQuerySubscription(
         if (import.meta.env.DEV)
           console.debug('[query-subscription] late close ignored:', e)
       })
+      resolveReady()
       return
     }
     queryId = snap.queryId
     lastRevision = snap.revision
+    sourceSubscriptionId = snap.sourceSubscriptionId
+    resolveReady()
 
     try {
       unlistenDelta = await events.queryDelta.listen((event) => {
@@ -104,6 +115,10 @@ export function createQuerySubscription(
   }
 
   return {
+    get subscriptionId() {
+      return sourceSubscriptionId
+    },
+    whenReady: () => ready,
     dispose: () => {
       if (disposed) return
       disposed = true

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -719,6 +719,13 @@ export type SubscriptionRuntimeState = 'live' | 'warm' | 'suspended'
 
 export interface ManagedChannelSubscription extends ChannelSubscription {
   setRuntimeState(state: SubscriptionRuntimeState): void
+  /**
+   * Underlying channel subscription id — matches the `subscriptionId` field on
+   * stream event payloads. Null until the subscription has opened.
+   */
+  readonly subscriptionId: string | null
+  /** Resolves once the underlying subscription is open (subscriptionId set). */
+  whenReady(): Promise<void>
 }
 
 export type MainChannelEvent = {

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
 import { json } from '@codemirror/lang-json'
-import { computed, defineAsyncComponent, ref, shallowRef, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue'
+import type { StreamConnectionState } from '@/adapters/types'
+import { COLUMN_ICONS, COLUMN_LABELS } from '@/columns/registry'
+import ColumnBadges from '@/components/common/ColumnBadges.vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useVerticalResize } from '@/composables/useVerticalResize'
-import { getAccountAvatarUrl } from '@/stores/accounts'
+import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
 import {
@@ -28,6 +39,7 @@ const { account, columnThemeVars } = useColumnTheme(() => props.column)
 const { serverInfoImageUrl } = useServerImages(() => props.column)
 const serversStore = useServersStore()
 const inspectorStore = useStreamInspectorStore()
+const accountsStore = useAccountsStore()
 const jsonLang = json()
 
 const isScopedToAccount = computed(() => props.column.accountId != null)
@@ -94,6 +106,85 @@ function selectRow(id: number) {
 function clearBuffer() {
   clearedBefore.value = Date.now()
   selectedId.value = null
+}
+
+// --- Status dashboard ---
+
+// 1s tick で「最終受信からの経過」をライブ更新する
+const now = ref(Date.now())
+let nowTimer: ReturnType<typeof setInterval> | null = null
+onMounted(() => {
+  nowTimer = setInterval(() => {
+    now.value = Date.now()
+  }, 1000)
+})
+onBeforeUnmount(() => {
+  if (nowTimer) clearInterval(nowTimer)
+})
+
+function hostOf(accountId: string | null): string {
+  if (!accountId) return '—'
+  return (
+    accountsStore.accounts.find((a) => a.id === accountId)?.host ?? accountId
+  )
+}
+
+/** account_id -> 最新イベント ts（buffer は新しい順なので最初に見た値が最新） */
+const lastEventTsByAccount = computed(() => {
+  const m = new Map<string, number>()
+  for (const e of inspectorStore.buffer) {
+    if (!m.has(e.accountId)) m.set(e.accountId, e.ts)
+  }
+  return m
+})
+
+function connToStatus(
+  c: StreamConnectionState | null,
+): 'online' | 'active' | 'offline' | 'unknown' | null {
+  switch (c) {
+    case 'connected':
+      return 'online'
+    case 'reconnecting':
+      return 'unknown'
+    case 'disconnected':
+      return 'offline'
+    default:
+      return null
+  }
+}
+
+const dashboardRows = computed(() => {
+  const aid = props.column.accountId
+  const rows = [...inspectorStore.runtimeStates.values()]
+    .filter((info) => aid == null || info.accountId === aid)
+    .map((info) => {
+      const connection = info.accountId
+        ? (inspectorStore.connectionState.get(info.accountId) ?? null)
+        : null
+      return {
+        columnId: info.columnId,
+        accountId: info.accountId,
+        host: hostOf(info.accountId),
+        onlineStatus: connToStatus(connection),
+        typeLabel: COLUMN_LABELS[info.columnType] ?? info.columnType,
+        typeIcon: COLUMN_ICONS[info.columnType] ?? 'circle',
+        state: info.state,
+        lastEventTs: info.accountId
+          ? (lastEventTsByAccount.value.get(info.accountId) ?? null)
+          : null,
+      }
+    })
+  rows.sort(
+    (a, b) =>
+      a.host.localeCompare(b.host) || a.typeLabel.localeCompare(b.typeLabel),
+  )
+  return rows
+})
+
+function ageText(ts: number | null): string {
+  if (ts == null) return '—'
+  const s = Math.max(0, Math.round((now.value - ts) / 1000))
+  return `${s}s`
 }
 
 // --- Display helpers ---
@@ -200,6 +291,25 @@ function onDetailWheel(e: WheelEvent) {
     </template>
 
     <div ref="wrapperRef" :class="$style.wrapper">
+      <!-- Status dashboard: kept-alive stream columns -->
+      <div v-if="dashboardRows.length > 0" :class="$style.dashboard">
+        <div
+          v-for="row in dashboardRows"
+          :key="row.columnId"
+          :class="[$style.mark, row.state !== 'live' && $style.markDim]"
+          :title="`${row.host} · ${row.typeLabel} · ${row.state} · ${ageText(
+            row.lastEventTs,
+          )}`"
+        >
+          <i :class="['ti', `ti-${row.typeIcon}`, $style.markIcon]" />
+          <ColumnBadges :account-id="row.accountId" :size="12" />
+          <span
+            v-if="row.onlineStatus"
+            :class="[$style.connDot, $style[`conn_${row.onlineStatus}`]]"
+          />
+        </div>
+      </div>
+
       <!-- Filter pills -->
       <div :class="$style.filters">
         <button
@@ -315,6 +425,73 @@ function onDetailWheel(e: WheelEvent) {
   flex-direction: column;
   flex: 1;
   min-height: 0;
+}
+
+.dashboard {
+  // ボトムバーのタブ同様、少数時は中央寄せ・多数時は横スクロール
+  // (scrollbar は隠す)。corner badge が上下にはみ出すぶん padding で逃がす。
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 12px;
+  border-bottom: 1px solid var(--nd-divider);
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.mark {
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  color: var(--nd-fg);
+  opacity: 0.85;
+  --column-badge-border: var(--nd-bg);
+}
+
+.markDim {
+  opacity: 0.35;
+}
+
+.markIcon {
+  font-size: 19px;
+}
+
+.connDot {
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  border: 1.5px solid var(--nd-bg);
+  box-sizing: border-box;
+}
+
+.conn_online {
+  background: var(--nd-statusOnline);
+}
+
+.conn_active {
+  background: var(--nd-statusActive);
+}
+
+.conn_unknown {
+  background: var(--nd-statusUnknown);
+}
+
+.conn_offline {
+  background: var(--nd-statusOffline);
 }
 
 .filters {

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -17,7 +17,7 @@ import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useVerticalResize } from '@/composables/useVerticalResize'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
-import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
 import {
   ALL_KINDS,
@@ -38,6 +38,7 @@ const props = defineProps<{
 const { account, columnThemeVars } = useColumnTheme(() => props.column)
 const { serverInfoImageUrl } = useServerImages(() => props.column)
 const serversStore = useServersStore()
+const deckStore = useDeckStore()
 const inspectorStore = useStreamInspectorStore()
 const accountsStore = useAccountsStore()
 const jsonLang = json()
@@ -57,16 +58,30 @@ const paused = ref(false)
 const selectedId = ref<number | null>(null)
 const enabledKinds = ref(new Set<string>(ALL_KINDS))
 const clearedBefore = ref(0)
+/** ダッシュボードで有効化中のカラム subscriptionId 集合。空 = 全カラム表示（複数同時可） */
+const focusedSubIds = ref(new Set<string>())
 
 const filteredBuffer = computed(() => {
   const aid = props.column.accountId
+  const subs = focusedSubIds.value
   return inspectorStore.buffer.filter((e) => {
     if (e.ts < clearedBefore.value) return false
     if (!enabledKinds.value.has(e.kind)) return false
     if (aid != null && e.accountId !== aid) return false
+    if (subs.size > 0 && !subs.has(e.payload.subscriptionId as string))
+      return false
     return true
   })
 })
+
+/** カラムマーククリックで有効/無効をトグル（複数同時に有効化できる。kind ピルと同様） */
+function onMarkClick(subId: string | null) {
+  if (!subId) return
+  const next = new Set(focusedSubIds.value)
+  if (next.has(subId)) next.delete(subId)
+  else next.add(subId)
+  focusedSubIds.value = next
+}
 
 // Freeze display when paused
 const displayBuffer = shallowRef<StreamEventEntry[]>([])
@@ -153,17 +168,23 @@ function connToStatus(
   }
 }
 
+// ボトムバーと同じ並び (deckStore.layout 順) で回す。layout に無いカラム
+// (削除済み / 別プロファイル) は自動的に外れるので残留しない。runtimeStates を
+// 持つ = stream 系カラムのみが対象。すべて reactive に追従する。
 const dashboardRows = computed(() => {
   const aid = props.column.accountId
-  const rows = [...inspectorStore.runtimeStates.values()]
-    .filter((info) => aid == null || info.accountId === aid)
-    .map((info) => {
-      const connection = info.accountId
-        ? (inspectorStore.connectionState.get(info.accountId) ?? null)
-        : null
-      return {
+  return deckStore.layout.flat().flatMap((colId) => {
+    const info = inspectorStore.runtimeStates.get(colId)
+    if (!info) return []
+    if (aid != null && info.accountId !== aid) return []
+    const connection = info.accountId
+      ? (inspectorStore.connectionState.get(info.accountId) ?? null)
+      : null
+    return [
+      {
         columnId: info.columnId,
         accountId: info.accountId,
+        subscriptionId: info.subscriptionId,
         host: hostOf(info.accountId),
         onlineStatus: connToStatus(connection),
         typeLabel: COLUMN_LABELS[info.columnType] ?? info.columnType,
@@ -172,13 +193,9 @@ const dashboardRows = computed(() => {
         lastEventTs: info.accountId
           ? (lastEventTsByAccount.value.get(info.accountId) ?? null)
           : null,
-      }
-    })
-  rows.sort(
-    (a, b) =>
-      a.host.localeCompare(b.host) || a.typeLabel.localeCompare(b.typeLabel),
-  )
-  return rows
+      },
+    ]
+  })
 })
 
 function ageText(ts: number | null): string {
@@ -293,13 +310,23 @@ function onDetailWheel(e: WheelEvent) {
     <div ref="wrapperRef" :class="$style.wrapper">
       <!-- Status dashboard: kept-alive stream columns -->
       <div v-if="dashboardRows.length > 0" :class="$style.dashboard">
-        <div
+        <button
           v-for="row in dashboardRows"
           :key="row.columnId"
-          :class="[$style.mark, row.state !== 'live' && $style.markDim]"
+          type="button"
+          class="_button"
+          :class="[
+            $style.mark,
+            {
+              [$style.markDim]: row.state !== 'live',
+              [$style.markActive]:
+                !!row.subscriptionId && focusedSubIds.has(row.subscriptionId),
+            },
+          ]"
           :title="`${row.host} · ${row.typeLabel} · ${row.state} · ${ageText(
             row.lastEventTs,
           )}`"
+          @click="onMarkClick(row.subscriptionId)"
         >
           <i :class="['ti', `ti-${row.typeIcon}`, $style.markIcon]" />
           <ColumnBadges :account-id="row.accountId" :size="12" />
@@ -307,7 +334,7 @@ function onDetailWheel(e: WheelEvent) {
             v-if="row.onlineStatus"
             :class="[$style.connDot, $style[`conn_${row.onlineStatus}`]]"
           />
-        </div>
+        </button>
       </div>
 
       <!-- Filter pills -->
@@ -454,9 +481,26 @@ function onDetailWheel(e: WheelEvent) {
   justify-content: center;
   width: 26px;
   height: 26px;
+  border-radius: var(--nd-radius-sm);
   color: var(--nd-fg);
   opacity: 0.85;
+  cursor: pointer;
   --column-badge-border: var(--nd-bg);
+  transition:
+    opacity var(--nd-duration-fast),
+    color var(--nd-duration-fast),
+    background var(--nd-duration-fast);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.markActive {
+  opacity: 1;
+  color: var(--nd-accent);
+  background: var(--nd-buttonHoverBg);
 }
 
 .markDim {

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -15,6 +15,7 @@ import { useConfirm } from '@/stores/confirm'
 import { type DeckColumn, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
 import { useOfflineModeStore } from '@/stores/offlineMode'
+import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
@@ -94,6 +95,15 @@ export function useColumnSetup(
     subscriptionRuntimeState = state
     const managed = subscription as Partial<ManagedChannelSubscription> | null
     managed?.setRuntimeState?.(state)
+    // Stream Inspector の dashboard 用に意図した state を通知（debug 観測のみ）
+    const col = getColumn()
+    useStreamInspectorStore().reportRuntimeState({
+      columnId: col.id,
+      accountId: col.accountId ?? null,
+      columnType: col.type,
+      state,
+      ts: Date.now(),
+    })
   }
 
   /** Register a stream event handler tracked for cleanup on disconnect */

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -84,6 +84,23 @@ export function useColumnSetup(
     subscription = sub
     const managed = subscription as Partial<ManagedChannelSubscription>
     managed.setRuntimeState?.(subscriptionRuntimeState)
+    reportRuntime()
+    // subscriptionId は open 解決後に確定するので、確定したら再通知
+    managed.whenReady?.().then(reportRuntime)
+  }
+
+  /** Stream Inspector dashboard 用に現在の runtime/subscriptionId を通知（debug 観測のみ） */
+  function reportRuntime() {
+    const col = getColumn()
+    const managed = subscription as Partial<ManagedChannelSubscription> | null
+    useStreamInspectorStore().reportRuntimeState({
+      columnId: col.id,
+      accountId: col.accountId ?? null,
+      columnType: col.type,
+      subscriptionId: managed?.subscriptionId ?? null,
+      state: subscriptionRuntimeState,
+      ts: Date.now(),
+    })
   }
 
   function disposeSubscription() {
@@ -95,15 +112,7 @@ export function useColumnSetup(
     subscriptionRuntimeState = state
     const managed = subscription as Partial<ManagedChannelSubscription> | null
     managed?.setRuntimeState?.(state)
-    // Stream Inspector の dashboard 用に意図した state を通知（debug 観測のみ）
-    const col = getColumn()
-    useStreamInspectorStore().reportRuntimeState({
-      columnId: col.id,
-      accountId: col.accountId ?? null,
-      columnType: col.type,
-      state,
-      ts: Date.now(),
-    })
+    reportRuntime()
   }
 
   /** Register a stream event handler tracked for cleanup on disconnect */

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -34,6 +34,7 @@ import { useStreamingBatch } from '@/composables/useStreamingBatch'
 import { isGuestAccount } from '@/stores/accounts'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
+import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { dedup } from '@/utils/dedup'
@@ -163,14 +164,18 @@ export function useNoteColumn(config: NoteColumnConfig) {
   //   - 可視・予算内: 通常通り live, batch flush 再開
   if (streamingBatch) {
     const { isVisible, isLive } = useColumnLive(config.getColumn().id)
+    const inspectorStore = useStreamInspectorStore()
     let runtimeTransition = 0
     watch(
-      [isVisible, isLive],
-      async ([visible, live]) => {
+      [isVisible, isLive, () => inspectorStore.capturing],
+      async ([visible, live, capturing]) => {
         const seq = ++runtimeTransition
         if (!visible) {
+          // Stream Inspector 観測中は画面外でも購読を維持し、イベントを
+          // buffer に流し続ける（Android 1カラムでの観測を可能にする）。
+          // 描画用 batch は止めたまま、Rust 側 subscription だけ live に保つ。
           streamingBatch.setPaused(true)
-          setSubscriptionRuntimeState('warm')
+          setSubscriptionRuntimeState(capturing ? 'live' : 'warm')
           return
         }
         if (!live) {

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -593,17 +593,21 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (now - lastResumeAt < 3000) return
     lastResumeAt = now
 
-    const sinceId = notes.value[0]?.id
+    const hadNotes = notes.value.length > 0
 
-    // Run cache fetch and API fetch in parallel
+    // Run cache fetch and API fetch in parallel. Fetch the LATEST page (not
+    // { sinceId }): while suspended the channel is unsubscribed and Misskey does
+    // not resend, so the missed range can exceed one page. A sinceId merge would
+    // splice in a partial page and leave a hidden hole. Fetching latest lets us
+    // detect a gap and replace cleanly instead of silently dropping notes (#506).
     const cachePromise =
       isStreaming && config.cache
         ? loadFilteredCache('resume-cache')
         : Promise.resolve([] as NormalizedNote[])
 
     let apiFailed = false
-    const apiPromise = sinceId
-      ? fetchAndDedup(adapter, { sinceId }).catch((e) => {
+    const apiPromise = hadNotes
+      ? fetchAndDedup(adapter, {}).catch((e) => {
           logWarn('resume-api', e)
           apiFailed = true
           return [] as NormalizedNote[]
@@ -612,6 +616,18 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
     const [cached, fetched] = await Promise.all([cachePromise, apiPromise])
     isOffline.value = apiFailed
+
+    // Gap: none of the freshly-fetched latest notes are currently displayed, so
+    // even the oldest of the latest page is newer than our topmost — more than
+    // one page was missed. Replace with the fresh page (older notes stay
+    // reachable by scrolling) rather than merging a gappy partial range.
+    const gap =
+      hadNotes && fetched.length > 0 && !fetched.some((n) => noteIds.has(n.id))
+
+    if (gap) {
+      mergeOrEnqueue(fetched, { replace: true })
+      return
+    }
 
     // Merge: update existing in-place, route new notes through streaming batch
     mergeOrEnqueue([...fetched, ...cached])

--- a/src/stores/streamInspector.ts
+++ b/src/stores/streamInspector.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
-import { computed, shallowRef, watch } from 'vue'
+import { computed, ref, shallowRef, watch } from 'vue'
 import { initAdapterFor } from '@/adapters/factory'
-import type { RawStreamEvent } from '@/adapters/types'
+import type { RawStreamEvent, StreamConnectionState } from '@/adapters/types'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
@@ -35,6 +35,7 @@ export const ALL_KINDS = [
   'stream-note-updated',
   'stream-mention',
   'stream-chat-message',
+  'stream-status',
 ] as const
 
 export const KIND_LABELS: Record<string, string> = {
@@ -44,6 +45,16 @@ export const KIND_LABELS: Record<string, string> = {
   'stream-note-updated': 'updated',
   'stream-mention': 'mention',
   'stream-chat-message': 'chat',
+  'stream-status': 'status',
+}
+
+/** カラム単位の runtime_state（フロントが意図した状態）スナップショット */
+export interface ColumnRuntimeInfo {
+  columnId: string
+  accountId: string | null
+  columnType: string
+  state: 'live' | 'warm' | 'suspended'
+  ts: number
 }
 
 export const useStreamInspectorStore = defineStore('streamInspector', () => {
@@ -54,6 +65,12 @@ export const useStreamInspectorStore = defineStore('streamInspector', () => {
   let nextId = 0
   const buffer = shallowRef<StreamEventEntry[]>([])
 
+  // --- Dashboard state ---
+  /** account_id -> 直近の WS 接続状態 (stream-status raw event 由来) */
+  const connectionState = ref<Map<string, StreamConnectionState>>(new Map())
+  /** column_id -> フロントが意図した runtime_state (keep-alive 中は live) */
+  const runtimeStates = ref<Map<string, ColumnRuntimeInfo>>(new Map())
+
   // --- Dedup ---
   let lastEventKey = ''
   let lastEventTs = 0
@@ -62,7 +79,7 @@ export const useStreamInspectorStore = defineStore('streamInspector', () => {
   // --- Subscription management ---
   type CleanupFn = () => void
   const cleanups: CleanupFn[] = []
-  let capturing = false
+  const capturing = ref(false)
   let pruneTimer: ReturnType<typeof setInterval> | null = null
 
   /** TTL を超えた entry を落とす（破壊的に buffer.value を差し替え） */
@@ -100,6 +117,11 @@ export const useStreamInspectorStore = defineStore('streamInspector', () => {
   function makeRawHandler(observer: BadgePair, accountId: string) {
     return (event: RawStreamEvent) => {
       const now = Date.now()
+      // 接続状態は dedup より前に拾う（buffer から落ちても dashboard には反映）
+      if (event.kind === 'stream-status') {
+        const state = event.payload.state as StreamConnectionState | undefined
+        if (state) connectionState.value.set(accountId, state)
+      }
       const key = `${event.kind}:${event.payload.subscriptionId ?? ''}:${accountId}`
       if (key === lastEventKey && now - lastEventTs < DEDUP_WINDOW_MS) return
       lastEventKey = key
@@ -174,12 +196,13 @@ export const useStreamInspectorStore = defineStore('streamInspector', () => {
     watch(
       hasInspector,
       (has) => {
-        if (has && !capturing) {
-          capturing = true
+        if (has && !capturing.value) {
+          capturing.value = true
           subscribeAll()
-        } else if (!has && capturing) {
-          capturing = false
+        } else if (!has && capturing.value) {
+          capturing.value = false
           unsubscribeAll()
+          connectionState.value = new Map()
         }
       },
       { immediate: true },
@@ -189,13 +212,22 @@ export const useStreamInspectorStore = defineStore('streamInspector', () => {
     watch(
       () => accountsStore.accounts.length,
       () => {
-        if (capturing) subscribeAll()
+        if (capturing.value) subscribeAll()
       },
     )
   }
 
+  /** 各カラムの runtime_state を Inspector に通知する (useColumnSetup から呼ぶ) */
+  function reportRuntimeState(info: ColumnRuntimeInfo) {
+    runtimeStates.value.set(info.columnId, info)
+  }
+
   return {
     buffer,
+    connectionState,
+    runtimeStates,
+    capturing,
+    reportRuntimeState,
     startWatching,
   }
 })

--- a/src/stores/streamInspector.ts
+++ b/src/stores/streamInspector.ts
@@ -53,6 +53,8 @@ export interface ColumnRuntimeInfo {
   columnId: string
   accountId: string | null
   columnType: string
+  /** 下流の channel subscription id (= stream event payload.subscriptionId)。未確定時 null */
+  subscriptionId: string | null
   state: 'live' | 'warm' | 'suspended'
   ts: number
 }


### PR DESCRIPTION
## Release v1.2.0

### 変更（origin/main..develop）
- fix: avoid hidden timeline gap on resume after suspend (#506)
- feat: stream inspector keep-alive + status dashboard (#506)
- feat: filter inspector log by column, fix dashboard staleness (#506)
- chore: bump version to 1.2.0

### 概要
Android のストリーミング常時接続不具合 (#506) に向けた**診断基盤と防御的修正**を中心とするリリース。

- **onResume gap-safe (#506)**: 画面外 suspend → 復帰時に1ページ超 missed だと隠れた穴ができる問題を、最新ページ取得 + gap 検出 + clean replace で防止。
- **Stream Inspector 改修 (#506)**: Inspector が存在する間は画面外カラムも購読維持 (keep-alive) して観測可能に。接続状態 + 各カラム runtime_state のダッシュボード、カラム別イベントフィルタ (複数選択) を追加。Android の 1 画面 1 カラム下でも WS ストリームを観測できるようにし、本症状の切り分け (WS 切断系 vs suspend/可視性系) を可能にする。

### #506 のステータス
本リリースは #506 の**診断ツール + 防御的修正**であり、「画面内 TL が pull-to-refresh しないと新着が来ない」という**本症状の根本原因は未確定**。よって #506 は**クローズせず継続調査**とする（`Refs #506`）。Stream Inspector で実機切り分け後、必要な修正を別途入れる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)