### PR TITLE
Release v1.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.4.1"
+version = "1.4.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -4,6 +4,8 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.view.ViewGroup
+import android.webkit.WebView
 import androidx.activity.enableEdgeToEdge
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -25,6 +27,35 @@ class MainActivity : TauriActivity() {
     super.onCreate(savedInstanceState)
     requestNotificationPermission()
     scheduleNotificationPolling()
+  }
+
+  /**
+   * フォアグラウンド復帰を WebView の JS に確実に伝える (#506)。
+   *
+   * Android WebView は復帰時に visibilitychange を発火しないことがあり、
+   * その場合フロントの deckResume (WS 再接続 + visibility リフレッシュ +
+   * 新着 refetch) が一切走らない。Tauri 側イベントも使えない: pin 済み
+   * tauri-runtime-wry 2.10 系は tao の Event::Resumed を握り潰すため
+   * RunEvent::Resumed は Android では発火しない。そこで Activity の
+   * onResume から DOM イベントを直接 dispatch する。
+   */
+  override fun onResume() {
+    super.onResume()
+    val root = window?.decorView?.rootView as? ViewGroup ?: return
+    findWebView(root)?.evaluateJavascript(
+      "window.dispatchEvent(new Event('nd-app-resumed'))",
+      null,
+    )
+  }
+
+  private fun findWebView(group: ViewGroup): WebView? {
+    for (i in 0 until group.childCount) {
+      when (val child = group.getChildAt(i)) {
+        is WebView -> return child
+        is ViewGroup -> findWebView(child)?.let { return it }
+      }
+    }
+    return null
   }
 
   private fun requestNotificationPermission() {

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.4.1"
+    "version": "1.4.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/query.ts
+++ b/src/adapters/misskey/query.ts
@@ -3,12 +3,8 @@ import type {
   NoteUpdateEvent,
   SubscriptionRuntimeState,
 } from '@/adapters/types'
-import {
-  events,
-  type JsonValue,
-  type NoteUpdate,
-  type QuerySnapshot,
-} from '@/bindings'
+import type { JsonValue, NoteUpdate, QuerySnapshot } from '@/bindings'
+import { onQueryDelta } from '@/core/queryDeltaBus'
 import { commands } from '@/utils/tauriInvoke'
 
 export interface CreateQuerySubscriptionOptions {
@@ -30,7 +26,7 @@ export interface CreateQuerySubscriptionOptions {
  *
  * Lifecycle:
  *  1. open() resolves → store queryId
- *  2. listen events.queryDelta → fan out inserts/deletes filtered by queryId
+ *  2. onQueryDelta (queryDeltaBus) → fan out inserts/deletes filtered by queryId
  *  3. dispose() → unlisten + queryClose
  *
  * `setRuntimeState()` maps live/warm/suspended to `query_set_runtime_state`,
@@ -74,29 +70,19 @@ export function createQuerySubscription(
     sourceSubscriptionId = snap.sourceSubscriptionId
     resolveReady()
 
-    try {
-      unlistenDelta = await events.queryDelta.listen((event) => {
-        if (disposed) return
-        const delta = event.payload
-        if (delta.queryId !== queryId) return
-        if (delta.revision <= lastRevision) return
-        for (const insert of delta.inserts) opts.onInsert(insert)
-        if (opts.onDelete) {
-          for (const id of delta.deletes) opts.onDelete(id)
-        }
-        if (opts.onUpdate) {
-          for (const u of delta.updates) opts.onUpdate(toNoteUpdateEvent(u))
-        }
-        lastRevision = delta.revision
-      })
-    } catch (e) {
-      console.error('[query-subscription] listen failed:', e)
-    }
-    if (disposed) {
-      unlistenDelta?.()
-      unlistenDelta = null
-      return
-    }
+    unlistenDelta = onQueryDelta((delta) => {
+      if (disposed) return
+      if (delta.queryId !== queryId) return
+      if (delta.revision <= lastRevision) return
+      for (const insert of delta.inserts) opts.onInsert(insert)
+      if (opts.onDelete) {
+        for (const id of delta.deletes) opts.onDelete(id)
+      }
+      if (opts.onUpdate) {
+        for (const u of delta.updates) opts.onUpdate(toNoteUpdateEvent(u))
+      }
+      lastRevision = delta.revision
+    })
 
     if (runtimeState !== 'live' && queryId) {
       commands.querySetRuntimeState(queryId, runtimeState).catch((e) => {

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -41,6 +41,7 @@ import { useNoteStore } from '@/stores/notes'
 import { usePerformanceStore } from '@/stores/performance'
 import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
+import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
 import { AppError, AUTH_ERROR_MESSAGE } from '@/utils/errors'
@@ -885,6 +886,34 @@ async function pullRefresh() {
     scrollToTop()
   }
 }
+
+// 復帰時 backlog 補填 (#506): 背景化中にリスナーが死んでいた間の通知を
+// REST で埋める。pull-refresh と同じ経路だがスクロール位置は動かさない。
+const uiStoreForResume = useUiStore()
+let lastResumeBackfill = 0
+watch(
+  () => uiStoreForResume.deckResumeSignal,
+  async () => {
+    if (Date.now() - lastResumeBackfill < 3000) return
+    lastResumeBackfill = Date.now()
+    try {
+      if (isCrossAccount.value) {
+        await connectCrossAccount(true)
+      } else {
+        const adapter = getAdapter()
+        if (!adapter) return
+        const fetched = await fetchNotifications(
+          adapter.api,
+          account.value?.host,
+        )
+        notifications.value = mergeNotifications(fetched, notifications.value)
+        saveCache()
+      }
+    } catch {
+      // 補填は best-effort (手動 pull-refresh で回復できる)
+    }
+  },
+)
 
 useColumnPullScroller(scroller)
 

--- a/src/composables/useColumnMount.dom.test.ts
+++ b/src/composables/useColumnMount.dom.test.ts
@@ -9,6 +9,7 @@ import {
   nextTick,
   shallowRef,
 } from 'vue'
+import { useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
 import {
   provideColumnMountRegistry,
@@ -155,6 +156,23 @@ describe('useColumnMount: 復帰時の visibility リフレッシュ (#506)', ()
     // 再 observe の初期エントリ (実ブラウザでは仕様上必ず配送される) で復元
     after?.callback([{ isIntersecting: true }])
     expect(live.isVisible.value).toBe(true)
+  })
+
+  it('アクティブカラムは IO が false でも可視扱いになる', async () => {
+    const { live } = mountHarness()
+    await nextTick()
+    const io = MockIntersectionObserver.instances.at(-1)
+
+    io?.callback([{ isIntersecting: false }])
+    expect(live.isVisible.value).toBe(false)
+
+    // モバイル swipe モードで stale false が残っても、表示中 (アクティブ)
+    // カラムのストリームは warm/Suspended に落ちない (#506 フォローアップ)
+    useDeckStore().setActiveColumn('col-1')
+    expect(live.isVisible.value).toBe(true)
+
+    useDeckStore().setActiveColumn('other-col')
+    expect(live.isVisible.value).toBe(false)
   })
 
   it('deckResume が保留中の unload timer を破棄して unmount フラップを防ぐ', async () => {

--- a/src/composables/useColumnMount.ts
+++ b/src/composables/useColumnMount.ts
@@ -12,6 +12,7 @@ import {
   type ShallowRef,
   watch,
 } from 'vue'
+import { useDeckStore } from '@/stores/deck'
 import { usePerformanceStore } from '@/stores/performance'
 import { useUiStore } from '@/stores/ui'
 
@@ -252,7 +253,18 @@ export function useColumnLive(columnId: string): {
 } {
   const visibility = inject(COLUMN_VISIBILITY_KEY, null)
   const live = inject(COLUMN_LIVE_KEY, null)
-  const isVisible = computed(() => visibility?.get(columnId) ?? true)
+  const deckStore = useDeckStore()
+  // アクティブカラムは IO 判定に関わらず常に可視扱いにする。
+  // shouldMount が isActive を例外にしているのと同じ理由: アクティブ =
+  // ユーザーが見ているカラムで、モバイル swipe モードでは唯一の表示カラム。
+  // IO の判定が stale false になっても (Android 背景化中の破棄イベント等)、
+  // 表示中カラムのストリームが warm→Suspended に落ちて新着が止まる事故を
+  // 構造的に防ぐ (#506 フォローアップ)。
+  const isVisible = computed(
+    () =>
+      deckStore.activeColumnId === columnId ||
+      (visibility?.get(columnId) ?? true),
+  )
   const isLive = computed(() => live?.get(columnId) ?? true)
   return { isVisible, isLive }
 }

--- a/src/composables/useDeckInit.ts
+++ b/src/composables/useDeckInit.ts
@@ -1,5 +1,5 @@
 import type { Ref } from 'vue'
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { loadCliCommands } from '@/commands/cliParser'
 import {
   registerDefaultCommands,
@@ -14,6 +14,7 @@ import {
 import { handleDeepLink } from '@/composables/useDeepLink'
 import { initOgpListener } from '@/composables/useOgpPreview'
 import { destroyApiBridge, initApiBridge } from '@/core/apiBridge'
+import { reattachQueryDeltaListener } from '@/core/queryDeltaBus'
 import { useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { usePluginsStore } from '@/stores/plugins'
@@ -58,9 +59,27 @@ export function useDeckInit(options: {
     }
   }
 
+  // Android ネイティブ (MainActivity.onResume) からの復帰通知 (#506)。
+  // WebView が visibilitychange を発火しない復帰パターンの保険。
+  // emitDeckResume の下流 (reconnect / observer 張り直し / refetch) は
+  // すべて冪等なので visibilitychange との二重発火は無害。
+  function onNativeResume() {
+    uiStore.emitDeckResume()
+  }
+
   function onPageHide() {
     deckStore.flushSave()
   }
+
+  // 背景化で失われうる Tauri イベントリスナーの再アタッチ (#506)。
+  // adapter の stream-event は useColumnSetup の reconnect() が張り直すが、
+  // ノート本体を運ぶ query-delta は bus に集約したのでここで張り直す。
+  watch(
+    () => uiStore.deckResumeSignal,
+    () => {
+      void reattachQueryDeltaListener()
+    },
+  )
 
   let updateCheckHandle: { cancel: () => void } | undefined
 
@@ -70,6 +89,7 @@ export function useDeckInit(options: {
     handleResizeRef = () => options.navbarRef.value?.handleResize()
     window.addEventListener('resize', handleResizeRef)
     document.addEventListener('visibilitychange', onVisibilityChange)
+    window.addEventListener('nd-app-resumed', onNativeResume)
     window.addEventListener('pagehide', onPageHide)
 
     // Critical: start streaming immediately
@@ -177,6 +197,7 @@ export function useDeckInit(options: {
     unregisterDefaultCommands()
     if (handleResizeRef) window.removeEventListener('resize', handleResizeRef)
     document.removeEventListener('visibilitychange', onVisibilityChange)
+    window.removeEventListener('nd-app-resumed', onNativeResume)
     window.removeEventListener('pagehide', onPageHide)
     unlistenQuickNote?.()
     unlistenDeepLink?.()

--- a/src/composables/useQuerySubscription.ts
+++ b/src/composables/useQuerySubscription.ts
@@ -1,11 +1,8 @@
 import { onScopeDispose, ref, shallowRef, watch } from 'vue'
 import { registerQuery, unregisterQuery } from '@/aiscript/events'
-import {
-  events,
-  type JsonValue,
-  type QueryRuntimeState,
-  type QuerySnapshot,
-} from '@/bindings'
+import type { JsonValue, QueryRuntimeState, QuerySnapshot } from '@/bindings'
+import { onQueryDelta } from '@/core/queryDeltaBus'
+import { useUiStore } from '@/stores/ui'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 export interface UseQuerySubscriptionOptions {
@@ -95,22 +92,25 @@ export function useQuerySubscription(opts: UseQuerySubscriptionOptions) {
     // queryId -> {flavor, accountId} マップを更新する。
     registerQuery(snapshot.queryId, snapshot.key)
 
-    unlistenDelta = await events.queryDelta.listen((event) => {
+    unlistenDelta = onQueryDelta((delta) => {
       if (disposed) return
-      const delta = event.payload
       if (delta.queryId !== queryId.value) return
       if (delta.revision <= revision.value) return
       for (const insert of delta.inserts) applyInsert(insert)
       for (const id of delta.deletes) applyDelete(id)
       revision.value = delta.revision
     })
-    if (disposed) {
-      unlistenDelta?.()
-      return
-    }
 
     await loadSnapshot()
   })()
+
+  // フォアグラウンド復帰時: リスナー停止中に取り逃した delta を snapshot
+  // 再取得で埋める (bus の再アタッチは useDeckInit 側で行う)。
+  const uiStore = useUiStore()
+  watch(
+    () => uiStore.deckResumeSignal,
+    () => void loadSnapshot(),
+  )
 
   if (opts.isLive) {
     const isLiveFn = opts.isLive

--- a/src/core/queryDeltaBus.ts
+++ b/src/core/queryDeltaBus.ts
@@ -1,0 +1,59 @@
+import { events, type QueryDelta } from '@/bindings'
+
+/**
+ * query-delta イベントの単一リスナー多重化 bus。
+ *
+ * Android では背景化中に Tauri イベントリスナーが失われることがある
+ * (adapter の stream-event 側は reconnect() で再登録する前提の実装)。
+ * queryDelta を各購読が個別に listen すると復帰時に再登録する術がない
+ * ため、Tauri への登録は本 bus の 1 本に集約し、復帰時は
+ * reattachQueryDeltaListener() で張り直す。JS 側の handler 集合は
+ * 影響を受けない。
+ */
+type DeltaHandler = (delta: QueryDelta) => void
+
+const handlers = new Set<DeltaHandler>()
+let unlisten: (() => void) | null = null
+let generation = 0
+let started = false
+
+/**
+ * queryDelta の購読を登録する。返り値で解除。
+ * 初回呼び出し時に Tauri リスナーを遅延アタッチする。
+ */
+export function onQueryDelta(handler: DeltaHandler): () => void {
+  handlers.add(handler)
+  if (!started) {
+    started = true
+    void reattachQueryDeltaListener()
+  }
+  return () => {
+    handlers.delete(handler)
+  }
+}
+
+/**
+ * Tauri リスナーを張り直す (フォアグラウンド復帰時用)。
+ * 古い登録は解除してから新規登録する。並行呼び出しは generation で
+ * 最後の 1 本だけが生き残る。
+ */
+export async function reattachQueryDeltaListener(): Promise<void> {
+  const gen = ++generation
+  unlisten?.()
+  unlisten = null
+  let fn: () => void
+  try {
+    fn = await events.queryDelta.listen((event) => {
+      for (const h of handlers) h(event.payload)
+    })
+  } catch (e) {
+    console.error('[query-delta-bus] listen failed:', e)
+    return
+  }
+  if (gen !== generation) {
+    // 待機中に新しい reattach が走った — こちらは破棄
+    fn()
+    return
+  }
+  unlisten = fn
+}

--- a/src/core/queryDeltaBus.ts
+++ b/src/core/queryDeltaBus.ts
@@ -44,7 +44,14 @@ export async function reattachQueryDeltaListener(): Promise<void> {
   let fn: () => void
   try {
     fn = await events.queryDelta.listen((event) => {
-      for (const h of handlers) h(event.payload)
+      for (const h of handlers) {
+        try {
+          h(event.payload)
+        } catch (e) {
+          // 1 つの handler の例外で他の購読への配送を止めない
+          console.error('[query-delta-bus] handler failed:', e)
+        }
+      }
     })
   } catch (e) {
     console.error('[query-delta-bus] listen failed:', e)


### PR DESCRIPTION
## v1.4.2

Android 実機検証 (v1.4.1) のフィードバックを受けた前景ストリーミングの追加修正。

### 変更一覧

- fix: モバイル前景でストリームが止まり続ける問題への追加修正 (#506)
- fix: レビュー指摘の反映 — 通知の復帰時 backlog 補填と bus の例外隔離 (#506)
- chore: bump version to 1.4.2

### 修正の要点

v1.4.1 実機検証で「表示中 TL に新着が流れず、Stream Inspector にもイベントが一切届かない」ことが判明。JS にイベント自体が届いていないことを示しており、3 層で対処:

1. **queryDelta リスナーの復帰時再アタッチ** — ノート本体を運ぶ query-delta は一度きりの listen で、Android 背景化でリスナーが失われると購読を作り直すまで新着が二度と届かなかった。Tauri 登録を queryDeltaBus に 1 本化し deckResume で張り直す。通知カラムは復帰時に REST で backlog 補填
2. **Kotlin MainActivity.onResume からの復帰シグナル注入** — deckResume が visibilitychange 頼みで、Android WebView が発火しない復帰パターンでは v1.4.1 の修正含め何も走らなかった (Tauri RunEvent::Resumed は pin 済み runtime-wry 2.10 では発火しない)
3. **アクティブカラムの常時可視扱い** — visibility が stale false でも表示中カラムのストリームが warm→Suspended に落ちない (shouldMount の isActive 例外と同じ構造)

### 検証

- vitest 1135 件 / typecheck / biome 通過 (回帰テスト: アクティブカラム可視化 + observer 張り直し + unload timer フラップ)
- Kotlin 実コンパイル確認済み (gradlew compileArm64DebugKotlin BUILD SUCCESSFUL)
- adversarial レビュー 1 本 (blocker ゼロ、nice-to-have 反映済み)

### 注意

- #506 #507 #508 の自動クローズはしない (実機検証後に手動クローズ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)