### PR TITLE
Release v1.3.7 (CI fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,14 @@ jobs:
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_targets }}
+
+      # rust-toolchain.toml が 1.92.0 を pin しているため、dtolnay が stable に
+      # 足した target は実ビルド (1.92.0) に効かない。override 配下で明示追加する。
+      - name: Add Rust targets (macOS universal)
+        if: matrix.rust_targets != ''
+        run: rustup target add ${RUST_TARGETS//,/ }
+        env:
+          RUST_TARGETS: ${{ matrix.rust_targets }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## 概要

v1.3.7 のリリース CI（`release.yml`）が macOS universal ビルドで失敗していたため、その修正を main に取り込む。

## 原因

`rust-toolchain.toml`（#cd38521c, 6/23 追加）で Rust を `1.92.0` に pin した結果、CI の `dtolnay/rust-toolchain@stable` が **stable** に追加した `x86_64-apple-darwin` target が、実ビルドで使われる **1.92.0** ツールチェインに反映されず、`universal-apple-darwin` ビルドが `x86_64-apple-darwin is not installed` で落ちていた。

- 6/20 v1.3.6 は pin 前のため成功
- 6/23 `rust-toolchain.toml` 追加
- 6/24 v1.3.7 失敗

## 修正

`targets:` を dtolnay（stable 用）に渡すのをやめ、`rust-toolchain.toml` の override（=1.92.0）が効いた状態で `rustup target add` する独立ステップを追加。Rust バージョンを workflow 側に二重管理しないため、将来 pin を上げても追従不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)