### PR TITLE
Release v1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.6",
+  "version": "1.3.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.6"
+version = "1.3.7"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.6"
+version = "1.3.7"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.6"
+    "version": "1.3.7"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -1106,7 +1106,10 @@ function onKeydown(e: KeyboardEvent) {
 .postOverlay {
   position: fixed;
   inset: 0;
-  z-index: var(--nd-z-navbar);
+  /* モーダルオーバーレイ tier。navbar (2000) だとモバイルの全画面ウィンドウ
+     (navbar + 1) より下になり投稿フォームを操作できなくなる (#669)。
+     他のモーダル系オーバーレイと揃えて popup tier に置く。 */
+  z-index: var(--nd-z-popup);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/deck/DeckPlayColumn.vue
+++ b/src/components/deck/DeckPlayColumn.vue
@@ -176,7 +176,9 @@ function scrollToTop() {
   composes: columnScroller from './column-common.module.scss';
 }
 
-.playCard {
+/* Self-nested for specificity 0,2,0 to beat ._button (0,1,0) regardless of
+   CSS chunk load order (padding が 0 に潰れて余白が消える問題, #669)。 */
+.playCard.playCard {
   display: flex;
   width: 100%;
   padding: 12px 14px;

--- a/src/composables/useDeckWindow.ts
+++ b/src/composables/useDeckWindow.ts
@@ -76,10 +76,12 @@ export async function openDeckWindow(
     const win = new WebviewWindow(windowId, {
       url,
       title: 'NoteDeck',
-      width: 900,
-      height: 700,
-      minWidth: 400,
-      minHeight: 400,
+      // Match the main window defaults (tauri.conf.json) so a new window
+      // opens at the same size instead of a smaller one.
+      width: 1200,
+      height: 800,
+      minWidth: 360,
+      minHeight: 640,
       decorations: false,
       resizable: true,
       visible: false,


### PR DESCRIPTION
## Changes since v1.3.6

- fix: 新しいウィンドウのデフォルトサイズをメインウィンドウに揃える (#668)
- fix: モバイルで投稿フォームが Play ウィンドウより下に潜る問題を修正 (#671)
- fix: アカウント設定ドロワーのスクロール領域を修正 (#670)
- fix: Misskey Play カラムのアイテム余白が消える問題を修正 (#669)
- fix: Biome 2.5 の organizeImports に追従
- chore: Rust と Node.js のツールチェーン版を固定

🤖 Generated with [Claude Code](https://claude.com/claude-code)