### PR TITLE
Release v1.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.4"
+version = "1.3.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.4"
+version = "1.3.5"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.4"
+    "version": "1.3.5"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -104,7 +104,7 @@ pub async fn api_get_user_achievements(
     user_id: String,
 ) -> Result<serde_json::Value> {
     let (db, client) = app_state.ready().await;
-    let (host, token) = get_credentials(&db, &account_id)?;
+    let (host, token) = get_credentials_or_anon(&db, &account_id)?;
     client
         .get_user_achievements(&host, &token, &user_id)
         .await

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/EditorTabs.vue
+++ b/src/components/common/EditorTabs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useTemplateRef } from 'vue'
+import { useSwipeTab } from '@/composables/useSwipeTab'
 
 export interface EditorTabDef {
   value: string
@@ -7,7 +8,7 @@ export interface EditorTabDef {
   label: string
 }
 
-defineProps<{
+const props = defineProps<{
   tabs: EditorTabDef[]
   modelValue: string
 }>()
@@ -18,10 +19,35 @@ const emit = defineEmits<{
 
 const tabsEl = useTemplateRef<HTMLDivElement>('tabsEl')
 
+function next(): boolean {
+  const idx = props.tabs.findIndex((t) => t.value === props.modelValue)
+  const n = props.tabs[idx + 1]
+  if (n) {
+    emit('update:modelValue', n.value)
+    return true
+  }
+  return false
+}
+
+function prev(): boolean {
+  const idx = props.tabs.findIndex((t) => t.value === props.modelValue)
+  const p = props.tabs[idx - 1]
+  if (p) {
+    emit('update:modelValue', p.value)
+    return true
+  }
+  return false
+}
+
+// 横スクロール / Shift+wheel → タブ切り替え
+useSwipeTab(tabsEl, next, prev, { checkHorizontalScroll: false })
+
+// 縦スクロール → タブバーの横スクロール変換
 function onWheel(e: WheelEvent) {
+  if (e.deltaX !== 0) return // useSwipeTab が処理する
   const el = tabsEl.value
   if (!el) return
-  el.scrollLeft += e.deltaY + e.deltaX
+  el.scrollLeft += e.deltaY
 }
 </script>
 

--- a/src/components/common/EditorTabs.vue
+++ b/src/components/common/EditorTabs.vue
@@ -27,7 +27,7 @@ const emit = defineEmits<{
       @click="emit('update:modelValue', t.value)"
     >
       <i :class="'ti ti-' + t.icon" />
-      <span v-if="modelValue === t.value" :class="$style.label">{{ t.label }}</span>
+      <span :class="$style.label">{{ t.label }}</span>
     </button>
   </div>
 </template>

--- a/src/components/common/EditorTabs.vue
+++ b/src/components/common/EditorTabs.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useTemplateRef } from 'vue'
+
 export interface EditorTabDef {
   value: string
   icon: string
@@ -13,10 +15,18 @@ defineProps<{
 const emit = defineEmits<{
   'update:modelValue': [value: string]
 }>()
+
+const tabsEl = useTemplateRef<HTMLDivElement>('tabsEl')
+
+function onWheel(e: WheelEvent) {
+  const el = tabsEl.value
+  if (!el) return
+  el.scrollLeft += e.deltaY + e.deltaX
+}
 </script>
 
 <template>
-  <div :class="$style.tabs">
+  <div ref="tabsEl" :class="$style.tabs" @wheel.prevent="onWheel">
     <button
       v-for="t in tabs"
       :key="t.value"
@@ -38,6 +48,12 @@ const emit = defineEmits<{
   gap: 0;
   border-bottom: 1px solid var(--nd-divider);
   flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .tab {
@@ -50,6 +66,7 @@ const emit = defineEmits<{
   color: var(--nd-fg);
   opacity: 0.5;
   border-bottom: 2px solid transparent;
+  flex-shrink: 0;
   transition: opacity var(--nd-duration-base), border-color var(--nd-duration-base);
 
   &:hover {

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -1550,6 +1550,10 @@ function onKeydown(e: KeyboardEvent) {
   &.mine {
     flex-direction: row-reverse;
 
+    .chatBubbleWrapper {
+      flex-direction: row-reverse;
+    }
+
     .chatBubble {
       background: var(--nd-accentedBg, rgba(134, 179, 0, 0.15));
       border-bottom-right-radius: 4px;

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -243,14 +243,15 @@ function reportBug() {
 }
 
 .aboutLogo {
-  width: 64px;
-  height: 64px;
+  width: 48px;
+  height: 48px;
+  border-radius: 10px;
 }
 
 .aboutTitle {
-  font-size: 1.2em;
-  font-weight: bold;
+  font-size: 0.85em;
   color: var(--nd-fg);
+  opacity: 0.7;
 }
 
 .aboutInfo {

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -48,12 +48,9 @@ const tabOptions = computed<readonly ('config' | 'code' | 'logs')[]>(() => {
   if (isNewInstall.value) {
     return ['code']
   }
-  const tabs: ('config' | 'code' | 'logs')[] = ['code']
+  const tabs: ('config' | 'code' | 'logs')[] = ['code', 'logs']
   if (plugin.value?.config && Object.keys(plugin.value.config).length > 0) {
     tabs.unshift('config')
-  }
-  if (pluginLogs.value.length > 0) {
-    tabs.push('logs')
   }
   return tabs
 })
@@ -92,7 +89,7 @@ const tabDefs = computed(() => {
       defs.push({
         value: 'logs',
         icon: 'list',
-        label: `ログ (${pluginLogs.value.length})`,
+        label: 'ログ',
       })
   }
   return defs

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -44,9 +44,9 @@ const pluginLogs = computed(() =>
 const isNewInstall = computed(() => !plugin.value)
 
 // --- Tabs ---
-const tabOptions = computed(() => {
+const tabOptions = computed<readonly ('config' | 'code' | 'logs')[]>(() => {
   if (isNewInstall.value) {
-    return ['code'] as const
+    return ['code']
   }
   const tabs: ('config' | 'code' | 'logs')[] = ['code']
   if (plugin.value?.config && Object.keys(plugin.value.config).length > 0) {
@@ -67,7 +67,7 @@ const defaultTab = computed(() => {
 })
 
 const { tab, containerRef: editorRef } = useEditorTabs(
-  ['config', 'code', 'logs'] as const,
+  tabOptions,
   (defaultTab.value as 'config' | 'code' | 'logs') ?? 'code',
 )
 

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -1747,18 +1747,17 @@ async function handlePosted(editedNoteId?: string) {
           <div v-if="isLoadingReactions" :class="$style.stateMessage">
             <LoadingSpinner />
           </div>
-          <div
+          <ColumnEmptyState
             v-else-if="reactionsError"
-            :class="[$style.stateMessage, $style.stateError]"
-          >
-            {{ reactionsError }}
-          </div>
-          <div
+            :message="reactionsError"
+            is-error
+            :image-url="serverErrorImageUrl"
+          />
+          <ColumnEmptyState
             v-else-if="reactionEntries.length === 0"
-            :class="$style.stateMessage"
-          >
-            リアクションはありません
-          </div>
+            message="リアクションはありません"
+            :image-url="serverInfoImageUrl"
+          />
         </div>
 
         <div v-show="topTab === 'pages'" :class="$style.pagesPane">

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -64,7 +64,7 @@ export const WINDOW_SIZES: Record<
   'note-detail': { width: 500, maxHeight: 600 },
   'note-inspector': { width: 620, maxHeight: 720 },
   'notification-inspector': { width: 620, maxHeight: 720 },
-  'user-profile': { width: 500, maxHeight: 650 },
+  'user-profile': { width: 800, maxHeight: 650 },
   'federation-instance': { width: 500, maxHeight: 650 },
   'follow-list': { width: 500, maxHeight: 650 },
   aiSettings: { width: 400, maxHeight: 700 },

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -77,8 +77,8 @@ export const WINDOW_SIZES: Record<
   profileEditor: { width: 400, maxHeight: 700 },
   // Login
   login: { width: 380, maxHeight: 480 },
-  // About — 診断ログのコードブロックとアクションボタンが収まる高さ
-  about: { width: 460, maxHeight: 640 },
+  // About — コードブロックは内部スクロールのため小さめで収まる
+  about: { width: 380, maxHeight: 520 },
   // Nav editor
   navEditor: { width: 400, maxHeight: 700 },
   // Performance editor


### PR DESCRIPTION
## Changes

- feat: リアクションタブの空状態に ColumnEmptyState を適用
- feat: プラグイン編集ウィンドウのログタブを常時表示
- feat: EditorTabs に横スクロール/Shift+wheel によるタブ切り替えを追加
- feat: EditorTabs にマウスホイール対応の横スクロールを追加
- feat: EditorTabs の全タブラベルを常時表示
- fix: 実績タブをアクセストークンなしでも取得可能にする
- fix: プラグイン編集ウィンドウの横スクロールが非表示のログタブに切り替わるバグを修正
- fix: AIカラムの自分メッセージのコピーボタンをバブルの左側に移動
- chore: Aboutウィンドウのサイズとヘッダースタイルをログインウィンドウに統一
- chore: プロフィール詳細ウィンドウのデフォルト幅を 800px に拡大

## Test plan

- [ ] CI（lint, typecheck, test, openapi_snapshot）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)