### PR TITLE
Release v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.1"
+version = "1.3.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.1"
+    "version": "1.3.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -435,6 +435,7 @@ function handleOpenStoreDetail(entry: StoreWidgetEntry) {
 }
 
 .widgetItem {
+  flex-shrink: 0;
   border: 1px solid var(--nd-divider);
   border-radius: 10px;
   background: var(--nd-panel);


### PR DESCRIPTION
## 概要

ウィジェットカラムの縦スクロール不具合を修正したパッチリリース。

## 変更点

- `fix`: ウィジェットカラムを縦スクロール可能にする (#652)
  - `.widgetItem` が flex column 内でデフォルト `flex-shrink: 1` のままだったため、ウィジェットが増えるとカラムがスクロールせず各アイテムが縦に圧縮され、`overflow: hidden` で本体が見切れていた。`flex-shrink: 0` を指定し、各ウィジェットが本来の高さを保ったまま `.widgetColumnBody` (`overflow-y: auto`) がスクロールするようにした。
- `chore`: bump version to 1.3.2 / regenerate openapi.json for 1.3.2

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)