### PR TITLE
Release v1.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.6.2",
+  "version": "1.6.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.6.2"
+version = "1.6.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.6.2"
+version = "1.6.3"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.6.2"
+    "version": "1.6.3"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -462,25 +462,22 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         // since `decorations: false` strips them from the OS frame.
         win_chrome::apply_to_main(app.handle());
 
-        // Fit window to monitor if larger than available screen (e.g. low-res VMs)
+        // Fit window to monitor if larger than available screen (e.g. low-res VMs).
+        // 物理px同士で比較・設定する: monitor.scale_factor() を介した論理px換算は
+        // WSLg 等のスケール誤報告で誤縮小の原因になる (#721)。
         #[cfg(not(mobile))]
         if let Some(w) = app.get_webview_window("main") {
-            if let Ok(Some(monitor)) = w.current_monitor() {
+            if let (Ok(Some(monitor)), Ok(outer)) = (w.current_monitor(), w.outer_size()) {
                 let screen = monitor.size();
-                let scale = monitor.scale_factor();
-                let screen_w = (screen.width as f64 / scale) as u32;
-                let screen_h = (screen.height as f64 / scale) as u32;
-
-                if let Ok(outer) = w.outer_size() {
-                    let win_w = (outer.width as f64 / scale) as u32;
-                    let win_h = (outer.height as f64 / scale) as u32;
-
-                    if win_w > screen_w || win_h > screen_h {
-                        let new_w = win_w.min(screen_w);
-                        let new_h = win_h.min(screen_h);
-                        let _ = w.set_size(tauri::LogicalSize::new(new_w, new_h));
-                        let _ = w.center();
-                    }
+                if outer.width > screen.width || outer.height > screen.height {
+                    // 誤縮小でモバイルレイアウト (420px 論理) に落ちないよう下限を設ける
+                    let scale = monitor.scale_factor();
+                    let floor_w = (600.0 * scale) as u32;
+                    let floor_h = (480.0 * scale) as u32;
+                    let new_w = outer.width.min(screen.width).max(floor_w);
+                    let new_h = outer.height.min(screen.height).max(floor_h);
+                    let _ = w.set_size(tauri::PhysicalSize::new(new_w, new_h));
+                    let _ = w.center();
                 }
             }
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/ui.test.ts
+++ b/src/aiscript/ui.test.ts
@@ -1,0 +1,80 @@
+import { Interpreter, Parser } from '@syuilo/aiscript'
+import { describe, expect, it } from 'vitest'
+import { createAiScriptUiLib, type UiComponent } from './ui'
+
+// Note: 本テストは Ui:render → valueToUiComponent の props 変換
+// （特にイベントハンドラ VFn の温存）を検証する。描画自体は
+// AiScriptUiRenderer.vue の責務なので実機で確認する。
+
+async function renderScript(src: string): Promise<UiComponent[]> {
+  let rendered: UiComponent[] = []
+  const ui = createAiScriptUiLib({
+    onRender: (components) => {
+      rendered = components
+    },
+  })
+  const interp = new Interpreter(ui, {})
+  await interp.exec(new Parser().parse(src))
+  return rendered
+}
+
+describe('Ui:render props conversion', () => {
+  it('preserves a top-level fn prop (Ui:C:button onClick)', async () => {
+    const comps = await renderScript(`
+      Ui:render([
+        Ui:C:button({
+          text: "go"
+          onClick: @() { 1 }
+        })
+      ])
+    `)
+    expect(comps).toHaveLength(1)
+    const onClick = comps[0]?.props.onClick as { type?: string }
+    expect(onClick?.type).toBe('fn')
+  })
+
+  it('preserves fn nested in the buttons array (Ui:C:buttons onClick)', async () => {
+    const comps = await renderScript(`
+      Ui:render([
+        Ui:C:buttons({
+          buttons: [{
+            text: "a"
+            disabled: false
+            onClick: @() { 1 }
+          }, {
+            text: "b"
+            primary: true
+            onClick: @() { 2 }
+          }]
+        })
+      ])
+    `)
+    expect(comps).toHaveLength(1)
+    const btns = comps[0]?.props.buttons as {
+      text: string
+      disabled?: boolean
+      primary?: boolean
+      onClick?: { type?: string }
+    }[]
+    expect(btns).toHaveLength(2)
+    expect(btns[0]?.text).toBe('a')
+    expect(btns[0]?.disabled).toBe(false)
+    expect(btns[0]?.onClick?.type).toBe('fn')
+    expect(btns[1]?.primary).toBe(true)
+    expect(btns[1]?.onClick?.type).toBe('fn')
+  })
+
+  it('still converts plain values with valToJs', async () => {
+    const comps = await renderScript(`
+      Ui:render([
+        Ui:C:select({
+          items: [{ text: "x", value: "1" }]
+          label: "sel"
+        })
+      ])
+    `)
+    const items = comps[0]?.props.items as { text: string; value: string }[]
+    expect(items[0]).toEqual({ text: 'x', value: '1' })
+    expect(comps[0]?.props.label).toBe('sel')
+  })
+})

--- a/src/aiscript/ui.ts
+++ b/src/aiscript/ui.ts
@@ -33,6 +33,24 @@ function genComponentId(): string {
   return `ais-${Date.now()}-${++componentIdCounter}`
 }
 
+// valToJs 相当の変換だが、ネストした fn を '<function>' に潰さず VFn のまま残す。
+// Ui:C:buttons の buttons 配列内 onClick など、props 直下以外のイベントハンドラは
+// AiScriptUiRenderer の callHandler が VFn を期待するためこちらを使う。
+function valToJsPreservingFn(val: Value): unknown {
+  if (val.type === 'fn') return val
+  if (val.type === 'arr') {
+    return (val.value as Value[]).map(valToJsPreservingFn)
+  }
+  if (val.type === 'obj') {
+    const obj: Record<string, unknown> = {}
+    for (const [k, v] of val.value as Map<string, Value>) {
+      obj[k] = valToJsPreservingFn(v)
+    }
+    return obj
+  }
+  return utils.valToJs(val)
+}
+
 function valueToUiComponent(val: Value): UiComponent | null {
   if (val.type !== 'obj') return null
   const obj = val.value as Map<string, Value>
@@ -57,7 +75,7 @@ function valueToUiComponent(val: Value): UiComponent | null {
         // Keep VFn as-is for event handlers
         props[k] = v
       } else {
-        props[k] = utils.valToJs(v)
+        props[k] = valToJsPreservingFn(v)
       }
     }
   }

--- a/src/components/common/MkMediaGrid.vue
+++ b/src/components/common/MkMediaGrid.vue
@@ -10,6 +10,7 @@ import {
 import type { NormalizedDriveFile } from '@/adapters/types'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useLongPress } from '@/composables/useLongPress'
+import { usePinchZoom } from '@/composables/usePinchZoom'
 import { usePortal } from '@/composables/usePortal'
 import { useSwipeTab } from '@/composables/useSwipeTab'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -49,6 +50,16 @@ function onLightboxSlideEnd() {
   lightboxSlideClass.value = null
 }
 
+// ピンチズーム / パン / ダブルタップズーム (#730)
+const {
+  transformStyle: zoomStyle,
+  zoomed,
+  reset: resetZoom,
+} = usePinchZoom(lightboxContentRef)
+
+// 画像切替・クローズでズームを解除
+watch(lightboxIndex, () => resetZoom())
+
 useSwipeTab(
   lightboxContentRef,
   () => {
@@ -73,6 +84,8 @@ useSwipeTab(
     classes: { swiping: 'nd-lb-swiping', snapBack: 'nd-lb-snap-back' },
     wheel: true,
     checkHorizontalScroll: false,
+    // ズーム中の1本指ドラッグはパンに割り当てる
+    enabled: () => !zoomed.value,
   },
 )
 const lightboxFile = computed(() =>
@@ -405,6 +418,7 @@ async function openInBrowser() {
           :src="safeMediaSrc(lightboxFile.url)"
           :alt="lightboxFile.name"
           :class="$style.lightboxImage"
+          :style="zoomStyle"
           draggable="false"
           v-bind="longPressHandlers"
           @contextmenu="onLightboxContextMenu"
@@ -707,7 +721,8 @@ async function openInBrowser() {
   align-items: center;
   justify-content: center;
   cursor: default;
-  touch-action: pan-y;
+  /* スワイプ / ピンチズーム / パンは JS で処理する */
+  touch-action: none;
 }
 
 .lightboxOverlay {
@@ -752,7 +767,7 @@ async function openInBrowser() {
   -webkit-touch-callout: default;
   -webkit-user-select: auto;
   user-select: auto;
-  touch-action: auto;
+  touch-action: none;
 }
 
 .lightboxVideo {

--- a/src/components/common/MkReactionPicker.vue
+++ b/src/components/common/MkReactionPicker.vue
@@ -361,6 +361,7 @@ onMounted(() => {
     max-width: 100%;
     max-height: 100%;
     flex: 1;
+    min-height: 0;
   }
 }
 
@@ -395,6 +396,8 @@ onMounted(() => {
 
 .pickerScroll {
   flex: 1;
+  /* flex 子の min-height:auto がコンテンツ高で膨らみスクロール不能になるのを防ぐ (#715) */
+  min-height: 0;
   overflow-y: auto;
   padding: 8px;
   contain: paint;

--- a/src/components/common/TitleBar.vue
+++ b/src/components/common/TitleBar.vue
@@ -63,7 +63,6 @@ const titleBarText = computed(() => {
   return `NoteDeck${suffix}`
 })
 const isMaximized = ref(false)
-const isCompactSize = ref(false)
 
 const MOBILE_WIDTH = 420
 const MOBILE_HEIGHT = 780
@@ -74,21 +73,12 @@ async function syncMaximized() {
   isMaximized.value = await appWindow.isMaximized()
 }
 
-async function syncMobileState() {
-  const factor = await appWindow.scaleFactor()
-  const size = await appWindow.innerSize()
-  const logicalWidth = size.width / factor
-  isCompactSize.value = logicalWidth <= MOBILE_WIDTH + 20
-}
-
 let unlisten: (() => void) | null = null
 
 onMounted(async () => {
   await syncMaximized()
-  await syncMobileState()
   unlisten = await appWindow.onResized(async () => {
     await syncMaximized()
-    await syncMobileState()
   })
 })
 
@@ -109,7 +99,7 @@ async function close() {
 }
 
 async function toggleMobileSize() {
-  if (isCompactSize.value) {
+  if (isCompact.value) {
     if (savedDesktopSize) {
       await appWindow.setSize(
         new LogicalSize(savedDesktopSize.width, savedDesktopSize.height),
@@ -125,11 +115,11 @@ async function toggleMobileSize() {
     } else if (isMaximized.value) {
       await appWindow.unmaximize()
     }
-    const factor = await appWindow.scaleFactor()
-    const current = await appWindow.innerSize()
+    // scaleFactor 換算は WSLg 等でスケール報告が揺れると狂うため、
+    // CSS 論理px (innerWidth/innerHeight) をそのまま保存する (#721)
     savedDesktopSize = {
-      width: current.width / factor,
-      height: current.height / factor,
+      width: window.innerWidth,
+      height: window.innerHeight,
     }
     await appWindow.setSize(new LogicalSize(MOBILE_WIDTH, MOBILE_HEIGHT))
   }
@@ -216,10 +206,10 @@ const menuRef = ref<InstanceType<typeof TitleBarMenu> | null>(null)
         </button>
         <button
           :class="[$style.titlebarBtn, $style.titlebarWindowBtn]"
-          :title="isCompactSize ? 'デスクトップサイズ' : 'モバイルサイズ'"
+          :title="isCompact ? 'デスクトップサイズ' : 'モバイルサイズ'"
           @click="toggleMobileSize"
         >
-          <i :class="isCompactSize ? 'ti ti-device-desktop' : 'ti ti-device-mobile'" />
+          <i :class="isCompact ? 'ti ti-device-desktop' : 'ti ti-device-mobile'" />
         </button>
       </template>
       <template v-if="isDesktop">

--- a/src/components/deck/DeckApiDocsColumn.vue
+++ b/src/components/deck/DeckApiDocsColumn.vue
@@ -70,6 +70,18 @@ const config = computed(() => ({
   overflow-y: auto;
 }
 
+/*
+ * Scalar はビューポート幅 (1000px) でしかナビサイドバーを畳まないため、
+ * 狭いカラムでも 288px 固定のサイドバーが居座り本文が窮屈になる (#708)。
+ * カラム幅 (DeckColumn の container) 基準で畳んで本文に全幅を渡す。
+ * !important は Scalar 側の `lg:flex` (media query + .scalar-app スコープ) に勝つため。
+ */
+@container (max-width: 768px) {
+  .docsContainer :global(.t-doc__sidebar) {
+    display: none !important;
+  }
+}
+
 .docsError {
   padding: 16px;
   color: var(--nd-love);

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -330,6 +330,8 @@ function handlePrimaryClick() {
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
+  /* row3 の折り返しで独立行になっても右端に寄せる (#729) */
+  margin-left: auto;
   opacity: 0;
   transition: opacity 0.15s;
 

--- a/src/composables/useDeckWindow.ts
+++ b/src/composables/useDeckWindow.ts
@@ -155,18 +155,21 @@ export async function saveCurrentWindowLayout(opts?: {
       '@tauri-apps/api/window'
     )
     const win = getCurrentWindow()
-    const [pos, size, monitor] = await Promise.all([
+    const [pos, size, monitor, factor] = await Promise.all([
       win.outerPosition(),
       win.outerSize(),
       currentMonitor(),
+      win.scaleFactor(),
     ])
 
+    // WebviewWindow の生成オプション (x/y/width/height) は論理px なので、
+    // 物理px で返る outerPosition/outerSize を論理px に正規化して保存する (#721)
     const layout: DeckWindowLayout = {
       id: deckStore.currentWindowId,
-      x: pos.x,
-      y: pos.y,
-      width: size.width,
-      height: size.height,
+      x: Math.round(pos.x / factor),
+      y: Math.round(pos.y / factor),
+      width: Math.round(size.width / factor),
+      height: Math.round(size.height / factor),
       monitor: monitor?.name ?? undefined,
     }
     deckStore.saveWindowLayout(layout, opts)
@@ -283,9 +286,10 @@ async function resolveWindowPosition(
     // Check if the saved monitor is still connected
     const savedMonitor = monitors.find((m) => m.name === wl.monitor)
     if (savedMonitor) {
-      // Monitor exists — verify coordinates are within its bounds
-      const mx = savedMonitor.position.x
-      const my = savedMonitor.position.y
+      // Monitor exists — verify coordinates are within its bounds.
+      // wl は論理px なのでモニター境界 (物理px) も論理px に揃える (#721)
+      const mx = savedMonitor.position.x / savedMonitor.scaleFactor
+      const my = savedMonitor.position.y / savedMonitor.scaleFactor
       const mw = savedMonitor.size.width / savedMonitor.scaleFactor
       const mh = savedMonitor.size.height / savedMonitor.scaleFactor
       if (
@@ -305,8 +309,8 @@ async function resolveWindowPosition(
 
     // Monitor disconnected — center on primary
     if (primary) {
-      const px = primary.position.x
-      const py = primary.position.y
+      const px = primary.position.x / primary.scaleFactor
+      const py = primary.position.y / primary.scaleFactor
       const pw = primary.size.width / primary.scaleFactor
       const ph = primary.size.height / primary.scaleFactor
       return {

--- a/src/composables/usePinchZoom.ts
+++ b/src/composables/usePinchZoom.ts
@@ -1,0 +1,198 @@
+import { computed, onUnmounted, type Ref, ref, watch } from 'vue'
+
+const MIN_SCALE = 1
+const MAX_SCALE = 8
+const DOUBLE_TAP_SCALE = 2.5
+// ピンチ終了時にこの倍率未満なら等倍へスナップバック
+const RESET_SNAP_SCALE = 1.05
+
+/**
+ * ライトボックス画像のピンチズーム / パン / ダブルタップズーム。
+ *
+ * 対象要素（コンテナ）にタッチイベントを直接バインドし、
+ * transform 用のインラインスタイルを返す。ズーム中は
+ * `zoomed` が true になるので、スワイプナビ等との排他に使う。
+ */
+export function usePinchZoom(targetRef: Ref<HTMLElement | null>) {
+  const scale = ref(1)
+  const translateX = ref(0)
+  const translateY = ref(0)
+
+  const zoomed = computed(() => scale.value > 1)
+  const transformStyle = computed(() =>
+    zoomed.value
+      ? {
+          transform: `translate(${translateX.value}px, ${translateY.value}px) scale(${scale.value})`,
+        }
+      : undefined,
+  )
+
+  function reset() {
+    scale.value = 1
+    translateX.value = 0
+    translateY.value = 0
+  }
+
+  /** 画像がコンテナから離れすぎないよう平行移動量を制限 */
+  function clampTranslate() {
+    if (!boundEl) return
+    const maxX = ((scale.value - 1) * boundEl.clientWidth) / 2
+    const maxY = ((scale.value - 1) * boundEl.clientHeight) / 2
+    translateX.value = Math.min(maxX, Math.max(-maxX, translateX.value))
+    translateY.value = Math.min(maxY, Math.max(-maxY, translateY.value))
+  }
+
+  let boundEl: HTMLElement | null = null
+
+  // --- Pinch ---
+  let pinching = false
+  let pinchStartDist = 0
+  let pinchStartScale = 1
+  let pinchStartMidX = 0
+  let pinchStartMidY = 0
+  let pinchStartTx = 0
+  let pinchStartTy = 0
+
+  // --- Pan (1本指、ズーム中のみ) ---
+  let panning = false
+  let panStartX = 0
+  let panStartY = 0
+  let panStartTx = 0
+  let panStartTy = 0
+
+  function touchDistance(a: Touch, b: Touch): number {
+    return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
+  }
+
+  function beginPinch(a: Touch, b: Touch) {
+    pinching = true
+    panning = false
+    pinchStartDist = touchDistance(a, b)
+    pinchStartScale = scale.value
+    pinchStartMidX = (a.clientX + b.clientX) / 2
+    pinchStartMidY = (a.clientY + b.clientY) / 2
+    pinchStartTx = translateX.value
+    pinchStartTy = translateY.value
+  }
+
+  function beginPan(t: Touch) {
+    panning = true
+    panStartX = t.clientX
+    panStartY = t.clientY
+    panStartTx = translateX.value
+    panStartTy = translateY.value
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    if (e.touches.length === 2) {
+      const [a, b] = [e.touches[0], e.touches[1]]
+      if (a && b) beginPinch(a, b)
+    } else if (e.touches.length === 1 && zoomed.value) {
+      const t = e.touches[0]
+      if (t) beginPan(t)
+    }
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (pinching && e.touches.length >= 2) {
+      const [a, b] = [e.touches[0], e.touches[1]]
+      if (!a || !b) return
+      e.preventDefault()
+
+      const next = Math.min(
+        MAX_SCALE,
+        Math.max(
+          MIN_SCALE,
+          (pinchStartScale * touchDistance(a, b)) / pinchStartDist,
+        ),
+      )
+      const midX = (a.clientX + b.clientX) / 2
+      const midY = (a.clientY + b.clientY) / 2
+      const rect = boundEl?.getBoundingClientRect()
+      if (!rect) return
+      const cx = rect.left + rect.width / 2
+      const cy = rect.top + rect.height / 2
+
+      // ピンチ開始時に中点の下にあった画像上の点を、現在の中点に追従させる
+      const ratio = next / pinchStartScale
+      translateX.value =
+        midX - cx - ratio * (pinchStartMidX - cx - pinchStartTx)
+      translateY.value =
+        midY - cy - ratio * (pinchStartMidY - cy - pinchStartTy)
+      scale.value = next
+      clampTranslate()
+    } else if (panning && e.touches.length === 1 && zoomed.value) {
+      const t = e.touches[0]
+      if (!t) return
+      e.preventDefault()
+      translateX.value = panStartTx + (t.clientX - panStartX)
+      translateY.value = panStartTy + (t.clientY - panStartY)
+      clampTranslate()
+    }
+  }
+
+  function onTouchEnd(e: TouchEvent) {
+    if (pinching && e.touches.length < 2) {
+      pinching = false
+      if (scale.value < RESET_SNAP_SCALE) {
+        reset()
+      } else {
+        // 残った1本指でそのままパンに移行
+        const t = e.touches[0]
+        if (t) beginPan(t)
+      }
+    } else if (panning && e.touches.length === 0) {
+      panning = false
+    }
+  }
+
+  function onDblclick(e: MouseEvent) {
+    if (zoomed.value) {
+      reset()
+      return
+    }
+    const rect = boundEl?.getBoundingClientRect()
+    if (!rect) return
+    const cx = rect.left + rect.width / 2
+    const cy = rect.top + rect.height / 2
+    scale.value = DOUBLE_TAP_SCALE
+    // タップ位置を中心にズームイン
+    translateX.value = (e.clientX - cx) * (1 - DOUBLE_TAP_SCALE)
+    translateY.value = (e.clientY - cy) * (1 - DOUBLE_TAP_SCALE)
+    clampTranslate()
+  }
+
+  function bind(el: HTMLElement) {
+    if (boundEl === el) return
+    unbind()
+    boundEl = el
+    el.addEventListener('touchstart', onTouchStart, { passive: true })
+    el.addEventListener('touchmove', onTouchMove, { passive: false })
+    el.addEventListener('touchend', onTouchEnd, { passive: true })
+    el.addEventListener('touchcancel', onTouchEnd, { passive: true })
+    el.addEventListener('dblclick', onDblclick)
+  }
+
+  function unbind() {
+    if (!boundEl) return
+    boundEl.removeEventListener('touchstart', onTouchStart)
+    boundEl.removeEventListener('touchmove', onTouchMove)
+    boundEl.removeEventListener('touchend', onTouchEnd)
+    boundEl.removeEventListener('touchcancel', onTouchEnd)
+    boundEl.removeEventListener('dblclick', onDblclick)
+    boundEl = null
+  }
+
+  watch(
+    targetRef,
+    (v) => {
+      if (v) bind(v)
+      else unbind()
+    },
+    { flush: 'post' },
+  )
+
+  onUnmounted(unbind)
+
+  return { transformStyle, zoomed, reset }
+}

--- a/src/composables/useSwipeTab.ts
+++ b/src/composables/useSwipeTab.ts
@@ -29,6 +29,8 @@ export interface SwipeOptions {
   wheel?: boolean
   /** Check for horizontally scrollable children before swiping (default: true) */
   checkHorizontalScroll?: boolean
+  /** Return false to temporarily disable swipe tracking (e.g. while zoomed) */
+  enabled?: () => boolean
 }
 
 /** Check if touch target is inside a horizontally scrollable element */
@@ -104,6 +106,7 @@ export function useSwipeTab(
   }
 
   function onTouchStart(e: TouchEvent) {
+    if (options?.enabled && !options.enabled()) return
     const touch = e.touches[0]
     if (!touch) return
     // Skip swipe if touch is inside a horizontally scrollable child (e.g. CodeMirror)
@@ -231,6 +234,7 @@ export function useSwipeTab(
   let lastWheelAt = 0
 
   function onWheel(e: WheelEvent) {
+    if (options?.enabled && !options.enabled()) return
     // Only react to horizontal scroll (deltaX) or shift+wheel (deltaY as horizontal)
     const dx = e.deltaX || (e.shiftKey ? e.deltaY : 0)
     if (dx === 0) return


### PR DESCRIPTION
## 変更内容

UI 系バグ修正リリース。

- fix(ui): HiDPI 環境でのビューポート判定とスケール換算を統一 (#721)
- fix(api-docs): 狭いカラムで Scalar のナビサイドバーを畳む (#708)
- fix(widgets): ストアカードのインストールボタンを右下に固定 (#729)
- fix(reaction-picker): 絵文字ピッカーが縦スクロールできない問題を修正 (#715)
- fix(media): ライトボックスにピンチズーム/パン/ダブルタップズームを追加 (#730)
- fix(aiscript): props ネスト内のイベントハンドラが無反応になる問題を修正
- chore: bump version to 1.6.3
- chore: regenerate openapi.json for 1.6.3

Closes #708
Closes #715
Closes #721
Closes #729
Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)