### PR TITLE
feat: cross-account カラムで hasToken 不要のキャッシュ遡りに対応

### DIFF
--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -252,7 +252,14 @@ pub async fn api_get_mentions(
             visibility.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, "mentions") {
+    // ダイレクト（specified）と通常メンションは別カラム・別キャッシュキー。
+    // 同じキーに混ぜると read 側（cacheKey='specified' / 'mentions'）と不整合になる。
+    let cache_key = if visibility.as_deref() == Some("specified") {
+        "specified"
+    } else {
+        "mentions"
+    };
+    if let Err(e) = db.cache_notes(&notes, cache_key) {
         tracing::warn!("[cache] failed to cache mentions: {e}");
     }
     Ok(notes)

--- a/src/components/deck/DeckMentionsColumn.vue
+++ b/src/components/deck/DeckMentionsColumn.vue
@@ -97,6 +97,7 @@ const {
       ? adapter.api.getMentions({ ...opts, visibility: 'specified' })
       : adapter.api.getMentions(opts),
   isCrossAccount: () => isCrossAccount.value,
+  cacheKey: () => config.value.cacheKey,
   isLoading,
   error,
   scroller,

--- a/src/composables/useCrossAccountNotes.ts
+++ b/src/composables/useCrossAccountNotes.ts
@@ -1,6 +1,10 @@
 import { computed, onMounted, type Ref, shallowRef } from 'vue'
 import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
+import {
+  loadCachedTimeline,
+  loadCachedTimelineBefore,
+} from '@/composables/useNoteColumnCache'
 import { useNoteScrollerRef } from '@/composables/useNoteScrollerRef'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useAccountsStore } from '@/stores/accounts'
@@ -19,6 +23,13 @@ export interface CrossAccountNotesOptions {
 
   /** Whether this is cross-account mode */
   isCrossAccount: () => boolean
+
+  /**
+   * Offline cache key (e.g. 'mentions' | 'specified')。指定すると、
+   * ログイン中アカウントが無い（全員ログアウト）場合でも全アカウントの
+   * SQLite キャッシュを読んで表示する。未指定なら従来通り live のみ。
+   */
+  cacheKey?: () => string | null
 
   /** Loading / error / scroller refs from useColumnSetup */
   isLoading: Ref<boolean>
@@ -81,6 +92,7 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
   const {
     fetchNotes,
     isCrossAccount,
+    cacheKey,
     isLoading,
     error,
     scroller,
@@ -108,10 +120,38 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
     }
   }
 
+  /** 全アカウント（ログアウト済み含む）の SQLite キャッシュを読んで merge する */
+  async function loadCrossAccountCache(): Promise<NormalizedNote[]> {
+    const key = cacheKey?.()
+    if (!key) return []
+    const results = await mapWithConcurrency(
+      accountsStore.accounts,
+      async (acc) => {
+        try {
+          return await loadCachedTimeline(acc.id, key)
+        } catch {
+          return []
+        }
+      },
+      3,
+    )
+    return dedupAsync(collectFulfilled(results))
+  }
+
   async function connectCrossAccount() {
     error.value = null
     isLoading.value = true
+
+    // オフラインファースト: キャッシュを即時表示（ログアウト中のアカウント分も含む）
+    const cached = await loadCrossAccountCache()
+    if (cached.length > 0) rawNotes.value = cached
+
     const accounts = accountsStore.accounts.filter((a) => a.hasToken)
+    // 全アカウントがログアウト中なら live fetch せずキャッシュ表示のみ
+    if (accounts.length === 0) {
+      isLoading.value = false
+      return
+    }
 
     try {
       const results = await mapWithConcurrency(
@@ -124,7 +164,11 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
         3,
       )
 
-      rawNotes.value = await dedupAsync(collectFulfilled(results))
+      // live を優先しつつキャッシュとマージ（dedup は先勝ち）
+      rawNotes.value = await dedupAsync([
+        ...collectFulfilled(results),
+        ...cached,
+      ])
     } catch (e) {
       error.value = AppError.from(e)
     } finally {
@@ -135,19 +179,36 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
   async function loadMoreCrossAccount() {
     if (isLoading.value || rawNotes.value.length === 0) return
     isLoading.value = true
-    const accounts = accountsStore.accounts.filter((a) => a.hasToken)
+    const key = cacheKey?.()
 
     try {
+      // 全アカウントを対象（ログアウト中も含む）。ログイン中は live API で
+      // untilId 遡り、ログアウト中は SQLite キャッシュを createdAt で遡る。
       const results = await mapWithConcurrency(
-        accounts,
+        accountsStore.accounts,
         async (acc) => {
-          const adapter = await multiAdapters.getOrCreate(acc.id)
-          if (!adapter) return []
           const lastForAccount = [...rawNotes.value]
             .reverse()
             .find((n) => n._accountId === acc.id)
-          if (!lastForAccount) return fetchNotes(adapter)
-          return fetchNotes(adapter, { untilId: lastForAccount.id })
+
+          if (acc.hasToken) {
+            const adapter = await multiAdapters.getOrCreate(acc.id)
+            if (!adapter) return []
+            if (!lastForAccount) return fetchNotes(adapter)
+            return fetchNotes(adapter, { untilId: lastForAccount.id })
+          }
+
+          // ログアウト中: hasToken 不要でキャッシュを遡る
+          if (!key || !lastForAccount) return []
+          try {
+            return await loadCachedTimelineBefore(
+              acc.id,
+              key,
+              lastForAccount.createdAt,
+            )
+          } catch {
+            return []
+          }
         },
         3,
       )


### PR DESCRIPTION
Refs #665, #666

> develop base のため `Closes` は発火しない。実クローズは develop→main の release PR 側で `Closes #665 #666` を入れる。

## なぜ

ログアウト中のアカウントを含む cross-account カラム（mentions / specified）には、これまでオフラインキャッシュ対応が**一切なかった**。全員ログアウト中だと、即時表示も過去ノートの遡りもできず何も見えなかった（#665 / #666）。本 PR でこの 2 つをまとめて導入する。

## 変更内容

- **`connectCrossAccount`**: 全アカウントの SQLite キャッシュを読んで即時表示。全員ログアウト中でも live fetch なしでキャッシュを表示する（オフラインファースト・**新規**）
- **`loadMoreCrossAccount`**: 全アカウントを対象にし、アカウント単位で分岐
  - ログイン中 (`hasToken`): 従来通り live API の `untilId` で遡る
  - ログアウト中: `loadCachedTimelineBefore` で `createdAt` カーソルにより遡る（**`hasToken` 不要・新規**）。`useNoteColumn.ts` の `loadMoreFromCache` と同じパターン
- **`api_get_mentions` (Rust)**: `visibility=specified` は `"specified"` キーでキャッシュし、通常メンション `"mentions"` と read 側 (`cacheKey`) を一致させる。混在による不整合を防ぐ（#666 の直接原因）
- **`DeckMentionsColumn`**: `cacheKey: () => config.value.cacheKey` を渡し mentions / specified 両カラムで機能

## 確認

- 動作確認済み（実機）
- pre-commit hook (biome / typecheck / bindings-snapshot / openapi-snapshot) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)