### PR TITLE
fix: ロール割り当て通知でロール名を表示 (#687)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=6f7d7a79d273392320a5f524df7e768347510eaa#6f7d7a79d273392320a5f524df7e768347510eaa"
+source = "git+https://github.com/hitalin/notecli?rev=6d42b895bb5fb5d4e1a84190329c9805609fb4f9#6d42b895bb5fb5d4e1a84190329c9805609fb4f9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.10"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "6f7d7a79d273392320a5f524df7e768347510eaa", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "6d42b895bb5fb5d4e1a84190329c9805609fb4f9", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -1880,6 +1880,17 @@
             },
             "description": "Grouped reactions (for reaction:grouped type)"
           },
+          "role": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UserRole",
+                "description": "Assigned role (for roleAssigned type)"
+              }
+            ]
+          },
           "type": {
             "type": "string"
           },

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -374,6 +374,8 @@ export interface NormalizedNotification {
   reactions?: ReactionInfo[]
   /** Grouped users (for renote:grouped type) */
   users?: NormalizedUser[]
+  /** Assigned role (for roleAssigned type) */
+  role?: UserRole
 }
 
 export interface CreateNoteParams {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2530,7 +2530,11 @@ reactions?: ReactionInfo[] | null;
 /**
  * Grouped users (for renote:grouped type)
  */
-users?: NormalizedUser[] | null }
+users?: NormalizedUser[] | null; 
+/**
+ * Assigned role (for roleAssigned type)
+ */
+role?: UserRole | null }
 export type NormalizedPoll = { choices: NormalizedPollChoice[]; multiple?: boolean; expiresAt: string | null }
 export type NormalizedPollChoice = { text: string; votes?: number; isVoted?: boolean }
 export type NormalizedUser = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; isBot?: boolean; isCat?: boolean; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; instance?: UserInstance | null }

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -430,6 +430,7 @@ const NOTIFICATION_ICONS: Record<string, string> = {
   receiveFollowRequest: 'clock',
   pollEnded: 'chart-arrows',
   achievementEarned: 'medal',
+  roleAssigned: 'badges',
   login: 'login-2',
   createToken: 'key',
 }
@@ -445,6 +446,7 @@ const NOTIFICATION_LABELS: Record<string, string> = {
   receiveFollowRequest: 'からフォローリクエスト',
   pollEnded: 'アンケートの結果が出ました',
   achievementEarned: '実績を獲得',
+  roleAssigned: 'ロールが付与されました',
   app: '通知',
   login: 'ログインがありました',
   createToken: 'アクセストークンが作成されました',
@@ -462,6 +464,7 @@ const NOTIFICATION_COLORS: Record<string, string> = {
   receiveFollowRequest: 'var(--nd-eventFollow)',
   pollEnded: 'var(--nd-eventOther)',
   achievementEarned: 'var(--nd-eventAchievement)',
+  roleAssigned: 'var(--nd-eventAchievement)',
   login: 'var(--nd-eventLogin)',
   createToken: 'var(--nd-eventOther)',
 }
@@ -1107,6 +1110,12 @@ onUnmounted(() => {
                     {{ ACHIEVEMENT_LABELS[notif.achievement] ?? notif.achievement }}
                   </div>
 
+                  <!-- Assigned role -->
+                  <div v-if="notif.type === 'roleAssigned' && notif.role" :class="$style.notifRole">
+                    <img v-if="notif.role.iconUrl" :src="notif.role.iconUrl" :alt="notif.role.name" :class="$style.notifRoleIcon" loading="lazy" />
+                    <span :class="$style.notifRoleName" :style="notif.role.color ? { color: notif.role.color } : undefined">{{ notif.role.name }}</span>
+                  </div>
+
                   <!-- Follow request actions -->
                   <div
                     v-if="notif.type === 'receiveFollowRequest' && notif.user"
@@ -1356,6 +1365,24 @@ onUnmounted(() => {
   color: var(--nd-fg);
   opacity: 0.7;
   margin-top: 2px;
+}
+
+.notifRole {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.notifRoleIcon {
+  width: 1.2em;
+  height: 1.2em;
+  object-fit: contain;
+}
+
+.notifRoleName {
+  font-size: 0.9em;
+  font-weight: 600;
 }
 
 .notifReaction {


### PR DESCRIPTION
## なぜ

#687 — `roleAssigned`（ロール割り当て）通知でロール名が分からない。

ラベルに生の型名 `roleAssigned` が出るだけで、どのロールが付与されたのか分からなかった。

## 原因

Misskey の `roleAssigned` 通知に含まれる `role`（ロール情報）が、notecli の `RawNotification` → `NormalizedNotification` 正規化で捨てられており、フロントにロール名が届いていなかった。加えて notedeck 側も `roleAssigned` のラベル/表示が未実装だった。

## 変更

**notecli** (hitalin/notecli#26, merged → rev `6d42b89`)
- `RawNotification` / `NormalizedNotification` に `role: Option<UserRole>` を追加し正規化で伝播
- 既存の specta / utoipa 対応 `UserRole` 型を再利用
- パースのテスト追加

**notedeck**
- notecli rev bump + `bindings.ts` / `openapi.json` 再生成
- `NormalizedNotification` 型 (`types.ts`) に `role` 追加
- `DeckNotificationColumn`: `roleAssigned` のラベル「ロールが付与されました」・アイコン `badges`・色を追加 + ロール名（アイコン・色付き）の表示ブロック

## テスト

- notecli: `cargo test get_notifications` → pass
- notedeck: `pnpm typecheck` / `biome check` / `pnpm test` (1130) / `cargo test openapi_snapshot` すべて pass

参照: #687（Closes は develop→main の release PR 側に記載）

🤖 Generated with [Claude Code](https://claude.com/claude-code)