### PR TITLE
Release v1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.3",
+  "version": "1.3.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.3"
+version = "1.3.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.3"
+version = "1.3.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.3"
+    "version": "1.3.4"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -58,6 +58,9 @@ function accept() {
 function cancel() {
   resolve({ accepted: false, remember: false })
 }
+function resolveAction(value: string) {
+  resolve({ accepted: true, remember: false, action: value })
+}
 
 useNativeDialog(dialogRef, visible, {
   get initialFocus() {
@@ -125,16 +128,29 @@ useNativeDialog(dialogRef, visible, {
           <span>{{ options.rememberLabel }}</span>
         </label>
         <div :class="$style.actions">
-          <button v-if="!options.hideCancel" class="_button" :class="$style.btnCancel" @click="cancel">
-            {{ options.cancelLabel || 'キャンセル' }}
-          </button>
-          <button
-            class="_button"
-            :class="options.type === 'danger' ? $style.btnDanger : $style.btnOk"
-            @click="accept"
-          >
-            {{ options.okLabel || 'OK' }}
-          </button>
+          <template v-if="options.actions">
+            <button
+              v-for="action in options.actions"
+              :key="action.value"
+              class="_button"
+              :class="action.primary ? (options.type === 'danger' ? $style.btnDanger : $style.btnOk) : $style.btnCancel"
+              @click="resolveAction(action.value)"
+            >
+              {{ action.label }}
+            </button>
+          </template>
+          <template v-else>
+            <button v-if="!options.hideCancel" class="_button" :class="$style.btnCancel" @click="cancel">
+              {{ options.cancelLabel || 'キャンセル' }}
+            </button>
+            <button
+              class="_button"
+              :class="options.type === 'danger' ? $style.btnDanger : $style.btnOk"
+              @click="accept"
+            >
+              {{ options.okLabel || 'OK' }}
+            </button>
+          </template>
         </div>
       </div>
     </dialog>

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -134,7 +134,7 @@ useNativeDialog(dialogRef, visible, {
               :key="action.value"
               class="_button"
               :class="action.primary ? (options.type === 'danger' ? $style.btnDanger : $style.btnOk) : $style.btnCancel"
-              @click="resolveAction(action.value)"
+              @click="action.cancel ? cancel() : resolveAction(action.value)"
             >
               {{ action.label }}
             </button>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -39,6 +39,7 @@ import MkPoll from './MkPoll.vue'
 import NoteMoreMenu from './NoteMoreMenu.vue'
 import NoteReactionPickerPopup from './NoteReactionPickerPopup.vue'
 import NoteReactionUsersPopup from './NoteReactionUsersPopup.vue'
+import RenoteMoreMenu from './RenoteMoreMenu.vue'
 
 const MkUserPopup = defineAsyncComponent(() => import('./MkUserPopup.vue'))
 const MkUrlPreview = defineAsyncComponent(() => import('./MkUrlPreview.vue'))
@@ -109,6 +110,7 @@ const { canInteract, isGuest } = useAccountMode(() => props.note._accountId)
 const { spawn: spawnRipple } = useRippleEffect()
 
 const moreMenuRef = ref<InstanceType<typeof NoteMoreMenu> | null>(null)
+const renoteMoreMenuRef = ref<InstanceType<typeof RenoteMoreMenu> | null>(null)
 const reactionPickerRef = ref<InstanceType<
   typeof NoteReactionPickerPopup
 > | null>(null)
@@ -489,6 +491,28 @@ const mentionPopupPortalRef = useTemplateRef<HTMLElement>(
 )
 usePortal(mentionPopupPortalRef)
 
+const renoteUserPopup = useHoverPopup()
+
+function onRenoteUserMouseEnter(e: MouseEvent) {
+  const el = e.currentTarget as HTMLElement
+  const rect = el.getBoundingClientRect()
+  popupTheme.value = extractColumnThemeVars(el)
+  renoteUserPopup.show({ x: rect.right + 8, y: rect.top })
+}
+
+function onRenoteUserMouseLeave() {
+  renoteUserPopup.hide()
+}
+
+function closeRenoteUserPopup() {
+  renoteUserPopup.forceClose()
+}
+
+const renoteUserPopupPortalRef = useTemplateRef<HTMLElement>(
+  'renoteUserPopupPortalRef',
+)
+usePortal(renoteUserPopupPortalRef)
+
 function handleReactionClick(e: MouseEvent, reaction: string) {
   if (longPressed.value) return
   if (!canInteract.value) {
@@ -555,7 +579,12 @@ function handlePickerReaction(reaction: string) {
         height="28"
         decoding="async"
       />
-      <span :class="$style.renoteUser">
+      <span
+        :class="$style.renoteUser"
+        @click.stop="navigateToUser(note.user.id, $event)"
+        @mouseenter="onRenoteUserMouseEnter"
+        @mouseleave="onRenoteUserMouseLeave"
+      >
         <MkMfm
           v-if="note.user.name"
           :text="note.user.name"
@@ -565,7 +594,10 @@ function handlePickerReaction(reaction: string) {
         />
         <template v-else>{{ note.user.username }}</template>
       </span>
-      <span :class="$style.renoteLabel">リノート</span>
+      <span :class="$style.renoteLabel">がリノート</span>
+      <button :class="$style.renoteMoreButton" @click.stop="renoteMoreMenuRef?.open($event)">
+        <i class="ti ti-dots" />
+      </button>
       <span :class="$style.renoteTime">{{ formatTime(note.createdAt) }}</span>
     </div>
 
@@ -904,6 +936,17 @@ function handlePickerReaction(reaction: string) {
     />
   </div>
 
+  <div v-if="renoteUserPopup.isVisible.value && isPureRenote" ref="renoteUserPopupPortalRef">
+    <MkUserPopup
+      :user-id="note.user.id"
+      :account-id="note._accountId"
+      :x="renoteUserPopup.position.value.x"
+      :y="renoteUserPopup.position.value.y"
+      :theme-vars="popupTheme"
+      @close="closeRenoteUserPopup"
+    />
+  </div>
+
   <NoteReactionUsersPopup
     ref="reactionUsersRef"
     :note-id="effectiveNote.id"
@@ -932,6 +975,13 @@ function handlePickerReaction(reaction: string) {
     @bookmark="emit('bookmark', $event)"
     @pin="emit('pin', $event)"
     @delete-and-edit="emit('deleteAndEdit', $event)"
+  />
+
+  <RenoteMoreMenu
+    v-if="isPureRenote"
+    ref="renoteMoreMenuRef"
+    :note="note"
+    @delete="emit('delete', $event)"
   />
 
   <NoteReactionPickerPopup
@@ -1115,6 +1165,11 @@ function handlePickerReaction(reaction: string) {
 
 .renoteUser {
   font-weight: bold;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 
   :deep(.custom-emoji) {
     height: 1.2em;
@@ -1127,8 +1182,27 @@ function handlePickerReaction(reaction: string) {
 }
 
 .renoteTime {
-  margin-left: auto;
   opacity: 0.6;
+}
+
+.renoteMoreButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 4px;
+  margin-left: auto;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+  transition: opacity var(--nd-duration-base), background var(--nd-duration-base);
+
+  &:hover {
+    background: color-mix(in srgb, currentColor 12%, transparent);
+    opacity: 1;
+  }
 }
 
 /* Main article layout */

--- a/src/components/common/RenoteMoreMenu.vue
+++ b/src/components/common/RenoteMoreMenu.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { NormalizedNote } from '@/adapters/types'
+import { useAccountMode } from '@/composables/useAccountMode'
+import { showLoginPrompt } from '@/composables/useLoginPrompt'
+import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
+import { useNavigation } from '@/composables/useNavigation'
+import { useAccountsStore } from '@/stores/accounts'
+import { useToast } from '@/stores/toast'
+import { AppError } from '@/utils/errors'
+import { commands, unwrap } from '@/utils/tauriInvoke'
+import PopupMenu from './PopupMenu.vue'
+
+const props = defineProps<{
+  note: NormalizedNote
+}>()
+
+const emit = defineEmits<{
+  delete: [note: NormalizedNote]
+}>()
+
+const { getOrCreate } = useMultiAccountAdapters()
+const toast = useToast()
+const accountsStore = useAccountsStore()
+const { canInteract, isGuest } = useAccountMode(() => props.note._accountId)
+const { navigateToNote } = useNavigation()
+
+const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
+const showDeleteConfirm = ref(false)
+const showReportForm = ref(false)
+const reportComment = ref('')
+
+type MenuView = 'main' | 'deleteConfirm' | 'reportForm'
+
+const currentView = computed<MenuView>(() => {
+  if (showDeleteConfirm.value) return 'deleteConfirm'
+  if (showReportForm.value) return 'reportForm'
+  return 'main'
+})
+
+const isMyRenote = computed(() => {
+  const account = accountsStore.accountMap.get(props.note._accountId)
+  return account?.userId === props.note.user.id
+})
+
+const noteWebUrl = computed(() => {
+  const n = props.note
+  return n.url ?? n.uri ?? `https://${n._serverHost}/notes/${n.id}`
+})
+
+function open(e: MouseEvent) {
+  popupMenuRef.value?.open(e)
+}
+
+function close() {
+  popupMenuRef.value?.close()
+}
+
+function resetSubViews() {
+  showDeleteConfirm.value = false
+  showReportForm.value = false
+  reportComment.value = ''
+}
+
+function backToMain() {
+  resetSubViews()
+}
+
+function openRenoteDetail() {
+  navigateToNote(props.note._accountId, props.note.id)
+  close()
+}
+
+async function copyAndClose(text: string) {
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.style.cssText = 'position:fixed;opacity:0'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    document.body.removeChild(ta)
+  }
+  close()
+}
+
+async function deleteRenote() {
+  try {
+    unwrap(await commands.apiDeleteNote(props.note._accountId, props.note.id))
+    emit('delete', props.note)
+    close()
+  } catch (e) {
+    const err = AppError.from(e)
+    toast.show(`削除に失敗しました（${err.displayCode}）`, 'error')
+  }
+}
+
+async function submitReport() {
+  if (!reportComment.value.trim()) return
+  try {
+    const adapter = await getOrCreate(props.note._accountId)
+    if (!adapter) return
+    await adapter.api.reportUser(props.note.user.id, reportComment.value)
+    toast.show('通報しました')
+    close()
+  } catch (e) {
+    const err = AppError.from(e)
+    toast.show(`通報に失敗しました（${err.displayCode}）`, 'error')
+  }
+}
+
+defineExpose({ open })
+</script>
+
+<template>
+  <PopupMenu ref="popupMenuRef" @close="resetSubViews">
+    <!-- Delete confirm -->
+    <template v-if="currentView === 'deleteConfirm'">
+      <div class="_popupConfirmText">このリノートを削除しますか？</div>
+      <button class="_popupItem _popupItemDanger" @click="deleteRenote">
+        <i class="ti ti-trash" />
+        削除
+      </button>
+      <button class="_popupItem" @click="backToMain">
+        <i class="ti ti-x" />
+        キャンセル
+      </button>
+    </template>
+
+    <!-- Report form -->
+    <template v-else-if="currentView === 'reportForm'">
+      <div class="_popupConfirmText">@{{ note.user.username }} を通報</div>
+      <div class="_popupReportInputWrap">
+        <textarea
+          v-model="reportComment"
+          class="_popupReportInput"
+          placeholder="通報理由を入力..."
+          rows="3"
+        />
+      </div>
+      <button
+        class="_popupItem _popupItemDanger"
+        :disabled="!reportComment.trim()"
+        @click="submitReport"
+      >
+        <i class="ti ti-alert-triangle" />
+        送信
+      </button>
+      <button class="_popupItem" @click="backToMain">
+        <i class="ti ti-x" />
+        キャンセル
+      </button>
+    </template>
+
+    <!-- Main menu -->
+    <template v-else>
+      <button class="_popupItem" @click="openRenoteDetail">
+        <i class="ti ti-info-circle" />
+        リノートの詳細
+      </button>
+      <button class="_popupItem" @click="copyAndClose(noteWebUrl)">
+        <i class="ti ti-link" />
+        リノートのリンクをコピー
+      </button>
+      <div class="_popupDivider" />
+      <button v-if="isMyRenote" class="_popupItem _popupItemDanger" @click="showDeleteConfirm = true">
+        <i class="ti ti-trash" />
+        リノート削除
+      </button>
+      <button v-else-if="!isGuest" class="_popupItem _popupItemDanger" @click="canInteract ? (showReportForm = true) : (showLoginPrompt(), close())">
+        <i class="ti ti-alert-triangle" />
+        リノートを通報
+      </button>
+    </template>
+  </PopupMenu>
+</template>

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -283,17 +283,20 @@ export function usePostFormState(
       const textToCheck =
         showCw.value && cw.value?.trim() ? cw.value : (text.value ?? '')
       if (isAnnoying(textToCheck)) {
-        const { confirm } = useConfirm()
-        const ok = await confirm({
+        const { confirmWithAction } = useConfirm()
+        const result = await confirmWithAction({
           title: 'この投稿は迷惑になる可能性があります',
-          message:
-            'テキストの拡大や位置指定の MFM が含まれています。公開範囲をホームに変更して投稿しますか？',
+          message: 'テキストの拡大や位置指定の MFM が含まれています。',
           type: 'warning',
-          okLabel: 'ホームに投稿',
-          cancelLabel: 'やめる',
+          actions: [
+            { value: 'home', label: 'ホームに投稿', primary: true },
+            { value: 'cancel', label: 'やめる' },
+            { value: 'ignore', label: 'このまま投稿' },
+          ],
         })
-        if (!ok) return
-        visibility.value = 'home'
+        if (!result || result === 'cancel') return
+        if (result === 'home') visibility.value = 'home'
+        // result === 'ignore' → そのまま public で投稿
       }
     }
 

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -28,6 +28,7 @@ import {
   saveMemo,
 } from '@/composables/useMemos'
 import { useAccountsStore } from '@/stores/accounts'
+import { useConfirm } from '@/stores/confirm'
 import { useSettingsStore } from '@/stores/settings'
 import { useThemeStore } from '@/stores/theme'
 import { useToast } from '@/stores/toast'
@@ -37,6 +38,16 @@ import {
 } from '@/utils/customTimelines'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+
+function isAnnoying(text: string): boolean {
+  return (
+    text.includes('$[x2') ||
+    text.includes('$[x3') ||
+    text.includes('$[x4') ||
+    text.includes('$[scale') ||
+    text.includes('$[position')
+  )
+}
 
 export function usePostFormState(
   props: {
@@ -266,6 +277,25 @@ export function usePostFormState(
     }
 
     if (!adapter || !canPost.value) return
+
+    // 迷惑投稿チェック: public かつ MFM 拡大/位置指定を含む場合に警告
+    if (!props.editNote && visibility.value === 'public') {
+      const textToCheck =
+        showCw.value && cw.value?.trim() ? cw.value : (text.value ?? '')
+      if (isAnnoying(textToCheck)) {
+        const { confirm } = useConfirm()
+        const ok = await confirm({
+          title: 'この投稿は迷惑になる可能性があります',
+          message:
+            'テキストの拡大や位置指定の MFM が含まれています。公開範囲をホームに変更して投稿しますか？',
+          type: 'warning',
+          okLabel: 'ホームに投稿',
+          cancelLabel: 'やめる',
+        })
+        if (!ok) return
+        visibility.value = 'home'
+      }
+    }
 
     isPosting.value = true
     error.value = null

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -290,11 +290,11 @@ export function usePostFormState(
           type: 'warning',
           actions: [
             { value: 'home', label: 'ホームに投稿', primary: true },
-            { value: 'cancel', label: 'やめる' },
+            { value: 'cancel', label: 'やめる', cancel: true },
             { value: 'ignore', label: 'このまま投稿' },
           ],
         })
-        if (!result || result === 'cancel') return
+        if (!result) return
         if (result === 'home') visibility.value = 'home'
         // result === 'ignore' → そのまま public で投稿
       }

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -18,6 +18,12 @@ export type ConfirmIcon =
   | 'waiting'
   | 'none'
 
+export interface ConfirmAction {
+  value: string
+  label: string
+  primary?: boolean
+}
+
 export interface ConfirmOptions {
   title: string
   message: string
@@ -26,6 +32,8 @@ export interface ConfirmOptions {
   type?: ConfirmType
   icon?: ConfirmIcon
   hideCancel?: boolean
+  /** 指定した場合、OK/Cancel の代わりにこの配列のボタンを表示する。 */
+  actions?: ConfirmAction[]
   /**
    * `message` に続けて表示するコードブロック (JSON / AiScript / markdown 等)。
    * 指定された場合 AppConfirm が `<pre>` でシンタックスハイライト表示する。
@@ -65,10 +73,12 @@ export interface ConfirmOptions {
 /**
  * 確認ダイアログの結果。`accepted` が OK 押下、`remember` は `rememberLabel`
  * 付きダイアログでチェックボックスが ON だったか。
+ * `action` は `actions` 配列を使ったダイアログで押されたボタンの value。
  */
 export interface ConfirmDecision {
   accepted: boolean
   remember: boolean
+  action?: string
 }
 
 const visible = ref(false)
@@ -99,11 +109,26 @@ export function useConfirm() {
     })
   }
 
+  /**
+   * `actions` 配列を持つダイアログを出し、押されたボタンの value を返す。
+   * キャンセル（ESC / ダイアログ外クリック）は null を返す。
+   */
+  function confirmWithAction(opts: ConfirmOptions): Promise<string | null> {
+    return confirmWithDecision(opts).then((d) => d.action ?? null)
+  }
+
   function resolve(decision: ConfirmDecision) {
     visible.value = false
     resolvePromise?.(decision)
     resolvePromise = null
   }
 
-  return { visible, options, confirm, confirmWithDecision, resolve }
+  return {
+    visible,
+    options,
+    confirm,
+    confirmWithDecision,
+    confirmWithAction,
+    resolve,
+  }
 }

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -22,6 +22,8 @@ export interface ConfirmAction {
   value: string
   label: string
   primary?: boolean
+  /** true のとき、このボタンはキャンセル扱い（confirmWithAction は null を返す）。 */
+  cancel?: boolean
 }
 
 export interface ConfirmOptions {


### PR DESCRIPTION
## Changes

- feat: リノートバーに「...」メニューとユーザーインタラクションを追加
- feat: 迷惑になる可能性がある投稿への警告を追加 (#657)
- feat: 迷惑投稿警告ダイアログを3択対応に拡張 (#657)
- refactor: confirmWithAction のキャンセル統一 — cancel フラグ導入

## Test plan

- [ ] CI (lint, typecheck, test, openapi_snapshot) が通ることを確認
- [ ] マージ後 `git tag -s v1.3.4 -m "Release v1.3.4"` → `git push origin v1.3.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)