### PR TITLE
Release v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -690,7 +690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2821,6 +2821,7 @@ dependencies = [
  "tokio-stream",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "ulid",
  "url",
@@ -4855,6 +4856,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5866,6 +5873,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2746,7 +2746,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.3.1"
-source = "git+https://github.com/hitalin/notecli?rev=a04ea9eeae256e503925eb2887058eaccc60a828#a04ea9eeae256e503925eb2887058eaccc60a828"
+source = "git+https://github.com/hitalin/notecli?rev=6ae8ca0b8cf5505d6a2665890834bf531122a613#6ae8ca0b8cf5505d6a2665890834bf531122a613"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ base64 = "0.22"
 encoding_rs = "0.8"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-axum = "0.2"
 tauri-plugin-os = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.2.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "a04ea9eeae256e503925eb2887058eaccc60a828", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "6ae8ca0b8cf5505d6a2665890834bf531122a613", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.2.1"
+version = "1.3.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.2.1"
+    "version": "1.3.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -1,0 +1,61 @@
+//! Healthcheck (#644) — アプリの自己診断。
+//!
+//! notecli の `doctor` と同じチェック (database / keychain / accounts /
+//! network / auth) を `diagnose()` で再利用し、notedeck 固有のランタイム状態
+//! (backend ready / cache / HEARTBEAT / ログ場所) を足して 1 つの [`HealthReport`]
+//! に集約する。About ウィンドウの healthcheck ダイアログがこれを表示する。
+
+use std::sync::Arc;
+
+use notecli::error::NoteDeckError;
+use tauri::{Manager, State};
+
+use super::{AppState, HeartbeatScheduler, Result};
+
+#[derive(serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthReport {
+    /// notecli doctor の結果 (database / keychain / accounts / network / auth)。
+    pub doctor: notecli::commands::doctor::Report,
+    /// バックエンド (DB + MisskeyClient) の初期化が完了しているか。
+    pub backend_ready: bool,
+    pub note_cache_count: i64,
+    pub db_size_bytes: i64,
+    /// HEARTBEAT scheduler の現在 interval (分)。未登録なら null。
+    pub heartbeat_interval_minutes: Option<u32>,
+    /// notedeck.log を含むログディレクトリ (#644)。解決できなければ null。
+    pub log_dir: Option<String>,
+}
+
+#[tauri::command]
+#[specta::specta]
+pub async fn run_healthcheck(
+    app: tauri::AppHandle,
+    app_state: State<'_, AppState>,
+    scheduler: State<'_, Arc<HeartbeatScheduler>>,
+) -> Result<HealthReport> {
+    let db = app_state.db().await;
+    let db_path = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| NoteDeckError::InvalidInput(e.to_string()))?
+        .join("notecli.db");
+
+    // doctor のチェックを丸ごと再利用 (account_spec = None で全アカウント対象)。
+    let doctor = notecli::commands::doctor::diagnose(db.as_ref(), &db_path, None).await?;
+    let (note_cache_count, db_size_bytes) = db.cache_stats()?;
+    let log_dir = app
+        .path()
+        .app_log_dir()
+        .ok()
+        .map(|p| p.to_string_lossy().into_owned());
+
+    Ok(HealthReport {
+        doctor,
+        backend_ready: app_state.is_ready(),
+        note_cache_count,
+        db_size_bytes,
+        heartbeat_interval_minutes: scheduler.current_interval(),
+        log_dir,
+    })
+}

--- a/src-tauri/src/commands/heartbeat.rs
+++ b/src-tauri/src/commands/heartbeat.rs
@@ -60,7 +60,7 @@ impl HeartbeatScheduler {
         let mut slot = match self.inner.lock() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("[heartbeat] scheduler mutex poisoned: {e}");
+                tracing::error!("[heartbeat] scheduler mutex poisoned: {e}");
                 return;
             }
         };
@@ -91,7 +91,7 @@ impl HeartbeatScheduler {
         let mut slot = match self.inner.lock() {
             Ok(g) => g,
             Err(e) => {
-                eprintln!("[heartbeat] scheduler mutex poisoned: {e}");
+                tracing::error!("[heartbeat] scheduler mutex poisoned: {e}");
                 return;
             }
         };
@@ -121,7 +121,7 @@ fn emit_tick(app: &tauri::AppHandle, source: &str) {
         source: source.to_string(),
     };
     if let Err(e) = app.emit(HEARTBEAT_EVENT_NAME, payload) {
-        eprintln!("[heartbeat] failed to emit tick: {e}");
+        tracing::error!("[heartbeat] failed to emit tick: {e}");
     }
 }
 

--- a/src-tauri/src/commands/heartbeat.rs
+++ b/src-tauri/src/commands/heartbeat.rs
@@ -100,7 +100,7 @@ impl HeartbeatScheduler {
         }
     }
 
-    fn current_interval(&self) -> Option<u32> {
+    pub(crate) fn current_interval(&self) -> Option<u32> {
         self.inner
             .lock()
             .ok()

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod content;
 mod drafts;
 mod enrichment;
 mod federation;
+mod health;
 mod heartbeat;
 mod lists;
 mod http;
@@ -31,6 +32,7 @@ pub use content::*;
 pub use drafts::*;
 pub use enrichment::*;
 pub use federation::*;
+pub use health::*;
 pub use heartbeat::*;
 pub use lists::*;
 pub use http::*;
@@ -95,6 +97,12 @@ impl AppState {
         // Also signal DB channel in case initialize_db() wasn't called
         let _ = self.db_tx.send(Some(Arc::clone(&db)));
         let _ = self.tx.send(Some(Arc::new(AppStateInner { db, client })));
+    }
+
+    /// Non-blocking check of full readiness (DB + MisskeyClient). Used by the
+    /// healthcheck so it can report startup state without awaiting init.
+    pub fn is_ready(&self) -> bool {
+        self.rx.borrow().is_some()
     }
 
     /// Await until DB is ready (fast path — does not wait for MisskeyClient).

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -233,6 +233,20 @@ pub fn get_settings_dir(app: tauri::AppHandle) -> Result<String> {
     Ok(settings_base_dir(&app)?.to_string_lossy().to_string())
 }
 
+/// Get the log directory path (`app_log_dir`, holds `notedeck.log` — #644).
+/// Separate from the settings dir, so the "ファイル → ログフォルダを開く" menu
+/// item can reveal it. Created if missing so it opens even when empty.
+#[tauri::command]
+#[specta::specta]
+pub fn get_log_dir(app: tauri::AppHandle) -> Result<String> {
+    let dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| NoteDeckError::InvalidInput(e.to_string()))?;
+    let _ = std::fs::create_dir_all(&dir);
+    Ok(dir.to_string_lossy().to_string())
+}
+
 /// Open a settings file in the OS default editor. WSL2 では xdg-open が GUI
 /// エディタへルーティングできないため、wslpath で Windows パスへ変換し
 /// cmd.exe start 経由で Windows 側の既定アプリに委譲する。

--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -45,7 +45,7 @@ pub async fn api_get_timeline(
         .get_timeline(&host, &token, &account_id, timeline_type, opts)
         .await?;
     if let Err(e) = db.cache_notes(&notes, &cache_key) {
-        eprintln!("[cache] failed to cache timeline notes: {e}");
+        tracing::warn!("[cache] failed to cache timeline notes: {e}");
     }
 
     // Background OGP prefetch: extract URLs and spawn async task (non-blocking)
@@ -182,7 +182,7 @@ pub async fn api_get_antenna_notes(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, &format!("antenna:{antenna_id}")) {
-        eprintln!("[cache] failed to cache antenna notes: {e}");
+        tracing::warn!("[cache] failed to cache antenna notes: {e}");
     }
     Ok(notes)
 }
@@ -209,7 +209,7 @@ pub async fn api_get_favorites(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, "favorites") {
-        eprintln!("[cache] failed to cache favorites: {e}");
+        tracing::warn!("[cache] failed to cache favorites: {e}");
     }
     Ok(notes)
 }
@@ -253,7 +253,7 @@ pub async fn api_get_mentions(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, "mentions") {
-        eprintln!("[cache] failed to cache mentions: {e}");
+        tracing::warn!("[cache] failed to cache mentions: {e}");
     }
     Ok(notes)
 }
@@ -295,7 +295,7 @@ pub async fn api_get_clip_notes(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, &format!("clip:{clip_id}")) {
-        eprintln!("[cache] failed to cache clip notes: {e}");
+        tracing::warn!("[cache] failed to cache clip notes: {e}");
     }
     Ok(notes)
 }
@@ -349,7 +349,7 @@ pub async fn api_get_channel_notes(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, &format!("channel:{channel_id}")) {
-        eprintln!("[cache] failed to cache channel notes: {e}");
+        tracing::warn!("[cache] failed to cache channel notes: {e}");
     }
     Ok(notes)
 }
@@ -380,7 +380,7 @@ pub async fn api_get_role_notes(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, &format!("role:{role_id}")) {
-        eprintln!("[cache] failed to cache role notes: {e}");
+        tracing::warn!("[cache] failed to cache role notes: {e}");
     }
     Ok(notes)
 }

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -55,7 +55,7 @@ pub async fn api_get_user_notes(
         )
         .await?;
     if let Err(e) = db.cache_notes(&notes, &format!("user:{user_id}")) {
-        eprintln!("[cache] failed to cache user notes: {e}");
+        tracing::warn!("[cache] failed to cache user notes: {e}");
     }
     Ok(notes)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,6 +38,39 @@ pub fn run() {
     }
 }
 
+/// Install the global `tracing` subscriber: stdout plus a daily-rotating
+/// `notedeck.log` in the OS log dir (`app_log_dir`). The `EnvFilter` keeps the
+/// previous default (`notedeck=info,notecli=info,warn`) and still honors `RUST_LOG`.
+/// If the log dir can't be resolved we log to stdout only — logging must never
+/// block startup. Called once from `setup`.
+fn init_logging(app: &tauri::App) {
+    use tracing_subscriber::prelude::*;
+
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "notedeck=info,notecli=info,warn".parse().expect("default tracing filter must parse"));
+
+    // File layer is optional: skipped if the log dir can't be created.
+    let file_layer = app
+        .path()
+        .app_log_dir()
+        .ok()
+        .filter(|dir| std::fs::create_dir_all(dir).is_ok())
+        .map(|dir| {
+            let appender = tracing_appender::rolling::daily(&dir, "notedeck.log");
+            let (non_blocking, guard) = tracing_appender::non_blocking(appender);
+            // Keep the writer thread alive for the whole process (flushes on drop),
+            // mirroring how the tokio runtime handle is leaked above.
+            Box::leak(Box::new(guard));
+            tracing_subscriber::fmt::layer().with_ansi(false).with_writer(non_blocking)
+        });
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer())
+        .with(file_layer)
+        .init();
+}
+
 fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
     // Limit tokio worker threads (~2MB stack per thread).
     // 4 threads balance concurrency (multi-server WS + OGP + DB) vs memory.
@@ -49,13 +82,6 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             .build()?,
     ));
     tauri::async_runtime::set(runtime.handle().clone());
-
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| "notedeck=info,notecli=info,warn".parse().expect("default tracing filter must parse")),
-        )
-        .init();
 
     let mut builder = tauri::Builder::default()
         .plugin(tauri_plugin_os::init())
@@ -95,6 +121,13 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
     let has_tray_for_setup = has_tray.clone();
 
     builder = builder.setup(move |app| {
+        // Structured logging (#644): stdout (unchanged behavior) + a daily-rotating
+        // file in the OS log dir, so background work (notecli wrapper / HEARTBEAT /
+        // AI SSE) leaves a trace for bug reports and the healthcheck view.
+        // Initialized here (not earlier) because the log dir needs the app handle;
+        // if it can't be resolved we fall back to stdout-only so startup never blocks.
+        init_logging(app);
+
         // tauri-specta typed events (e.g. QueryDelta) require the registry to be mounted.
         specta_builder.mount_events(app);
 
@@ -108,7 +141,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
         // Initialize platform keychain + filesystem migrations (both lightweight)
         if let Err(e) = notecli::keychain::init_store() {
-            eprintln!("Warning: keychain unavailable ({e})");
+            tracing::warn!("keychain unavailable ({e})");
         }
         migrations::run_fs(&app_dir)?;
 
@@ -195,14 +228,14 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             let db = match db_handle.join().expect("db open thread panicked") {
                 Ok(d) => std::sync::Arc::new(d),
                 Err(e) => {
-                    eprintln!("Fatal: DB open failed: {e}");
+                    tracing::error!("Fatal: DB open failed: {e}");
                     return;
                 }
             };
             let client = match client_handle.join().expect("client init thread panicked") {
                 Ok(c) => std::sync::Arc::new(c),
                 Err(e) => {
-                    eprintln!("Fatal: MisskeyClient init failed: {e}");
+                    tracing::error!("Fatal: MisskeyClient init failed: {e}");
                     return;
                 }
             };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -702,6 +702,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::delete_settings_file,
             commands::rename_settings_file,
             commands::get_settings_dir,
+            commands::get_log_dir,
             commands::open_settings_file_in_editor,
             commands::read_root_settings_file,
             commands::write_root_settings_file,
@@ -720,6 +721,8 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::heartbeat_unconfigure,
             commands::heartbeat_trigger_now,
             commands::heartbeat_status,
+            // Healthcheck (#644) — notecli doctor + ランタイム状態の自己診断
+            commands::run_healthcheck,
             // Secret Vault (#564) — 外部サービス接続のメタデータ + secret 管理
             commands::vault_list_connections,
             commands::vault_get_connection,

--- a/src-tauri/src/ogp/mod.rs
+++ b/src-tauri/src/ogp/mod.rs
@@ -379,7 +379,7 @@ impl OgpCache {
                     match plugin.summarize(&parsed, &self.http_client).await {
                         Ok(data) => return Ok(data),
                         Err(e) => {
-                            eprintln!("[ogp] plugin failed for {url}: {e}, falling back");
+                            tracing::warn!("[ogp] plugin failed for {url}: {e}, falling back");
                             break;
                         }
                     }

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -205,13 +205,13 @@ pub async fn run_delta_flusher(app: AppHandle) {
         };
         for delta in runtime.drain_pending() {
             if let Err(e) = delta.emit(&app) {
-                eprintln!("[query-delta] emit failed: {e}");
+                tracing::warn!("[query-delta] emit failed: {e}");
             }
         }
         let captures = runtime.drain_captures();
         if !captures.is_empty() {
             if let Err(e) = (NoteCaptureBatch { captures }).emit(&app) {
-                eprintln!("[note-capture-batch] emit failed: {e}");
+                tracing::warn!("[note-capture-batch] emit failed: {e}");
             }
         }
     }

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -124,7 +124,7 @@ impl TauriEmitter {
             builder = builder.channel_id(NOTIFICATION_CHANNEL_ID);
         }
         if let Err(e) = builder.show() {
-            eprintln!("[notification] failed to send: {e}");
+            tracing::warn!("[notification] failed to send: {e}");
         }
     }
 }
@@ -239,7 +239,7 @@ impl FrontendEmitter for TauriEmitter {
             payload: &payload,
         };
         if let Err(e) = self.app.emit("stream-event", &wrapped) {
-            eprintln!("[stream] emit {event} failed: {e}");
+            tracing::warn!("[stream] emit {event} failed: {e}");
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -1720,6 +1720,19 @@ async getSettingsDir() : Promise<Result<string, { code: string; message: string 
 }
 },
 /**
+ * Get the log directory path (`app_log_dir`, holds `notedeck.log` — #644).
+ * Separate from the settings dir, so the "ファイル → ログフォルダを開く" menu
+ * item can reveal it. Created if missing so it opens even when empty.
+ */
+async getLogDir() : Promise<Result<string, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_log_dir") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Open a settings file in the OS default editor. WSL2 では xdg-open が GUI
  * エディタへルーティングできないため、wslpath で Windows パスへ変換し
  * cmd.exe start 経由で Windows 側の既定アプリに委譲する。
@@ -1883,6 +1896,14 @@ async heartbeatTriggerNow() : Promise<Result<null, { code: string; message: stri
 async heartbeatStatus() : Promise<Result<number | null, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("heartbeat_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async runHealthcheck() : Promise<Result<HealthReport, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("run_healthcheck") };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -2285,6 +2306,19 @@ export type ChatMessageReaction = { user: ChatReactionUser | null; reaction: str
 export type ChatReactionUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null }
 export type ChatRoom = { id: string; name: string | null; description: string | null }
 export type ChatUser = { id: string; name: string | null; username: string; host: string | null; avatarUrl: string | null; emojis?: Partial<{ [key in string]: string }>; avatarDecorations?: AvatarDecoration[] }
+export type Check = { 
+/**
+ * チェック項目名 (database, keychain, credentials, network, auth)
+ */
+name: string; status: Status; message: string; 
+/**
+ * アカウント別チェックの場合の対象 (@user@host)。環境チェックは None。
+ */
+account?: string | null; 
+/**
+ * 失敗・警告時にユーザーが実行すべき修復コマンド/手順。
+ */
+fix?: string | null }
 /**
  * Metadata for a single CLI argument.
  */
@@ -2447,6 +2481,23 @@ export type FollowChartSection = { followings: FollowChartGroup; followers: Foll
  * packages/backend/src/models/GalleryPost.ts。
  */
 export type GalleryPost = { id: string; createdAt: string; updatedAt: string; title: string; description: string | null; userId: string; user?: NormalizedUser | null; files: NormalizedDriveFile[]; isSensitive?: boolean; likedCount?: number; isLiked?: boolean | null }
+export type HealthReport = { 
+/**
+ * notecli doctor の結果 (database / keychain / accounts / network / auth)。
+ */
+doctor: Report; 
+/**
+ * バックエンド (DB + MisskeyClient) の初期化が完了しているか。
+ */
+backendReady: boolean; noteCacheCount: number; dbSizeBytes: number; 
+/**
+ * HEARTBEAT scheduler の現在 interval (分)。未登録なら null。
+ */
+heartbeatIntervalMinutes: number | null; 
+/**
+ * notedeck.log を含むログディレクトリ (#644)。解決できなければ null。
+ */
+logDir: string | null }
 export type HttpFetchRequest = { url: string; method: string | null; headers: Partial<{ [key in string]: string }> | null; body: string | null; timeoutMs: number | null }
 export type HttpFetchResponse = { status: number; headers: Partial<{ [key in string]: string }>; body: string }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
@@ -2554,6 +2605,7 @@ itemIds: string[] }
 export type QueryRuntimeState = "live" | "warm" | "suspended"
 export type QuerySnapshot = { queryId: string; key: QueryKey; runtimeState: QueryRuntimeState; subscriberCount: number; revision: number; sourceSubscriptionId: string | null }
 export type ReactionInfo = { user: NormalizedUser; reaction: string }
+export type Report = { ok: boolean; checks: Check[] }
 export type SearchOptions = { limit?: number; sinceId: string | null; untilId: string | null; sinceDate: number | null; untilDate: number | null; 
 /**
  * 指定ユーザーのノートのみに絞る (notes/search の userId)
@@ -2586,6 +2638,7 @@ export type ServerNotesChartSection = { total: number[]; inc: number[]; dec: num
  */
 export type ServerUsersChart = { local: ServerUsersChartSection; remote: ServerUsersChartSection }
 export type ServerUsersChartSection = { total: number[]; inc: number[]; dec: number[] }
+export type Status = "ok" | "warn" | "fail"
 export type StoredServer = { host: string; software: string; version: string; featuresJson: string; updatedAt: number }
 export type SummaryData = { title: string | null; description: string | null; icon: string | null; sitename: string | null; thumbnail: string | null; medias: string[]; player: Player | null; url: string; sensitive: boolean }
 export type TimelineFilter = { withRenotes: boolean | null; withReplies: boolean | null; withFiles: boolean | null; withBots: boolean | null; withSensitive: boolean | null }

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -546,6 +546,9 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
 
 .twemoji {
   height: 1.25em;
+  /* width 属性 (20px) を上書きし、幅を高さ=font-size に追従させる。
+     これがないと MFM の $[x2]/$[x3]/$[x4] で絵文字が拡大されない。 */
+  width: auto;
   vertical-align: -0.25em;
   object-fit: contain;
 }

--- a/src/components/common/TitleBarMenu.vue
+++ b/src/components/common/TitleBarMenu.vue
@@ -6,7 +6,7 @@ import { onMounted, ref } from 'vue'
 
 import { usePortal } from '@/composables/usePortal'
 import { useVaporTransition } from '@/composables/useVaporTransition'
-import { getSettingsDir } from '@/utils/settingsFs'
+import { getLogDir, getSettingsDir } from '@/utils/settingsFs'
 
 const menuOpen = ref(false)
 const activeCategory = ref<string | null>(null)
@@ -113,6 +113,12 @@ async function openSettingsDir() {
   closeMenu()
 }
 
+async function openLogDir() {
+  const dir = await getLogDir()
+  if (dir) await revealItemInDir(dir)
+  closeMenu()
+}
+
 // ── Actions ──
 const zoomLevel = ref(1)
 
@@ -152,6 +158,10 @@ defineExpose({ toggleMenu })
           <button class="_popupItem" @click="openSettingsDir">
             <i class="ti ti-folder-open" />
             <span>設定フォルダを開く</span>
+          </button>
+          <button class="_popupItem" @click="openLogDir">
+            <i class="ti ti-folder-open" />
+            <span>ログフォルダを開く</span>
           </button>
           <div class="_popupDivider" />
           <button class="_popupItem" @click="toggleAutostart">

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -1,16 +1,91 @@
 <script setup lang="ts">
 import { getTauriVersion } from '@tauri-apps/api/app'
 import { openUrl } from '@tauri-apps/plugin-opener'
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref, shallowRef } from 'vue'
+import type { HealthReport, Status } from '@/bindings'
 import { useUpdater } from '@/composables/useUpdater'
 import { useUiStore } from '@/stores/ui'
-import { commands } from '@/utils/tauriInvoke'
+import { AppError } from '@/utils/errors'
+import { commands, unwrap } from '@/utils/tauriInvoke'
 import { version as appVersion } from '../../../package.json'
 
 const tauriVersion = ref('')
 const rustVersion = ref('')
 const copied = ref(false)
 const uiStore = useUiStore()
+
+// 自己診断 (#644): notecli doctor + ランタイム状態。About を開いた時に走らせ、
+// 「情報をコピー」「バグを報告」の本文に診断を同梱する (VS Code Report Issue モデル)。
+const health = shallowRef<HealthReport | null>(null)
+const healthLoading = ref(false)
+const healthError = ref<string | null>(null)
+
+const STATUS_ICON: Record<Status, string> = {
+  ok: 'ti ti-circle-check',
+  warn: 'ti ti-alert-triangle',
+  fail: 'ti ti-circle-x',
+}
+
+const overallStatus = computed<Status>(() => {
+  const checks = health.value?.doctor.checks ?? []
+  if (checks.some((c) => c.status === 'fail')) return 'fail'
+  if (checks.some((c) => c.status === 'warn')) return 'warn'
+  return 'ok'
+})
+
+// 正常な項目は畳んで、注意・問題だけ出す (健康なら "正常" の一行で済む)。
+const problemChecks = computed(() =>
+  (health.value?.doctor.checks ?? []).filter((c) => c.status !== 'ok'),
+)
+
+const healthSummary = computed(() => {
+  if (healthLoading.value) return '診断中...'
+  if (healthError.value) return '診断に失敗しました'
+  if (!health.value) return ''
+  const fails = problemChecks.value.filter((c) => c.status === 'fail').length
+  const warns = problemChecks.value.filter((c) => c.status === 'warn').length
+  if (fails > 0) return `${fails} 件の問題`
+  if (warns > 0) return `${warns} 件の警告`
+  return '正常'
+})
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / 1024 / 1024).toFixed(1)} MB`
+}
+
+async function runHealthcheck() {
+  if (healthLoading.value) return
+  healthLoading.value = true
+  healthError.value = null
+  try {
+    health.value = unwrap(await commands.runHealthcheck())
+  } catch (e) {
+    healthError.value = AppError.from(e).message
+  } finally {
+    healthLoading.value = false
+  }
+}
+
+/** 診断結果を Markdown 風テキストに整形 (コピー / バグ報告で同梱)。 */
+function diagnosticsText(): string {
+  const r = health.value
+  if (!r) return ''
+  const sym = (s: Status) =>
+    s === 'ok' ? 'OK' : s === 'warn' ? 'WARN' : 'FAIL'
+  const lines = r.doctor.checks.map(
+    (c) =>
+      `- [${sym(c.status)}] ${c.account ? `${c.account} ` : ''}${c.name}: ${c.message}${c.fix ? ` (→ ${c.fix})` : ''}`,
+  )
+  lines.push(`- backendReady: ${r.backendReady}`)
+  lines.push(`- cache: ${r.noteCacheCount} notes / ${fmtBytes(r.dbSizeBytes)}`)
+  lines.push(
+    `- heartbeat: ${r.heartbeatIntervalMinutes != null ? `${r.heartbeatIntervalMinutes}min` : 'off'}`,
+  )
+  if (r.logDir) lines.push(`- logDir: ${r.logDir}`)
+  return lines.join('\n')
+}
 const {
   isChecking,
   isUpToDate,
@@ -53,6 +128,7 @@ onMounted(async () => {
   } catch {
     // Fallback for environments where Tauri API is unavailable
   }
+  runHealthcheck()
 })
 
 const infoRows = [
@@ -66,7 +142,9 @@ const infoRows = [
 ]
 
 function getInfoText() {
-  return infoRows.map((r) => `${r.label}: ${r.get()}`).join('\n')
+  const info = infoRows.map((r) => `${r.label}: ${r.get()}`).join('\n')
+  const diag = diagnosticsText()
+  return diag ? `${info}\n\n# 診断\n${diag}` : info
 }
 
 async function copyInfo() {
@@ -79,7 +157,9 @@ async function copyInfo() {
 
 function reportBug() {
   const env = infoRows.map((r) => `- **${r.label}**: ${r.get()}`).join('\n')
-  const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
+  const diag = diagnosticsText()
+  const diagSection = diag ? `\n\n## 診断\n\n${diag}` : ''
+  const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}${diagSection}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
   const url = `https://github.com/hitalin/notedeck/issues/new?labels=bug&body=${encodeURIComponent(body)}`
   openUrl(url)
 }
@@ -97,6 +177,31 @@ function reportBug() {
         <span :class="$style.aboutLabel">{{ row.label }}:</span>
         <span :class="$style.aboutValue">{{ row.get() }}</span>
       </div>
+    </div>
+
+    <div :class="$style.diag">
+      <div :class="$style.diagHead">
+        <i
+          :class="[
+            healthLoading ? 'ti ti-loader-2' : healthError ? STATUS_ICON.fail : STATUS_ICON[overallStatus],
+            $style.diagIcon,
+            !healthLoading && !healthError && $style[overallStatus],
+            healthError && $style.fail,
+          ]"
+        />
+        <span :class="$style.diagSummary">診断: {{ healthSummary }}</span>
+        <button class="_button" :class="$style.diagRefresh" :disabled="healthLoading" title="再診断" @click="runHealthcheck">
+          <i class="ti ti-refresh" />
+        </button>
+      </div>
+      <div v-if="healthError" :class="$style.diagError">{{ healthError }}</div>
+      <template v-else>
+        <div v-for="(c, i) in problemChecks" :key="i" :class="$style.checkRow">
+          <i :class="[STATUS_ICON[c.status], $style.checkIcon, $style[c.status]]" />
+          <span :class="$style.checkName">{{ c.account ? `${c.account} ` : '' }}{{ c.name }}</span>
+          <span :class="$style.checkMsg">{{ c.message }}</span>
+        </div>
+      </template>
     </div>
 
     <div :class="$style.actions">
@@ -191,6 +296,83 @@ function reportBug() {
 .updateBtn {
   background: var(--nd-accent) !important;
   color: var(--nd-fgOnAccent, #fff) !important;
+}
+
+.diag {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 16px;
+  font-size: 0.85em;
+}
+
+.diagHead {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.diagIcon {
+  font-size: 1em;
+
+  &.ok { color: var(--nd-success); }
+  &.warn { color: var(--nd-warn); }
+  &.fail { color: var(--nd-error); }
+}
+
+.diagSummary {
+  color: var(--nd-fg);
+  font-weight: 600;
+}
+
+.diagRefresh {
+  position: absolute;
+  right: 0;
+  background: transparent;
+  border: none;
+  color: var(--nd-fg);
+  opacity: 0.6;
+  cursor: pointer;
+  padding: 2px 4px;
+
+  &:hover { opacity: 1; }
+  &:disabled { opacity: 0.3; cursor: default; }
+}
+
+.diagError {
+  color: var(--nd-error);
+  font-size: 0.9em;
+}
+
+.checkRow {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  padding-left: 2px;
+  line-height: 1.4;
+}
+
+.checkIcon {
+  flex-shrink: 0;
+  font-size: 0.9em;
+
+  &.ok { color: var(--nd-success); }
+  &.warn { color: var(--nd-warn); }
+  &.fail { color: var(--nd-error); }
+}
+
+.checkName {
+  color: var(--nd-fg);
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.checkMsg {
+  color: var(--nd-fg);
+  opacity: 0.9;
+  word-break: break-word;
 }
 
 .actions { @include action-bar; }

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -63,6 +63,11 @@ export async function getSettingsDir(): Promise<string> {
   return unwrap(await commands.getSettingsDir())
 }
 
+export async function getLogDir(): Promise<string> {
+  if (!isTauri) return ''
+  return unwrap(await commands.getLogDir())
+}
+
 /**
  * OS 既定アプリ (通常はユーザーが登録したテキストエディタ) で設定ファイルを開く。
  * WSL2 環境では xdg-open が GUI エディタへ届かないため、Rust 側で


### PR DESCRIPTION
## v1.3.0

### Features

- **feat: ファイルログ出力 (#644)** — `tracing-appender` で stdout に加え OS ログディレクトリへ日次ローテーションのファイルログ (`notedeck.log`) を出力。障害追跡・バグ報告に利用可能
- **feat: アプリ自己診断 (healthcheck) (#644)** — notecli doctor (database / keychain / accounts / network / auth) + ランタイム状態 (backend ready / cache / HEARTBEAT / ログ場所) を集約。About を開くと診断を表示し、「情報をコピー」「バグを報告」に同梱 (VS Code "Report Issue" モデル)。File メニューに「ログフォルダを開く」を追加

### Fixes

- **fix: MFM の scale 関数で Unicode 絵文字が拡大されない問題を修正**

### Chore

- notecli を doctor library 化版 (PR hitalin/notecli#23) に rev pin bump
- bump version to 1.3.0 / regenerate openapi.json

Closes #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)