### PR TITLE
Release v1.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.6.3",
+  "version": "1.6.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.6.3"
+version = "1.6.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.6.3"
+version = "1.6.4"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.6.3"
+    "version": "1.6.4"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/common.test.ts
+++ b/src/aiscript/common.test.ts
@@ -1,0 +1,127 @@
+import { values } from '@syuilo/aiscript'
+import type { VFn } from '@syuilo/aiscript/interpreter/value.js'
+import { describe, expect, it } from 'vitest'
+import {
+  createAiScriptInterpreter,
+  createInterpreterOptions,
+  execAiScript,
+  parseAiScript,
+} from './common'
+
+// Note: #733 — stepCount は interpreter インスタンスの生涯累積のため、
+// Async:interval コールバック等の繰り返し実行で maxStep に達し
+// 常駐ウィジェットが時間経過でエラー死していた。
+// コールバック実行 (execFn / execFnSync) ごとにリセットされることを検証する。
+
+const CODE = `/// @ 1.2.1
+@heavy() {
+  var i = 0
+  for 20000 {
+    i += 1
+  }
+  i
+}
+capture(heavy)
+`
+
+async function setupHeavyCallback() {
+  const errors: Error[] = []
+  let captured: VFn | null = null
+  const env = {
+    capture: values.FN_NATIVE(([fn]) => {
+      captured = fn as VFn
+      return values.NULL
+    }),
+  }
+  const ioOpts = createInterpreterOptions({
+    onOutput: () => {},
+    onError: (e) => errors.push(e),
+  })
+  const { ast, legacy } = parseAiScript(CODE)
+  expect(legacy).toBe(false)
+  const interp = createAiScriptInterpreter(env, ioOpts, legacy)
+  await execAiScript(interp, ast, legacy)
+  expect(captured).not.toBeNull()
+  return { interp, captured: captured as unknown as VFn, errors }
+}
+
+describe('createAiScriptInterpreter stepCount reset (#733)', () => {
+  // async 実行は irqRate ごとに macrotask へ yield するため実時間がかかる
+  it('execFn の繰り返し呼び出しで stepCount が累積せず maxStep を超えない', {
+    timeout: 30000,
+  }, async () => {
+    const { interp, captured, errors } = await setupHeavyCallback()
+
+    await interp.execFn(captured, [])
+    const stepsPerCall = interp.stepCount
+    // 1回の実行では maxStep(100000) に届かないが、累積すれば必ず超える規模
+    expect(stepsPerCall).toBeGreaterThan(10000)
+    expect(stepsPerCall).toBeLessThan(100000)
+
+    const calls = Math.ceil(200000 / stepsPerCall)
+    for (let i = 0; i < calls; i++) {
+      await interp.execFn(captured, [])
+    }
+    expect(errors).toEqual([])
+  })
+
+  it('execFnSync の繰り返し呼び出しで stepCount が累積せず maxStep を超えない', async () => {
+    const { interp, captured, errors } = await setupHeavyCallback()
+
+    interp.execFnSync(captured, [])
+    const stepsPerCall = interp.stepCount
+    expect(stepsPerCall).toBeGreaterThan(10000)
+    expect(stepsPerCall).toBeLessThan(100000)
+
+    const calls = Math.ceil(200000 / stepsPerCall)
+    for (let i = 0; i < calls; i++) {
+      interp.execFnSync(captured, [])
+    }
+    expect(errors).toEqual([])
+  })
+
+  // 実際に問題が起きた経路: Async:interval は aiscript 内部で
+  // opts.topCall (= interp.execFn) を呼ぶため、ラッパーが効くことを検証する
+  it('Async:interval コールバックの累積で maxStep を超えない', {
+    timeout: 30000,
+  }, async () => {
+    const errors: Error[] = []
+    let ticks = 0
+    const env = {
+      tick: values.FN_NATIVE(() => {
+        ticks++
+        return values.NULL
+      }),
+    }
+    const ioOpts = createInterpreterOptions({
+      onOutput: () => {},
+      onError: (e) => errors.push(e),
+    })
+    const code = `/// @ 1.2.1
+Async:interval(1, @() {
+  var j = 0
+  for 8000 {
+    j += 1
+  }
+  tick()
+})
+`
+    const { ast, legacy } = parseAiScript(code)
+    const interp = createAiScriptInterpreter(env, ioOpts, legacy)
+    await execAiScript(interp, ast, legacy)
+
+    // 1 tick ≒ 24000+ steps なので 5 tick で累積 100000 を確実に超える
+    await new Promise<void>((resolve) => {
+      const handle = setInterval(() => {
+        if (ticks >= 5 || errors.length > 0) {
+          clearInterval(handle)
+          resolve()
+        }
+      }, 50)
+    })
+    interp.abort()
+
+    expect(errors).toEqual([])
+    expect(ticks).toBeGreaterThanOrEqual(5)
+  })
+})

--- a/src/aiscript/common.ts
+++ b/src/aiscript/common.ts
@@ -50,19 +50,48 @@ export function parseAiScript(code: string): {
   return { ast, legacy }
 }
 
+/**
+ * コールバック実行 (execFn / execFnSync) のたびに stepCount をリセットする。
+ * stepCount は interpreter インスタンスの生涯累積で、Async:interval や
+ * UI イベントハンドラの実行分も同じカウンタを消費するため、これがないと
+ * 常駐スクリプトが時間経過で必ず MaxStepExceeded になる (#733)。
+ * maxStep 本来の目的 (1回の実行の暴走防止) は維持される。
+ *
+ * aiscript の autobind は初回 get で own property にキャッシュし、set は
+ * prototype 側の共有クロージャを書き換える (全インスタンスに波及する) ため、
+ * 必ず get してから own property を上書きすること。
+ */
+function resetStepCountPerCallback(interp: Interpreter): void {
+  const origExecFn = interp.execFn
+  interp.execFn = (fn, args) => {
+    interp.stepCount = 0
+    return origExecFn(fn, args)
+  }
+  // legacy interpreter (0.19) には execFnSync がない
+  const origExecFnSync = interp.execFnSync as
+    | Interpreter['execFnSync']
+    | undefined
+  if (typeof origExecFnSync === 'function') {
+    interp.execFnSync = (fn, args) => {
+      interp.stepCount = 0
+      return origExecFnSync(fn, args)
+    }
+  }
+}
+
 export function createAiScriptInterpreter(
   env: Record<string, Value>,
   ioOpts: ReturnType<typeof createInterpreterOptions>,
   legacy: boolean,
 ): Interpreter {
-  if (legacy) {
-    const interp = new LegacyInterpreter(
-      env as Record<string, never>,
-      ioOpts as unknown as ConstructorParameters<typeof LegacyInterpreter>[1],
-    )
-    return interp as unknown as Interpreter
-  }
-  return new Interpreter(env, ioOpts)
+  const interp = legacy
+    ? (new LegacyInterpreter(
+        env as Record<string, never>,
+        ioOpts as unknown as ConstructorParameters<typeof LegacyInterpreter>[1],
+      ) as unknown as Interpreter)
+    : new Interpreter(env, ioOpts)
+  resetStepCountPerCallback(interp)
+  return interp
 }
 
 export async function execAiScript(

--- a/src/aiscript/execute.ts
+++ b/src/aiscript/execute.ts
@@ -1,6 +1,10 @@
-import { type Ast, Interpreter, Parser } from '@syuilo/aiscript'
+import { type Ast, Parser } from '@syuilo/aiscript'
 import { type AiScriptEnvOptions, createAiScriptEnv } from './api'
-import { type AiScriptIOCallbacks, createInterpreterOptions } from './common'
+import {
+  type AiScriptIOCallbacks,
+  createAiScriptInterpreter,
+  createInterpreterOptions,
+} from './common'
 import { sanitizeCode } from './sanitize'
 
 export type ExecuteOptions = AiScriptEnvOptions & AiScriptIOCallbacks
@@ -24,7 +28,7 @@ export async function executeAiScript(
 
   const env = createAiScriptEnv(options)
   const ioOpts = createInterpreterOptions(options)
-  const interpreter = new Interpreter(env, ioOpts)
+  const interpreter = createAiScriptInterpreter(env, ioOpts, false)
   try {
     await interpreter.exec(ast)
   } catch (e) {

--- a/src/components/deck/DeckAiScriptColumn.vue
+++ b/src/components/deck/DeckAiScriptColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Ast, Interpreter, Parser } from '@syuilo/aiscript'
+import { type Ast, type Interpreter, Parser } from '@syuilo/aiscript'
 import {
   computed,
   defineAsyncComponent,
@@ -11,7 +11,10 @@ import {
   watch,
 } from 'vue'
 import { createAiScriptEnv } from '@/aiscript/api'
-import { createInterpreterOptions } from '@/aiscript/common'
+import {
+  createAiScriptInterpreter,
+  createInterpreterOptions,
+} from '@/aiscript/common'
 import {
   cleanupNoteDeckEnv,
   createNoteDeckEnv,
@@ -256,7 +259,11 @@ async function run() {
   if (currentNdCtx) cleanupNoteDeckEnv(currentNdCtx)
   currentNdCtx = ndCtx
 
-  const interp = new Interpreter({ ...env, ...ndEnv, ...ui }, ioOpts)
+  const interp = createAiScriptInterpreter(
+    { ...env, ...ndEnv, ...ui },
+    ioOpts,
+    false,
+  )
   ndCtx.interpreter = interp
   interpreter.value = interp
 

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Ast, Interpreter, Parser } from '@syuilo/aiscript'
+import { type Ast, type Interpreter, Parser } from '@syuilo/aiscript'
 import {
   computed,
   defineAsyncComponent,
@@ -10,7 +10,10 @@ import {
   watch,
 } from 'vue'
 import { createAiScriptEnv } from '@/aiscript/api'
-import { createInterpreterOptions } from '@/aiscript/common'
+import {
+  createAiScriptInterpreter,
+  createInterpreterOptions,
+} from '@/aiscript/common'
 import {
   cleanupNoteDeckEnv,
   createNoteDeckEnv,
@@ -212,7 +215,11 @@ async function run() {
   const ndEnv = createNoteDeckEnv(ndCtx)
   currentNdCtx = ndCtx
 
-  const interp = new Interpreter({ ...env, ...ndEnv, ...ui }, ioOpts)
+  const interp = createAiScriptInterpreter(
+    { ...env, ...ndEnv, ...ui },
+    ioOpts,
+    false,
+  )
   ndCtx.interpreter = interp
   interpreter.value = interp
 

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { type Ast, Interpreter, Parser } from '@syuilo/aiscript'
+import { type Ast, type Interpreter, Parser } from '@syuilo/aiscript'
 import {
   computed,
   defineAsyncComponent,
@@ -10,7 +10,10 @@ import {
   watch,
 } from 'vue'
 import { createAiScriptEnv } from '@/aiscript/api'
-import { createInterpreterOptions } from '@/aiscript/common'
+import {
+  createAiScriptInterpreter,
+  createInterpreterOptions,
+} from '@/aiscript/common'
 import {
   cleanupNoteDeckEnv,
   createNoteDeckEnv,
@@ -201,7 +204,11 @@ async function run() {
   const ndEnv = createNoteDeckEnv(ndCtx)
   currentNdCtx = ndCtx
 
-  const interp = new Interpreter({ ...env, ...ndEnv, ...ui }, ioOpts)
+  const interp = createAiScriptInterpreter(
+    { ...env, ...ndEnv, ...ui },
+    ioOpts,
+    false,
+  )
   ndCtx.interpreter = interp
   interpreter.value = interp
 


### PR DESCRIPTION
## 変更内容

- fix(aiscript): コールバック実行ごとに stepCount をリセットし常駐ウィジェットのエラー死を防ぐ
- docs(site): BRANDING.md の iceberg 構造に沿って LP を初見向けに再構成
- chore: bump version to 1.6.4
- chore: regenerate openapi.json for 1.6.4

## ハイライト

常駐型ウィジェット（毎秒更新の digital-clock 等）がデッキを開いて約10分で MaxStepExceeded エラーになり停止する問題の修正リリース。maxStep 判定用の stepCount が interpreter 生涯累積だったのが原因で、コールバック実行 (execFn / execFnSync) 単位でリセットするよう修正。1回の実行の暴走防止という maxStep 本来の目的は維持。

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)