### PR TITLE
docs(site): ランディングページを初見向けに再構成

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>NoteDeck - Misskey 統合環境 (IDE)</title>
-  <meta name="description" content="複数の Misskey サーバーをひとつのデッキで。閲覧・投稿・検索・連携をひとつに統合。ネイティブの軽さ、オフライン対応、ローカル全文検索。Windows, macOS, Linux, Android 対応のオープンソース Misskey IDE。" />
-  <meta property="og:title" content="NoteDeck — Misskey IDE" />
-  <meta property="og:description" content="複数の Misskey サーバーをひとつのデッキで。閲覧・投稿・検索・連携を統合した Misskey 統合環境。" />
+  <title>NoteDeck — あなたの Misskey が棲む、デッキ。 | Misskey IDE</title>
+  <meta name="description" content="複数の Misskey サーバーをひとつのデッキで。見たノートは手元に残り、オフラインでも読める。軽くて速い、Windows, macOS, Linux, Android 対応のオープンソース Misskey IDE (統合デッキ環境)。" />
+  <meta property="og:title" content="NoteDeck — あなたの Misskey が棲む、デッキ。" />
+  <meta property="og:description" content="複数の Misskey サーバーをひとつのデッキで。見たノートは手元に残り、オフラインでも読める。軽くて速い Misskey IDE。" />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://raw.githubusercontent.com/hitalin/notedeck/main/src-tauri/icons/128x128%402x.png" />
   <link rel="icon" href="https://raw.githubusercontent.com/hitalin/notedeck/main/src-tauri/icons/32x32.png" type="image/png" />
@@ -33,7 +33,6 @@
         <div class="nav-items">
           <a href="#why">特長</a>
           <a href="#features">機能</a>
-          <a href="#architecture">アーキテクチャ</a>
           <a href="#download">ダウンロード</a>
           <a href="https://misstore.hital.in">Store</a>
         </div>
@@ -53,7 +52,6 @@
     <div class="nav-mobile-drawer">
       <a href="#why" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">特長</a>
       <a href="#features" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">機能</a>
-      <a href="#architecture" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">アーキテクチャ</a>
       <a href="#download" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">ダウンロード</a>
       <a href="https://misstore.hital.in" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">Store</a>
       <a href="https://github.com/hitalin/notedeck" class="nav-mobile-item" onclick="document.querySelector('.nav-root').classList.remove('nav-open')">GitHub</a>
@@ -70,7 +68,9 @@
       <img src="https://raw.githubusercontent.com/hitalin/notedeck/main/src-tauri/icons/128x128%402x.png" alt="" class="hero-logo" />
       <span class="hero-wordmark">Note<span>Deck</span></span>
     </h1>
-    <p class="tagline">Misskey Integrated Deck Environment</p>
+    <p class="tagline">あなたの Misskey が棲む、デッキ。</p>
+    <p class="hero-lead">無料で使える、軽くて速い Misskey クライアント。</p>
+    <a href="#download" class="btn btn-primary">ダウンロード</a>
   </section>
 
   <!-- Screenshot -->
@@ -89,87 +89,30 @@
           <div class="pillar-icon">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
           </div>
-          <h3>全鯖をひとつのデッキで</h3>
-          <p class="pillar-lead">複数サーバーの通知・TL・検索を<strong>クロスアカウントで統合表示。</strong></p>
+          <h3>全部のサーバーが、ひとつの画面に</h3>
+          <p class="pillar-lead">通知・タイムライン・検索を<strong>アカウント横断でまとめて一覧。</strong></p>
           <p>misskey.io、にじみす、すしすきー — 何鯖使っていても、ひとつのデッキにまとめて把握。アカウントごとにブラウザのタブを開く時代は終わり。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
           </div>
-          <h3>オフラインファースト</h3>
-          <p class="pillar-lead">ノートはローカル DB に蓄積。<strong>オフラインでも読める。</strong></p>
-          <p>流れたタイムラインもローカル SQLite に自動保存。全文検索で過去の投稿を即座に発見。ネットワークが切れても、蓄積したノートはいつでも閲覧可能。</p>
+          <h3>見たノートは、手元に残る</h3>
+          <p class="pillar-lead">流れてきたノートを、<strong>アプリが自動で覚えている。</strong></p>
+          <p>流れたタイムラインはローカル DB に自動保存。「あのノートどこだっけ？」も全文検索で一瞬。電波がなくても読み返せて、サーバーから消えても手元には残ります。</p>
         </div>
         <div class="pillar glass fade-in" data-direction="up">
           <div class="pillar-icon">
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
           </div>
-          <h3>ネイティブの速さ</h3>
-          <p class="pillar-lead">ブラウザや VM のオーバーヘッドなし。<strong>圧倒的に軽量。</strong></p>
-          <p>Tauri v2 + Rust バックエンドによるネイティブバイナリ。ブラウザタブや Flutter ランタイムの重さとは無縁。起動も一瞬、バッテリーにも優しい。</p>
-        </div>
-      </div>
-
-      <h3 class="pillars-subtitle fade-in" data-direction="up">なぜ「IDE」を名乗るのか</h3>
-      <p class="pillars-sublead fade-in" data-direction="up">クライアントではなく、Misskey と向き合う統合環境であるための 3 つ。</p>
-      <div class="pillars-grid">
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
-          </div>
-          <h3>マーケットプレイス内蔵</h3>
-          <p class="pillar-lead">プラグイン・テーマ・ウィジット・スキルを<strong>ワンクリックで。</strong></p>
-          <p>非公式マーケットプレイス misstore から直接インストール、アカウントごとに有効化を切替。AiScript エディタとライブプレビューも内蔵し、自作したものはその場で動く。</p>
-        </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.51 4.04 3 5.5l7 7Z"/><path d="M3.22 12H9.5l.5-1 2 4.5 2-7 1.5 3.5h5.27"/></svg>
-          </div>
-          <h3>AI が、デッキに棲む</h3>
-          <p class="pillar-lead">読むだけじゃない、<strong>投稿もリアクションも AI に任せる。</strong></p>
-          <p>AI チャット専用カラム + ノートメニューから AI アクション。書き込み系は確認ダイアログで誤動作防止。HEARTBEAT で無人時間中も定期チェック。Anthropic / OpenAI / OpenRouter から自由に選択。</p>
-        </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/><line x1="11" y1="8" x2="11" y2="14"/></svg>
-          </div>
-          <h3>プロトコルが、丸見え</h3>
-          <p class="pillar-lead">WebSocket も生 JSON も<strong>そのまま覗ける。</strong></p>
-          <p>Stream Inspector で WS 受信をリアルタイム監視。Note / Notification / User の Raw JSON ビュー、settings.json の内蔵エディタ。機密フィールドは自動マスク。Misskey の挙動を学ぶ最短ルート。</p>
-        </div>
-      </div>
-
-      <h3 class="pillars-subtitle fade-in" data-direction="up">プラットフォームとして</h3>
-      <p class="pillars-sublead fade-in" data-direction="up">NoteDeck が <em>閉じた箱</em> ではなく <em>開いた箱</em> であるための３つ。</p>
-      <div class="pillars-grid">
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-          </div>
-          <h3>自己拡張する IDE</h3>
-          <p class="pillar-lead">デッキの挙動も、<strong>世界の情報も、取り込む。</strong></p>
-          <p>検索・投稿・カラム操作・通知・メモなど NoteDeck の全機能に加え、翻訳・天気・GitHub など <strong>Web UI が CORS で触れない任意の外部 API</strong> までを AiScript・AI から直接叩ける (ネイティブアプリだけの特権)。認証が要る API も内蔵 Vault に「接続」として登録するだけ — シークレットは OS キーチェーンに収まり、AI の目には触れない。新コマンドを書けば、その瞬間コマンドパレットに登録され、AI ツールとしても自動公開される。</p>
-        </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 20h10"/><path d="M10 20c5.5-2.5.8-6.4 3-10"/><path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/><path d="M14.1 6a7 7 0 0 1-1.1 4c1.9-.6 3-1.5 3.6-2.6.6-1.2.6-2.5-.1-4.6-2.1.8-3 1.5-3.5 2.7-.2.5-.4 1.2-.4 1.8 0 0 0 0 0 0z"/></svg>
-          </div>
-          <h3>AI と一緒に育つ IDE</h3>
-          <p class="pillar-lead">使うほど、<strong>自分専用の道具に育っていく。</strong></p>
-          <p>AI 自身が CSS・キーバインド・navbar から、プラグイン・テーマ・ウィジット・<strong>AI 自身のペルソナ</strong>まで直接編集できる。カラム追加・サイドバー切替・アカウント切替などの UI 操作も会話から代行 (操作箇所はテーマカラーで光って可視化)。MisStore からの導入も削除も会話で完結し、観察したことは永続記憶として次のセッションへ。出荷時の機能で固定されない、人間と AI が一緒に手を入れていく IDE。</p>
-        </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-          </div>
-          <h3>外部から駆動できる</h3>
-          <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ API で叩く。</strong></p>
-          <p>ローカル HTTP API でデッキを丸ごと操作 — 投稿・TL 取得・カラム操作・コマンド実行まで、トークンを渡すだけの簡単認証で繋がる。AI チャットも AiScript も CLI も外部ツールも<strong>同じ操作セットを共有する設計</strong>だから、Raycast・Obsidian・Stream Deck から、OpenClaw・Hermes Agent・Claude Cowork といった AI エージェントの手足まで、一度書けば全経路から呼べる。</p>
+          <h3>軽くて、速い</h3>
+          <p class="pillar-lead">ブラウザではなく、<strong>Rust 製のネイティブアプリ。</strong></p>
+          <p>起動は一瞬、スクロールはなめらか、バッテリーにも優しい。開きっぱなしのブラウザタブや重いランタイムとは無縁です。</p>
         </div>
       </div>
     </div>
   </section>
+
   <!-- Guest mode CTA -->
   <section class="section-alt">
     <div class="section-inner section-narrow">
@@ -196,12 +139,12 @@
         <div class="highlight-text glass">
           <span class="highlight-badge">デッキ UI</span>
           <h3>自由に並べる、自分だけのレイアウト</h3>
-          <p>HTL・LTL・通知・検索・リスト・アンテナ・チャンネル・チャット — あらゆるカラムを横に並べて一覧。カラム幅はドラッグで自由に調整、プロファイルとして保存すればワンクリックで切り替え。</p>
+          <p>ホーム・ローカル・通知・検索・リスト・アンテナ・チャンネル・チャット — あらゆるカラムを横に並べて一覧。幅はドラッグで自由に調整、並びは「プロファイル」として保存してワンクリックで切り替え。</p>
           <ul class="highlight-list">
             <li>16 種類以上のカラムタイプ</li>
-            <li>クロスアカウント通知・検索の統合表示</li>
+            <li>複数アカウントの通知・検索を統合表示</li>
             <li>カラムをポップアウトして別ウィンドウ化</li>
-            <li>PiP（常時手前）表示でマルチモニター活用</li>
+            <li>PiP（常に手前の小窓）でマルチモニター活用</li>
           </ul>
         </div>
       </div>
@@ -209,13 +152,13 @@
       <!-- Highlight: Offline -->
       <div class="highlight-row fade-in" data-direction="right">
         <div class="highlight-text glass">
-          <span class="highlight-badge">オフライン &amp; ローカル DB</span>
+          <span class="highlight-badge">オフラインでも</span>
           <h3>流れたノートも、ここに残る</h3>
           <p>タイムラインに流れてきたノートは自動でローカル SQLite に蓄積。サーバーからノートが消えても、連合が切れても、手元のデータは残り続けます。</p>
           <ul class="highlight-list">
-            <li>FTS5 全文検索 — 過去ノートを一瞬で発見</li>
+            <li>全文検索で過去のノートを一瞬で発見</li>
             <li>オフラインモード切り替えでバッテリー節約</li>
-            <li>DB ファイルコピーで丸ごとバックアップ</li>
+            <li>DB ファイルのコピーで丸ごとバックアップ</li>
             <li>サーバーが消えても投稿は手元に残る</li>
           </ul>
         </div>
@@ -224,14 +167,14 @@
       <!-- Highlight: Security -->
       <div class="highlight-row fade-in" data-direction="left">
         <div class="highlight-text glass">
-          <span class="highlight-badge">セキュリティ</span>
-          <h3>トークンは OS が守る</h3>
-          <p>ブラウザの localStorage にトークンを保存する Web クライアントとは設計が違います。NoteDeck はアクセストークンを OS のキーチェーン（macOS Keychain / Windows Credential Manager / Linux Secret Service）に暗号化保存。ブラウザ拡張や XSS によるトークン窃取は構造的に不可能です。</p>
+          <span class="highlight-badge">あんしん</span>
+          <h3>ログイン情報は、OS が守る</h3>
+          <p>アカウントの鍵になるトークンは、ブラウザ内保存ではなく OS のキーチェーン（macOS Keychain / Windows 資格情報マネージャーなど）に暗号化して保管。アプリの中に平文で置かない設計です。</p>
           <ul class="highlight-list">
-            <li>OS キーチェーンで暗号化保管</li>
-            <li>メモリ上のトークンは自動 zeroize</li>
-            <li>localhost API は DNS Rebinding 対策済み</li>
-            <li>SSRF 防止（プライベート IP 範囲をブロック）</li>
+            <li>OS のキーチェーンで暗号化保管</li>
+            <li>使い終わったトークンはメモリからも消去</li>
+            <li>ローカル API は外部サイトからのアクセスを遮断</li>
+            <li>対策の詳細は <a href="https://github.com/hitalin/notedeck/blob/main/SECURITY.md">SECURITY</a> で公開</li>
           </ul>
         </div>
       </div>
@@ -248,74 +191,137 @@
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
           </div>
-          <h4>キーボード駆動</h4>
-          <p>コマンドパレット（Ctrl+K）で 30 以上のコマンドを検索・実行。全キーバインドをカスタマイズ可能。</p>
+          <h4>キーボードで完結</h4>
+          <p>コマンドパレット（Ctrl+K）で 30 以上のコマンドを検索・実行。キーバインドは全部カスタマイズ可能。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
           </div>
           <h4>Boss Key &amp; Quick Note</h4>
-          <p>Ctrl+Shift+B でウィンドウを即隠し。Ctrl+Alt+N でどこからでも即投稿。グローバルホットキーはデスクトップならでは。</p>
-        </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
-          </div>
-          <h4>フォーク対応</h4>
-          <p>Misskey 本家および Misskey 系フォークに対応。サーバー種別は自動検出、API 差分はアダプター層が吸収。</p>
-        </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
-          </div>
-          <h4>リッチプレビュー</h4>
-          <p>YouTube・Spotify・ニコ動・Pixiv・Amazon 等 16 種の専用 OGP パーサー。URL を貼るだけでリッチに展開。</p>
+          <p>Ctrl+Shift+B でウィンドウを一瞬で隠す。Ctrl+Alt+N でどの画面からでも即投稿。グローバルホットキーはデスクトップならでは。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
           </div>
-          <h4>MFM &amp; KaTeX</h4>
-          <p>Misskey Flavored Markdown 全構文対応。KaTeX 数式レンダリング + Shiki コードハイライトもネイティブ実装。</p>
+          <h4>MFM も数式も</h4>
+          <p>Misskey 独自の文字装飾 (MFM) に全構文対応。数式（KaTeX）やコードのハイライトもきれいに表示します。</p>
+        </div>
+        <div class="feature-card glass fade-in" data-direction="up">
+          <div class="feature-card-icon">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+          </div>
+          <h4>URL を貼るだけでプレビュー</h4>
+          <p>YouTube・Spotify・ニコ動・Pixiv・Amazon など 16 サイトの専用プレビュー対応。リンクを貼るだけでリッチに展開。</p>
+        </div>
+        <div class="feature-card glass fade-in" data-direction="up">
+          <div class="feature-card-icon">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
+          </div>
+          <h4>フォークにも対応</h4>
+          <p>Misskey 本家だけでなく、Misskey 系フォークのサーバーでも使えます。サーバー種別は自動判別、細かな違いはアプリが吸収。</p>
+        </div>
+        <div class="feature-card glass fade-in" data-direction="up">
+          <div class="feature-card-icon">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="0.5"/><circle cx="17.5" cy="10.5" r="0.5"/><circle cx="8.5" cy="7.5" r="0.5"/><circle cx="6.5" cy="12.5" r="0.5"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 011.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.555C21.965 6.012 17.461 2 12 2z"/></svg>
+          </div>
+          <h4>見た目は自分好みに</h4>
+          <p>Misskey のテーマがそのまま使えて、デッキの壁紙も設定可能。ダーク/ライト自動切り替え、ジェスチャ操作、OS ネイティブ通知にも対応。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
           </div>
           <h4>サーバーとの共生</h4>
-          <p>サーバー広告を正しく表示する数少ないサードパーティクライアント。表示頻度もサーバー設定に準拠。</p>
+          <p>サーバー広告を正しく表示する数少ないサードパーティクライアント。表示頻度もサーバーの設定に準拠します。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           </div>
           <h4>データはあなたのもの</h4>
-          <p>notecli.db コピーで完全バックアップ。設定 JSON エクスポート/インポート。ログアウト後もデータ保持を選択可能。</p>
-        </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="0.5"/><circle cx="17.5" cy="10.5" r="0.5"/><circle cx="8.5" cy="7.5" r="0.5"/><circle cx="6.5" cy="12.5" r="0.5"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 011.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.555C21.965 6.012 17.461 2 12 2z"/></svg>
-          </div>
-          <h4>カスタマイズ</h4>
-          <p>Misskey テーマ互換 + デッキ壁紙。ダーク/ライト自動切り替え。ジェスチャ操作、ネイティブ OS 通知対応。</p>
+          <p>DB ファイルのコピーで丸ごとバックアップ。設定のエクスポート/インポートも。ログアウト後もデータ保持を選べます。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
           </div>
-          <h4>パフォーマンスチューニング</h4>
-          <p>省メモリ〜高パフォーマンスのプリセット。Adaptive Quality でフレームレート自動最適化。3 段階画像キャッシュ。</p>
+          <h4>軽さを選べる</h4>
+          <p>省メモリから高パフォーマンスまでプリセットで切り替え。フレームレートは端末に合わせて自動最適化。</p>
         </div>
       </div>
     </div>
   </section>
 
-  <!-- Architecture -->
-  <section class="section-default" id="architecture">
+  <!-- IDE reveal -->
+  <section class="section-default" id="ide">
+    <div class="section-inner">
+      <h2 class="section-title fade-in" data-direction="up">実は、これ「IDE」なんです</h2>
+      <p class="section-sub fade-in" data-direction="up">NoteDeck の正体は <strong>Misskey 統合デッキ環境</strong> (Integrated Deck Environment)。</p>
+      <div class="pillars-grid">
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
+          </div>
+          <h3>ストアで、着せ替えと機能追加</h3>
+          <p class="pillar-lead">プラグイン・テーマ・ウィジットを<strong>ワンクリックで。</strong></p>
+          <p>専用ストア <a href="https://misstore.hital.in">misstore</a> から直接インストールして、アカウントごとに ON/OFF。AiScript エディタとライブプレビューも内蔵し、自作したものはその場で動きます。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.51 4.04 3 5.5l7 7Z"/><path d="M3.22 12H9.5l.5-1 2 4.5 2-7 1.5 3.5h5.27"/></svg>
+          </div>
+          <h3>AI が、デッキに棲む</h3>
+          <p class="pillar-lead">要約も投稿もリアクションも、<strong>頼める相棒。</strong></p>
+          <p>AI チャット専用カラムに加え、ノートメニューから直接 AI アクション。書き込む前には必ず確認してくれるので勝手には動きません。留守の間の定期チェックも。Anthropic / OpenAI / OpenRouter から自由に選べます。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/><line x1="11" y1="8" x2="11" y2="14"/></svg>
+          </div>
+          <h3>中身が、ぜんぶ見える</h3>
+          <p class="pillar-lead">Misskey の裏側を、<strong>そのまま観察できる。</strong></p>
+          <p>サーバーとのやり取りをリアルタイムで覗けるインスペクタや、ノートの生データ（Raw JSON）ビューを内蔵。機密フィールドは自動マスク。Misskey の仕組みを学ぶ最短ルートです。</p>
+        </div>
+      </div>
+
+      <h3 class="pillars-subtitle fade-in" data-direction="up">閉じた箱ではなく、開いた箱</h3>
+      <p class="pillars-sublead fade-in" data-direction="up">出荷時の機能で終わらない。使う人の手で広がっていくために。</p>
+      <div class="pillars-grid">
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+          </div>
+          <h3>自分で拡張できる</h3>
+          <p class="pillar-lead">新しいコマンドを書けば、<strong>その場でデッキの機能になる。</strong></p>
+          <p>AiScript で書いたコマンドは即コマンドパレットに載り、AI のツールとしても使える。翻訳・天気・GitHub など外部のサービスも取り込めます。鍵が要るサービスも安全に登録でき、中身が AI に見られることはありません。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 20h10"/><path d="M10 20c5.5-2.5.8-6.4 3-10"/><path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/><path d="M14.1 6a7 7 0 0 1-1.1 4c1.9-.6 3-1.5 3.6-2.6.6-1.2.6-2.5-.1-4.6-2.1.8-3 1.5-3.5 2.7-.2.5-.4 1.2-.4 1.8 0 0 0 0 0 0z"/></svg>
+          </div>
+          <h3>AI と一緒に育つ</h3>
+          <p class="pillar-lead">使うほど、<strong>自分専用の道具に育っていく。</strong></p>
+          <p>テーマ・キーバインドから AI 自身のペルソナまで、AI が会話から直接編集。カラム追加やアカウント切替などの UI 操作も代行し、操作した場所は光って見える。覚えたことは次の会話にも引き継がれます。</p>
+        </div>
+        <div class="pillar glass fade-in" data-direction="up">
+          <div class="pillar-icon">
+            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+          </div>
+          <h3>外部からも動かせる</h3>
+          <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ入口から。</strong></p>
+          <p>ローカル API でデッキを丸ごと操作 — 投稿もタイムライン取得もカラム操作も。Raycast・Obsidian・Stream Deck から AI エージェントまで、一度書けばどこからでも呼べます。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- For developers -->
+  <section class="section-default" id="dev">
     <div class="section-inner section-narrow">
-      <h2 class="section-title fade-in" data-direction="up">アーキテクチャ</h2>
-      <p class="section-sub fade-in" data-direction="up">ブラウザアプリには実現できない構造的な優位性</p>
+      <h2 class="section-title fade-in" data-direction="up">開発者のみなさんへ</h2>
+      <p class="section-sub fade-in" data-direction="up">NoteDeck はオープンソース (AGPL-3.0)。本家と同じ Vue 3 + TypeScript なので、本家のコードが読める人ならそのまま読めます。</p>
       <div class="arch-grid">
         <div class="arch-layer glass fade-in" data-direction="left">
           <div class="arch-label">フロントエンド</div>
@@ -342,23 +348,11 @@
           </div>
         </div>
       </div>
-
-    </div>
-  </section>
-
-  <!-- Hackable: developer experience built on the architecture above -->
-  <section class="section-default" id="hackable">
-    <div class="section-inner section-narrow">
-      <h2 class="section-title fade-in" data-direction="up">Misskey 開発者なら、すぐ貢献できる</h2>
-      <p class="section-sub fade-in" data-direction="up">上の構造そのものが、開発体験になっている。</p>
-      <div class="arch-grid">
-        <div class="arch-layer glass fade-in" data-direction="up">
-          <div class="arch-label">Hackable</div>
-          <div class="arch-desc">Misskey 本家と同じ Vue 3 + TypeScript なので、本家のコードが読める人なら NoteDeck もそのまま読める。<strong>開発者ツールと API ドキュメントをアプリ内に内蔵</strong>し、フォーク開発者・サーバー管理者でも動作検証や拡張がアプリだけで完結する。</div>
-          <div class="arch-tags">
-            <span>学習コストゼロ</span><span>DevTools 内蔵</span><span>API Doc 内蔵</span><span>AGPL-3.0</span>
-          </div>
-        </div>
+      <div class="arch-tags arch-doc-links fade-in" data-direction="up">
+        <a href="https://github.com/hitalin/notedeck/blob/main/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/hitalin/notedeck/blob/main/DEVELOPMENT.md">Development</a>
+        <a href="https://github.com/hitalin/notedeck/blob/main/STRATEGY.md">Strategy</a>
+        <a href="https://github.com/hitalin/notedeck/blob/main/CONTRIBUTING.md">Contributing</a>
       </div>
     </div>
   </section>

--- a/site/style.css
+++ b/site/style.css
@@ -134,6 +134,8 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .hero>*{opacity:0;transform:translateY(16px);animation:fadeUp .7s var(--ease) forwards}
 .hero>*:nth-child(1){animation-delay:0s}
 .hero>*:nth-child(2){animation-delay:.1s}
+.hero>*:nth-child(3){animation-delay:.2s}
+.hero>*:nth-child(4){animation-delay:.3s}
 @keyframes fadeUp{to{opacity:1;transform:translateY(0)}}
 @media(prefers-reduced-motion:reduce){.blob,.hero h1 .hero-logo{animation:none}}
 .hero h1{display:flex;align-items:center;justify-content:center;gap:.6rem;font-size:clamp(2.5rem,6vw,4rem);font-weight:800;letter-spacing:-0.02em}
@@ -141,7 +143,8 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 @keyframes heroHeartbeat{0%,55%,100%{transform:scale(1)}10%{transform:scale(1.18)}22%{transform:scale(1)}32%{transform:scale(1.1)}44%{transform:scale(1)}}
 @keyframes heroHeartglow{0%,55%,100%{filter:none}10%,32%{filter:drop-shadow(0 0 14px rgba(134,179,0,0.6))}}
 .hero h1 .hero-wordmark span{background:linear-gradient(135deg,var(--accent),var(--accent-dark));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
-.hero .tagline{font-size:clamp(1.05rem,2.5vw,1.3rem);color:var(--text-muted);max-width:540px}
+.hero .tagline{font-size:clamp(1.15rem,3vw,1.5rem);font-weight:700;color:var(--text-sub);max-width:540px}
+.hero .hero-lead{font-size:clamp(.9rem,2vw,1rem);color:var(--text-muted);max-width:560px;margin-top:-.5rem}
 
 /* ===== Buttons ===== */
 .btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.5rem;border-radius:var(--radius-pill);font-size:.95rem;font-weight:700;text-decoration:none;font-family:inherit;transition:all .25s var(--ease);background-image:none;background-size:auto}
@@ -236,6 +239,9 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .arch-desc{color:var(--text-muted);font-size:.85rem;line-height:1.7}
 .arch-tags{display:flex;gap:.5rem;justify-content:center;flex-wrap:wrap;margin-top:.75rem}
 .arch-tags span{font-size:.7rem;font-weight:700;color:var(--text-muted);background:var(--surface);border:1px solid var(--border);padding:.15em .6em;border-radius:var(--radius-pill)}
+.arch-tags a{font-size:.8rem;font-weight:700;color:var(--accent);background:var(--surface);background-image:none;border:1px solid var(--border);padding:.25em .9em;border-radius:var(--radius-pill);transition:all .2s var(--ease)}
+.arch-tags a:hover{border-color:var(--accent);background:var(--accent-soft)}
+.arch-doc-links{margin-top:1.25rem}
 .arch-arrow{display:flex;justify-content:center;padding:.25rem 0}
 
 /* ===== Download ===== */


### PR DESCRIPTION
## 概要

BRANDING.md の iceberg 構造（ポップ → 廃人ご褒美 → 開発者）に沿って、ランディングページを初見の Misskey ユーザーにも伝わる構成へ再編。情報を捨てるのではなく、読む順番を並べ替えて専門的な話を下層に沈める。

## 変更点

- **Hero**: ジャーゴンだったタグライン (`Misskey Integrated Deck Environment`) を「あなたの Misskey が棲む、デッキ。」に差し替え、ダウンロードボタンを Hero 直下に配置
- **3 本柱**: 見出し・リードを平易な言葉に書き直し（実装用語は本文の補足に降格）
- **IDE リビール**: 「なぜ IDE を名乗るのか」を機能紹介の後の「実は、これ『IDE』なんです」に改題。「プラットフォームとして」は内部用語 (CORS/Vault/capability 等) を日常語に訳して「閉じた箱ではなく、開いた箱」として維持
- **セキュリティ**: DNS Rebinding / SSRF / zeroize 等の用語を日常語に置き換え、詳細は SECURITY.md へのリンクに
- **開発者向け**: アーキテクチャ + Hackable の 2 セクションを「開発者のみなさんへ」1 セクションに統合。3 層構造の図 (Vue 3 + TypeScript / Tauri v2 / notecli) は維持し、GitHub ドキュメントへのリンク集を追加
- **メタデータ**: title / description / og に「Misskey IDE」を残し検索性を維持

LP から削った技術的内容は ARCHITECTURE.md / SECURITY.md / STRATEGY.md / DEVELOPMENT.md で既にカバー済みのため移設なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)