### PR TITLE
Release v1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2745,8 +2745,8 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "notecli"
-version = "0.3.1"
-source = "git+https://github.com/hitalin/notecli?rev=6ae8ca0b8cf5505d6a2665890834bf531122a613#6ae8ca0b8cf5505d6a2665890834bf531122a613"
+version = "0.4.0"
+source = "git+https://github.com/hitalin/notecli?rev=6f7d7a79d273392320a5f524df7e768347510eaa#6f7d7a79d273392320a5f524df7e768347510eaa"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.0"
+version = "1.3.1"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "6ae8ca0b8cf5505d6a2665890834bf531122a613", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "6f7d7a79d273392320a5f524df7e768347510eaa", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.0"
+    "version": "1.3.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/commands/cliHandlers.ts
+++ b/src/commands/cliHandlers.ts
@@ -123,7 +123,7 @@ export function createCliHandlers(
       })
     },
 
-    tl: (args) => {
+    timeline: (args) => {
       const accountId = activeAccountId()
       if (!accountId) return
       const type = (args.trim() || 'home') as string

--- a/src/commands/cliIcons.ts
+++ b/src/commands/cliIcons.ts
@@ -2,7 +2,7 @@
 export const CLI_ICONS: Record<string, string> = {
   post: 'send',
   search: 'search',
-  tl: 'list',
+  timeline: 'list',
   notifications: 'bell',
   mentions: 'at',
   note: 'note',

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -6,6 +6,7 @@ import type { HealthReport, Status } from '@/bindings'
 import { useUpdater } from '@/composables/useUpdater'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
+import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { version as appVersion } from '../../../package.json'
 
@@ -68,24 +69,24 @@ async function runHealthcheck() {
   }
 }
 
-/** 診断結果を Markdown 風テキストに整形 (コピー / バグ報告で同梱)。 */
-function diagnosticsText(): string {
+// 診断結果をデバッグログ体裁に整形 (UI のコードブロック・コピー・バグ報告で共用)。
+const diagnosticsLog = computed<string>(() => {
   const r = health.value
   if (!r) return ''
   const sym = (s: Status) =>
-    s === 'ok' ? 'OK' : s === 'warn' ? 'WARN' : 'FAIL'
+    s === 'ok' ? '[OK]  ' : s === 'warn' ? '[WARN]' : '[FAIL]'
   const lines = r.doctor.checks.map(
     (c) =>
-      `- [${sym(c.status)}] ${c.account ? `${c.account} ` : ''}${c.name}: ${c.message}${c.fix ? ` (→ ${c.fix})` : ''}`,
+      `${sym(c.status)} ${c.account ? `${c.account} ` : ''}${c.name}: ${c.message}${c.fix ? ` (→ ${c.fix})` : ''}`,
   )
-  lines.push(`- backendReady: ${r.backendReady}`)
-  lines.push(`- cache: ${r.noteCacheCount} notes / ${fmtBytes(r.dbSizeBytes)}`)
+  lines.push(`backendReady: ${r.backendReady}`)
+  lines.push(`cache: ${r.noteCacheCount} notes / ${fmtBytes(r.dbSizeBytes)}`)
   lines.push(
-    `- heartbeat: ${r.heartbeatIntervalMinutes != null ? `${r.heartbeatIntervalMinutes}min` : 'off'}`,
+    `heartbeat: ${r.heartbeatIntervalMinutes != null ? `${r.heartbeatIntervalMinutes}min` : 'off'}`,
   )
-  if (r.logDir) lines.push(`- logDir: ${r.logDir}`)
+  if (r.logDir) lines.push(`logDir: ${r.logDir}`)
   return lines.join('\n')
-}
+})
 const {
   isChecking,
   isUpToDate,
@@ -143,8 +144,8 @@ const infoRows = [
 
 function getInfoText() {
   const info = infoRows.map((r) => `${r.label}: ${r.get()}`).join('\n')
-  const diag = diagnosticsText()
-  return diag ? `${info}\n\n# 診断\n${diag}` : info
+  const diag = diagnosticsLog.value
+  return diag ? `${info}\n\n# 診断\n\`\`\`\n${diag}\n\`\`\`` : info
 }
 
 async function copyInfo() {
@@ -157,8 +158,8 @@ async function copyInfo() {
 
 function reportBug() {
   const env = infoRows.map((r) => `- **${r.label}**: ${r.get()}`).join('\n')
-  const diag = diagnosticsText()
-  const diagSection = diag ? `\n\n## 診断\n\n${diag}` : ''
+  const diag = diagnosticsLog.value
+  const diagSection = diag ? `\n\n## 診断\n\n\`\`\`\n${diag}\n\`\`\`` : ''
   const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}${diagSection}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
   const url = `https://github.com/hitalin/notedeck/issues/new?labels=bug&body=${encodeURIComponent(body)}`
   openUrl(url)
@@ -195,13 +196,13 @@ function reportBug() {
         </button>
       </div>
       <div v-if="healthError" :class="$style.diagError">{{ healthError }}</div>
-      <template v-else>
-        <div v-for="(c, i) in problemChecks" :key="i" :class="$style.checkRow">
-          <i :class="[STATUS_ICON[c.status], $style.checkIcon, $style[c.status]]" />
-          <span :class="$style.checkName">{{ c.account ? `${c.account} ` : '' }}{{ c.name }}</span>
-          <span :class="$style.checkMsg">{{ c.message }}</span>
-        </div>
-      </template>
+      <!-- 診断ログを log 言語としてシンタックスハイライト (エディタ系ウィンドウと同じ見た目) -->
+      <div
+        v-else-if="diagnosticsLog"
+        :key="`diag-${highlighterLoaded}`"
+        :class="$style.logBlock"
+        v-html="highlightCode(diagnosticsLog, 'log')"
+      />
     </div>
 
     <div :class="$style.actions">
@@ -346,33 +347,29 @@ function reportBug() {
   font-size: 0.9em;
 }
 
-.checkRow {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  padding-left: 2px;
-  line-height: 1.4;
-}
+.logBlock {
+  text-align: left;
+  font-size: 0.75em;
+  line-height: 1.5;
+  border-radius: var(--nd-radius-sm);
+  border: 1px solid var(--nd-panelBorder);
+  overflow: hidden;
 
-.checkIcon {
-  flex-shrink: 0;
-  font-size: 0.9em;
+  :global(pre) {
+    margin: 0;
+    padding: 8px 10px;
+    max-height: 200px;
+    overflow: auto;
+    background: var(--nd-codeBg, var(--nd-panelHighlight));
+    scrollbar-width: thin;
+  }
 
-  &.ok { color: var(--nd-success); }
-  &.warn { color: var(--nd-warn); }
-  &.fail { color: var(--nd-error); }
-}
-
-.checkName {
-  color: var(--nd-fg);
-  opacity: 0.7;
-  flex-shrink: 0;
-}
-
-.checkMsg {
-  color: var(--nd-fg);
-  opacity: 0.9;
-  word-break: break-word;
+  :global(code) {
+    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    white-space: pre-wrap;
+    word-break: break-word;
+    user-select: all;
+  }
 }
 
 .actions { @include action-bar; }

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -77,8 +77,8 @@ export const WINDOW_SIZES: Record<
   profileEditor: { width: 400, maxHeight: 700 },
   // Login
   login: { width: 380, maxHeight: 480 },
-  // About
-  about: { width: 380, maxHeight: 480 },
+  // About — 診断ログのコードブロックとアクションボタンが収まる高さ
+  about: { width: 460, maxHeight: 640 },
   // Nav editor
   navEditor: { width: 400, maxHeight: 700 },
   // Performance editor

--- a/src/utils/highlight.ts
+++ b/src/utils/highlight.ts
@@ -108,6 +108,8 @@ function initHighlighter(): Promise<void> {
       import('shiki/dist/langs/sql.mjs'),
       import('shiki/dist/langs/typescript.mjs'),
       import('shiki/dist/langs/yaml.mjs'),
+      // healthcheck の診断ログ表示用 (#644)
+      import('shiki/dist/langs/log.mjs'),
     ])
 
     highlighter = shikiCore.createHighlighterCoreSync({


### PR DESCRIPTION
## v1.3.1

v1.3.0 で追加した healthcheck (#644) の表示改善と依存更新。

### Improvements

- **feat: healthcheck の診断ログを log 構文でハイライト表示 (#644)** — About の診断ログを shiki の `log` 言語でシンタックスハイライトし、エディタ系ウィンドウと同じコードブロックの見た目に。情報コピー / バグ報告の診断本文もコードブロックで囲む。About ウィンドウを 460×640 に拡大

### Chore

- **notecli を v0.4.0 に更新** — CLI コマンド `tl` → `timeline` リネームに追従 (cliHandlers / cliIcons のキー更新)
- bump version to 1.3.1 / regenerate openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)