### PR TITLE
Release v1.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -107,7 +107,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -118,7 +118,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1044,7 +1044,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1248,7 +1248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2000,7 +2000,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=b05e65dd359f42f326f93fc0264925b49f1d0dbf#b05e65dd359f42f326f93fc0264925b49f1d0dbf"
+source = "git+https://github.com/hitalin/notecli?rev=f510fb835c116507bb332154576cfd733297c3da#f510fb835c116507bb332154576cfd733297c3da"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2885,7 +2885,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4023,7 +4023,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -4152,7 +4152,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4209,7 +4209,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4687,7 +4687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5487,7 +5487,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5686,6 +5686,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6009,7 +6010,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6431,6 +6432,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
@@ -6502,7 +6512,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.4.2"
+version = "1.4.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.4.2"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "b05e65dd359f42f326f93fc0264925b49f1d0dbf", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "f510fb835c116507bb332154576cfd733297c3da", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -252,17 +252,21 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
             commands::export_account_list(&app_handle, &db);
 
-            // Emit account list to frontend early — before full AppState.initialize() —
-            // so the accounts store can populate without waiting for IPC readiness.
-            commands::emit_accounts_early(&app_handle, &db);
-
-            // Streaming manager (depends on DB)
+            // Streaming manager (depends on DB)。
+            // 必ず emit_accounts_early より前に manage する: アカウント一覧を
+            // 受けた JS は即カラムを mount して query_subscribe_* を invoke する
+            // ため、後に置くと State 未登録で "state not managed" の即時エラー
+            // になる race がある (query 購読は初回失敗すると再試行されない)。
             let emitter = std::sync::Arc::new(streaming::TauriEmitter::new(app_handle.clone()));
             app_handle.manage(notecli::streaming::StreamingManager::new(
                 emitter,
                 event_bus.clone(),
                 db.clone(),
             ));
+
+            // Emit account list to frontend early — before full AppState.initialize() —
+            // so the accounts store can populate without waiting for IPC readiness.
+            commands::emit_accounts_early(&app_handle, &db);
 
             // Stage 2: Signal full AppState — unblocks commands needing MisskeyClient.
             app_state.initialize(db.clone(), client.clone());

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/misskey/query.ts
+++ b/src/adapters/misskey/query.ts
@@ -49,11 +49,26 @@ export function createQuerySubscription(
   })
 
   ;(async () => {
-    let snap: QuerySnapshot
-    try {
-      snap = await opts.open()
-    } catch (e) {
-      console.error('[query-subscription] open failed:', e)
+    // open() は WS 接続 + 購読作成を含み、起動直後 (ネットワーク未確立 /
+    // バックエンド初期化中) は失敗しうる。一発死させると WS が後で復活
+    // しても Rust 側に購読が存在せず replay 対象にならないため、notecli の
+    // 再接続ループと同じ Equal Jitter バックオフで成功するまで再試行する。
+    let snap: QuerySnapshot | null = null
+    let backoffMs = 1000
+    const BACKOFF_CAP_MS = 30_000
+    while (!disposed) {
+      try {
+        snap = await opts.open()
+        break
+      } catch (e) {
+        console.error('[query-subscription] open failed (retrying):', e)
+        const jittered = backoffMs / 2 + Math.random() * (backoffMs / 2)
+        await new Promise((r) => setTimeout(r, jittered))
+        backoffMs = Math.min(backoffMs * 2, BACKOFF_CAP_MS)
+      }
+    }
+    if (!snap) {
+      // disposed by unmount while retrying
       resolveReady()
       return
     }


### PR DESCRIPTION
## v1.4.3

Android で WebSocket ストリーミングが一度も動いていなかった真因の修正。

### 変更一覧

- fix: ストリーム購読の起動 race と一発死を解消 (#506)
- chore: bump notecli to f510fb8 (Android WS の TLS webpki-roots フォールバック)
- chore: bump version to 1.4.3

### 真因 (4 方向コード精査 + vendored source 裏取りで確定)

**notecli の WebSocket が `rustls-tls-native-roots` のみで、Android では root 証明書の探索が Termux 専用パスしか見ず 0 件 → 全 wss:// 接続が TLS 段階で必ず失敗**。さらに notecli の再接続ループは初回接続成功後にしか起動しないため、失敗は無音で恒久化していた。REST (reqwest = webpki-roots 同梱) は正常、デスクトップ (OS 証明書ストア) も正常 — 実機の全観測と整合。**Android の WS ストリーミングは最初から一度も動いていなかった**。

### 修正

1. **notecli hitalin/notecli#28**: `rustls-tls-webpki-roots` 併用。native certs 0 件時に Mozilla 同梱ルートへフォールバック (REST と同じ信頼モデル)。デスクトップは native 優先のまま
2. **起動 race 除去**: StreamingManager の manage を emit_accounts_early より前に移動 ("state not managed" 即死の排除)
3. **購読の自己回復**: query 購読 open() の一発死を Equal Jitter バックオフ (cap 30s) の再試行ループに。「初回失敗 = 永久沈黙」クラスを根絶

v1.4.1/v1.4.2 の修正 (visibility 復元 / リスナー再アタッチ / 復帰シグナル / backlog 補填) は「WS 確立後」の防御層として有効で、本修正により初めて機能する。

### 検証

- Cargo.lock で tokio-tungstenite → webpki-roots 0.26.11 の解決を確認
- tokio-tungstenite 0.26.2 tls.rs のフォールバック実装を直接確認
- vitest 1135 件 / cargo check / typecheck / biome 通過

### 注意

- #506 #507 #508 の自動クローズはしない (実機検証後に手動クローズ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)