### PR TITLE
Release v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.2.0"
+version = "1.2.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckStackCell.vue
+++ b/src/components/deck/DeckStackCell.vue
@@ -3,6 +3,7 @@ import { computed, toRef, useCssModule, useTemplateRef } from 'vue'
 import { COLUMN_COMPONENTS } from '@/columns/registry'
 import { useColumnMount } from '@/composables/useColumnMount'
 import type { DeckColumn } from '@/stores/deck'
+import { useStreamInspectorStore } from '@/stores/streamInspector'
 
 const props = defineProps<{
   colId: string
@@ -22,9 +23,13 @@ defineEmits<{
 const $style = useCssModule()
 const cellRef = useTemplateRef<HTMLElement>('cellRef')
 
+// Stream Inspector が存在する間は画面外カラムも mount 維持し、購読を生かして
+// 観測可能にする（モバイルの自動 unload 対策）。
+const inspectorStore = useStreamInspectorStore()
 const { shouldMount } = useColumnMount(props.colId, cellRef, {
   isCompact: toRef(props, 'isCompact'),
   isActive: toRef(props, 'isActive'),
+  keepMounted: computed(() => inspectorStore.capturing),
 })
 
 const columnComponent = computed(() =>

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -58,29 +58,32 @@ const paused = ref(false)
 const selectedId = ref<number | null>(null)
 const enabledKinds = ref(new Set<string>(ALL_KINDS))
 const clearedBefore = ref(0)
-/** ダッシュボードで有効化中のカラム subscriptionId 集合。空 = 全カラム表示（複数同時可） */
-const focusedSubIds = ref(new Set<string>())
+/**
+ * 無効化(OFF)したカラムの subscriptionId 集合。デフォルトは全カラム有効＝空集合。
+ * kind ピルと同じファセット型: 有効(色付き)=そのカラムのイベントを流す。
+ * クリックで OFF にしたカラムだけ除外する。
+ */
+const disabledSubIds = ref(new Set<string>())
 
 const filteredBuffer = computed(() => {
   const aid = props.column.accountId
-  const subs = focusedSubIds.value
+  const disabled = disabledSubIds.value
   return inspectorStore.buffer.filter((e) => {
     if (e.ts < clearedBefore.value) return false
     if (!enabledKinds.value.has(e.kind)) return false
     if (aid != null && e.accountId !== aid) return false
-    if (subs.size > 0 && !subs.has(e.payload.subscriptionId as string))
-      return false
+    if (disabled.has(e.payload.subscriptionId as string)) return false
     return true
   })
 })
 
-/** カラムマーククリックで有効/無効をトグル（複数同時に有効化できる。kind ピルと同様） */
+/** カラムマーククリックで有効/無効をトグル（デフォルト全有効、クリックで OFF） */
 function onMarkClick(subId: string | null) {
   if (!subId) return
-  const next = new Set(focusedSubIds.value)
+  const next = new Set(disabledSubIds.value)
   if (next.has(subId)) next.delete(subId)
   else next.add(subId)
-  focusedSubIds.value = next
+  disabledSubIds.value = next
 }
 
 // Freeze display when paused
@@ -318,9 +321,10 @@ function onDetailWheel(e: WheelEvent) {
           :class="[
             $style.mark,
             {
-              [$style.markDim]: row.state !== 'live',
               [$style.markActive]:
-                !!row.subscriptionId && focusedSubIds.has(row.subscriptionId),
+                !!row.subscriptionId && !disabledSubIds.has(row.subscriptionId),
+              [$style.markOff]:
+                !!row.subscriptionId && disabledSubIds.has(row.subscriptionId),
             },
           ]"
           :title="`${row.host} · ${row.typeLabel} · ${row.state} · ${ageText(
@@ -515,8 +519,13 @@ function onDetailWheel(e: WheelEvent) {
   }
 }
 
-.markDim {
-  opacity: 0.35;
+// 無効化(OFF=除外)したカラム。ボトムバーの非アクティブタブと同じく dim。
+.markOff {
+  opacity: 0.3;
+
+  &:hover {
+    opacity: 0.55;
+  }
 }
 
 .markIcon {

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -500,7 +500,19 @@ function onDetailWheel(e: WheelEvent) {
 .markActive {
   opacity: 1;
   color: var(--nd-accent);
-  background: var(--nd-buttonHoverBg);
+
+  // ボトムバーの .tabActive と同じ表現: 全面塗りではなく下線バー + accent 文字色
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: -5px;
+    left: 50%;
+    translate: -50% 0;
+    width: 16px;
+    height: 2.5px;
+    border-radius: 3px 3px 0 0;
+    background: var(--nd-accent);
+  }
 }
 
 .markDim {

--- a/src/composables/useColumnMount.ts
+++ b/src/composables/useColumnMount.ts
@@ -172,6 +172,13 @@ export function useColumnMount(
   opts: {
     isCompact: Ref<boolean>
     isActive: Ref<boolean>
+    /**
+     * While true, keep this column mounted even when off-screen. Set by the
+     * Stream Inspector (capturing) so off-screen columns stay subscribed and
+     * observable on mobile, where they would otherwise unload after a few
+     * seconds. Debug-scoped: only true while an inspector column exists.
+     */
+    keepMounted?: Ref<boolean>
   },
 ): { shouldMount: ComputedRef<boolean> } {
   const registry = inject(COLUMN_REGISTRY_KEY, null)
@@ -196,7 +203,10 @@ export function useColumnMount(
   onBeforeUnmount(() => registry.unregister(colId))
 
   const shouldMount = computed(
-    () => opts.isActive.value || registry.isMounted(colId),
+    () =>
+      opts.isActive.value ||
+      registry.isMounted(colId) ||
+      (opts.keepMounted?.value ?? false),
   )
   return { shouldMount }
 }


### PR DESCRIPTION
## Release v1.2.1

### 変更（origin/main..develop）
- style: match active dashboard marks to bottom-bar tabs (#506)
- fix: keep columns mounted while inspecting so mobile observation works (#506)
- fix: invert dashboard column filter to all-on facet model (#506)
- chore: bump version to 1.2.1

### 概要
Stream Inspector の UX 改善（フロントのみ）:
- ダッシュボードのアクティブマークをボトムバーのタブと同じ表現（accent + 下線）に統一。
- **keep-mounted**: Inspector が存在する間は画面外カラムも mount 維持。モバイル(compact)が画面外カラムを unload してしまい、keep-alive watch ごと消えてイベント・接続状態・subscriptionId が観測不能になっていた問題を解消（`useColumnMount` に `keepMounted`、`DeckStackCell` が inspector の capturing を渡す）。
- カラム別フィルタを**全有効デフォルトのファセット型**に反転（色付き=有効=流す、クリックで OFF 除外。kind ピルと同じ）。

### #506 のステータス
本リリースは Stream Inspector の観測 UX 改善のみ。**Android 本症状「接続済みなのに note が 1 件も流れてこない」の修正ではない**（root cause 未確定）。よって #506 は**クローズせず継続調査**（`Refs #506`）。次は notecli/Rust 側の WS ヘルスチェック（doctor 相当）で「subscribe 送信済みか / フレーム受信数 / 最後の note 時刻」を logcat 無しで可視化し、真因を切り分ける方針。

🤖 Generated with [Claude Code](https://claude.com/claude-code)