### PR TITLE
Release v1.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.2"
+version = "1.3.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.2"
+    "version": "1.3.3"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -295,6 +295,15 @@ const isOwnNote = computed(() => {
   return account?.userId === effectiveNote.value.user.id
 })
 
+// リノート可否（Misskey WebUI と同じ判定）
+// public/home は誰でも可、followers は自分のノートのみ、specified は不可
+const canRenote = computed(() => {
+  const v = effectiveNote.value.visibility
+  return (
+    v === 'public' || v === 'home' || (v === 'followers' && isOwnNote.value)
+  )
+})
+
 // User hover popup
 const userPopup = useHoverPopup()
 const popupTheme = ref<Record<string, string>>({})
@@ -817,11 +826,14 @@ function handlePickerReaction(reaction: string) {
               {{ effectiveNote.repliesCount }}
             </span>
           </button>
-          <button :class="[$style.footerButton, $style.renoteButton, { [$style.renoted]: isRenoted, [$style.footerDisabled]: isGuest }]" :disabled="isGuest" @click.stop="canInteract ? openRenoteMenu($event) : showLoginPrompt()">
+          <button v-if="canRenote" :class="[$style.footerButton, $style.renoteButton, { [$style.renoted]: isRenoted, [$style.footerDisabled]: isGuest }]" :disabled="isGuest" @click.stop="canInteract ? openRenoteMenu($event) : showLoginPrompt()">
             <i class="ti ti-repeat" />
             <span v-if="effectiveNote.renoteCount > 0" :class="$style.buttonCount">
               {{ effectiveNote.renoteCount }}
             </span>
+          </button>
+          <button v-else :class="[$style.footerButton, $style.renoteButton, $style.footerDisabled]" disabled>
+            <i class="ti ti-ban" />
           </button>
           <button
             :class="[$style.footerButton, $style.reactionButton, { [$style.footerDisabled]: isGuest }]"

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -670,6 +670,7 @@ function onKeydown(e: KeyboardEvent) {
               <span :class="$style.postingDots">...</span>
             </template>
             <template v-else>
+              {{ editNote ? '編集' : replyTo ? '返信' : renoteId ? '引用' : scheduledAt ? '予約' : 'ノート' }}
               <svg viewBox="0 0 24 24" width="16" height="16" :class="$style.submitIcon">
                 <template v-if="editNote">
                   <path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
@@ -684,7 +685,6 @@ function onKeydown(e: KeyboardEvent) {
                   <path d="M22 2L11 13M22 2l-7 20-4-9-9-4z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
                 </template>
               </svg>
-              {{ editNote ? '編集' : replyTo ? '返信' : renoteId ? '引用' : scheduledAt ? '予約' : 'ノート' }}
             </template>
           </button>
         </div>

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -2,7 +2,7 @@
 import { getTauriVersion } from '@tauri-apps/api/app'
 import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, onMounted, ref, shallowRef } from 'vue'
-import type { HealthReport, Status } from '@/bindings'
+import type { Check, HealthReport, Status } from '@/bindings'
 import { useUpdater } from '@/composables/useUpdater'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
@@ -25,6 +25,16 @@ const STATUS_ICON: Record<Status, string> = {
   ok: 'ti ti-circle-check',
   warn: 'ti ti-alert-triangle',
   fail: 'ti ti-circle-x',
+}
+
+const STATUS_SYM: Record<Status, string> = {
+  ok: '[OK]  ',
+  warn: '[WARN]',
+  fail: '[FAIL]',
+}
+
+function formatCheck(c: Check): string {
+  return `${STATUS_SYM[c.status]} ${c.account ? `${c.account} ` : ''}${c.name}: ${c.message}${c.fix ? ` (→ ${c.fix})` : ''}`
 }
 
 const overallStatus = computed<Status>(() => {
@@ -50,12 +60,6 @@ const healthSummary = computed(() => {
   return '正常'
 })
 
-function fmtBytes(n: number): string {
-  if (n < 1024) return `${n} B`
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
-  return `${(n / 1024 / 1024).toFixed(1)} MB`
-}
-
 async function runHealthcheck() {
   if (healthLoading.value) return
   healthLoading.value = true
@@ -69,24 +73,11 @@ async function runHealthcheck() {
   }
 }
 
-// 診断結果をデバッグログ体裁に整形 (UI のコードブロック・コピー・バグ報告で共用)。
-const diagnosticsLog = computed<string>(() => {
-  const r = health.value
-  if (!r) return ''
-  const sym = (s: Status) =>
-    s === 'ok' ? '[OK]  ' : s === 'warn' ? '[WARN]' : '[FAIL]'
-  const lines = r.doctor.checks.map(
-    (c) =>
-      `${sym(c.status)} ${c.account ? `${c.account} ` : ''}${c.name}: ${c.message}${c.fix ? ` (→ ${c.fix})` : ''}`,
-  )
-  lines.push(`backendReady: ${r.backendReady}`)
-  lines.push(`cache: ${r.noteCacheCount} notes / ${fmtBytes(r.dbSizeBytes)}`)
-  lines.push(
-    `heartbeat: ${r.heartbeatIntervalMinutes != null ? `${r.heartbeatIntervalMinutes}min` : 'off'}`,
-  )
-  if (r.logDir) lines.push(`logDir: ${r.logDir}`)
-  return lines.join('\n')
-})
+// 問題のある行だけをデバッグログ体裁に整形 (UI 表示・コピー・バグ報告で共用)。
+// 正常時は空文字なのでブロックも本文の診断セクションも出ない。
+const diagnosticsLog = computed<string>(() =>
+  problemChecks.value.map(formatCheck).join('\n'),
+)
 const {
   isChecking,
   isUpToDate,
@@ -196,7 +187,7 @@ function reportBug() {
         </button>
       </div>
       <div v-if="healthError" :class="$style.diagError">{{ healthError }}</div>
-      <!-- 診断ログを log 言語としてシンタックスハイライト (エディタ系ウィンドウと同じ見た目) -->
+      <!-- 問題のある行だけを log 言語でシンタックスハイライト (正常時は非表示) -->
       <div
         v-else-if="diagnosticsLog"
         :key="`diag-${highlighterLoaded}`"


### PR DESCRIPTION
## Changes

- fix: 鍵ノートのリノートボタンを禁止アイコンにする (#655)
- fix: 診断ログを問題のある行だけ表示する (#656)
- chore: Misskey WebUI に合わせてテキストとマークの位置を入れ替え (#654)

## Checklist

- [x] バージョン同期 (package.json / Cargo.toml / tauri.conf.json)
- [x] openapi.json 再生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)