### PR TITLE
Release v1.3.6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,8 +57,26 @@
           NDK_HOME = "${androidHome}/ndk/27.0.12077973";
           GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidHome}/build-tools/36.0.0/aapt2";
 
+          # WSL2: WebKitGTK EGL workaround (software rendering fallback)
+          WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+          LIBGL_ALWAYS_SOFTWARE = "1";
+
           shellHook = ''
             export PATH="${androidHome}/platform-tools:$PATH"
+            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (desktopDeps ++ (with pkgs; [
+              gdk-pixbuf
+              pango
+              cairo
+              glib
+              atk
+              harfbuzz
+              libsoup_3
+              libx11
+              libxcb
+              libxext
+              libxrender
+              libGL
+            ]))}:$LD_LIBRARY_PATH"
           '';
         };
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.5",
+  "version": "1.3.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -88,11 +88,5 @@
     "vite": "^8.0.0",
     "vitest": "^3.2.1",
     "vue-tsc": "^3.1.5"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "lefthook"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  lefthook: true
+  ttf2woff2: true
+  vue-demi: true

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.5"
+version = "1.3.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.5"
+version = "1.3.6"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.5"
+    "version": "1.3.6"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/EditorTabs.vue
+++ b/src/components/common/EditorTabs.vue
@@ -103,10 +103,15 @@ function onWheel(e: WheelEvent) {
     opacity: 1;
     border-bottom-color: var(--nd-accent);
     color: var(--nd-accent);
+
+    .label {
+      display: inline;
+    }
   }
 }
 
 .label {
+  display: none;
   white-space: nowrap;
 }
 </style>

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -1067,26 +1067,28 @@ function onKeydown(e: KeyboardEvent) {
                 {{ session.lastMessagePreview }}
               </div>
             </div>
-            <div :class="$style.rowActions">
-              <button
-                class="_button"
-                :class="$style.rowActionBtn"
-                title="名前を変更"
-                @click="onRenameSession($event, session.id)"
-              >
-                <i class="ti ti-pencil" />
-              </button>
-              <button
-                class="_button"
-                :class="[$style.rowActionBtn, $style.rowActionBtnDanger]"
-                title="削除"
-                @click="onDeleteSession($event, session.id)"
-              >
-                <i class="ti ti-trash" />
-              </button>
-            </div>
-            <div :class="$style.rowTime">
-              {{ relativeTime(session.updatedAt) }}
+            <div :class="$style.rowRight">
+              <div :class="$style.rowTime">
+                {{ relativeTime(session.updatedAt) }}
+              </div>
+              <div :class="$style.rowActions">
+                <button
+                  class="_button"
+                  :class="$style.rowActionBtn"
+                  title="名前を変更"
+                  @click="onRenameSession($event, session.id)"
+                >
+                  <i class="ti ti-pencil" />
+                </button>
+                <button
+                  class="_button"
+                  :class="[$style.rowActionBtn, $style.rowActionBtnDanger]"
+                  title="削除"
+                  @click="onDeleteSession($event, session.id)"
+                >
+                  <i class="ti ti-trash" />
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1474,12 +1476,17 @@ function onKeydown(e: KeyboardEvent) {
   white-space: nowrap;
 }
 
+.rowRight {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  flex-shrink: 0;
+  gap: 2px;
+}
+
 .rowTime {
   font-size: 0.75em;
   opacity: 0.5;
-  flex-shrink: 0;
-  align-self: flex-start;
-  margin-top: 2px;
 }
 
 // スキルカラムの行アクションと同じパターン: hover で出現するインラインボタン群。

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -301,6 +301,11 @@ const {
   maxItems: MAX_PROFILE_NOTES,
   onError: raiseWindowError,
 })
+// ゲスト時は withFiles フィルタが無視されて全ノートが返るため、
+// filesNotes.length === 0 ではなく実際のファイル有無で判定する
+const hasFilesContent = computed(() =>
+  filesNotes.value.some((n) => n.files.length > 0),
+)
 
 // Achievements top-tab
 const achievements = ref<Achievement[]>([])
@@ -1685,9 +1690,11 @@ async function handlePosted(editedNoteId?: string) {
           <div v-if="isLoadingFiles" :class="$style.stateMessage">
             <LoadingSpinner />
           </div>
-          <div v-if="!isLoadingFiles && filesNotes.length === 0" :class="$style.stateMessage">
-            ファイルはありません
-          </div>
+          <ColumnEmptyState
+            v-else-if="!hasFilesContent"
+            message="ファイルはありません"
+            :image-url="serverInfoImageUrl"
+          />
         </div>
 
         <!--

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -64,7 +64,7 @@ export const WINDOW_SIZES: Record<
   'note-detail': { width: 500, maxHeight: 600 },
   'note-inspector': { width: 620, maxHeight: 720 },
   'notification-inspector': { width: 620, maxHeight: 720 },
-  'user-profile': { width: 800, maxHeight: 650 },
+  'user-profile': { width: 620, maxHeight: 650 },
   'federation-instance': { width: 500, maxHeight: 650 },
   'follow-list': { width: 500, maxHeight: 650 },
   aiSettings: { width: 400, maxHeight: 700 },


### PR DESCRIPTION
## Changes

### Fix
- ファイルタブの空状態が表示されない問題を修正 (#661)
- EditorTabs のラベルをアクティブタブのみ表示する (#663)
- AIカラムのセッションアイテムの編集・削除ボタンを日付の下・右端に移動

### Chore
- プロフィール詳細ウィンドウのデフォルト幅を 800px → 620px に縮小
- pnpm v11 の allowBuilds 設定を pnpm-workspace.yaml に移行
- fix dev shell for non-NixOS Linux (WSL2)

## Test plan
- [ ] CI (lint, typecheck, test, openapi_snapshot) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)