### PR TITLE
Release v1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.5.0"
+version = "1.6.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.5.0"
+    "version": "1.6.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/http.rs
+++ b/src-tauri/src/commands/http.rs
@@ -24,10 +24,13 @@
 
 use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
+
+use crate::vault::ssrf::PinningResolver;
 
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 const MAX_TIMEOUT_SECS: u64 = 120;
@@ -76,9 +79,16 @@ pub async fn http_fetch(
         ));
     }
 
+    // DNS pinning resolver: 名前解決後の IP を check_ip_safe で検証してから
+    // 接続する。validate_external_url の host 文字列検査だけでは、A レコードが
+    // loopback / private / メタデータ (169.254.169.254) を指す公開ホスト名や
+    // DNS rebinding を防げない。vault の外向き fetch と同じ防御を共有する。
+    // resolver は redirect の各 hop でも呼ばれるため、リダイレクト先の内部宛ても
+    // 同様に弾かれる。
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(timeout_secs))
         .redirect(reqwest::redirect::Policy::limited(5))
+        .dns_resolver(Arc::new(PinningResolver::new()))
         .build()
         .map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
@@ -140,8 +150,8 @@ fn parse_method(method: Option<&str>) -> Result<reqwest::Method, String> {
 }
 
 /// URL が外部公開向けに安全か検証する。host 名が IP 直書きならその IP を、
-/// hostname なら reserved TLD を弾く。実際の DNS 解決後の IP チェックは
-/// reqwest 内部に任せる (= 一次防御)。
+/// hostname なら reserved TLD を弾く (= 一次防御)。DNS 解決後の IP 検証は
+/// http_fetch が注入する PinningResolver が担う (二次防御・rebinding 対策)。
 pub fn validate_external_url(url_str: &str) -> Result<(), String> {
     let url =
         reqwest::Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::path::PathBuf;
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use notecli::error::NoteDeckError;
 use tauri::Manager;
@@ -8,6 +9,53 @@ use super::Result;
 
 /// Settings subdirectory name under app_data_dir.
 const SETTINGS_DIR: &str = "notedeck";
+
+/// 設定ファイルを原子的に書き込む (#719)。同ディレクトリの一時ファイルへ
+/// 書いて fsync してから rename する。直接 `fs::write` (truncate → write) だと
+/// 書き込み途中のクラッシュ・電源断で途中切れの壊れたファイルが残りうる —
+/// 特に permissions.json5 が壊れると権限記憶が失われる。rename は同一 FS 内で
+/// atomic なので、読み手は常に旧内容か新内容のいずれか完全な方を見る。
+///
+/// `mode` 指定時は rename 前に一時ファイルへ適用する (機密ファイルが一瞬でも
+/// 緩い権限で見えないように)。
+fn atomic_write(path: &Path, content: &str, mode: Option<u32>) -> Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        NoteDeckError::InvalidInput(format!("path has no parent: {}", path.display()))
+    })?;
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| NoteDeckError::InvalidInput(format!("invalid path: {}", path.display())))?;
+    // 一時名は同ディレクトリ内 (cross-device rename を避ける) + pid で衝突回避。
+    let tmp = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+
+    let write_result = (|| -> std::io::Result<()> {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(content.as_bytes())?;
+        #[cfg(unix)]
+        if let Some(m) = mode {
+            use std::os::unix::fs::PermissionsExt;
+            f.set_permissions(fs::Permissions::from_mode(m))?;
+        }
+        // fsync — rename が耐久性を持つのは中身がディスクに届いてから。
+        f.sync_all()?;
+        Ok(())
+    })();
+    #[cfg(not(unix))]
+    let _ = mode;
+    if let Err(e) = write_result {
+        let _ = fs::remove_file(&tmp);
+        return Err(NoteDeckError::InvalidInput(format!(
+            "Failed to write {}: {e}",
+            path.display()
+        )));
+    }
+
+    fs::rename(&tmp, path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        NoteDeckError::InvalidInput(format!("Failed to write {}: {e}", path.display()))
+    })
+}
 
 /// Allowed subdirectory names for settings files. Also the set included in settings backup.
 const ALLOWED_SUBDIRS: &[&str] = &[
@@ -122,19 +170,10 @@ pub fn write_settings_file(
             ))
         })?;
     }
-    fs::write(&path, content).map_err(|e| {
-        NoteDeckError::InvalidInput(format!("Failed to write {}: {e}", path.display()))
-    })?;
-
     // Tighten permissions for sensitive subdirectories — AI session content
     // may contain user secrets accidentally typed into prompts.
-    #[cfg(unix)]
-    if subdir == "sessions" {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o600));
-    }
-
-    Ok(())
+    let mode = if subdir == "sessions" { Some(0o600) } else { None };
+    atomic_write(&path, content, mode)
 }
 
 /// Delete a settings file.
@@ -224,9 +263,7 @@ pub fn read_root_settings_file(app: tauri::AppHandle, name: &str) -> Result<Stri
 #[specta::specta]
 pub fn write_root_settings_file(app: tauri::AppHandle, name: &str, content: &str) -> Result<()> {
     let path = resolve_root_path(&app, name)?;
-    fs::write(&path, content).map_err(|e| {
-        NoteDeckError::InvalidInput(format!("Failed to write {}: {e}", path.display()))
-    })
+    atomic_write(&path, content, None)
 }
 
 /// Get the settings directory path (so users can open it in file manager).
@@ -483,6 +520,46 @@ pub async fn import_settings_json(app: tauri::AppHandle) -> Result<bool> {
 mod tests {
     use super::*;
     use std::collections::BTreeMap;
+
+    #[test]
+    fn atomic_write_creates_and_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("permissions.json5");
+
+        atomic_write(&path, "{ v: 1 }", None).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{ v: 1 }");
+
+        // 上書きも旧内容を完全に置き換える
+        atomic_write(&path, "{ v: 2 }", None).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "{ v: 2 }");
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_temp_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json5");
+        atomic_write(&path, "{}", None).unwrap();
+
+        // 成功後、同ディレクトリに一時ファイル (.<name>.<pid>.tmp) が残らない
+        let leftovers: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.ends_with(".tmp"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files remained: {leftovers:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_applies_mode() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("secret.json5");
+        atomic_write(&path, "{}", Some(0o600)).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
 
     #[test]
     fn validate_subdir_allowed() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -777,6 +777,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             perf_config::update_performance_config,
             perf_config::get_performance_config,
             permissions_gate::permissions_sync,
+            permissions_gate::permissions_lockdown,
         ])
         .events(tauri_specta::collect_events![
             query_runtime::QueryDelta,

--- a/src-tauri/src/permissions_gate.rs
+++ b/src-tauri/src/permissions_gate.rs
@@ -58,6 +58,24 @@ pub fn permissions_sync(external_granted: HashMap<String, bool>) -> Result<(), S
     Ok(())
 }
 
+/// external gate をフェイルセーフに倒す (#718)。sync がリトライ後も失敗し
+/// 続けると、フロントの絞った権限が Rust に届かず古い広い map のまま動いて
+/// しまう。フロントは失敗確定時にこれを呼び、floor 以外を全 deny の状態
+/// (空 map) に固定する。以後は次の成功 sync が来るまで最小権限で動く。
+///
+/// 引数を取らないので、payload の serialize / 大きさ起因で `permissions_sync`
+/// が失敗するケースでも到達できる (IPC 自体が全断ならこの呼び出しも失敗する
+/// が、その場合フロントは警告に残す)。
+#[tauri::command]
+#[specta::specta]
+pub fn permissions_lockdown() -> Result<(), String> {
+    let mut guard = EXTERNAL_GRANTED
+        .write()
+        .map_err(|e| format!("permissions lockdown lock poisoned: {e}"))?;
+    *guard = Some(HashMap::new());
+    Ok(())
+}
+
 /// テスト用: sync 状態を初期化する。
 #[cfg(test)]
 pub fn reset_external_granted_for_test() {
@@ -320,6 +338,20 @@ mod tests {
         assert!(!is_granted("deck.read"));
         // floor は synced 値に関わらず true (resolveFor 側でも clamp 済み)
         assert!(is_granted("clips.read"));
+        reset_external_granted_for_test();
+    }
+
+    #[test]
+    fn lockdown_denies_non_floor_even_after_broad_sync() {
+        // 広い権限が同期された後に lockdown すると floor 以外は全 deny (#718)
+        sync(&[("notes.write", true), ("notifications", true)]);
+        assert!(is_granted("notes.write"));
+        permissions_lockdown().unwrap();
+        assert!(!is_granted("notes.write"));
+        assert!(!is_granted("notifications"));
+        // floor は lockdown 後も維持 (トークン発行 = read 同意の下限)
+        assert!(is_granted("notes.read"));
+        assert!(is_granted("account.read"));
         reset_external_granted_for_test();
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/api.ts
+++ b/src/aiscript/api.ts
@@ -132,7 +132,7 @@ export function createAiScriptEnv(
     const endpoint = endpointVal?.type === 'str' ? endpointVal.value : ''
     // plugin principal は endpoint 対応表 gate で判定 (#712 §5.5 / #711)。
     // 拒否なら throw (プラグイン作者向けの理由付きメッセージ)
-    assertMisskeyApiAllowed(options.principal, endpoint)
+    await assertMisskeyApiAllowed(options.principal, endpoint)
     const params =
       paramsVal?.type === 'obj'
         ? (utils.valToJs(paramsVal) as Record<string, unknown>)

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -362,7 +362,7 @@ function createPluginSpecificEnv(
     }
     const endpoint = endpointVal?.type === 'str' ? endpointVal.value : ''
     // プラグインの生 Misskey API は endpoint 対応表 gate に従属 (#712 / #711)
-    assertMisskeyApiAllowed(
+    await assertMisskeyApiAllowed(
       { kind: 'plugin', pluginId: plugin.installId, name: plugin.name },
       endpoint,
     )

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2226,6 +2226,24 @@ async permissionsSync(externalGranted: Partial<{ [key in string]: boolean }>) : 
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * external gate をフェイルセーフに倒す (#718)。sync がリトライ後も失敗し
+ * 続けると、フロントの絞った権限が Rust に届かず古い広い map のまま動いて
+ * しまう。フロントは失敗確定時にこれを呼び、floor 以外を全 deny の状態
+ * (空 map) に固定する。以後は次の成功 sync が来るまで最小権限で動く。
+ * 
+ * 引数を取らないので、payload の serialize / 大きさ起因で `permissions_sync`
+ * が失敗するケースでも到達できる (IPC 自体が全断ならこの呼び出しも失敗する
+ * が、その場合フロントは警告に残す)。
+ */
+async permissionsLockdown() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("permissions_lockdown") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -256,6 +256,32 @@ describe('dispatchCapability — confirmation flow', () => {
     expect(calls).toEqual(['confirm:test を実行しますか?', 'execute'])
   })
 
+  it('injects trusted marker on the confirm options (#720)', async () => {
+    let seenTrusted: boolean | undefined
+    registerCapability(
+      makeCapability({
+        id: 'notes.create',
+        permissions: ['notes.write'],
+        requiresConfirmation: true,
+        execute: () => 'posted',
+      }),
+    )
+    await dispatchCapability(
+      'notes.create',
+      { text: 'hi' },
+      ctxWithPreset('full'),
+      {
+        confirmFn: async (opts) => {
+          seenTrusted = opts.trusted
+          return { accepted: true, remember: false }
+        },
+      },
+    )
+    // dispatcher 経由の権限確認は本体の信頼マーカーが立つ (プラグインの
+    // Mk:confirm は立てられない)
+    expect(seenTrusted).toBe(true)
+  })
+
   it('returns user_cancelled and SKIPS execute when user cancels', async () => {
     let executed = false
     registerCapability(

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -282,6 +282,32 @@ describe('dispatchCapability — confirmation flow', () => {
     expect(seenTrusted).toBe(true)
   })
 
+  it('injects dedupKey (scope:capabilityId) for a skippable scope (#720)', async () => {
+    let seenKey: string | undefined
+    registerCapability(
+      makeCapability({
+        id: 'notes.create',
+        permissions: ['notes.write'],
+        requiresConfirmation: true,
+        execute: () => 'posted',
+      }),
+    )
+    await dispatchCapability(
+      'notes.create',
+      { text: 'hi' },
+      ctxWithPreset('full'),
+      {
+        confirmFn: async (opts) => {
+          seenKey = opts.dedupKey
+          return { accepted: true, remember: false }
+        },
+      },
+    )
+    // ai.chat principal の skip scope は 'ai.chat' なので dedupKey は
+    // `ai.chat:notes.create` (同一操作の待機分を自動承認するためのキー)
+    expect(seenKey).toBe('ai.chat:notes.create')
+  })
+
   it('returns user_cancelled and SKIPS execute when user cancels', async () => {
     let executed = false
     registerCapability(

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -148,6 +148,9 @@ export async function dispatchCapability(
     skipScope !== null &&
     isConfirmSkipped(skipScope, cap.id)
   if (confirmOpts && !skipConfirmed) {
+    // 信頼マーカー (#720): これは NoteDeck 本体の権限確認である。プラグインの
+    // Mk:confirm はこのフラグを立てられないので、システム確認になりすませない。
+    confirmOpts.trusted = true
     // 帰属表示 (#712 §3.3): 誰の要求かをダイアログ冒頭に必須表示する。
     // 無人 HEARTBEAT のモーダルが本人のチャット確認と誤認されないよう、
     // capability 側実装に任せず dispatcher が一律で注入する。

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -31,6 +31,7 @@ import {
   confirmSkipScope,
   isConfirmSkipped,
   resolveFor,
+  whenPermissionsReady,
 } from '@/permissions/store'
 import { getAccountLabel, useAccountsStore } from '@/stores/accounts'
 import {
@@ -84,6 +85,10 @@ export async function dispatchCapability(
   ctx: DispatchContext,
   options?: DispatchOptions,
 ): Promise<DispatchResult> {
+  // 起動直後は permissions.json5 の読込 (async) が終わる前に autoRun
+  // ウィジェット等がここへ到達しうる。デフォルト値での誤判定 (「今後確認
+  // しない」記憶の取りこぼし #716) を防ぐため、読込完了を待ってから判定する。
+  await whenPermissionsReady()
   // capabilityId は (a) registry に格納されている dotted id (`time.now`) か、
   // (b) Anthropic / OpenAI が返す sanitized name (`time_now`) のどちらかで
   // 来る可能性がある。前者は直接 lookup、後者は逆引きで解決する。

--- a/src/capabilities/dispatcher.ts
+++ b/src/capabilities/dispatcher.ts
@@ -151,6 +151,12 @@ export async function dispatchCapability(
     // 信頼マーカー (#720): これは NoteDeck 本体の権限確認である。プラグインの
     // Mk:confirm はこのフラグを立てられないので、システム確認になりすませない。
     confirmOpts.trusted = true
+    // 同一操作の dedup key (#720): 「今後確認しない」で許可したら、キューで
+    // 待機している同じ scope×capability の確認も自動承認させる (#716 の
+    // 「一度の同意を同一操作の待機分へ波及」)。skip 不可 scope では付けない。
+    if (skipScope !== null) {
+      confirmOpts.dedupKey = `${skipScope}:${cap.id}`
+    }
     // 帰属表示 (#712 §3.3): 誰の要求かをダイアログ冒頭に必須表示する。
     // 無人 HEARTBEAT のモーダルが本人のチャット確認と誤認されないよう、
     // capability 側実装に任せず dispatcher が一律で注入する。

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -85,6 +85,10 @@ useNativeDialog(dialogRef, visible, {
         :class="[entering && $style.contentEnter, leaving && $style.contentLeave]"
       >
         <div :class="$style.header">
+          <div v-if="options.trusted" :class="$style.trusted">
+            <i class="ti ti-shield-lock" />
+            <span>NoteDeck の権限確認</span>
+          </div>
           <div v-if="iconType" :class="$style.icon">
             <SystemIcon :type="iconType" />
           </div>
@@ -166,6 +170,27 @@ useNativeDialog(dialogRef, visible, {
 .header {
   padding: 20px 20px 4px;
   text-align: center;
+}
+
+// 信頼マーカー (#720): NoteDeck 本体の権限確認であることを示す。プラグインの
+// Mk:confirm はこのバッジを出せないので、システム確認となりすませない。
+.trusted {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 10px;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.72em;
+  font-weight: bold;
+  color: var(--nd-accent);
+  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--nd-accent) 35%, transparent);
+
+  i {
+    font-size: 1.15em;
+    line-height: 1;
+  }
 }
 
 .icon {

--- a/src/permissions/misskeyApiGate.test.ts
+++ b/src/permissions/misskeyApiGate.test.ts
@@ -18,73 +18,73 @@ afterEach(() => {
 })
 
 describe('assertMisskeyApiAllowed (#712 §5.5)', () => {
-  it('plugin=readonly では notes/create が拒否され、notes/show は通る', () => {
+  it('plugin=readonly では notes/create が拒否され、notes/show は通る', async () => {
     setPluginPreset('readonly')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'p1' },
         'notes/create',
       ),
-    ).toThrow(/permission_denied.*notes\.write/)
-    expect(() =>
+    ).rejects.toThrow(/permission_denied.*notes\.write/)
+    await expect(
       assertMisskeyApiAllowed({ kind: 'plugin', pluginId: 'p1' }, 'notes/show'),
-    ).not.toThrow()
+    ).resolves.toBeUndefined()
   })
 
-  it('plugin 行で notes.write を許可すると notes/create が通る', () => {
+  it('plugin 行で notes.write を許可すると notes/create が通る', async () => {
     setPluginPreset('full')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'p1' },
         'notes/create',
       ),
-    ).not.toThrow()
+    ).resolves.toBeUndefined()
   })
 
-  it('対応表に無い endpoint は deny-by-default', () => {
+  it('対応表に無い endpoint は deny-by-default', async () => {
     setPluginPreset('full')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'p1' },
         'some-fork/original-endpoint',
       ),
-    ).toThrow(/unknown endpoint/)
+    ).rejects.toThrow(/unknown endpoint/)
   })
 
-  it('admin 系 / 高感度 endpoint は full でも deny', () => {
+  it('admin 系 / 高感度 endpoint は full でも deny', async () => {
     setPluginPreset('full')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'p1' },
         'admin/accounts/delete',
       ),
-    ).toThrow(/開放されません/)
-    expect(() =>
+    ).rejects.toThrow(/開放されません/)
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'p1' },
         'i/regenerate-token',
       ),
-    ).toThrow(/開放されません/)
+    ).rejects.toThrow(/開放されません/)
   })
 
-  it('user (playground) は gate 免除', () => {
+  it('user (playground) は gate 免除', async () => {
     setPluginPreset('readonly')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed({ kind: 'user' }, 'notes/create'),
-    ).not.toThrow()
-    expect(() =>
+    ).resolves.toBeUndefined()
+    await expect(
       assertMisskeyApiAllowed({ kind: 'user' }, 'admin/accounts/delete'),
-    ).not.toThrow()
+    ).resolves.toBeUndefined()
   })
 
-  it('拒否は pluginDenials に記録される (#712 §8.4)', () => {
+  it('拒否は pluginDenials に記録される (#712 §8.4)', async () => {
     setPluginPreset('readonly')
-    expect(() =>
+    await expect(
       assertMisskeyApiAllowed(
         { kind: 'plugin', pluginId: 'badge-plugin' },
         'notes/create',
       ),
-    ).toThrow()
+    ).rejects.toThrow()
     const entry = getPluginDenial('badge-plugin')
     expect(entry?.lastTarget).toBe('Mk:api notes/create')
     expect(entry?.lastKeys).toEqual(['notes.write'])

--- a/src/permissions/misskeyApiGate.ts
+++ b/src/permissions/misskeyApiGate.ts
@@ -17,19 +17,25 @@ import {
 import { recordPluginDenial } from './pluginDenials'
 import type { Principal } from './principal'
 import type { PermissionKey } from './schema'
-import { resolveForProfiled } from './store'
+import { resolveForProfiled, whenPermissionsReady } from './store'
 
 /**
- * principal が endpoint を呼んでよいか判定し、拒否なら throw する。
+ * principal が endpoint を呼んでよいか判定し、拒否なら throw (reject) する。
  * plugin 拒否はプラグインカラムの拒否バッジ (#712 §8.4) にも記録する。
  */
-export function assertMisskeyApiAllowed(
+export async function assertMisskeyApiAllowed(
   principal: Principal,
   endpoint: string,
-): void {
+): Promise<void> {
   // user (playground) は gate 免除。ai.chat / ai.heartbeat / external は
   // そもそも Mk:api に到達しない (AiScript env は plugin / user のみ)
   if (principal.kind !== 'plugin') return
+
+  // 起動直後は permissions.json5 の読込 (async) 完了前に autoRun ウィジェット
+  // 等がここへ到達しうる。plugin のデフォルトプロファイル (safe) はユーザーの
+  // 制限 (readonly 等) より広いため、読込前の判定は許可側に倒れる (#716)。
+  // dispatcher と同じく読込完了を待ってから判定する。
+  await whenPermissionsReady()
 
   const rule: MisskeyEndpointRule | undefined = MISSKEY_ENDPOINT_RULES[endpoint]
 

--- a/src/permissions/store.init.test.ts
+++ b/src/permissions/store.init.test.ts
@@ -1,0 +1,52 @@
+// permissions.json5 の初回読込 (async) と起動直後の判定のレース (#716)。
+// autoRun ウィジェットが読込完了前に dispatch へ到達すると、confirmSkips が
+// 空のデフォルト値で判定されて「今後確認しない」の記憶が効かない。
+// settingsFs をモックして読込を保留し、whenPermissionsReady の待機を検証する。
+import { describe, expect, it, vi } from 'vitest'
+
+let resolveRead: ((content: string) => void) | undefined
+
+vi.mock('@/utils/settingsFs', () => ({
+  isTauri: true,
+  readPermissionsSettings: () =>
+    new Promise<string>((resolve) => {
+      resolveRead = resolve
+    }),
+  readAiSettings: () => Promise.resolve(''),
+  writeAiSettings: () => Promise.resolve(),
+  writePermissionsSettings: () => Promise.resolve(),
+}))
+
+vi.mock('@/utils/tauriInvoke', () => ({
+  commands: {
+    permissionsSync: () => Promise.resolve({ status: 'ok', data: null }),
+  },
+  unwrap: (r: unknown) => r,
+}))
+
+describe('whenPermissionsReady (#716)', () => {
+  it('読込完了前は解決せず、完了後に confirmSkips が反映される', async () => {
+    const { whenPermissionsReady, isConfirmSkipped } = await import('./store')
+
+    let ready = false
+    const p = whenPermissionsReady().then(() => {
+      ready = true
+    })
+
+    // 読込が保留されている間は resolve されない
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(ready).toBe(false)
+    // この時点で判定するとデフォルト値 (confirmSkips 空) — これがバグの再現
+    expect(isConfirmSkipped('plugin:widget:w1', 'http.fetch')).toBe(false)
+
+    resolveRead?.(
+      JSON.stringify({
+        confirmSkips: { 'plugin:widget:w1': ['http.fetch'] },
+      }),
+    )
+    await p
+    expect(ready).toBe(true)
+    expect(isConfirmSkipped('plugin:widget:w1', 'http.fetch')).toBe(true)
+  })
+})

--- a/src/permissions/store.init.test.ts
+++ b/src/permissions/store.init.test.ts
@@ -75,4 +75,26 @@ describe('whenPermissionsReady (#716)', () => {
     )
     await expect(p).rejects.toThrow(/permission_denied.*notes\.react/)
   })
+
+  it('破損した permissions.json5 は最小権限へフォールバックする (#719)', async () => {
+    const {
+      _resetPermissionsForTest,
+      whenPermissionsReady,
+      resolveForProfiled,
+    } = await import('./store')
+    _resetPermissionsForTest()
+
+    // 初回読込をトリガし、readPermissionsSettings が呼ばれて resolveRead が
+    // 再代入されるまでマイクロタスクを進めてから、パース不能な内容を返す
+    const ready = whenPermissionsReady()
+    await Promise.resolve()
+    await Promise.resolve()
+    resolveRead?.('{ this is not valid json5 ,,,')
+    await ready
+
+    // デフォルト (plugin=safe) なら notes.react は許可されるが、破損時は
+    // readonly へ倒れるので拒否される (無言の権限拡大を防ぐ)
+    const plugin = resolveForProfiled('plugin')
+    expect(plugin['notes.react']).toBe(false)
+  })
 })

--- a/src/permissions/store.init.test.ts
+++ b/src/permissions/store.init.test.ts
@@ -76,13 +76,17 @@ describe('whenPermissionsReady (#716)', () => {
     await expect(p).rejects.toThrow(/permission_denied.*notes\.react/)
   })
 
-  it('破損した permissions.json5 は最小権限へフォールバックする (#719)', async () => {
+  it('破損した permissions.json5 は最小権限へフォールバックし、トーストで通知する (#719 #722)', async () => {
     const {
       _resetPermissionsForTest,
       whenPermissionsReady,
       resolveForProfiled,
     } = await import('./store')
+    const { useToast } = await import('@/stores/toast')
     _resetPermissionsForTest()
+    // 直前のテストのトーストを消しておく
+    const { toasts } = useToast()
+    toasts.value = []
 
     // 初回読込をトリガし、readPermissionsSettings が呼ばれて resolveRead が
     // 再代入されるまでマイクロタスクを進めてから、パース不能な内容を返す
@@ -96,5 +100,8 @@ describe('whenPermissionsReady (#716)', () => {
     // readonly へ倒れるので拒否される (無言の権限拡大を防ぐ)
     const plugin = resolveForProfiled('plugin')
     expect(plugin['notes.react']).toBe(false)
+    // 無言で狭めず warning トーストで知らせる (#722)
+    const warn = toasts.value.find((t) => t.type === 'warning')
+    expect(warn?.text).toContain('最小権限で起動')
   })
 })

--- a/src/permissions/store.init.test.ts
+++ b/src/permissions/store.init.test.ts
@@ -49,4 +49,30 @@ describe('whenPermissionsReady (#716)', () => {
     expect(ready).toBe(true)
     expect(isConfirmSkipped('plugin:widget:w1', 'http.fetch')).toBe(true)
   })
+
+  it('Mk:api gate も読込完了を待ち、制限済みプロファイルで判定する', async () => {
+    const { _resetPermissionsForTest } = await import('./store')
+    const { assertMisskeyApiAllowed } = await import('./misskeyApiGate')
+    _resetPermissionsForTest()
+
+    // plugin=readonly に制限したユーザーの起動直後を再現。読込前のデフォルト
+    // (safe) は notes.react を許可するので、待たずに判定すると許可側に倒れる
+    let settled = false
+    const p = assertMisskeyApiAllowed(
+      { kind: 'plugin', pluginId: 'w1' },
+      'notes/reactions/create',
+    ).finally(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    resolveRead?.(
+      JSON.stringify({
+        principals: { plugin: { preset: 'readonly', custom: {} } },
+      }),
+    )
+    await expect(p).rejects.toThrow(/permission_denied.*notes\.react/)
+  })
 })

--- a/src/permissions/store.serialize.test.ts
+++ b/src/permissions/store.serialize.test.ts
@@ -1,0 +1,60 @@
+// save() の書き込みと reload の読込の直列化 (#716)。書き込み完了前に
+// 読み戻すと、メモリ上の権限変更・確認スキップ記憶が旧内容へ巻き戻る。
+// read/write を制御可能にモックし、reload が pending write を待つことを検証。
+import { describe, expect, it, vi } from 'vitest'
+
+let readCalls = 0
+let resolveWrite: (() => void) | undefined
+
+vi.mock('@/utils/settingsFs', () => ({
+  isTauri: true,
+  readPermissionsSettings: () => {
+    readCalls++
+    return Promise.resolve(
+      JSON.stringify({ confirmSkips: { 'ai.chat': ['persisted.cap'] } }),
+    )
+  },
+  readAiSettings: () => Promise.resolve(''),
+  writeAiSettings: () => Promise.resolve(),
+  writePermissionsSettings: () =>
+    new Promise<void>((resolve) => {
+      resolveWrite = resolve
+    }),
+}))
+
+vi.mock('@/utils/tauriInvoke', () => ({
+  commands: {
+    permissionsSync: () => Promise.resolve({ status: 'ok', data: null }),
+  },
+  unwrap: (r: unknown) => r,
+}))
+
+describe('save → reload 直列化 (#716)', () => {
+  it('reload の読込は進行中の save の書き込み完了を待つ', async () => {
+    const {
+      usePermissionsConfig,
+      reloadPermissionsConfig,
+      whenPermissionsReady,
+    } = await import('./store')
+
+    // 初期化完了を待つ (初回 read 1 回)
+    usePermissionsConfig()
+    await whenPermissionsReady()
+    expect(readCalls).toBe(1)
+
+    // save() で書き込みを開始 (mock により pending)
+    const { save } = usePermissionsConfig()
+    save()
+
+    // 書き込み完了前に reload を要求 — read はまだ走らない
+    const reloaded = reloadPermissionsConfig()
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(readCalls).toBe(1)
+
+    // 書き込みを完了させると reload の read が進む
+    resolveWrite?.()
+    await reloaded
+    expect(readCalls).toBe(2)
+  })
+})

--- a/src/permissions/store.sync.test.ts
+++ b/src/permissions/store.sync.test.ts
@@ -6,6 +6,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 let syncCalls = 0
 let syncFailuresRemaining = 0
 let lockdownCalls = 0
+let toastCalls: Array<{ text: string; type: string }> = []
+
+// toast は show() 内で dismiss を setTimeout する。fake timer 下では
+// runAllTimersAsync が dismiss まで走らせてしまうため、呼び出し自体を記録する
+// 軽量モックにして通知が出たことを検証する。
+vi.mock('@/stores/toast', () => ({
+  useToast: () => ({
+    show: (text: string, type = 'info') => {
+      toastCalls.push({ text, type })
+    },
+    dismiss: () => {},
+    toasts: { value: [] },
+  }),
+}))
 
 vi.mock('@/utils/settingsFs', () => ({
   isTauri: true,
@@ -38,6 +52,7 @@ beforeEach(() => {
   syncCalls = 0
   syncFailuresRemaining = 0
   lockdownCalls = 0
+  toastCalls = []
   vi.useFakeTimers()
 })
 
@@ -66,13 +81,14 @@ describe('syncExternalToRust リトライ (#718)', () => {
     await done
 
     expect(syncCalls).toBe(3)
-    // 回復したので恒久失敗の警告は出ず、lockdown も呼ばれない
+    // 回復したので恒久失敗の警告は出ず、lockdown も toast も出ない
     expect(
       warn.mock.calls.some((c) =>
         String(c[0]).includes('permissions_sync failed'),
       ),
     ).toBe(false)
     expect(lockdownCalls).toBe(0)
+    expect(toastCalls).toEqual([])
     warn.mockRestore()
   })
 
@@ -101,6 +117,10 @@ describe('syncExternalToRust リトライ (#718)', () => {
     ).toBe(true)
     // 失敗確定後は Rust gate をフェイルセーフに倒す (#718)
     expect(lockdownCalls).toBe(1)
+    // 自動制限を warning トーストで知らせる (#722)
+    expect(toastCalls).toHaveLength(1)
+    expect(toastCalls[0]?.type).toBe('warning')
+    expect(toastCalls[0]?.text).toContain('外部連携を一時的に制限')
     warn.mockRestore()
   })
 })

--- a/src/permissions/store.sync.test.ts
+++ b/src/permissions/store.sync.test.ts
@@ -1,0 +1,97 @@
+// permissions_sync (Rust external gate への同期) の一時障害リトライ (#718)。
+// sync を握りつぶすと Rust gate が古い広い権限のまま動くため、一時的な失敗は
+// リトライで回復させる。permissionsSync を「N 回失敗して成功」に設定し検証。
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let syncCalls = 0
+let syncFailuresRemaining = 0
+
+vi.mock('@/utils/settingsFs', () => ({
+  isTauri: true,
+  readPermissionsSettings: () =>
+    Promise.resolve(JSON.stringify({ principals: {} })),
+  readAiSettings: () => Promise.resolve(''),
+  writeAiSettings: () => Promise.resolve(),
+  writePermissionsSettings: () => Promise.resolve(),
+}))
+
+vi.mock('@/utils/tauriInvoke', () => ({
+  commands: {
+    permissionsSync: () => {
+      syncCalls++
+      if (syncFailuresRemaining > 0) {
+        syncFailuresRemaining--
+        return Promise.reject(new Error('sync failed'))
+      }
+      return Promise.resolve({ status: 'ok', data: null })
+    },
+  },
+  unwrap: (r: unknown) => r,
+}))
+
+beforeEach(() => {
+  syncCalls = 0
+  syncFailuresRemaining = 0
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('syncExternalToRust リトライ (#718)', () => {
+  it('一時的な sync 失敗はリトライで回復する', async () => {
+    const {
+      _resetPermissionsForTest,
+      usePermissionsConfig,
+      reloadPermissionsConfig,
+    } = await import('./store')
+    _resetPermissionsForTest()
+    // 初回 init 経由の sync を先に流し切り、_initStarted=true にしてから
+    // カウントをリセットする (reloadPermissionsConfig の二重 sync 経路を避ける)
+    usePermissionsConfig()
+    await vi.runAllTimersAsync()
+    syncCalls = 0
+    syncFailuresRemaining = 2 // 2 回失敗 → 3 回目で成功
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const done = reloadPermissionsConfig()
+    await vi.runAllTimersAsync()
+    await done
+
+    expect(syncCalls).toBe(3)
+    // 回復したので恒久失敗の警告は出ない
+    expect(
+      warn.mock.calls.some((c) =>
+        String(c[0]).includes('permissions_sync failed'),
+      ),
+    ).toBe(false)
+    warn.mockRestore()
+  })
+
+  it('リトライを使い切ったら警告を残して throw しない', async () => {
+    const {
+      _resetPermissionsForTest,
+      usePermissionsConfig,
+      reloadPermissionsConfig,
+    } = await import('./store')
+    _resetPermissionsForTest()
+    usePermissionsConfig()
+    await vi.runAllTimersAsync()
+    syncCalls = 0
+    syncFailuresRemaining = 99 // 常に失敗
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const done = reloadPermissionsConfig()
+    await vi.runAllTimersAsync()
+    await expect(done).resolves.toBeUndefined()
+
+    expect(syncCalls).toBe(3) // MAX_ATTEMPTS
+    expect(
+      warn.mock.calls.some((c) =>
+        String(c[0]).includes('permissions_sync failed after 3 attempts'),
+      ),
+    ).toBe(true)
+    warn.mockRestore()
+  })
+})

--- a/src/permissions/store.sync.test.ts
+++ b/src/permissions/store.sync.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let syncCalls = 0
 let syncFailuresRemaining = 0
+let lockdownCalls = 0
 
 vi.mock('@/utils/settingsFs', () => ({
   isTauri: true,
@@ -25,6 +26,10 @@ vi.mock('@/utils/tauriInvoke', () => ({
       }
       return Promise.resolve({ status: 'ok', data: null })
     },
+    permissionsLockdown: () => {
+      lockdownCalls++
+      return Promise.resolve({ status: 'ok', data: null })
+    },
   },
   unwrap: (r: unknown) => r,
 }))
@@ -32,6 +37,7 @@ vi.mock('@/utils/tauriInvoke', () => ({
 beforeEach(() => {
   syncCalls = 0
   syncFailuresRemaining = 0
+  lockdownCalls = 0
   vi.useFakeTimers()
 })
 
@@ -60,12 +66,13 @@ describe('syncExternalToRust リトライ (#718)', () => {
     await done
 
     expect(syncCalls).toBe(3)
-    // 回復したので恒久失敗の警告は出ない
+    // 回復したので恒久失敗の警告は出ず、lockdown も呼ばれない
     expect(
       warn.mock.calls.some((c) =>
         String(c[0]).includes('permissions_sync failed'),
       ),
     ).toBe(false)
+    expect(lockdownCalls).toBe(0)
     warn.mockRestore()
   })
 
@@ -92,6 +99,8 @@ describe('syncExternalToRust リトライ (#718)', () => {
         String(c[0]).includes('permissions_sync failed after 3 attempts'),
       ),
     ).toBe(true)
+    // 失敗確定後は Rust gate をフェイルセーフに倒す (#718)
+    expect(lockdownCalls).toBe(1)
     warn.mockRestore()
   })
 })

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -199,8 +199,15 @@ const _file: Ref<PermissionsFileConfig> = ref(defaultPermissionsFile())
 const _initialized: Ref<boolean> = ref(false)
 let _initStarted = false
 let _initPromise: Promise<void> | null = null
+// 進行中の save() の書き込み。reload (再読込) が未完了の書き込みより前の
+// 内容を読み戻してメモリ上の変更・確認スキップ記憶を巻き戻さないよう、
+// 読込はこれを待ってから走る (#716)。
+let _pendingWrite: Promise<unknown> = Promise.resolve()
 
 async function _initFileStorage(): Promise<void> {
+  // 進行中の save() の書き込みを待ってから読む (save→reload レースで
+  // 未完了の書き込みより前の内容を読み戻さない #716)。
+  await _pendingWrite.catch(() => {})
   const content = await readPermissionsSettings()
   if (content) {
     try {
@@ -285,7 +292,9 @@ export function usePermissionsConfig() {
   }
 
   function save(): void {
-    writePermissionsSettings(`${JSON5.stringify(_file.value, null, 2)}\n`)
+    _pendingWrite = writePermissionsSettings(
+      `${JSON5.stringify(_file.value, null, 2)}\n`,
+    )
       .then(syncExternalToRust)
       .catch((e: unknown) =>
         console.warn('[permissions] failed to write permissions.json5:', e),
@@ -316,6 +325,7 @@ export function _resetPermissionsForTest(): void {
   _initialized.value = false
   _initStarted = false
   _initPromise = null
+  _pendingWrite = Promise.resolve()
 }
 
 // --- principal → 実効権限の解決 ---

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -198,6 +198,7 @@ export function migrateLegacyPermissions(
 const _file: Ref<PermissionsFileConfig> = ref(defaultPermissionsFile())
 const _initialized: Ref<boolean> = ref(false)
 let _initStarted = false
+let _initPromise: Promise<void> | null = null
 
 async function _initFileStorage(): Promise<void> {
   const content = await readPermissionsSettings()
@@ -275,7 +276,11 @@ export function usePermissionsConfig() {
   if (!_initStarted) {
     _initStarted = true
     if (isTauri) {
-      _initFileStorage().then(syncExternalToRust)
+      _initPromise = _initFileStorage()
+        .then(syncExternalToRust)
+        .catch((e: unknown) => {
+          console.warn('[permissions] initial load failed:', e)
+        })
     }
   }
 
@@ -294,11 +299,23 @@ export function usePermissionsConfig() {
   }
 }
 
+/**
+ * permissions.json5 の初回読込完了を待つ (#716)。起動直後は読込 (async) が
+ * 終わる前に autoRun ウィジェット等が dispatch へ到達しうる。デフォルト値
+ * (confirmSkips 空・デフォルトプロファイル) での誤判定を防ぐため、dispatcher
+ * は判定前にこれを await する。読込不要な環境 (非 Tauri) では即時解決。
+ */
+export function whenPermissionsReady(): Promise<void> {
+  usePermissionsConfig() // 初期化トリガ (singleton)
+  return _initPromise ?? Promise.resolve()
+}
+
 /** @internal テスト用。state を初期化する。 */
 export function _resetPermissionsForTest(): void {
   _file.value = defaultPermissionsFile()
   _initialized.value = false
   _initStarted = false
+  _initPromise = null
 }
 
 // --- principal → 実効権限の解決 ---

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -45,6 +45,25 @@ const READONLY_PROFILE: PermissionsConfig = {
   custom: {} as never,
 }
 
+/**
+ * permissions.json5 が壊れて読めないときのフォールバック (#719)。全 principal を
+ * readonly に倒す — 新規インストール時デフォルト (plugin = safe + network.external)
+ * に倒すと、権限を絞っていたユーザーがファイル破損だけで無言のうちに権限拡大して
+ * しまう。破損は異常事態なので最小権限で起動し、ユーザーが設定 UI で復旧できる状態に
+ * する (external の Misskey read floor は resolve 時に clampForPrincipal が保証)。
+ */
+function safeFallbackFile(): PermissionsFileConfig {
+  const principals: Record<string, PermissionsConfig> = {}
+  for (const id of PROFILED_PRINCIPAL_IDS) {
+    principals[id] = normalizeProfile(READONLY_PROFILE, id)
+  }
+  return {
+    schemaVersion: PERMISSIONS_SCHEMA_VERSION,
+    principals,
+    confirmSkips: {},
+  }
+}
+
 // --- Defaults ---
 
 /**
@@ -215,8 +234,9 @@ async function _initFileStorage(): Promise<void> {
         JSON5.parse(content) as Partial<PermissionsFileConfig>,
       )
     } catch (e) {
+      // 破損時はデフォルト (plugin=safe) でなく最小権限へ倒す (#719)
       console.warn('[permissions] failed to parse permissions.json5:', e)
-      _file.value = defaultPermissionsFile()
+      _file.value = safeFallbackFile()
     }
     _initialized.value = true
     return
@@ -260,12 +280,31 @@ async function _initFileStorage(): Promise<void> {
  * する。フロント (dispatcher) と Rust (core proxy gate) の 2 つの enforce 点が
  * 別々の値で動く時間帯を作らない — 再読込・保存は必ずこれを伴う (#712 §4.2)。
  */
+const SYNC_MAX_ATTEMPTS = 3
+const SYNC_RETRY_BASE_MS = 200
+
 async function syncExternalToRust(): Promise<void> {
   if (!isTauri) return
-  try {
-    unwrap(await commands.permissionsSync(resolveForProfiled('external')))
-  } catch (e) {
-    console.warn('[permissions] permissions_sync failed:', e)
+  // 呼び出し時点の granted を送る。sync 失敗を握りつぶすと Rust gate が古い
+  // (広い) 権限のまま動き続けるため、一時障害はリトライで回復させる (#718)。
+  // それでも失敗が続いたら警告に残す (恒久的な silent fail を作らない)。
+  const granted = resolveForProfiled('external')
+  for (let attempt = 1; attempt <= SYNC_MAX_ATTEMPTS; attempt++) {
+    try {
+      unwrap(await commands.permissionsSync(granted))
+      return
+    } catch (e) {
+      if (attempt === SYNC_MAX_ATTEMPTS) {
+        console.warn(
+          `[permissions] permissions_sync failed after ${SYNC_MAX_ATTEMPTS} attempts:`,
+          e,
+        )
+        return
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, SYNC_RETRY_BASE_MS * attempt),
+      )
+    }
   }
 }
 

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -13,6 +13,7 @@
 
 import JSON5 from 'json5'
 import { type Ref, ref } from 'vue'
+import { useToast } from '@/stores/toast'
 import {
   isTauri,
   readAiSettings,
@@ -237,6 +238,11 @@ async function _initFileStorage(): Promise<void> {
       // 破損時はデフォルト (plugin=safe) でなく最小権限へ倒す (#719)
       console.warn('[permissions] failed to parse permissions.json5:', e)
       _file.value = safeFallbackFile()
+      // 無言で権限を狭めない (#722): ユーザーに最小権限起動を知らせる
+      useToast().show(
+        '権限設定を読み込めなかったため、安全のため最小権限で起動しました。設定から権限を確認してください。',
+        'warning',
+      )
     }
     _initialized.value = true
     return
@@ -307,6 +313,11 @@ async function syncExternalToRust(): Promise<void> {
         } catch (e2) {
           console.warn('[permissions] permissions_lockdown also failed:', e2)
         }
+        // 無言で外部連携を止めない (#722): 自動制限をユーザーに知らせる
+        useToast().show(
+          '権限の同期に失敗したため、外部連携を一時的に制限しました。アプリを再起動すると復旧します。',
+          'warning',
+        )
         return
       }
       await new Promise((resolve) =>

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -287,7 +287,6 @@ async function syncExternalToRust(): Promise<void> {
   if (!isTauri) return
   // 呼び出し時点の granted を送る。sync 失敗を握りつぶすと Rust gate が古い
   // (広い) 権限のまま動き続けるため、一時障害はリトライで回復させる (#718)。
-  // それでも失敗が続いたら警告に残す (恒久的な silent fail を作らない)。
   const granted = resolveForProfiled('external')
   for (let attempt = 1; attempt <= SYNC_MAX_ATTEMPTS; attempt++) {
     try {
@@ -295,10 +294,19 @@ async function syncExternalToRust(): Promise<void> {
       return
     } catch (e) {
       if (attempt === SYNC_MAX_ATTEMPTS) {
+        // リトライ枯渇。古い広い権限のまま動かさないよう Rust gate を
+        // フェイルセーフに倒す (floor 以外を全 deny #718)。無引数なので
+        // payload 起因の sync 失敗でも到達しうる。lockdown も失敗 (IPC 全断)
+        // なら Rust は到達不能なので警告に残すしかない。
         console.warn(
-          `[permissions] permissions_sync failed after ${SYNC_MAX_ATTEMPTS} attempts:`,
+          `[permissions] permissions_sync failed after ${SYNC_MAX_ATTEMPTS} attempts; locking external gate down:`,
           e,
         )
+        try {
+          unwrap(await commands.permissionsLockdown())
+        } catch (e2) {
+          console.warn('[permissions] permissions_lockdown also failed:', e2)
+        }
         return
       }
       await new Promise((resolve) =>

--- a/src/stores/confirm.test.ts
+++ b/src/stores/confirm.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { useConfirm } from './confirm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { _resetConfirmForTest, useConfirm } from './confirm'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  _resetConfirmForTest()
+})
 
 describe('useConfirm', () => {
   it('confirm() resolves to true when accepted', async () => {
@@ -30,12 +39,66 @@ describe('useConfirm', () => {
     await expect(p).resolves.toEqual({ accepted: true, remember: true })
   })
 
-  it('opening a new dialog rejects the previous one as not-accepted', async () => {
-    const { confirmWithDecision, resolve } = useConfirm()
+  // #716: 起動時に複数ウィジェットが一斉に確認要求すると、旧実装は先行の
+  // ダイアログを user_cancelled で横取りして最後の 1 件しか確認できなかった。
+  // 同時要求はキューに積み、順番に全件表示する。
+  it('同時要求は先行ダイアログを横取りせずキューされる (#716)', async () => {
+    const { confirmWithDecision, resolve, options, visible } = useConfirm()
     const first = confirmWithDecision({ title: '1', message: '' })
     const second = confirmWithDecision({ title: '2', message: '' })
-    await expect(first).resolves.toEqual({ accepted: false, remember: false })
+
+    // 表示中は最初の要求のまま (横取りされない)
+    expect(visible.value).toBe(true)
+    expect(options.value.title).toBe('1')
+
+    resolve({ accepted: true, remember: true })
+    await expect(first).resolves.toEqual({ accepted: true, remember: true })
+
+    // leave transition 待ちの後、次のダイアログが表示される
+    expect(visible.value).toBe(false)
+    vi.runAllTimers()
+    expect(visible.value).toBe(true)
+    expect(options.value.title).toBe('2')
+
+    resolve({ accepted: false, remember: false })
+    await expect(second).resolves.toEqual({ accepted: false, remember: false })
+    vi.runAllTimers()
+    expect(visible.value).toBe(false)
+  })
+
+  it('3 件同時要求は FIFO 順に全件表示・解決される (#716)', async () => {
+    const { confirmWithDecision, resolve, options } = useConfirm()
+    const decisions = [
+      { accepted: true, remember: true },
+      { accepted: false, remember: false },
+      { accepted: true, remember: false },
+    ] as const
+    const promises = [1, 2, 3].map((n) =>
+      confirmWithDecision({ title: String(n), message: '' }),
+    )
+    for (const [i, decision] of decisions.entries()) {
+      expect(options.value.title).toBe(String(i + 1))
+      resolve({ ...decision })
+      await expect(promises[i]).resolves.toEqual(decision)
+      vi.runAllTimers()
+    }
+  })
+
+  it('キュー待機中に来た新規要求も末尾に並ぶ (#716)', async () => {
+    const { confirmWithDecision, resolve, options } = useConfirm()
+    const first = confirmWithDecision({ title: '1', message: '' })
+    const second = confirmWithDecision({ title: '2', message: '' })
     resolve({ accepted: true, remember: false })
-    await expect(second).resolves.toEqual({ accepted: true, remember: false })
+    await first
+    // leave transition 待ちの間 (ダイアログ非表示) に来た要求
+    const third = confirmWithDecision({ title: '3', message: '' })
+    vi.runAllTimers()
+    expect(options.value.title).toBe('2')
+    resolve({ accepted: true, remember: false })
+    await second
+    vi.runAllTimers()
+    expect(options.value.title).toBe('3')
+    resolve({ accepted: false, remember: false })
+    await expect(third).resolves.toEqual({ accepted: false, remember: false })
   })
 })

--- a/src/stores/confirm.test.ts
+++ b/src/stores/confirm.test.ts
@@ -101,4 +101,35 @@ describe('useConfirm', () => {
     resolve({ accepted: false, remember: false })
     await expect(third).resolves.toEqual({ accepted: false, remember: false })
   })
+
+  // #720: 単一 principal がキューを埋め尽くす DoS を防ぐ。上限超過分は
+  // 自動キャンセルで即解決し、既にキューにある正当な確認は保持する。
+  it('キューが上限に達したら超過分は自動キャンセルされる (#720)', async () => {
+    const { confirmWithDecision, resolve } = useConfirm()
+    // 1 件目を表示中にし、残り MAX_QUEUE(32) 件でキューを満たす
+    const displayed = confirmWithDecision({ title: 'shown', message: '' })
+    const queued: Array<Promise<{ accepted: boolean }>> = []
+    for (let i = 0; i < 32; i++) {
+      queued.push(confirmWithDecision({ title: `q${i}`, message: '' }))
+    }
+    // 33 件目 (キュー 33 個目) は上限超過で即キャンセル解決される
+    const overflow = confirmWithDecision({ title: 'overflow', message: '' })
+    await expect(overflow).resolves.toEqual({
+      accepted: false,
+      remember: false,
+    })
+
+    // 表示中とキュー済みは影響を受けない (overflow だけが落ちる)
+    resolve({ accepted: true, remember: false })
+    await expect(displayed).resolves.toEqual({
+      accepted: true,
+      remember: false,
+    })
+    vi.runAllTimers()
+    resolve({ accepted: true, remember: false })
+    await expect(queued[0]).resolves.toEqual({
+      accepted: true,
+      remember: false,
+    })
+  })
 })

--- a/src/stores/confirm.test.ts
+++ b/src/stores/confirm.test.ts
@@ -132,4 +132,66 @@ describe('useConfirm', () => {
       remember: false,
     })
   })
+
+  // #720/#716: 「今後確認しない」で許可したら、キューで待つ同一操作
+  // (同じ dedupKey) は再度聞かず同じ許可で自動解決する。
+  it('remember 許可はキュー内の同一操作を自動承認する (#720)', async () => {
+    const { confirmWithDecision, resolve } = useConfirm()
+    const KEY = 'plugin:widget:w1:http.fetch'
+    const first = confirmWithDecision({
+      title: 'http',
+      message: '',
+      dedupKey: KEY,
+    })
+    const sameA = confirmWithDecision({
+      title: 'http',
+      message: '',
+      dedupKey: KEY,
+    })
+    const sameB = confirmWithDecision({
+      title: 'http',
+      message: '',
+      dedupKey: KEY,
+    })
+    // 別操作 (異なる dedupKey) は波及しない
+    const other = confirmWithDecision({
+      title: 'other',
+      message: '',
+      dedupKey: 'plugin:widget:w1:notes.write',
+    })
+
+    // 1 件目を「今後確認しない」で許可
+    resolve({ accepted: true, remember: true })
+    await expect(first).resolves.toEqual({ accepted: true, remember: true })
+    // 同一 dedupKey の待機分は自動承認 (remember は記録済みなので false で返す)
+    await expect(sameA).resolves.toEqual({ accepted: true, remember: false })
+    await expect(sameB).resolves.toEqual({ accepted: true, remember: false })
+
+    // 別操作は自動承認されず、通常どおり次に表示される
+    vi.runAllTimers()
+    resolve({ accepted: false, remember: false })
+    await expect(other).resolves.toEqual({ accepted: false, remember: false })
+  })
+
+  it('remember なし許可では同一操作を自動承認しない (#720)', async () => {
+    const { confirmWithDecision, resolve } = useConfirm()
+    const KEY = 'plugin:widget:w1:http.fetch'
+    const first = confirmWithDecision({
+      title: 'http',
+      message: '',
+      dedupKey: KEY,
+    })
+    const same = confirmWithDecision({
+      title: 'http',
+      message: '',
+      dedupKey: KEY,
+    })
+
+    // remember なしで許可 → 波及しない (待機分は個別に確認される)
+    resolve({ accepted: true, remember: false })
+    await expect(first).resolves.toEqual({ accepted: true, remember: false })
+    vi.runAllTimers()
+    resolve({ accepted: false, remember: false })
+    await expect(same).resolves.toEqual({ accepted: false, remember: false })
+  })
 })

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -77,6 +77,14 @@ export interface ConfirmOptions {
     description?: string
     permissions?: string[]
   }
+  /**
+   * NoteDeck 本体の権限確認であることを示す信頼マーカー (#720)。dispatcher が
+   * capability 確認を出すときにのみ true を注入する。AppConfirm はこのとき
+   * 偽装不能な視覚バッジ (盾アイコン + ラベル) を表示する。プラグインの
+   * `Mk:confirm` / `Mk:dialog` は title / message しか制御できずこのフラグを
+   * 立てられないので、システムの権限確認になりすませない。
+   */
+  trusted?: boolean
 }
 
 /**

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -94,6 +94,28 @@ const visible = ref(false)
 const options = ref<ConfirmOptions>({ title: '', message: '' })
 let resolvePromise: ((value: ConfirmDecision) => void) | null = null
 
+// 同時に複数の確認要求が来たときの待ち行列 (#716)。表示中のダイアログを
+// 横取りキャンセルせず、解決後に FIFO で順番に表示する — 起動時に複数の
+// autoRun ウィジェットが一斉に http.fetch の確認を要求しても全件確認できる。
+const queue: Array<{
+  opts: ConfirmOptions
+  resolve: (value: ConfirmDecision) => void
+}> = []
+
+// 次のダイアログは前のダイアログの leave transition (200ms) が終わってから
+// 出す。即時差し替えだと直前のダイアログへの連打・Enter がそのまま次の確認を
+// 許可してしまう (権限確認なので誤許可を作らない)。
+const NEXT_DIALOG_DELAY_MS = 250
+// leave transition 待ちの間 (visible=false かつ次のダイアログ未表示) を表す。
+// この間に来た新規要求もキュー末尾に並べる。
+let drainScheduled = false
+
+function show(entry: (typeof queue)[number]): void {
+  options.value = entry.opts
+  visible.value = true
+  resolvePromise = entry.resolve
+}
+
 export function useConfirm() {
   /**
    * 確認ダイアログを出し、OK 押下なら true を返す。既存呼び出しの主経路。
@@ -106,15 +128,16 @@ export function useConfirm() {
   /**
    * 確認ダイアログを出し、OK/キャンセルと remember チェック状態を返す。
    * dispatcher が `rememberLabel` 付き capability の確認に使う。
+   * 表示中のダイアログがあればキューに積まれ、順番が来るまで解決しない。
    */
   function confirmWithDecision(opts: ConfirmOptions): Promise<ConfirmDecision> {
-    if (resolvePromise) {
-      resolvePromise({ accepted: false, remember: false })
-    }
-    options.value = opts
-    visible.value = true
     return new Promise<ConfirmDecision>((resolve) => {
-      resolvePromise = resolve
+      const entry = { opts, resolve }
+      if (resolvePromise || drainScheduled) {
+        queue.push(entry)
+      } else {
+        show(entry)
+      }
     })
   }
 
@@ -130,6 +153,14 @@ export function useConfirm() {
     visible.value = false
     resolvePromise?.(decision)
     resolvePromise = null
+    if (queue.length > 0) {
+      drainScheduled = true
+      setTimeout(() => {
+        drainScheduled = false
+        const next = queue.shift()
+        if (next) show(next)
+      }, NEXT_DIALOG_DELAY_MS)
+    }
   }
 
   return {
@@ -140,4 +171,13 @@ export function useConfirm() {
     confirmWithAction,
     resolve,
   }
+}
+
+/** @internal テスト用。module-scope の state を初期化する。 */
+export function _resetConfirmForTest(): void {
+  visible.value = false
+  options.value = { title: '', message: '' }
+  resolvePromise = null
+  queue.length = 0
+  drainScheduled = false
 }

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -110,6 +110,12 @@ const NEXT_DIALOG_DELAY_MS = 250
 // この間に来た新規要求もキュー末尾に並べる。
 let drainScheduled = false
 
+// キューの上限 (#720)。単一の principal (プラグイン等) が Mk:confirm を無制限に
+// 呼んでキューを埋め尽くし、正当な確認を後方へ押し込む DoS を防ぐ。起動時の
+// autoRun ウィジェット群の正当な同時確認を妨げないよう十分に大きく取り、
+// 超過分は自動的にキャンセル扱い (accepted:false) で即解決する。
+const MAX_QUEUE = 32
+
 function show(entry: (typeof queue)[number]): void {
   options.value = entry.opts
   visible.value = true
@@ -134,6 +140,11 @@ export function useConfirm() {
     return new Promise<ConfirmDecision>((resolve) => {
       const entry = { opts, resolve }
       if (resolvePromise || drainScheduled) {
+        // キューが上限に達したら自動キャンセル (#720)。埋め尽くし DoS 防止。
+        if (queue.length >= MAX_QUEUE) {
+          resolve({ accepted: false, remember: false })
+          return
+        }
         queue.push(entry)
       } else {
         show(entry)

--- a/src/stores/confirm.ts
+++ b/src/stores/confirm.ts
@@ -85,6 +85,14 @@ export interface ConfirmOptions {
    * 立てられないので、システムの権限確認になりすませない。
    */
   trusted?: boolean
+  /**
+   * 同一操作をまとめる不透明な識別子 (#720)。このダイアログが「今後確認しない」
+   * チェック付きで許可されると、キューで待機している同じ `dedupKey` のダイアログも
+   * 同じ許可で自動解決される (再度聞かない)。confirm 層はこの文字列の意味を
+   * 解釈しない — dispatcher が `scope:capabilityId` を渡し、「一度の同意を同一
+   * 操作の待機分へ波及させる」#716 の理想を満たす。
+   */
+  dedupKey?: string
 }
 
 /**
@@ -170,8 +178,20 @@ export function useConfirm() {
 
   function resolve(decision: ConfirmDecision) {
     visible.value = false
+    const dedupKey = options.value.dedupKey
     resolvePromise?.(decision)
     resolvePromise = null
+    // 「今後確認しない」で許可されたら、キューで待つ同一操作 (同じ dedupKey) を
+    // 同じ許可で自動解決する (#720/#716: 一度の同意を同一操作の待機分へ波及)。
+    // remember は記録済みなので重複記録を避けるため false で返す。
+    if (decision.accepted && decision.remember && dedupKey) {
+      for (let i = queue.length - 1; i >= 0; i--) {
+        if (queue[i]?.opts.dedupKey === dedupKey) {
+          const [removed] = queue.splice(i, 1)
+          removed?.resolve({ accepted: true, remember: false })
+        }
+      }
+    }
     if (queue.length > 0) {
       drainScheduled = true
       setTimeout(() => {


### PR DESCRIPTION
## 概要

権限 principal 分離 (#712) 由来の穴を横断的に塞ぐ堅牢化リリース。ウィジットの一斉起動で確認ダイアログが 1 つだけ出て他が `user_cancelled` になるバグ (#716) を起点に、dispatcher を通らない経路まで監査し、確認フロー・読込レース・安全側フォールバック・通知・SSRF・確認の信頼性を整理した。

## 変更点

### 確認ダイアログ (#716 / #720)
- 単一 in-flight で後続を横取りキャンセルしていた確認ダイアログを FIFO キュー化
- 「今後確認しない」で許可したら、キューで待機する同一操作 (`scope:capabilityId`) を自動承認（一度の同意を待機分へ波及）
- キュー上限 (32) で埋め尽くし DoS を防止
- dispatcher 経由の権限確認に偽装不能な信頼マーカー（盾バッジ）を表示。プラグインの `Mk:confirm` は立てられず、本家 AiScript 互換は不変

### 読込レース (#716)
- `dispatchCapability` / `Mk:api` gate が権限判定前に `permissions.json5` の読込完了を待つ（単一 enforce 点の維持）
- `save()`→`reload` を直列化し、変更・記憶の巻き戻しを防止

### 安全側フォールバック + 通知 (#718 / #719 / #722)
- 設定ファイル書込を原子化（temp + fsync + rename）
- `permissions.json5` 破損時は全 principal を最小権限にフォールバック
- 外部 gate の sync 失敗はリトライし、枯渇時は deny に倒す（`permissions_lockdown`）
- 上記フォールバックはいずれも warning トーストで通知（無言で権限を狭めない）

### SSRF (#717)
- 外向き HTTP (`http_fetch`) に DNS 解決後の IP 検証（`PinningResolver`）を注入し、rebinding / 内部宛てを遮断

## Closes

Closes #716
Closes #718
Closes #719
Closes #720
Closes #722

## Changelog

- fix(confirm): 一度の「今後確認しない」を同一操作の待機分へ波及させる (#720)
- feat(permissions): 権限フォールバックをトーストで通知する (#722)
- fix(permissions): sync 失敗確定時に external gate を deny へ倒す (#718)
- feat(confirm): システム権限確認に偽装不能な信頼マーカーを付ける (#720)
- fix(permissions): sync 失敗のリトライと破損時の最小権限フォールバック (#718 #719)
- fix(confirm): 確認ダイアログのキューに上限を設ける (#720)
- fix(settings): 設定ファイルの書き込みを原子的にする (#719)
- fix(permissions): save の書込と reload の読込を直列化する (#716)
- fix(http): 外向き HTTP に DNS 解決後の SSRF 検証を追加 (#717)
- fix(permissions): Mk:api gate も permissions.json5 読込完了を待つ (#716)
- fix(permissions): 確認ダイアログのキュー化と権限読込レースの解消 (#716)
