### PR TITLE
fix: ストア install ボタンの角丸と「Misskeyについて」狭カラム崩れ (#681, #676)

### DIFF
--- a/src/components/deck/DeckAboutMisskeyColumn.vue
+++ b/src/components/deck/DeckAboutMisskeyColumn.vue
@@ -465,7 +465,7 @@ onMounted(() => {
 /* Members */
 .membersGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 8px;
   padding: 0 16px 12px;
 }
@@ -502,7 +502,7 @@ onMounted(() => {
 /* Sponsors */
 .sponsorsGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
   gap: 16px;
   padding: 0 16px 16px;
   align-items: center;

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -774,7 +774,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
   height: 22px;
   font-size: 11px;
   font-weight: 600;
-  border-radius: 2px;
+  border-radius: var(--nd-radius-full);
   background: var(--nd-accent);
   color: var(--nd-fgOnAccent);
   transition: filter 0.1s, opacity 0.1s;

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -341,7 +341,7 @@ const disabled = computed(
   height: 22px;
   font-size: 11px;
   font-weight: 600;
-  border-radius: 2px;
+  border-radius: var(--nd-radius-full);
   background: var(--nd-accent);
   color: var(--nd-fgOnAccent);
   transition:

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -380,7 +380,7 @@ function handlePrimaryClick() {
   height: 22px;
   font-size: 11px;
   font-weight: 600;
-  border-radius: 2px;
+  border-radius: var(--nd-radius-full);
   background: var(--nd-accent);
   color: var(--nd-fgOnAccent);
   transition:


### PR DESCRIPTION
## なぜ

ストア閲覧時の install ボタンが角張っていて Misskey らしくない (#681)、「Misskeyについて」カラムが狭幅でレイアウト崩れ (#676)。第1陣（trivial な UI 修正）として対応。

## 変更

- **#681**: ストアの「インストール」ボタンを pill 状 (`var(--nd-radius-full)`) に統一
  - プラグイン (`PluginCard.vue`) / ウィジェット (`WidgetCard.vue`) / スキル (`DeckSkillColumn.vue`) の 3 種すべて
  - テーマはカードクリックで適用するため install ボタンなし → 対象外
- **#676**: About Misskey カラムの members グリッドを 2 列固定 (`repeat(2, 1fr)`)、sponsors も最小幅を下げて狭カラムで複数列を維持

## 確認

- biome / vue-tsc 通過（pre-commit hook）
- CSS のみの変更

Closes は develop→main の release PR 側で付与する運用のため、ここでは参照のみ: #681 #676