### PR TITLE
Release v1.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.3.10",
+  "version": "1.3.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=6f7d7a79d273392320a5f524df7e768347510eaa#6f7d7a79d273392320a5f524df7e768347510eaa"
+source = "git+https://github.com/hitalin/notecli?rev=6d42b895bb5fb5d4e1a84190329c9805609fb4f9#6d42b895bb5fb5d4e1a84190329c9805609fb4f9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.3.10"
+version = "1.3.11"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.3.10"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "6f7d7a79d273392320a5f524df7e768347510eaa", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "6d42b895bb5fb5d4e1a84190329c9805609fb4f9", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.3.10"
+version = "1.3.11"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -1880,6 +1880,17 @@
             },
             "description": "Grouped reactions (for reaction:grouped type)"
           },
+          "role": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UserRole",
+                "description": "Assigned role (for roleAssigned type)"
+              }
+            ]
+          },
           "type": {
             "type": "string"
           },

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.3.10"
+    "version": "1.3.11"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/content.rs
+++ b/src-tauri/src/commands/content.rs
@@ -124,7 +124,9 @@ pub async fn api_get_roles(
     account_id: String,
 ) -> Result<serde_json::Value> {
     let (db, client) = app_state.ready().await;
-    let (host, token) = get_credentials_or_anon(&db, &account_id)?;
+    // roles/list は本家 Misskey で requireCredential: true（roles/users は匿名可）。
+    // 匿名トークンでは必ず 401 になるため認証必須として扱う。
+    let (host, token) = get_credentials(&db, &account_id)?;
     client.get_roles(&host, &token).await
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.3.10",
+  "version": "1.3.11",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -374,6 +374,8 @@ export interface NormalizedNotification {
   reactions?: ReactionInfo[]
   /** Grouped users (for renote:grouped type) */
   users?: NormalizedUser[]
+  /** Assigned role (for roleAssigned type) */
+  role?: UserRole
 }
 
 export interface CreateNoteParams {

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2530,7 +2530,11 @@ reactions?: ReactionInfo[] | null;
 /**
  * Grouped users (for renote:grouped type)
  */
-users?: NormalizedUser[] | null }
+users?: NormalizedUser[] | null; 
+/**
+ * Assigned role (for roleAssigned type)
+ */
+role?: UserRole | null }
 export type NormalizedPoll = { choices: NormalizedPollChoice[]; multiple?: boolean; expiresAt: string | null }
 export type NormalizedPollChoice = { text: string; votes?: number; isVoted?: boolean }
 export type NormalizedUser = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; isBot?: boolean; isCat?: boolean; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; instance?: UserInstance | null }

--- a/src/components/common/ColumnEmptyState.vue
+++ b/src/components/common/ColumnEmptyState.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import type { AppError } from '@/utils/errors'
 import { proxyUrl } from '@/utils/imageProxy'
+import { restrictedAccessNotice } from '@/utils/restrictedAccess'
 import SystemIcon from './SystemIcon.vue'
 
 const props = withDefaults(
   defineProps<{
-    /** メッセージテキスト */
-    message: string
+    /** メッセージテキスト。error 指定時は省略可（error から導出）。 */
+    message?: string
     /** Misskey サーバーのカスタム画像 URL（infoImageUrl / notFoundImageUrl / serverErrorImageUrl） */
     imageUrl?: string
     /** エラー状態かどうか */
@@ -20,6 +22,19 @@ const props = withDefaults(
     ctaLabel?: string
     /** CTA ボタンのアイコン（Tabler icon クラス名、例: 'ti-pencil'） */
     ctaIcon?: string
+    /**
+     * API エラー。指定すると CREDENTIAL_REQUIRED / ACCESS_DENIED を
+     * 「このサーバーは○○を公開していません」等の案内に出し分ける
+     * （本家は匿名公開だが一部フォークが認証必須に絞っているエンドポイント向け）。
+     * 該当しないエラーは message 同様そのまま表示する。
+     */
+    error?: AppError | null
+    /** error の案内で使う対象名詞（例: '連合情報' / 'ユーザー情報'）。 */
+    subject?: string
+    /** ログイン済みか。未ログイン時のみ「公開していません」案内にする。 */
+    hasToken?: boolean
+    /** info 状態（CREDENTIAL_REQUIRED 未ログイン等）で使う画像。未指定なら imageUrl。 */
+    infoImageUrl?: string
   }>(),
   {
     isError: false,
@@ -30,17 +45,42 @@ const emit = defineEmits<{
   cta: []
 }>()
 
-const resolvedImageUrl = computed(() => proxyUrl(props.imageUrl))
+/** error 指定時、CREDENTIAL_REQUIRED 等を案内文に変換（該当しなければ生メッセージ）。 */
+const notice = computed(() => {
+  if (!props.error) return null
+  return (
+    restrictedAccessNotice(
+      props.error,
+      props.subject ?? '情報',
+      props.hasToken ?? false,
+    ) ?? { message: props.error.message, info: false }
+  )
+})
+
+const effectiveMessage = computed(
+  () => notice.value?.message ?? props.message ?? '',
+)
+const effectiveIsError = computed(() =>
+  notice.value ? !notice.value.info : props.isError,
+)
+
+const resolvedImageUrl = computed(() =>
+  proxyUrl(
+    notice.value?.info
+      ? (props.infoImageUrl ?? props.imageUrl)
+      : props.imageUrl,
+  ),
+)
 
 const resolvedFallbackType = computed<'info' | 'question' | 'error'>(() => {
   if (props.fallbackKind === 'notFound') return 'question'
   if (props.fallbackKind) return props.fallbackKind
-  return props.isError ? 'error' : 'info'
+  return effectiveIsError.value ? 'error' : 'info'
 })
 </script>
 
 <template>
-  <div :class="[$style.root, isError && $style.error]">
+  <div :class="[$style.root, effectiveIsError && $style.error]">
     <img
       v-if="resolvedImageUrl"
       :src="resolvedImageUrl"
@@ -54,7 +94,7 @@ const resolvedFallbackType = computed<'info' | 'question' | 'error'>(() => {
       :type="resolvedFallbackType"
       :class="$style.fallbackIcon"
     />
-    <div :class="$style.message">{{ message }}</div>
+    <div :class="$style.message">{{ effectiveMessage }}</div>
     <button
       v-if="ctaLabel"
       :class="$style.cta"

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue'
+import { computed, defineAsyncComponent, ref, useTemplateRef, watch } from 'vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkMfm from '@/components/common/MkMfm.vue'
@@ -29,12 +29,11 @@ const props = defineProps<{
 
 // --- Tab ---
 type Tab = 'notes' | 'users' | 'roles'
-const TAB_DEFS: ColumnTabDef[] = [
+const ALL_TAB_DEFS: ColumnTabDef[] = [
   { value: 'notes', label: 'ノート' },
   { value: 'users', label: 'ユーザー' },
   { value: 'roles', label: 'ロール' },
 ]
-const tabs: Tab[] = TAB_DEFS.map((t) => t.value as Tab)
 const activeTab = ref<Tab>('notes')
 const columnContentRef = ref<HTMLElement | null>(null)
 
@@ -74,6 +73,19 @@ const {
   cache: {
     getKey: () => 'explore',
   },
+})
+
+// roles/list は本家 Misskey で認証必須。ログアウト/ゲスト時はロールタブを出さない
+// (TL カラムでホーム/ソーシャルを隠すのと同じ方針。ログアウト中である旨はカラム
+//  共通のテロップで示されるため、ここで個別の案内は出さない)。
+const tabDefs = computed<ColumnTabDef[]>(() =>
+  account.value?.hasToken
+    ? ALL_TAB_DEFS
+    : ALL_TAB_DEFS.filter((t) => t.value !== 'roles'),
+)
+// タブが消えたとき (ログアウト等) は notes に戻す
+watch(tabDefs, (defs) => {
+  if (!defs.some((t) => t.value === activeTab.value)) activeTab.value = 'notes'
 })
 
 // --- Users tab ---
@@ -191,7 +203,9 @@ function switchTab(tab: string) {
 }
 
 // Tab slide animation
-const exploreTabIndex = computed(() => tabs.indexOf(activeTab.value))
+const exploreTabIndex = computed(() =>
+  tabDefs.value.findIndex((t) => t.value === activeTab.value),
+)
 useTabSlide(exploreTabIndex, columnContentRef)
 
 function refresh() {
@@ -239,7 +253,7 @@ usePortal(postPortalRef)
 
     <div ref="columnContentRef" :class="$style.exploreContent">
       <ColumnTabs
-        :tabs="TAB_DEFS"
+        :tabs="tabDefs"
         :model-value="activeTab"
         :swipe-target="columnContentRef"
         @update:model-value="switchTab"

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -2,6 +2,7 @@
 import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import MkMfm from '@/components/common/MkMfm.vue'
 import MkNote from '@/components/common/MkNote.vue'
 import MkUserListItem from '@/components/common/MkUserListItem.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
@@ -84,6 +85,7 @@ interface UserSummary {
   avatarUrl: string | null
   followersCount: number
   description: string | null
+  emojis?: Record<string, string>
 }
 
 const users = ref<UserSummary[]>([])
@@ -266,7 +268,12 @@ usePortal(postPortalRef)
           <div v-if="isLoading && notes.length === 0" :class="$style.columnLoading">
             <LoadingSpinner />
           </div>
-          <template v-if="!(isLoading && notes.length === 0)">
+          <ColumnEmptyState
+            v-else-if="notes.length === 0"
+            message="ノートが見つかりません"
+            :image-url="serverInfoImageUrl"
+          />
+          <template v-else>
             <NoteScroller ref="noteScrollerRef" :items="notes" :focused-id="focusedNoteId" :class="$style.tlScroller" @scroll="handleScroll" @near-end="loadMore">
               <template #default="{ item, index }">
                 <div>
@@ -295,10 +302,10 @@ usePortal(postPortalRef)
 
       <!-- Users tab -->
       <template v-else-if="activeTab === 'users'">
-        <div :class="$style.exploreList">
-          <div v-if="usersLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
-          <ColumnEmptyState v-else-if="usersError" :message="usersError" :image-url="serverErrorImageUrl" is-error />
-          <ColumnEmptyState v-else-if="users.length === 0" message="ユーザーが見つかりません" :image-url="serverInfoImageUrl" />
+        <div v-if="usersLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
+        <ColumnEmptyState v-else-if="usersError" :message="usersError" :image-url="serverErrorImageUrl" is-error />
+        <ColumnEmptyState v-else-if="users.length === 0" message="ユーザーが見つかりません" :image-url="serverInfoImageUrl" />
+        <div v-else :class="$style.exploreList">
           <MkUserListItem
             v-for="user in users"
             :key="user.id"
@@ -307,7 +314,14 @@ usePortal(postPortalRef)
             :server-host="account?.host"
           >
             <template #meta>
-              <div v-if="user.description" :class="$style.exploreUserDesc">{{ user.description }}</div>
+              <div v-if="user.description" :class="$style.exploreUserDesc">
+                <MkMfm
+                  :text="user.description"
+                  :emojis="user.emojis"
+                  :server-host="account?.host ?? undefined"
+                  plain
+                />
+              </div>
               <div :class="$style.exploreUserMeta">
                 <i class="ti ti-users" /> {{ user.followersCount }}
               </div>
@@ -326,10 +340,10 @@ usePortal(postPortalRef)
             </span>
             <span>{{ selectedRole.name }}</span>
           </div>
-          <div :class="$style.exploreList">
-            <div v-if="roleUsersLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
-            <ColumnEmptyState v-else-if="roleUsersError" :message="roleUsersError" :image-url="serverErrorImageUrl" is-error />
-            <ColumnEmptyState v-else-if="roleUsers.length === 0" message="ユーザーがいません" :image-url="serverInfoImageUrl" />
+          <div v-if="roleUsersLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
+          <ColumnEmptyState v-else-if="roleUsersError" :message="roleUsersError" :image-url="serverErrorImageUrl" is-error />
+          <ColumnEmptyState v-else-if="roleUsers.length === 0" message="ユーザーがいません" :image-url="serverInfoImageUrl" />
+          <div v-else :class="$style.exploreList">
             <MkUserListItem
               v-for="user in roleUsers"
               :key="user.id"
@@ -342,10 +356,10 @@ usePortal(postPortalRef)
 
         <!-- Roles list -->
         <template v-else>
-          <div :class="$style.exploreList">
-            <div v-if="rolesLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
-            <ColumnEmptyState v-else-if="rolesError" :message="rolesError" :image-url="serverErrorImageUrl" is-error />
-            <ColumnEmptyState v-else-if="roles.length === 0" message="ロールが見つかりません" :image-url="serverInfoImageUrl" />
+          <div v-if="rolesLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
+          <ColumnEmptyState v-else-if="rolesError" :message="rolesError" :image-url="serverErrorImageUrl" is-error />
+          <ColumnEmptyState v-else-if="roles.length === 0" message="ロールが見つかりません" :image-url="serverInfoImageUrl" />
+          <div v-else :class="$style.exploreList">
             <button
               v-for="role in roles"
               :key="role.id"

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -102,7 +102,7 @@ interface UserSummary {
 
 const users = ref<UserSummary[]>([])
 const usersLoading = ref(false)
-const usersError = ref<string | null>(null)
+const usersError = ref<AppError | null>(null)
 const usersFetched = ref(false)
 
 async function fetchUsers() {
@@ -123,7 +123,7 @@ async function fetchUsers() {
     ) as unknown as UserSummary[]
     usersFetched.value = true
   } catch (e) {
-    usersError.value = AppError.from(e).message
+    usersError.value = AppError.from(e)
   } finally {
     usersLoading.value = false
   }
@@ -317,7 +317,14 @@ usePortal(postPortalRef)
       <!-- Users tab -->
       <template v-else-if="activeTab === 'users'">
         <div v-if="usersLoading" :class="$style.columnLoading"><LoadingSpinner /></div>
-        <ColumnEmptyState v-else-if="usersError" :message="usersError" :image-url="serverErrorImageUrl" is-error />
+        <ColumnEmptyState
+          v-else-if="usersError"
+          :error="usersError"
+          subject="ユーザー情報"
+          :has-token="!!account?.hasToken"
+          :image-url="serverErrorImageUrl"
+          :info-image-url="serverInfoImageUrl"
+        />
         <ColumnEmptyState v-else-if="users.length === 0" message="ユーザーが見つかりません" :image-url="serverInfoImageUrl" />
         <div v-else :class="$style.exploreList">
           <MkUserListItem

--- a/src/components/deck/DeckFederationColumn.vue
+++ b/src/components/deck/DeckFederationColumn.vue
@@ -235,9 +235,11 @@ function onInstanceClick(inst: FederationInstance) {
 
       <ColumnEmptyState
         v-if="error && instances.length === 0"
-        :message="error.message"
+        :error="error"
+        subject="連合情報"
+        :has-token="!!account?.hasToken"
         :image-url="serverErrorImageUrl"
-        is-error
+        :info-image-url="serverInfoImageUrl"
       />
       <ColumnEmptyState
         v-else-if="!isLoading && instances.length === 0"

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -430,6 +430,7 @@ const NOTIFICATION_ICONS: Record<string, string> = {
   receiveFollowRequest: 'clock',
   pollEnded: 'chart-arrows',
   achievementEarned: 'medal',
+  roleAssigned: 'badges',
   login: 'login-2',
   createToken: 'key',
 }
@@ -445,6 +446,7 @@ const NOTIFICATION_LABELS: Record<string, string> = {
   receiveFollowRequest: 'からフォローリクエスト',
   pollEnded: 'アンケートの結果が出ました',
   achievementEarned: '実績を獲得',
+  roleAssigned: 'ロールが付与されました',
   app: '通知',
   login: 'ログインがありました',
   createToken: 'アクセストークンが作成されました',
@@ -462,6 +464,7 @@ const NOTIFICATION_COLORS: Record<string, string> = {
   receiveFollowRequest: 'var(--nd-eventFollow)',
   pollEnded: 'var(--nd-eventOther)',
   achievementEarned: 'var(--nd-eventAchievement)',
+  roleAssigned: 'var(--nd-eventAchievement)',
   login: 'var(--nd-eventLogin)',
   createToken: 'var(--nd-eventOther)',
 }
@@ -1107,6 +1110,12 @@ onUnmounted(() => {
                     {{ ACHIEVEMENT_LABELS[notif.achievement] ?? notif.achievement }}
                   </div>
 
+                  <!-- Assigned role -->
+                  <div v-if="notif.type === 'roleAssigned' && notif.role" :class="$style.notifRole">
+                    <img v-if="notif.role.iconUrl" :src="notif.role.iconUrl" :alt="notif.role.name" :class="$style.notifRoleIcon" loading="lazy" />
+                    <span :class="$style.notifRoleName" :style="notif.role.color ? { color: notif.role.color } : undefined">{{ notif.role.name }}</span>
+                  </div>
+
                   <!-- Follow request actions -->
                   <div
                     v-if="notif.type === 'receiveFollowRequest' && notif.user"
@@ -1356,6 +1365,24 @@ onUnmounted(() => {
   color: var(--nd-fg);
   opacity: 0.7;
   margin-top: 2px;
+}
+
+.notifRole {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.notifRoleIcon {
+  width: 1.2em;
+  height: 1.2em;
+  object-fit: contain;
+}
+
+.notifRoleName {
+  font-size: 0.9em;
+  font-weight: 600;
 }
 
 .notifReaction {

--- a/src/utils/restrictedAccess.ts
+++ b/src/utils/restrictedAccess.ts
@@ -1,0 +1,33 @@
+import type { AppError } from './errors'
+
+/**
+ * サーバーが匿名取得を許可していない (requireCredential) エンドポイントで返る
+ * CREDENTIAL_REQUIRED / ACCESS_DENIED を、生エラー文字列の代わりに表示する案内に変換する。
+ *
+ * 本家 Misskey では匿名公開だが一部フォーク (yamisskey 系) が認証必須に絞っている
+ * `federation/instances` や `users` などで使う。静的に常時不可能なもの (`roles/list` 等)
+ * はタブ非表示で対応するためここでは扱わない。
+ *
+ * @param subject 「連合情報」「ユーザー情報」など、公開対象を表す名詞
+ * @param hasToken ログイン済みか (未ログインかどうかで文面を変える)
+ * @returns 案内を出すべきなら `{ message, info }`、該当しなければ `null` (生エラー表示にフォールバック)
+ */
+export function restrictedAccessNotice(
+  err: AppError,
+  subject: string,
+  hasToken: boolean,
+): { message: string; info: boolean } | null {
+  const code = err.displayCode
+  const credentialRequired = code === 'CREDENTIAL_REQUIRED'
+  const accessDenied = code === 'ACCESS_DENIED' || code === 'PERMISSION_DENIED'
+
+  // 未ログイン: このサーバーが匿名公開していないだけ (ログインすれば見られる場合がある)
+  if (credentialRequired && !hasToken) {
+    return { message: `このサーバーは${subject}を公開していません`, info: true }
+  }
+  // ログイン済みでも弾かれる: 権限不足 (read:federation 不許可 / モデレーター権限要 等)
+  if (credentialRequired || accessDenied) {
+    return { message: `${subject}の閲覧権限がありません`, info: false }
+  }
+  return null
+}


### PR DESCRIPTION
## Release v1.3.11

### Changes

- **feat**: 連合情報を公開しないサーバーで `ColumnEmptyState` に案内を出し分け (#690)
- **fix**: ログアウト中は「見つける」のロールタブを非表示にする
- **fix**: 「見つける」カラムの空状態表示とユーザー bio の MFM 描画を修正 (#688)
- **fix**: ロール割り当て通知でロール名を表示 (#687)

### Version bump

- `package.json` / `src-tauri/Cargo.toml` / `src-tauri/tauri.conf.json` → 1.3.11
- `Cargo.lock` / `openapi.json` 再生成

Closes #687
Closes #688
Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)