### PR TITLE
Release v1.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.9",
+  "version": "1.3.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.9"
+version = "1.3.10"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.9"
+version = "1.3.10"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.9"
+    "version": "1.3.10"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -48,6 +48,7 @@ pub async fn auth_start(
             "read:gallery",
             "read:gallery-likes",
             "write:gallery-likes",
+            "read:federation",
         ]
         .into_iter()
         .map(String::from)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckEmojiColumn.vue
+++ b/src/components/deck/DeckEmojiColumn.vue
@@ -45,11 +45,18 @@ const copiedName = ref<string | null>(null)
 const categoryBarRef = ref<HTMLElement | null>(null)
 
 function onCategoryBarWheel(ev: WheelEvent) {
-  if (!categoryBarRef.value) return
-  const dx = ev.deltaX || ev.deltaY
-  if (dx === 0) return
+  const el = categoryBarRef.value
+  if (!el) return
+  // WebView2 (Windows) では Shift+wheel が deltaX でなく deltaY で届くため、
+  // 横スクロール (deltaX) を優先しつつ縦ホイールも横スクロールに変換する。
+  const delta = ev.deltaX !== 0 ? ev.deltaX : ev.deltaY
+  if (delta === 0) return
+  const max = el.scrollWidth - el.clientWidth
+  if (max <= 0) return
+  const next = Math.max(0, Math.min(max, el.scrollLeft + delta))
+  if (next === el.scrollLeft) return
+  el.scrollLeft = next
   ev.preventDefault()
-  categoryBarRef.value.scrollLeft += dx
 }
 
 // Bind wheel as non-passive (needed for preventDefault)

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -110,7 +110,23 @@ watch(code, (val) => {
   }, 500)
 })
 
-onBeforeUnmount(flushPendingSave)
+// 走っているインタプリタ (＝Async:interval などのタイマー) を止め、
+// Nd:* で登録したコマンド/購読も解放する。再実行前とアンマウント時に呼ぶ。
+function stop() {
+  if (interpreter.value) {
+    interpreter.value.abort()
+    interpreter.value = null
+  }
+  if (currentNdCtx) {
+    cleanupNoteDeckEnv(currentNdCtx)
+    currentNdCtx = null
+  }
+}
+
+onBeforeUnmount(() => {
+  flushPendingSave()
+  stop()
+})
 
 async function run() {
   if (running.value) return
@@ -177,7 +193,8 @@ async function run() {
     },
   })
 
-  if (currentNdCtx) cleanupNoteDeckEnv(currentNdCtx)
+  // 再実行時は前のインタプリタ (残った Async:interval 等) を確実に止める。
+  stop()
   const ndCtx: NoteDeckEnvContext = {
     commandStore,
     getAiConfig: () => aiConfig.value,


### PR DESCRIPTION
## Release v1.3.10

### 変更点

- **fix**: 連合カラムが閲覧できない問題を修正 — MiAuth スコープに `read:federation` を追加 (#674)
- **fix**: カスタム絵文字カラムのカテゴリバーを横スクロール（縦ホイール含む）でも移動可能に
- **fix**: ウィジェットの再実行・アンマウント時にインタプリタを abort

### 補足

- #674 の修正は MiAuth 要求スコープの追加のため、**既存ユーザーは再認証（ログアウト→再ログイン）が必要**です。
- #673（「見つける」ノート/ユーザータブ）は yamisskey 側の `secure: true` による API 制限が原因で NoteDeck 側では解決不可のため、本リリースには含みません（yamisskey-dev/yamisskey#315 で対応依頼中）。

Closes #674
