### PR TITLE
Release v1.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.4.5",
+  "version": "1.4.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.4.5"
+version = "1.4.6"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.4.5"
+    "version": "1.4.6"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -174,6 +174,14 @@ const addMenuT = useVaporTransition(showAddMenu, { leaveDuration: 200 })
 const composeShow = computed(
   () => showCompose.value && accountsStore.accounts.length > 0,
 )
+// 初期選択はトークン保持アカウントを優先する。1 番目がログアウト中でも
+// 投稿できないアカウントで開かない (#693)
+const composeAccountId = computed(() => {
+  // composeShow がアカウント 1 件以上を保証するので '' には実質落ちない
+  const fallback =
+    accountsStore.accounts.find((a) => a.hasToken) ?? accountsStore.accounts[0]
+  return pendingComposeAccountId.value ?? fallback?.id ?? ''
+})
 const composeT = useVaporTransition(composeShow, { leaveDuration: 200 })
 const fileDropShow = computed(() => fileDrop.isDragging.value)
 const fileDropT = useVaporTransition(fileDropShow, { leaveDuration: 200 })
@@ -323,7 +331,7 @@ function acceptCrossWindowDrop() {
     <div v-if="composeT.visible.value" ref="composePortalRef">
       <MkPostForm
         :class="[composeT.entering.value && $style.modalEnter, composeT.leaving.value && $style.modalLeave]"
-        :account-id="pendingComposeAccountId ?? accountsStore.accounts[0]!.id"
+        :account-id="composeAccountId"
         :initial-file-paths="pendingFilePaths"
         @close="closeCompose"
         @posted="closeCompose"

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -17,6 +17,7 @@ import { useBackButton } from '@/composables/useBackButton'
 import { useDeckInit } from '@/composables/useDeckInit'
 import { requestMoveColumn } from '@/composables/useDeckWindow'
 import { useFileDrop } from '@/composables/useFileDrop'
+import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useNavigation } from '@/composables/useNavigation'
 import { usePortal } from '@/composables/usePortal'
 import { useRippleEffect } from '@/composables/useRippleEffect'
@@ -24,7 +25,7 @@ import { provideScrollDirection } from '@/composables/useScrollDirection'
 import { useSpotlightStore } from '@/composables/useSpotlight'
 import { useUpdater } from '@/composables/useUpdater'
 import { useVaporTransition } from '@/composables/useVaporTransition'
-import { useAccountsStore } from '@/stores/accounts'
+import { isGuestAccount, useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
 import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { useToast } from '@/stores/toast'
@@ -98,9 +99,16 @@ const wallpaperStyle = computed(() =>
 const IMAGE_EXTENSIONS = /\.(jpe?g|png|gif|webp|avif|bmp|svg)$/i
 
 function openCompose() {
-  if (accountsStore.accounts.length === 0) {
-    // 他の auth 必須操作と同じく無言で握りつぶさずフィードバックを返す (#693)
-    useToast().show('ログインすると投稿できます', 'info')
+  const accounts = accountsStore.accounts
+  if (!accounts.some((a) => a.hasToken)) {
+    // 投稿可能なアカウントが無い間は無言で握りつぶさずフィードバックを返す (#693)。
+    // ログアウト済みアカウントが残っていれば再ログイン誘導、
+    // 未ログイン (0 件・ゲストのみ) なら新規ログイン誘導。
+    if (accounts.some((a) => !isGuestAccount(a))) {
+      showLoginPrompt()
+    } else {
+      useToast().show('ログインすると投稿できます', 'info')
+    }
     return
   }
   showCompose.value = !showCompose.value

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -27,6 +27,7 @@ import { useVaporTransition } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
 import { useStreamInspectorStore } from '@/stores/streamInspector'
+import { useToast } from '@/stores/toast'
 import { useIsCompactLayout, useUiStore } from '@/stores/ui'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckBottomBar from './DeckBottomBar.vue'
@@ -97,7 +98,11 @@ const wallpaperStyle = computed(() =>
 const IMAGE_EXTENSIONS = /\.(jpe?g|png|gif|webp|avif|bmp|svg)$/i
 
 function openCompose() {
-  if (accountsStore.accounts.length === 0) return
+  if (accountsStore.accounts.length === 0) {
+    // 他の auth 必須操作と同じく無言で握りつぶさずフィードバックを返す (#693)
+    useToast().show('ログインすると投稿できます', 'info')
+    return
+  }
   showCompose.value = !showCompose.value
   if (!showCompose.value) {
     pendingFilePaths.value = []

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -116,6 +116,8 @@ const noteColumnConfig: NoteColumnConfig = {
   cache: {
     getKey: () => tlType.value,
   },
+  // フィルタ違いのカラム間で dedup レスポンスを共有しない (#651)
+  fetchKey: () => JSON.stringify(columnFilters.value),
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {
       // biome-ignore lint/style/noNonNullAssertion: column.accountId は connect ガードで保証
@@ -139,8 +141,8 @@ const noteColumnConfig: NoteColumnConfig = {
       })
     },
   },
-  filterCachedNotes: (cached) =>
-    cached.filter((n) => matchesFilter(n, columnFilters.value, tlType.value)),
+  filterNotes: (incoming) =>
+    incoming.filter((n) => matchesFilter(n, columnFilters.value, tlType.value)),
 }
 
 // --- DeckNoteColumn ref (expose: account, scroller, reconnect, switchWithSnapshot, notes, columnThemeVars) ---

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -1,0 +1,265 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { type App, createApp, defineComponent, nextTick, ref } from 'vue'
+import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
+import { type Account, useAccountsStore } from '@/stores/accounts'
+import type { DeckColumn } from '@/stores/deck'
+import { useUiStore } from '@/stores/ui'
+import { matchesFilter } from '@/utils/timelineFilter'
+import { type NoteColumnConfig, useNoteColumn } from './useNoteColumn'
+
+// tauri-specta bindings: 全コマンドを空成功で応答（SQLite キャッシュは空扱い）
+vi.mock('@/bindings', () => ({
+  commands: new Proxy(
+    {},
+    {
+      get:
+        () =>
+        (..._args: unknown[]) =>
+          Promise.resolve({ status: 'ok', data: [] }),
+    },
+  ),
+}))
+
+const fakeStream = {
+  connect: vi.fn(),
+  reconnect: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  subNote: vi.fn(),
+  unsubNote: vi.fn(),
+  cleanup: vi.fn(),
+}
+const fakeAdapter = { api: {}, stream: fakeStream } as unknown as ServerAdapter
+
+vi.mock('@/adapters/factory', () => ({
+  initAdapterFor: vi.fn(async () => ({
+    adapter: fakeAdapter,
+    serverInfo: { iconUrl: '' },
+  })),
+}))
+
+function note(id: string, visibility = 'public'): NormalizedNote {
+  return {
+    id,
+    createdAt: `2026-07-01T00:00:${id.slice(-2).padStart(2, '0')}.000Z`,
+    text: id,
+    cw: null,
+    visibility,
+    user: { id: `user-${id}`, username: id, host: null },
+    files: [],
+    reactions: {},
+  } as unknown as NormalizedNote
+}
+
+/** マイクロタスクと nextTick を数周流して非同期チェーンを収束させる */
+async function flush(rounds = 6) {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('useNoteColumn: 放置復帰の stale-tab ガードと REST 可視性フィルタ (#651)', () => {
+  let apps: App[] = []
+  let pinia: ReturnType<typeof createPinia>
+
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
+    pinia = createPinia()
+    setActivePinia(pinia)
+  })
+
+  afterEach(() => {
+    for (const app of apps) app.unmount()
+    apps = []
+    vi.useRealTimers()
+  })
+
+  function addAccount(id: string) {
+    useAccountsStore().accounts.push({
+      id,
+      host: 'example.com',
+      userId: `uid-${id}`,
+      username: id,
+      displayName: null,
+      avatarUrl: null,
+      software: 'misskey-dev/misskey',
+      hasToken: true,
+    } as Account)
+  }
+
+  function mountColumn(opts: {
+    accountId: string
+    columnId?: string
+    fetch: NoteColumnConfig['fetch']
+    filterNotes?: NoteColumnConfig['filterNotes']
+    fetchKey?: NoteColumnConfig['fetchKey']
+  }) {
+    const tlKey = ref('home')
+    let api: ReturnType<typeof useNoteColumn> | null = null
+    const Host = defineComponent({
+      setup() {
+        api = useNoteColumn({
+          getColumn: () =>
+            ({
+              id: opts.columnId ?? `col-${opts.accountId}`,
+              type: 'timeline',
+              accountId: opts.accountId,
+            }) as DeckColumn,
+          fetch: opts.fetch,
+          cache: { getKey: () => tlKey.value },
+          filterNotes: opts.filterNotes,
+          fetchKey: opts.fetchKey,
+        })
+        return () => null
+      },
+    })
+    const app = createApp(Host)
+    app.use(pinia)
+    app.mount(document.createElement('div'))
+    apps.push(app)
+    if (!api) throw new Error('harness setup failed')
+    return { tlKey, api: api as ReturnType<typeof useNoteColumn> }
+  }
+
+  function ids(api: ReturnType<typeof useNoteColumn>): string[] {
+    return api.notes.value.map((n) => n.id)
+  }
+
+  it('復帰フェッチ中にタブが切り替わったら旧タブの結果を破棄する', async () => {
+    addAccount('acc-resume')
+    let resolveResume: ((n: NormalizedNote[]) => void) | undefined
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h01')]) // mount 時 connect (home)
+      .mockImplementationOnce(
+        () =>
+          new Promise<NormalizedNote[]>((r) => {
+            resolveResume = r
+          }),
+      ) // 復帰時 catch-up (home, 未解決のまま保持)
+    const { tlKey, api } = mountColumn({
+      accountId: 'acc-resume',
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    expect(ids(api)).toEqual(['h01'])
+
+    // dedup レスポンスキャッシュ (TTL 5s) を確実に失効させてから復帰
+    vi.advanceTimersByTime(6000)
+    useUiStore().emitDeckResume()
+    await flush(2)
+    expect(resolveResume).toBeDefined()
+
+    // catch-up 未解決のうちにローカルタブへ切り替え（表示もローカルに差し替わる）
+    tlKey.value = 'local'
+    api.setNotes([note('l01')])
+
+    // ホーム TL の遅延レスポンス到着 — 現在ノートと重なりゼロ → gap 置換経路
+    resolveResume?.([note('h02'), note('h03')])
+    await flush()
+
+    // 旧タブの結果は破棄され、ローカルタブは汚染されない
+    expect(ids(api)).toEqual(['l01'])
+  })
+
+  it('復帰フェッチ完了までタブが同じなら通常どおりマージされる', async () => {
+    addAccount('acc-merge')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h01')])
+      .mockResolvedValueOnce([note('h01'), note('h02')])
+    const { api } = mountColumn({
+      accountId: 'acc-merge',
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    expect(ids(api)).toEqual(['h01'])
+
+    vi.advanceTimersByTime(6000)
+    useUiStore().emitDeckResume()
+    await flush()
+
+    expect(ids(api)).toContain('h01')
+    expect(ids(api)).toContain('h02')
+  })
+
+  it('reconnect(connect) 中にタブが切り替わったら旧タブの結果を破棄する', async () => {
+    addAccount('acc-reconnect')
+    let resolveReconnect: ((n: NormalizedNote[]) => void) | undefined
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h01')]) // mount 時 connect
+      .mockImplementationOnce(
+        () =>
+          new Promise<NormalizedNote[]>((r) => {
+            resolveReconnect = r
+          }),
+      ) // reconnect 経由の connect
+    const { tlKey, api } = mountColumn({
+      accountId: 'acc-reconnect',
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    expect(ids(api)).toEqual(['h01'])
+
+    vi.advanceTimersByTime(6000)
+    const done = api.reconnect()
+    await flush(2)
+    expect(resolveReconnect).toBeDefined()
+
+    tlKey.value = 'local'
+    api.setNotes([note('l01')])
+
+    resolveReconnect?.([note('h02')])
+    await done
+    await flush()
+
+    expect(ids(api)).toEqual(['l01'])
+  })
+
+  it('REST 取得結果にも可視性フィルタが適用される (local は public のみ)', async () => {
+    addAccount('acc-filter')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue([note('p01', 'public'), note('f02', 'followers')])
+    const { api } = mountColumn({
+      accountId: 'acc-filter',
+      fetch: () => fetchImpl(),
+      filterNotes: (notes) =>
+        notes.filter((n) => matchesFilter(n, undefined, 'local')),
+    })
+    await flush()
+
+    expect(ids(api)).toEqual(['p01'])
+  })
+
+  it('dedup キーがフィルタ指紋 (fetchKey) を含み、フィルタ違いのカラム間でレスポンスを共有しない', async () => {
+    addAccount('acc-dedup')
+    const fetchA = vi.fn().mockResolvedValue([note('a01')])
+    const fetchB = vi.fn().mockResolvedValue([note('b01')])
+
+    const colA = mountColumn({
+      accountId: 'acc-dedup',
+      columnId: 'col-a',
+      fetch: () => fetchA(),
+      fetchKey: () => JSON.stringify({}),
+    })
+    await flush()
+    expect(ids(colA.api)).toEqual(['a01'])
+
+    // 5 秒以内 (dedup TTL 内) に同一アカウント・同一 TL 種別で別フィルタのカラムを開く
+    const colB = mountColumn({
+      accountId: 'acc-dedup',
+      columnId: 'col-b',
+      fetch: () => fetchB(),
+      fetchKey: () => JSON.stringify({ withFiles: true }),
+    })
+    await flush()
+
+    expect(fetchB).toHaveBeenCalled()
+    expect(ids(colB.api)).toEqual(['b01'])
+  })
+})

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -63,8 +63,18 @@ export interface NoteColumnConfig {
     adapter: ServerAdapter,
     currentNotes: NormalizedNote[],
   ) => Promise<{ notes: NormalizedNote[]; mode: 'replace' | 'prepend' }>
-  /** Filter cached notes after loading from SQLite (e.g. timeline column filters) */
-  filterCachedNotes?: (notes: NormalizedNote[]) => NormalizedNote[]
+  /**
+   * クライアント側防御フィルタ。SQLite キャッシュ復元と REST 取得結果の
+   * 両方に適用される (ストリーミング挿入はカラム側 subscribe 内で適用)。
+   * local/global の public 限定などサーバー応答に依存しない可視性保証 (#651)。
+   */
+  filterNotes?: (notes: NormalizedNote[]) => NormalizedNote[]
+  /**
+   * dedup レスポンスキャッシュの追加識別子 (例: カラムフィルタの JSON)。
+   * 同一アカウント・同一 TL 種別でフィルタ違いのカラムがレスポンスを
+   * 共有しないようにする (#651)。
+   */
+  fetchKey?: () => string
   /**
    * When provided, delays `connect()` until this ref becomes `true`.
    * Used by timeline columns to wait for policy detection before connecting.
@@ -227,9 +237,18 @@ export function useNoteColumn(config: NoteColumnConfig) {
     () => notes.value[0]?.id ?? null,
   )
 
-  /** Apply filterCachedNotes if configured */
-  function applyFilter(cached: NormalizedNote[]): NormalizedNote[] {
-    return config.filterCachedNotes ? config.filterCachedNotes(cached) : cached
+  /** Apply filterNotes if configured */
+  function applyFilter(incoming: NormalizedNote[]): NormalizedNote[] {
+    return config.filterNotes ? config.filterNotes(incoming) : incoming
+  }
+
+  /**
+   * 非同期フェッチ中にタブ (cache key) が切り替わったら結果を破棄するための
+   * ガード。フェッチ開始時に呼んで capture し、await 後に返り値で検査する (#651)。
+   */
+  function tabGuard(): () => boolean {
+    const key = config.cache?.getKey() ?? 'default'
+    return () => (config.cache?.getKey() ?? 'default') === key
   }
 
   /** Load and filter cached timeline notes. Returns empty array on failure. */
@@ -276,14 +295,19 @@ export function useNoteColumn(config: NoteColumnConfig) {
   }
 
   function getDedupKey(): string {
-    return `${config.getColumn().accountId}:${config.cache?.getKey() ?? 'default'}`
+    const fetchKey = config.fetchKey ? `:${config.fetchKey()}` : ''
+    return `${config.getColumn().accountId}:${config.cache?.getKey() ?? 'default'}${fetchKey}`
   }
 
   async function fetchAndDedup(
     adapter: ServerAdapter,
     opts: { sinceId?: string } = {},
   ): Promise<NormalizedNote[]> {
-    return dedup(getDedupKey(), () => config.fetch(adapter, opts))
+    const fetched = await dedup(getDedupKey(), () =>
+      config.fetch(adapter, opts),
+    )
+    // REST 取得もキャッシュ・ストリーミングと同じ防御フィルタを通す (#651)
+    return applyFilter(fetched)
   }
 
   function verifyStaleNotes(
@@ -344,6 +368,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
       return
     }
 
+    const stillCurrent = tabGuard()
+
     // Restore snapshot from a previously unmounted instance (instant re-mount)
     const colId = config.getColumn().id
     const cacheKey = config.cache?.getKey()
@@ -370,6 +396,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
     // Display cached notes as soon as they arrive (don't wait for API)
     const cachedNotes = await cachePromise
+    if (!stillCurrent()) return
     let cachedIds: string[] = []
     if (cachedNotes.length > 0) {
       setNotes(cachedNotes)
@@ -439,6 +466,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
       const sinceId =
         !hasCached && notes.value.length > 0 ? notes.value[0]?.id : undefined
       const fetched = await fetchAndDedup(adapter, sinceId ? { sinceId } : {})
+      // フェッチ中にタブが切り替わっていたら旧タブの結果を破棄 (#651)
+      if (!stillCurrent()) return
       const freshIds = new Set(fetched.map((n) => n.id))
 
       if (fetched.length > 0) {
@@ -465,6 +494,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (!column.accountId || !cacheKey) return
     const lastNote = notes.value.at(-1)
     if (!lastNote) return
+    const stillCurrent = tabGuard()
     isLoading.value = true
     try {
       const older = await loadCachedTimelineBefore(
@@ -472,6 +502,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
         cacheKey,
         lastNote.createdAt,
       )
+      if (!stillCurrent()) return
       const filtered = applyFilter(older)
       if (filtered.length > 0) {
         setNotes(insertIntoSorted(notes.value, filtered))
@@ -497,10 +528,12 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (!adapter) return
     const lastNote = notes.value.at(-1)
     if (!lastNote) return
+    const stillCurrent = tabGuard()
     isLoading.value = true
     try {
       const older = await config.fetch(adapter, { untilId: lastNote.id })
-      setNotes(insertIntoSorted(notes.value, older))
+      if (!stillCurrent()) return
+      setNotes(insertIntoSorted(notes.value, applyFilter(older)))
     } catch (e) {
       logWarn('load-more', e)
       isOffline.value = true
@@ -568,8 +601,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (!adapter) return
     if (config.validate && !config.validate()) return
     const sinceId = notes.value[0]?.id
+    const stillCurrent = tabGuard()
     try {
       const fetched = await fetchAndDedup(adapter, sinceId ? { sinceId } : {})
+      if (!stillCurrent()) return
       if (fetched.length > 0) mergeUpdate(fetched)
       isOffline.value = false
     } catch (e) {
@@ -599,6 +634,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     lastResumeAt = now
 
     const hadNotes = notes.value.length > 0
+    const stillCurrent = tabGuard()
 
     // Run cache fetch and API fetch in parallel. Fetch the LATEST page (not
     // { sinceId }): while suspended the channel is unsubscribed and Misskey does
@@ -620,6 +656,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
       : Promise.resolve([] as NormalizedNote[])
 
     const [cached, fetched] = await Promise.all([cachePromise, apiPromise])
+    // フェッチ中にタブが切り替わっていたら旧タブの結果を破棄 (#651)。
+    // ガードなしだと下の gap 判定が別 TL のページで発火し、カラム全体が
+    // 期待外の公開範囲のノートに丸ごと置換される。
+    if (!stillCurrent()) return
     isOffline.value = apiFailed
 
     // Gap: none of the freshly-fetched latest notes are currently displayed, so
@@ -670,13 +710,14 @@ export function useNoteColumn(config: NoteColumnConfig) {
   /** Disconnect, reset, and reconnect with fresh config state */
   async function reconnect(useCache = false) {
     const adapter = getAdapter()
+    const stillCurrent = tabGuard()
     if (useOfflineModeStore().isOfflineMode) {
       // Offline mode: load cache only, skip API fetch and streaming
       setNotes([])
       isLoading.value = true
       if (useCache && config.cache) {
         const filtered = await loadFilteredCache('reconnect-cache')
-        if (filtered.length > 0) setNotes(filtered)
+        if (stillCurrent() && filtered.length > 0) setNotes(filtered)
       }
       isOffline.value = true
       isLoading.value = false
@@ -691,10 +732,13 @@ export function useNoteColumn(config: NoteColumnConfig) {
         // Load cache if requested
         if (useCache && config.cache) {
           const filtered = await loadFilteredCache('reconnect-cache')
+          if (!stillCurrent()) return
           if (filtered.length > 0) setNotes(filtered)
         }
         // Fetch latest from API
         const fetched = await fetchAndDedup(adapter)
+        // フェッチ中にタブが切り替わっていたら旧タブの結果を破棄 (#651)
+        if (!stillCurrent()) return
         mergeOrEnqueue(fetched)
         isOffline.value = false
       } catch (e) {
@@ -739,11 +783,11 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
     // Fetch diff from API to update snapshot with latest data
     const sinceId = snapshotNotes[0]?.id
-    const snapshotCacheKey = config.cache?.getKey() ?? 'default'
+    const stillCurrent = tabGuard()
     try {
       const fetched = await fetchAndDedup(adapter, sinceId ? { sinceId } : {})
       // Guard: discard if tab changed during async fetch
-      if ((config.cache?.getKey() ?? 'default') !== snapshotCacheKey) return
+      if (!stillCurrent()) return
       // Snapshot already has existing notes — only enqueue brand-new ones
       mergeOrEnqueue(fetched)
       isOffline.value = false

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -20,6 +20,7 @@ import {
   saveDraft,
 } from '@/composables/useDrafts'
 import { useFileAttachment } from '@/composables/useFileAttachment'
+import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import {
   deleteMemo,
   ensureMemosLoaded,
@@ -277,6 +278,14 @@ export function usePostFormState(
     }
 
     if (!adapter || !canPost.value) return
+
+    // ログアウト済み (トークン無し) アカウントは API 到達前に止める (#693)。
+    // 素通しすると生の "No token found" エラーが出た上、救済のサーバー
+    // 下書き保存もトークン必須で必ず失敗する。入力は消さずフォームに残す。
+    if (account.value?.hasToken === false) {
+      showLoginPrompt()
+      return
+    }
 
     // 迷惑投稿チェック: public かつ MFM 拡大/位置指定を含む場合に警告
     if (!props.editNote && visibility.value === 'public') {


### PR DESCRIPTION
## Changes

- fix: 放置復帰時に別公開範囲ノートが TL カラムへ混入する問題を解消 (#651)
- fix: アカウント0件時のノートボタン無反応にログイン誘導トーストを表示 (#693)
- fix: ログアウト済みアカウントのみの状態で投稿フォーム・投稿が素通りする穴を塞ぐ (#693)
- fix: 投稿フォームの初期アカウントはトークン保持アカウントを優先 (#693)
- chore: bump version to 1.4.6

## Issues

Closes #651
Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)