### PR TITLE
Release v1.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.8",
+  "version": "1.3.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.8"
+version = "1.3.9"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.8"
+version = "1.3.9"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.8"
+    "version": "1.3.9"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.3.9

1.3.8 リリース時に version bump コミットが main へのマージに含まれず、main が 1.3.8 のままになっていたのを追いかけて修正するリリース。

### 変更点
- feat: お気に入りカラムをログアウト中も追加可能に (#684)
- feat: 通知/メンション/ダイレクトカラムをログアウト中も追加可能に
- feat: cross-account カラムで hasToken 不要のキャッシュ遡りに対応
- fix: ストア install ボタンの角丸と「Misskeyについて」狭カラム崩れ
- chore: bump version to 1.3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)