### PR TITLE
Release v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.6.4",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.6.4"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.6.4"
+version = "1.7.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.6.4"
+    "version": "1.7.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -23,11 +23,19 @@ import {
   useVaporTransitionGroup,
 } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
-import { CUSTOM_TL_ICONS } from '@/utils/customTimelines'
-import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
 import { formatTime } from '@/utils/formatTime'
 import { proxyThumbUrl, proxyUrl } from '@/utils/imageProxy'
-import { parseMfm } from '@/utils/mfm'
+import {
+  buildReactionsData,
+  canRenoteNote,
+  clampMenuPosition,
+  deriveActiveModeFlags,
+  deriveChannelInfo,
+  extractNoteUrls,
+  isLongNoteText,
+  isPureRenote as isPureRenoteNote,
+  resolveEffectiveNoteBase,
+} from '@/utils/noteViewModel'
 import { spawnReactionEffect } from '@/utils/reactionEffect'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { extractColumnThemeVars } from '@/utils/themeVars'
@@ -67,32 +75,24 @@ const props = defineProps<{
   disableArticleClick?: boolean
 }>()
 
+// ビューモデル導出は utils/noteViewModel.ts に抽出済み (#707)
 /** Pure renote → show inner note, otherwise show note itself */
-const effectiveNote = computed(() => {
-  const base =
-    props.note.renote && props.note.text === null
-      ? props.note.renote
-      : props.note
-  return applyNoteViewInterruptors(base, props.note._accountId)
-})
+const effectiveNote = computed(() =>
+  applyNoteViewInterruptors(
+    resolveEffectiveNoteBase(props.note),
+    props.note._accountId,
+  ),
+)
 const allEmojis = computed(() => ({
   ...effectiveNote.value.emojis,
   ...effectiveNote.value.user.emojis,
 }))
-const isPureRenote = computed(
-  () => props.note.renote && props.note.text === null,
-)
+const isPureRenote = computed(() => isPureRenoteNote(props.note))
 
 /** 本文から抽出した URL（renote の url/uri と一致するものは除外） */
-const extractedUrls = computed<string[]>(() => {
-  const text = effectiveNote.value.text
-  if (!text) return []
-  const tokens = parseMfm(text)
-  const renote = effectiveNote.value.renote
-  return extractUrlFromMfm(tokens).filter(
-    (u) => u !== renote?.url && u !== renote?.uri,
-  )
-})
+const extractedUrls = computed<string[]>(() =>
+  extractNoteUrls(effectiveNote.value),
+)
 
 provideNoteAccountId(props.note._accountId)
 
@@ -159,23 +159,7 @@ const {
   navigateToChannel: navToChannel,
 } = useNavigation()
 
-function hashChannelColor(id: string): string {
-  let h = 0
-  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0
-  const hue = ((h % 360) + 360) % 360
-  return `hsl(${hue}, 65%, 55%)`
-}
-
-const channelInfo = computed(() => {
-  const ch = effectiveNote.value.channel
-  const id = ch?.id ?? effectiveNote.value.channelId
-  if (!id) return null
-  return {
-    id,
-    name: ch?.name ?? null,
-    color: ch?.color || hashChannelColor(id),
-  }
-})
+const channelInfo = computed(() => deriveChannelInfo(effectiveNote.value))
 
 const showChannelInfo = computed(
   () => !!channelInfo.value && !props.hideChannelBadge && !props.embedded,
@@ -191,8 +175,7 @@ const accountsStore = useAccountsStore()
 const myAccount = computed(() =>
   accountsStore.accountMap.get(props.note._accountId),
 )
-const { resolveEmoji: resolveEmojiRaw, reactionUrl: reactionUrlRaw } =
-  useEmojiResolver()
+const { reactionUrl: reactionUrlRaw } = useEmojiResolver()
 const instanceIconUrl = computed(() => {
   const inst = effectiveNote.value.user.instance
   if (!inst) return null
@@ -221,18 +204,14 @@ function openRenoteMenu(e: MouseEvent) {
   }
   const el = e.currentTarget as HTMLElement
   renoteMenuTheme.value = extractColumnThemeVars(el)
-  const rect = el.getBoundingClientRect()
-  let x = rect.left
-  let y = rect.bottom + 4
-  const menuWidth = 200
-  const menuHeight = 80
-  const vw = document.documentElement.clientWidth
-  const vh = document.documentElement.clientHeight
-  if (x + menuWidth > vw) x = vw - menuWidth - 8
-  if (y + menuHeight > vh) y = Math.max(8, rect.top - menuHeight - 4)
-  x = Math.max(8, x)
-  y = Math.max(8, y)
-  renoteMenuPos.value = { x, y }
+  renoteMenuPos.value = clampMenuPosition(
+    el.getBoundingClientRect(),
+    { width: 200, height: 80 },
+    {
+      width: document.documentElement.clientWidth,
+      height: document.documentElement.clientHeight,
+    },
+  )
 
   // Check if already renoted
   myRenoteId.value = null
@@ -282,29 +261,16 @@ const softMuteCollapsed = computed(
     visibility.isSoftWordMuted(effectiveNote.value) && !wordMuteRevealed.value,
 )
 
-const LONG_TEXT_THRESHOLD = 500
-const LONG_TEXT_LINES = 8
-const isLongText = computed(() => {
-  const text = effectiveNote.value.text
-  if (!text || effectiveNote.value.cw !== null) return false
-  if (text.length > LONG_TEXT_THRESHOLD) return true
-  const lines = text.split('\n').length
-  return lines > LONG_TEXT_LINES
-})
+const isLongText = computed(() => isLongNoteText(effectiveNote.value))
 
 const isOwnNote = computed(() => {
   const account = accountsStore.accountMap.get(props.note._accountId)
   return account?.userId === effectiveNote.value.user.id
 })
 
-// リノート可否（Misskey WebUI と同じ判定）
-// public/home は誰でも可、followers は自分のノートのみ、specified は不可
-const canRenote = computed(() => {
-  const v = effectiveNote.value.visibility
-  return (
-    v === 'public' || v === 'home' || (v === 'followers' && isOwnNote.value)
-  )
-})
+const canRenote = computed(() =>
+  canRenoteNote(effectiveNote.value, isOwnNote.value),
+)
 
 // User hover popup
 const userPopup = useHoverPopup()
@@ -335,23 +301,9 @@ const VISIBILITY_ICONS: Record<NoteVisibility, string> = {
     'M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z',
 }
 
-const DEFAULT_MODE_ICON = 'M12 2a10 10 0 100 20 10 10 0 000-20z'
-
-const activeModeFlags = computed(() => {
-  const flags = effectiveNote.value.modeFlags
-  if (!flags) return []
-  return Object.entries(flags)
-    .filter(([, v]) => v)
-    .map(([key]) => {
-      const match = key.match(/^isNoteIn(.+)Mode$/)
-      const label = match?.[1] ?? key
-      return {
-        key,
-        label,
-        icon: CUSTOM_TL_ICONS[label.toLowerCase()] ?? DEFAULT_MODE_ICON,
-      }
-    })
-})
+const activeModeFlags = computed(() =>
+  deriveActiveModeFlags(effectiveNote.value.modeFlags),
+)
 
 function navigateToDetail() {
   if (props.disableArticleClick) return
@@ -365,30 +317,9 @@ function navigateToUser(userId: string, e: Event) {
   navToUser(props.note._accountId, userId)
 }
 
-const reactionsData = computed(() => {
-  const n = effectiveNote.value
-  const reactions = n.reactions
-  const keys = Object.keys(reactions)
-  if (keys.length === 0)
-    return {
-      sorted: [] as { reaction: string; count: number }[],
-      urls: {} as Record<string, string | null>,
-    }
-  keys.sort()
-  const sorted: { reaction: string; count: number }[] = new Array(keys.length)
-  const urls: Record<string, string | null> = {}
-  for (let i = 0; i < keys.length; i++) {
-    const reaction = keys[i] as string
-    sorted[i] = { reaction, count: reactions[reaction] as number }
-    urls[reaction] = reactionUrlRaw(
-      reaction,
-      n.emojis,
-      n.reactionEmojis,
-      n._serverHost,
-    )
-  }
-  return { sorted, urls }
-})
+const reactionsData = computed(() =>
+  buildReactionsData(effectiveNote.value, reactionUrlRaw),
+)
 
 const sortedReactions = computed(() => reactionsData.value.sorted)
 const reactionUrls = computed(() => reactionsData.value.urls)

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -28,7 +28,7 @@ import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { buildPreviewNote } from '@/utils/buildPreviewNote'
-import { parseMfm } from '@/utils/mfm'
+import { buildReplyMentions } from '@/utils/replyMentions'
 import {
   formatScheduleAbsolute,
   formatScheduleRelative,
@@ -39,6 +39,8 @@ import MkDrivePicker from './MkDrivePicker.vue'
 import MkMfm from './MkMfm.vue'
 import MkNote from './MkNote.vue'
 import MkPostFormButtonsPicker from './MkPostFormButtonsPicker.vue'
+import PostFormFilePreviews from './post-form/PostFormFilePreviews.vue'
+import PostFormPollEditor from './post-form/PostFormPollEditor.vue'
 
 const MkReactionPicker = defineAsyncComponent(
   () => import('./MkReactionPicker.vue'),
@@ -145,23 +147,6 @@ const {
   },
   { memoMode: props.memoMode },
 )
-
-// Stable keys for poll choices (avoid index-based v-for key bugs on add/remove)
-let pollKeyCounter = 0
-const pollChoiceKeys = ref<number[]>(
-  pollChoices.value.map(() => pollKeyCounter++),
-)
-
-const origAddPollChoice = addPollChoice
-const origRemovePollChoice = removePollChoice
-const addPollChoiceKeyed = () => {
-  origAddPollChoice()
-  pollChoiceKeys.value.push(pollKeyCounter++)
-}
-const removePollChoiceKeyed = (index: number) => {
-  origRemovePollChoice(index)
-  pollChoiceKeys.value.splice(index, 1)
-}
 
 // --- Auto-save toggle (persisted in settings, like preview).
 // 非 memoMode は drafts に自動保存、memoMode は memos に自動保存。
@@ -362,40 +347,8 @@ onMounted(async () => {
     visibility.value = props.editNote.visibility
   } else if (props.replyTo) {
     visibility.value = props.replyTo.visibility
-    const myUserId = account.value?.userId
-    const mentions: string[] = []
-    const seen = new Set<string>()
-
-    // 1. Reply target user
-    const replyUser = props.replyTo.user
-    if (replyUser.id !== myUserId) {
-      const acct = replyUser.host
-        ? `@${replyUser.username}@${replyUser.host}`
-        : `@${replyUser.username}`
-      mentions.push(acct)
-      seen.add(acct.toLowerCase())
-    }
-
-    // 2. Mentions in the reply target's text (reply chain participants)
-    if (props.replyTo.text) {
-      for (const token of parseMfm(props.replyTo.text)) {
-        if (token.type !== 'mention') continue
-        const acct = token.acct
-        const lower = acct.toLowerCase()
-        if (seen.has(lower)) continue
-        // Skip self
-        const isSelf = token.host
-          ? token.username.toLowerCase() ===
-              account.value?.username?.toLowerCase() &&
-            token.host.toLowerCase() === account.value?.host?.toLowerCase()
-          : token.username.toLowerCase() ===
-            account.value?.username?.toLowerCase()
-        if (isSelf) continue
-        seen.add(lower)
-        mentions.push(acct)
-      }
-    }
-
+    // リプライ先 + 本文中の会話参加者へのメンションを prefill (#707 で抽出)
+    const mentions = buildReplyMentions(props.replyTo, account.value ?? null)
     if (mentions.length > 0) {
       text.value = `${mentions.join(' ')} `
     }
@@ -791,55 +744,21 @@ function onKeydown(e: KeyboardEvent) {
       </div>
 
       <!-- Poll editor -->
-      <div v-if="showPoll" :class="$style.pollEditor">
-        <div v-for="(_, i) in pollChoices" :key="pollChoiceKeys[i]" :class="$style.pollChoiceRow">
-          <input
-            v-model="pollChoices[i]"
-            :class="$style.pollChoiceInput"
-            :placeholder="`選択肢 ${i + 1}`"
-          />
-          <button
-            v-if="pollChoices.length > 2"
-            class="_button"
-            :class="$style.pollChoiceRemove"
-            @click="removePollChoiceKeyed(i)"
-          >
-            <i class="ti ti-x" />
-          </button>
-        </div>
-        <div :class="$style.pollActions">
-          <button
-            v-if="pollChoices.length < 10"
-            class="_button"
-            :class="$style.pollAddBtn"
-            @click="addPollChoiceKeyed"
-          >
-            <i class="ti ti-plus" /> 選択肢を追加
-          </button>
-          <label :class="$style.pollMultipleLabel">
-            <input v-model="pollMultiple" type="checkbox" />
-            複数選択
-          </label>
-        </div>
-      </div>
+      <PostFormPollEditor
+        v-if="showPoll"
+        v-model:multiple="pollMultiple"
+        :choices="pollChoices"
+        @add="addPollChoice"
+        @remove="removePollChoice"
+      />
 
       <!-- File previews -->
-      <div v-if="attachedFiles.length > 0 || isUploading" :class="$style.filePreviewArea">
-        <div v-for="file in attachedFiles" :key="file.id" :class="$style.filePreview">
-          <img
-            v-if="file.thumbnailUrl || file.type.startsWith('image/')"
-            :src="file.thumbnailUrl || file.url"
-            :class="$style.fileThumb"
-          />
-          <div v-else :class="$style.fileIcon">
-            <i class="ti ti-file-text" />
-          </div>
-          <button class="_button" :class="$style.fileRemove" title="削除" @click="removeFile(file.id)">
-            <i class="ti ti-x" />
-          </button>
-        </div>
-        <div v-if="isUploading" :class="$style.fileUploading">アップロード中...</div>
-      </div>
+      <PostFormFilePreviews
+        v-if="attachedFiles.length > 0 || isUploading"
+        :files="attachedFiles"
+        :uploading="isUploading"
+        @remove="removeFile"
+      />
 
       <!-- Error -->
       <div v-if="error" :class="$style.postError">{{ error }}</div>
@@ -1731,84 +1650,6 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 /* ── Poll editor ── */
-.pollEditor {
-  padding: 8px 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.pollChoiceRow {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-}
-
-.pollChoiceInput {
-  flex: 1;
-  padding: 6px 10px;
-  font-size: 0.9em;
-  font-family: inherit;
-  color: var(--nd-fg);
-  background: var(--nd-buttonBg);
-  border: none;
-  border-radius: var(--nd-radius-sm);
-  outline: none;
-
-  &::placeholder {
-    color: var(--nd-fg);
-    opacity: 0.35;
-  }
-}
-
-.pollChoiceRemove {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: var(--nd-radius-sm);
-  color: var(--nd-fg);
-  opacity: 0.5;
-  flex-shrink: 0;
-
-  &:hover {
-    opacity: 1;
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
-
-.pollActions {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding-top: 2px;
-}
-
-.pollAddBtn {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  font-size: 0.8em;
-  color: var(--nd-accent);
-  border-radius: var(--nd-radius-sm);
-
-  &:hover {
-    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
-  }
-}
-
-.pollMultipleLabel {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 0.8em;
-  color: var(--nd-fg);
-  opacity: 0.7;
-  cursor: pointer;
-}
-
 /* ── Footer ── */
 .footer {
   position: relative;
@@ -1979,65 +1820,6 @@ function onKeydown(e: KeyboardEvent) {
 }
 
 /* ── File preview ── */
-.filePreviewArea {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 24px;
-}
-
-.filePreview {
-  position: relative;
-  width: 80px;
-  height: 80px;
-  border-radius: var(--nd-radius-md);
-  overflow: hidden;
-  background: var(--nd-buttonBg);
-}
-
-.fileThumb {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.fileIcon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 100%;
-  color: var(--nd-fg);
-  opacity: 0.5;
-}
-
-.fileRemove {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 32px;
-  height: 32px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 50%;
-  background: var(--nd-overlayDark);
-  color: #fff;
-  cursor: pointer;
-}
-
-.fileUploading {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 80px;
-  height: 80px;
-  border-radius: var(--nd-radius-md);
-  background: var(--nd-buttonBg);
-  font-size: 0.7em;
-  opacity: 0.6;
-}
-
 /* ── Schedule indicator (textarea 右下にフローティング) ── */
 .scheduleIndicator {
   position: absolute;

--- a/src/components/common/post-form/PostFormFilePreviews.vue
+++ b/src/components/common/post-form/PostFormFilePreviews.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import type { NormalizedDriveFile } from '@/adapters/types'
+
+/**
+ * 投稿フォームの添付ファイルプレビュー列 (#707 MkPostForm 分割)。
+ * 削除は remove emit で親の state 操作に委ねる。
+ */
+defineProps<{
+  files: NormalizedDriveFile[]
+  uploading: boolean
+}>()
+
+const emit = defineEmits<{
+  remove: [fileId: string]
+}>()
+</script>
+
+<template>
+  <div :class="$style.filePreviewArea">
+    <div v-for="file in files" :key="file.id" :class="$style.filePreview">
+      <img
+        v-if="file.thumbnailUrl || file.type.startsWith('image/')"
+        :src="file.thumbnailUrl || file.url"
+        :class="$style.fileThumb"
+      />
+      <div v-else :class="$style.fileIcon">
+        <i class="ti ti-file-text" />
+      </div>
+      <button class="_button" :class="$style.fileRemove" title="削除" @click="emit('remove', file.id)">
+        <i class="ti ti-x" />
+      </button>
+    </div>
+    <div v-if="uploading" :class="$style.fileUploading">アップロード中...</div>
+  </div>
+</template>
+
+<style lang="scss" module>
+.filePreviewArea {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 24px;
+}
+
+.filePreview {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--nd-radius-md);
+  overflow: hidden;
+  background: var(--nd-buttonBg);
+}
+
+.fileThumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.fileIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: var(--nd-fg);
+  opacity: 0.5;
+}
+
+.fileRemove {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--nd-overlayDark);
+  color: #fff;
+  cursor: pointer;
+}
+
+.fileUploading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--nd-radius-md);
+  background: var(--nd-buttonBg);
+  font-size: 0.7em;
+  opacity: 0.6;
+}
+</style>

--- a/src/components/common/post-form/PostFormPollEditor.vue
+++ b/src/components/common/post-form/PostFormPollEditor.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+/**
+ * 投稿フォームのアンケート編集ブロック (#707 MkPostForm 分割)。
+ * choices は usePostFormState の pollChoices と同一参照で、入力は
+ * in-place 更新、増減は add / remove emit で親の state 操作に委ねる。
+ */
+const props = defineProps<{
+  choices: string[]
+}>()
+
+const multiple = defineModel<boolean>('multiple', { required: true })
+
+const emit = defineEmits<{
+  add: []
+  remove: [index: number]
+}>()
+
+// Stable keys for poll choices (avoid index-based v-for key bugs on add/remove)
+let keyCounter = 0
+const choiceKeys = ref<number[]>(props.choices.map(() => keyCounter++))
+
+function addChoice() {
+  emit('add')
+  choiceKeys.value.push(keyCounter++)
+}
+
+function removeChoice(index: number) {
+  emit('remove', index)
+  choiceKeys.value.splice(index, 1)
+}
+
+// 下書き復元などで choices が丸ごと差し替わった場合はキーを振り直す。
+// add / remove 経由の増減は上で同期済みなので、長さ不一致のときだけ。
+watch(
+  () => props.choices.length,
+  (len) => {
+    if (choiceKeys.value.length === len) return
+    choiceKeys.value = props.choices.map(() => keyCounter++)
+  },
+)
+</script>
+
+<template>
+  <div :class="$style.pollEditor">
+    <div v-for="(_, i) in choices" :key="choiceKeys[i]" :class="$style.pollChoiceRow">
+      <input
+        v-model="choices[i]"
+        :class="$style.pollChoiceInput"
+        :placeholder="`選択肢 ${i + 1}`"
+      />
+      <button
+        v-if="choices.length > 2"
+        class="_button"
+        :class="$style.pollChoiceRemove"
+        @click="removeChoice(i)"
+      >
+        <i class="ti ti-x" />
+      </button>
+    </div>
+    <div :class="$style.pollActions">
+      <button
+        v-if="choices.length < 10"
+        class="_button"
+        :class="$style.pollAddBtn"
+        @click="addChoice"
+      >
+        <i class="ti ti-plus" /> 選択肢を追加
+      </button>
+      <label :class="$style.pollMultipleLabel">
+        <input v-model="multiple" type="checkbox" />
+        複数選択
+      </label>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" module>
+.pollEditor {
+  padding: 8px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pollChoiceRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pollChoiceInput {
+  flex: 1;
+  padding: 6px 10px;
+  font-size: 0.9em;
+  font-family: inherit;
+  color: var(--nd-fg);
+  background: var(--nd-buttonBg);
+  border: none;
+  border-radius: var(--nd-radius-sm);
+  outline: none;
+
+  &::placeholder {
+    color: var(--nd-fg);
+    opacity: 0.35;
+  }
+}
+
+.pollChoiceRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fg);
+  opacity: 0.5;
+  flex-shrink: 0;
+
+  &:hover {
+    opacity: 1;
+    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
+  }
+}
+
+.pollActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 2px;
+}
+
+.pollAddBtn {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  font-size: 0.8em;
+  color: var(--nd-accent);
+  border-radius: var(--nd-radius-sm);
+
+  &:hover {
+    background: light-dark(rgba(0, 0, 0, 0.05), rgba(255, 255, 255, 0.05));
+  }
+}
+
+.pollMultipleLabel {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8em;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  cursor: pointer;
+}
+</style>

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -361,13 +361,15 @@ const canRetry = computed(
 )
 
 /**
- * 失敗した user + assistant のペアを取り除き、同じ内容で通常の送信経路を
- * 再走行する。history が失敗前と同一になるので、送信ロジックの分岐を増やさず
- * に済む。
+ * 失敗ターンの再試行 (#508 / #737)。
+ * - resend: user + placeholder を取り除いて同じ内容を通常送信で再走行
+ * - continue: 実行済み tool_use / tool_result を残したまま続きを生成
+ *   (write capability を再実行しない継続モード)
  */
 async function retryLastSend(): Promise<void> {
-  const text = sendLoop.prepareRetry(currentSessionId.value)
-  if (text) await sendMessage(text)
+  const retry = sendLoop.prepareRetry(currentSessionId.value)
+  if (!retry) return
+  await sendMessage(retry.text, { continuation: retry.mode === 'continue' })
 }
 
 // --- 送信 ---
@@ -480,13 +482,18 @@ function ensureSession(): string {
   return session.id
 }
 
-async function sendMessage(presetText?: string | Event) {
+async function sendMessage(
+  presetText?: string | Event,
+  opts?: { continuation?: boolean },
+) {
   // template の @click からは Event が渡るので string のみ preset 扱いにする。
   // preset は retryLastSend からの再送で、入力欄のドラフトには触れない。
   const preset = typeof presetText === 'string' ? presetText : undefined
   const text = (preset ?? input.value).trim()
   if (!text || aiChat.isStreaming.value) return
   sendLoop.retryContext.value = null
+  // 継続 (#737): user メッセージを追加せず失敗ターンの続きを生成する
+  const continuation = opts?.continuation === true
 
   // Slash コマンドは AI を経由せず capability を直接実行する経路。
   // provider 未接続でも動くので、provider check より先に分岐する。
@@ -572,6 +579,7 @@ async function sendMessage(presetText?: string | Event) {
     connectionId: resolved.connection.id,
     model: resolved.model,
     tools: toolsForProvider,
+    continuation,
     // round ごとに context を組み直す (memos / vault 開示状態は round 間で
     // 変わりうるため)。history は sendLoop が組み立てた wire history。
     buildSystem: async (history) => {
@@ -1104,7 +1112,8 @@ function onKeydown(e: KeyboardEvent) {
         <div ref="messagesEndRef" />
       </div>
 
-      <!-- ストリーム切断 (#508) からの再試行導線。tool 実行済みターンでは出ない -->
+      <!-- ストリーム切断 (#508) からの再試行導線。tool 実行済みターンは
+           実行済み結果を保持したまま続きを生成する継続モードで再試行する (#737) -->
       <div v-if="canRetry" :class="$style.retryBar">
         <button class="_button" :class="$style.retryBtn" @click="retryLastSend">
           <i class="ti ti-refresh" />

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -12,7 +12,6 @@ import {
 } from 'vue'
 import { createQuerySubscription } from '@/adapters/misskey/query'
 import type {
-  AvatarDecoration,
   ChannelSubscription,
   ChatMessage,
   NormalizedDriveFile,
@@ -39,6 +38,15 @@ import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useChatMessageStore } from '@/stores/chatMessageStore'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
+import {
+  buildCrossAccountHistoryEntries,
+  buildPerAccountHistoryEntries,
+  buildPerAccountPrefetchTargets,
+  chatMessageMatchesSearch,
+  type CrossAccountChatHistoryEntry as HistoryEntry,
+  matchesChatSearch,
+  type PerAccountChatHistoryEntry as PerAccountHistoryEntry,
+} from '@/utils/chatHistoryEntries'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { listenTauri } from '@/utils/tauriEvents'
@@ -151,24 +159,13 @@ const textareaRef = ref<HTMLTextAreaElement | null>(null)
 let chatSub: ChannelSubscription | null = null
 
 // --- Cross-account history ---
-interface HistoryEntry {
-  key: string
-  accountId: string
-  serverHost: string
-  message: ChatMessage
-  isRoom: boolean
-  name: string
-  /** 表示名 (`name`) が user-defined か (false なら fallback の username/roomId を使用)。 */
-  hasName: boolean
-  /** name に含まれる `:shortcode:` を画像に解決するための辞書。 */
-  emojis?: Record<string, string>
-  avatarUrl?: string
-  avatarDecorations?: AvatarDecoration[]
-  otherId?: string
-  roomId?: string
-}
-
+// entry 構築ロジックは utils/chatHistoryEntries.ts に抽出済み (#707)
 const historyEntries = shallowRef<HistoryEntry[]>([])
+
+/** entry 構築時にアカウント id から自分の userId を引く (自分発信の DM 判定用)。 */
+function getUserIdForAccount(accountId: string): string | undefined {
+  return accountsStore.accounts.find((a) => a.id === accountId)?.userId
+}
 
 // 履歴 view (#483) の絞り込み。AI カラム ([DeckAiColumn.vue]) と同じ
 // header-extra 入力 + 大文字小文字無視の substring match パターン。
@@ -176,19 +173,11 @@ const historyEntries = shallowRef<HistoryEntry[]>([])
 // (`entry.message.text`)。
 const searchQuery = ref('')
 
-function matchesSearch(name: string, preview: string | null | undefined) {
-  const q = searchQuery.value.trim().toLowerCase()
-  if (!q) return true
-  if (name.toLowerCase().includes(q)) return true
-  if (preview?.toLowerCase().includes(q)) return true
-  return false
-}
-
 const filteredHistoryEntries = computed<HistoryEntry[]>(() =>
   historyEntries.value.filter(
     (e) =>
       !(!e.isRoom && isPartnerMuted(e.accountId, e.otherId)) &&
-      matchesSearch(e.name, e.message.text),
+      matchesChatSearch(searchQuery.value, e.name, e.message.text),
   ),
 )
 
@@ -217,16 +206,9 @@ const filteredMessages = computed(() => {
   // ミュート送信者の発言は常に隠す（room 内個別発言にも適用）。検索の前段。
   const acc = activeAccountId.value
   const visible = messages.value.filter((m) => !isMessageHidden(acc, m))
-  const q = convSearchQuery.value.trim().toLowerCase()
-  if (!q) return visible
-  return visible.filter((m) => {
-    if (m.text?.toLowerCase().includes(q)) return true
-    const u = m.fromUser
-    if (u?.name?.toLowerCase().includes(q)) return true
-    if (u?.username?.toLowerCase().includes(q)) return true
-    if (m.file?.name.toLowerCase().includes(q)) return true
-    return false
-  })
+  const q = convSearchQuery.value
+  if (!q.trim()) return visible
+  return visible.filter((m) => chatMessageMatchesSearch(q, m))
 })
 
 const hasNoConvSearchHits = computed(
@@ -294,98 +276,6 @@ async function loadCachedHistory(accountId: string): Promise<ChatMessage[]> {
   } catch {
     return []
   }
-}
-
-/**
- * cross-account history view の entry 構築 (#460)。
- * 全アカウントから集めた message を thread (room/DM) 単位の最新 1 件に dedup する。
- * cache hydrate phase / API reconcile phase の両方から呼ぶ。
- */
-function buildCrossAccountHistoryEntries(
-  allMessages: { msg: ChatMessage; accountId: string; host: string }[],
-): HistoryEntry[] {
-  const entries: HistoryEntry[] = []
-  const seen = new Set<string>()
-  const sorted = [...allMessages].sort(
-    (a, b) =>
-      new Date(b.msg.createdAt).getTime() - new Date(a.msg.createdAt).getTime(),
-  )
-
-  for (const { msg, accountId, host } of sorted) {
-    const uid = accountsStore.accounts.find((a) => a.id === accountId)?.userId
-    if (msg.toRoomId) {
-      const key = `${accountId}:room:${msg.toRoomId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      entries.push({
-        key,
-        accountId,
-        serverHost: host,
-        message: msg,
-        isRoom: true,
-        name: msg.toRoom?.name || 'Room',
-        hasName: !!msg.toRoom?.name,
-        // ChatRoom には emojis 辞書が無いので、最新メッセージ送信者の辞書で代替する
-        // (同一サーバー上の shortcode は同じ辞書で解決できる)
-        emojis: msg.fromUser?.emojis ?? undefined,
-        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
-        avatarDecorations: msg.fromUser?.avatarDecorations,
-        roomId: msg.toRoomId,
-      })
-    } else {
-      const otherId = msg.fromUserId === uid ? msg.toUserId : msg.fromUserId
-      if (!otherId) continue
-      const key = `${accountId}:user:${otherId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      const other = msg.fromUserId === uid ? msg.toUser : msg.fromUser
-      entries.push({
-        key,
-        accountId,
-        serverHost: host,
-        message: msg,
-        isRoom: false,
-        name: other?.name || other?.username || otherId,
-        hasName: !!other?.name,
-        emojis: other?.emojis ?? undefined,
-        avatarUrl: other?.avatarUrl ?? undefined,
-        avatarDecorations: other?.avatarDecorations,
-        otherId,
-      })
-    }
-  }
-
-  return entries
-}
-
-/**
- * Per-account history (chatHistory: ChatMessage[]) から prefetch 対象 thread を
- * 抽出する (#460 B-6)。`fromUserId === uid` で送信側 / 受信側を判定して
- * thread の相手 (otherId or roomId) を導出する。
- */
-function buildPerAccountPrefetchTargets(
-  accountId: string,
-  uid: string | undefined,
-  msgs: ChatMessage[],
-): PrefetchTarget[] {
-  const seen = new Set<string>()
-  const targets: PrefetchTarget[] = []
-  for (const msg of msgs) {
-    if (msg.toRoomId) {
-      const key = `room:${msg.toRoomId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      targets.push({ accountId, isRoom: true, targetId: msg.toRoomId })
-    } else {
-      const otherId = msg.fromUserId === uid ? msg.toUserId : msg.fromUserId
-      if (!otherId) continue
-      const key = `user:${otherId}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      targets.push({ accountId, isRoom: false, targetId: otherId })
-    }
-  }
-  return targets
 }
 
 async function connectPerAccount() {
@@ -524,7 +414,10 @@ async function connectCrossAccount() {
   const cachedAll = cachedResults.flat()
   if (cachedAll.length > 0) {
     chatMessageStore.put(cachedAll.map((x) => x.msg))
-    historyEntries.value = buildCrossAccountHistoryEntries(cachedAll)
+    historyEntries.value = buildCrossAccountHistoryEntries(
+      cachedAll,
+      getUserIdForAccount,
+    )
     isLoading.value = false
   }
 
@@ -576,7 +469,10 @@ async function connectCrossAccount() {
     if (r.status === 'fulfilled') allMessages.push(...r.value)
   }
   chatMessageStore.put(allMessages.map((x) => x.msg))
-  historyEntries.value = buildCrossAccountHistoryEntries(allMessages)
+  historyEntries.value = buildCrossAccountHistoryEntries(
+    allMessages,
+    getUserIdForAccount,
+  )
   isLoading.value = false
 
   // B-6: ログイン中アカウントの thread を裏で prefetch (UI 変更なし)。
@@ -597,19 +493,6 @@ async function connectCrossAccount() {
   void prefetchThreads(prefetchTargets)
 }
 
-// Per-account history entries
-interface PerAccountHistoryEntry {
-  key: string
-  message: ChatMessage
-  isRoom: boolean
-  name: string
-  hasName: boolean
-  emojis?: Record<string, string>
-  avatarUrl?: string
-  avatarDecorations?: AvatarDecoration[]
-  otherId?: string
-}
-
 /**
  * 履歴を経由せず直接ユーザー会話を開くための軽量ターゲット
  * (プロフィールからの DM 起動など)。`message` を持たないため
@@ -624,53 +507,15 @@ interface ConversationTarget {
   otherId: string
 }
 
-const perAccountHistoryEntries = computed<PerAccountHistoryEntry[]>(() => {
-  const seen = new Set<string>()
-  const entries: PerAccountHistoryEntry[] = []
-
-  for (const msg of chatHistory.value) {
-    if (msg.toRoomId) {
-      if (seen.has(`room:${msg.toRoomId}`)) continue
-      seen.add(`room:${msg.toRoomId}`)
-      entries.push({
-        key: `room:${msg.toRoomId}`,
-        message: msg,
-        isRoom: true,
-        name: msg.toRoom?.name || 'Room',
-        hasName: !!msg.toRoom?.name,
-        emojis: msg.fromUser?.emojis ?? undefined,
-        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
-        avatarDecorations: msg.fromUser?.avatarDecorations,
-      })
-    } else {
-      const otherId =
-        msg.fromUserId === myUserId.value ? msg.toUserId : msg.fromUserId
-      if (!otherId || seen.has(`user:${otherId}`)) continue
-      seen.add(`user:${otherId}`)
-      const other =
-        msg.fromUserId === myUserId.value ? msg.toUser : msg.fromUser
-      entries.push({
-        key: `user:${otherId}`,
-        message: msg,
-        isRoom: false,
-        name: other?.name || other?.username || otherId,
-        hasName: !!other?.name,
-        emojis: other?.emojis ?? undefined,
-        avatarUrl: other?.avatarUrl ?? undefined,
-        avatarDecorations: other?.avatarDecorations,
-        otherId,
-      })
-    }
-  }
-
-  return entries
-})
+const perAccountHistoryEntries = computed<PerAccountHistoryEntry[]>(() =>
+  buildPerAccountHistoryEntries(chatHistory.value, myUserId.value),
+)
 
 const filteredPerAccountEntries = computed<PerAccountHistoryEntry[]>(() =>
   perAccountHistoryEntries.value.filter(
     (e) =>
       !(!e.isRoom && isPartnerMuted(props.column.accountId, e.otherId)) &&
-      matchesSearch(e.name, e.message.text),
+      matchesChatSearch(searchQuery.value, e.name, e.message.text),
   ),
 )
 

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -11,11 +11,7 @@ import {
   watch,
 } from 'vue'
 import { createQuerySubscription } from '@/adapters/misskey/query'
-import type {
-  ChannelSubscription,
-  ChatMessage,
-  NormalizedDriveFile,
-} from '@/adapters/types'
+import type { ChatMessage, NormalizedDriveFile } from '@/adapters/types'
 import type { ChatReactionUser } from '@/bindings'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
@@ -24,6 +20,10 @@ import MkChatMessage from '@/components/common/MkChatMessage.vue'
 import MkDrivePicker from '@/components/common/MkDrivePicker.vue'
 import MkMfm from '@/components/common/MkMfm.vue'
 import NoteScroller from '@/components/common/NoteScroller.vue'
+import {
+  type ChatThreadTarget,
+  useChatThread,
+} from '@/composables/useChatThread'
 import {
   type PrefetchTarget,
   useChatThreadPrefetch,
@@ -137,14 +137,62 @@ const chatSound = useNoteSound(() => account.value?.host, 'syuilo/waon')
 const { isPartnerMuted, isMessageHidden } = useChatVisibility()
 
 const viewMode = ref<'history' | 'conversation'>('history')
-// B-5: messages は chatMessageStore からの ID 参照のみで管理する。
-// `messageIds` の真値を持ち、`messages` は store から resolve した derived。
-// これにより WS の reaction/unreaction event が store.applyUpdate 経由で
-// in-place 更新されると、UI が自動的に再描画される。
-const messageIds = ref<string[]>([])
-const messages = computed(() => chatMessageStore.resolve(messageIds.value))
-const currentOtherId = ref<string | null>(null)
-const currentRoomId = ref<string | null>(null)
+
+// 会話 thread の状態機械 (#707): cache hydrate → API reconcile → ライブ購読の
+// ladder (#460 B-1/B-2) と message id 管理 (B-5) は useChatThread に抽出済み。
+// ここは port (Tauri commands / adapter 解決 / WS 購読) を束ねるだけ。
+const thread = useChatThread({
+  store: chatMessageStore,
+  getCached: async (accountId, threadId, untilId, limit) =>
+    unwrap(
+      await commands.apiGetCachedChatThreadMessages(
+        accountId,
+        threadId,
+        untilId,
+        limit,
+      ),
+    ) as unknown as ChatMessage[],
+  resolveApi: async (accountId) => {
+    // cross-account は multiAdapters、per-account はカラムの adapter
+    const adapter = isCrossAccount.value
+      ? await multiAdapters.getOrCreate(accountId)
+      : getAdapter()
+    if (!adapter) return null
+    return {
+      fetch: (target, opts) =>
+        target.kind === 'room'
+          ? adapter.api.getChatRoomMessages(target.roomId, opts)
+          : adapter.api.getChatUserMessages(target.otherId, opts),
+    }
+  },
+  subscribe: async (accountId, target, handlers) => {
+    // cross-account は共有 adapter の WS を明示的に張る
+    // (per-account はカラムの adapter が接続済み)
+    if (isCrossAccount.value) {
+      const adapter = await multiAdapters.getOrCreate(accountId)
+      adapter?.stream.connect()
+    }
+    return createQuerySubscription({
+      open: async () =>
+        unwrap(
+          target.kind === 'room'
+            ? await commands.querySubscribeChatRoom(accountId, target.roomId)
+            : await commands.querySubscribeChatUser(accountId, target.otherId),
+        ),
+      onInsert: (item) => handlers.onInsert(item as unknown as ChatMessage),
+      onDelete: (id) => handlers.onDelete(id),
+    })
+  },
+  onIncoming: (msg) => onNewMessage(msg),
+})
+
+const { messages, messageIds } = thread
+const currentRoomId = computed(() =>
+  thread.target.value?.kind === 'room' ? thread.target.value.roomId : null,
+)
+const currentOtherId = computed(() =>
+  thread.target.value?.kind === 'user' ? thread.target.value.otherId : null,
+)
 const conversationTitle = ref('')
 const conversationOtherAvatarUrl = ref<string | null>(null)
 const conversationAccountId = ref<string | null>(null)
@@ -155,8 +203,6 @@ const showEmojiPicker = ref(false)
 const showDrivePicker = ref(false)
 const attachedFile = ref<NormalizedDriveFile | null>(null)
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
-
-let chatSub: ChannelSubscription | null = null
 
 // --- Cross-account history ---
 // entry 構築ロジックは utils/chatHistoryEntries.ts に抽出済み (#707)
@@ -361,37 +407,6 @@ function setChatHistory(msgs: ChatMessage[]) {
   chatHistoryIds.value = msgs.map((m) => m.id)
 }
 
-/**
- * Conversation の messages を store + IDs に流す (B-5)。
- */
-function setMessages(msgs: ChatMessage[]) {
-  chatMessageStore.put(msgs)
-  messageIds.value = msgs.map((m) => m.id)
-}
-
-function appendMessage(msg: ChatMessage) {
-  if (messageIds.value.includes(msg.id)) return
-  chatMessageStore.put([msg])
-  messageIds.value = [...messageIds.value, msg.id]
-}
-
-function prependMessages(older: ChatMessage[]) {
-  if (older.length === 0) return
-  chatMessageStore.put(older)
-  const existing = new Set(messageIds.value)
-  const newIds = older
-    .slice()
-    .reverse()
-    .map((m) => m.id)
-    .filter((id) => !existing.has(id))
-  messageIds.value = [...newIds, ...messageIds.value]
-}
-
-function removeMessage(messageId: string) {
-  messageIds.value = messageIds.value.filter((id) => id !== messageId)
-  chatMessageStore.remove(messageId)
-}
-
 async function connectCrossAccount() {
   // ログアウト中のアカウントもキャッシュから履歴を出す (#460)。`hasToken` filter を外す。
   const accounts = accountsStore.accounts
@@ -531,9 +546,6 @@ const hasNoSearchHits = computed(() => {
 async function openConversation(
   entry: HistoryEntry | PerAccountHistoryEntry | ConversationTarget,
 ) {
-  chatSub?.dispose()
-  chatSub = null
-
   // 検索 state は thread をまたいで持ち越さない。
   showConvSearch.value = false
   convSearchQuery.value = ''
@@ -562,124 +574,36 @@ async function openConversation(
   )
   const isLoggedOut = !entryAccount?.hasToken
 
-  // Get adapter: cross-account uses multiAdapters, per-account uses getAdapter()
-  const adapter = isCrossAccount.value
-    ? await multiAdapters.getOrCreate(entryAccountId)
-    : getAdapter()
-  if (!adapter && !isLoggedOut) {
-    isLoading.value = false
-    return
-  }
-
-  // ログアウト中はキャッシュから読むだけ。WS subscription も貼らない。
-  // closure capture 後の narrowing が効かないため、ローカルに保持する。
-  const accountIdForCache = entryAccountId
-  async function loadCachedThread(threadId: string): Promise<ChatMessage[]> {
-    try {
-      const cached = unwrap(
-        await commands.apiGetCachedChatThreadMessages(
-          accountIdForCache,
-          threadId,
-          null,
-          50,
-        ),
-      ) as unknown as ChatMessage[]
-      return cached.slice().reverse()
-    } catch {
-      return []
-    }
-  }
+  const target: ChatThreadTarget = entry.isRoom
+    ? {
+        kind: 'room',
+        roomId:
+          ('roomId' in entry ? entry.roomId : undefined) ??
+          ('message' in entry ? (entry.message.toRoomId ?? '') : ''),
+      }
+    : {
+        kind: 'user',
+        otherId:
+          'otherId' in entry && entry.otherId
+            ? entry.otherId
+            : 'message' in entry
+              ? entry.message.fromUserId === myUserId.value
+                ? (entry.message.toUserId ?? '')
+                : entry.message.fromUserId
+              : '',
+      }
 
   try {
-    if (entry.isRoom) {
-      const roomId =
-        'roomId' in entry
-          ? entry.roomId
-          : 'message' in entry
-            ? (entry.message.toRoomId ?? '')
-            : ''
-      currentRoomId.value = roomId ?? ''
-      currentOtherId.value = null
-      const threadId = `r:${currentRoomId.value}`
-
-      // 1. Cache hydrate (B-2): 即時に thread を表示する。
-      const cached = await loadCachedThread(threadId)
-      if (cached.length > 0) {
-        setMessages(cached)
+    const outcome = await thread.open(entryAccountId, target, {
+      loggedOut: isLoggedOut,
+      // cache hydrate できた時点で即表示する (B-2)
+      onHydrated: () => {
         viewMode.value = 'conversation'
         isLoading.value = false
         scrollToBottom()
-      }
-
-      if (isLoggedOut || !adapter) {
-        if (cached.length === 0) setMessages([])
-      } else {
-        // 2. 並行で API fetch して reconcile
-        try {
-          const msgs = await adapter.api.getChatRoomMessages(
-            currentRoomId.value,
-          )
-          setMessages(msgs.slice().reverse())
-        } catch {
-          // cache hydrate 済みならそのまま、空ならそのまま空 (error は最終 catch で吸収)
-          if (cached.length === 0) setMessages([])
-        }
-        if (isCrossAccount.value) adapter.stream.connect()
-        chatSub = createQuerySubscription({
-          open: async () =>
-            unwrap(
-              await commands.querySubscribeChatRoom(
-                entryAccountId,
-                currentRoomId.value ?? '',
-              ),
-            ),
-          onInsert: (item) => onNewMessage(item as unknown as ChatMessage),
-          onDelete: (id) => onMessageDeleted(id),
-        })
-      }
-    } else {
-      const otherId =
-        'otherId' in entry && entry.otherId
-          ? entry.otherId
-          : 'message' in entry
-            ? entry.message.fromUserId === myUserId.value
-              ? (entry.message.toUserId ?? '')
-              : entry.message.fromUserId
-            : ''
-      currentOtherId.value = otherId
-      currentRoomId.value = null
-      const threadId = `u:${otherId}`
-
-      // 1. Cache hydrate (B-2)
-      const cached = await loadCachedThread(threadId)
-      if (cached.length > 0) {
-        setMessages(cached)
-        viewMode.value = 'conversation'
-        isLoading.value = false
-        scrollToBottom()
-      }
-
-      if (isLoggedOut || !adapter) {
-        if (cached.length === 0) setMessages([])
-      } else {
-        // 2. 並行で API fetch して reconcile
-        try {
-          const msgs = await adapter.api.getChatUserMessages(otherId)
-          setMessages(msgs.slice().reverse())
-        } catch {
-          if (cached.length === 0) setMessages([])
-        }
-        if (isCrossAccount.value) adapter.stream.connect()
-        chatSub = createQuerySubscription({
-          open: async () =>
-            unwrap(
-              await commands.querySubscribeChatUser(entryAccountId, otherId),
-            ),
-          onInsert: (item) => onNewMessage(item as unknown as ChatMessage),
-          onDelete: (id) => onMessageDeleted(id),
-        })
-      }
-    }
+      },
+    })
+    if (outcome === 'aborted') return
     viewMode.value = 'conversation'
     scrollToBottom()
   } catch (e) {
@@ -693,23 +617,15 @@ function onNewMessage(msg: ChatMessage) {
   if (messageIds.value.includes(msg.id)) return
   // ミュート送信者の着信は存在ごと無視（append もサウンドもしない）
   if (isMessageHidden(activeAccountId.value, msg)) return
-  appendMessage(msg)
+  thread.append(msg)
   if (!props.column.soundMuted) chatSound.play()
   // 検索中は表示位置を維持する (新着で自動スクロールするとヒット箇所を見失うため)。
   if (!isConvSearching.value) scrollToBottom()
 }
 
-function onMessageDeleted(messageId: string) {
-  removeMessage(messageId)
-}
-
 function goBack() {
-  chatSub?.dispose()
-  chatSub = null
+  thread.close()
   viewMode.value = 'history'
-  messageIds.value = []
-  currentOtherId.value = null
-  currentRoomId.value = null
   conversationAccountId.value = null
   conversationServerHost.value = null
   // 検索 state は view ごとに独立。view 切替時に持ち越さない。
@@ -748,7 +664,7 @@ async function sendMessage() {
     messageText.value = ''
     attachedFile.value = null
     if (!messageIds.value.includes(sent.id)) {
-      appendMessage(sent)
+      thread.append(sent)
       scrollToBottom()
     }
   } catch (e) {
@@ -935,76 +851,19 @@ async function loadOlder() {
   const conversationAccount = accountsStore.accounts.find((a) => a.id === accId)
   const isLoggedOut = !conversationAccount?.hasToken
 
-  const adapter = isCrossAccount.value
-    ? await multiAdapters.getOrCreate(accId)
-    : getAdapter()
-  if (!adapter && !isLoggedOut) return
-
-  const oldest = messages.value[0]
-  if (!oldest) return
   isLoading.value = true
-
-  // ログアウト/エラー時のキャッシュからの過去取得
-  const accountIdForCache = accId
-  const oldestForCache = oldest
-  const threadId = currentRoomId.value
-    ? `r:${currentRoomId.value}`
-    : currentOtherId.value
-      ? `u:${currentOtherId.value}`
-      : null
-  async function loadCachedOlder(): Promise<ChatMessage[]> {
-    if (!threadId) return []
-    try {
-      const cached = unwrap(
-        await commands.apiGetCachedChatThreadMessages(
-          accountIdForCache,
-          threadId,
-          oldestForCache.id,
-          50,
-        ),
-      ) as unknown as ChatMessage[]
-      return cached
-    } catch {
-      return []
-    }
-  }
-
   try {
-    let older: ChatMessage[]
-    if (isLoggedOut || !adapter) {
-      older = await loadCachedOlder()
-    } else if (currentRoomId.value) {
-      try {
-        older = await adapter.api.getChatRoomMessages(currentRoomId.value, {
-          untilId: oldest.id,
+    const prevFirstId = messageIds.value[0]
+    const added = await thread.loadOlder(accId, { loggedOut: isLoggedOut })
+    // Restore scroll position to the previously first message after prepend
+    if (added && prevFirstId) {
+      await nextTick()
+      const newIndex = messageIds.value.indexOf(prevFirstId)
+      if (newIndex >= 0) {
+        chatScroller.value?.scrollToIndex(newIndex, {
+          align: 'start',
+          behavior: 'instant',
         })
-      } catch {
-        older = await loadCachedOlder()
-      }
-    } else if (currentOtherId.value) {
-      try {
-        older = await adapter.api.getChatUserMessages(currentOtherId.value, {
-          untilId: oldest.id,
-        })
-      } catch {
-        older = await loadCachedOlder()
-      }
-    } else {
-      return
-    }
-    if (older.length > 0) {
-      const prevFirstId = messageIds.value[0]
-      prependMessages(older)
-      // Restore scroll position to the previously first message after prepend
-      if (prevFirstId) {
-        await nextTick()
-        const newIndex = messageIds.value.indexOf(prevFirstId)
-        if (newIndex >= 0) {
-          chatScroller.value?.scrollToIndex(newIndex, {
-            align: 'start',
-            behavior: 'instant',
-          })
-        }
       }
     }
   } catch (e) {
@@ -1109,8 +968,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  chatSub?.dispose()
-  chatSub = null
+  thread.close()
   for (const unlisten of reactionUnlisteners) unlisten()
   reactionUnlisteners.length = 0
   unregisterRoot?.()

--- a/src/composables/useAiSendLoop.test.ts
+++ b/src/composables/useAiSendLoop.test.ts
@@ -343,8 +343,8 @@ describe('runSend: エラー時の partial 温存 (#508)', () => {
   })
 })
 
-describe('retryContext (#646: write capability 二重実行防止)', () => {
-  it('tool 未実行 (toolRound=0) のエラーで retryContext を記録する', async () => {
+describe('retryContext (#646 → #737: write capability 二重実行防止)', () => {
+  it('tool 未実行 (toolRound=0) のエラーで mode=resend を記録する', async () => {
     const { deps } = makeDeps([
       () => {
         throw new Error('boom')
@@ -357,10 +357,11 @@ describe('retryContext (#646: write capability 二重実行防止)', () => {
     expect(loop.retryContext.value).toMatchObject({
       sessionId: 's1',
       userText: 'こんにちは',
+      mode: 'resend',
     })
   })
 
-  it('tool 実行済みターンのエラーでは記録しない', async () => {
+  it('tool 実行済みターンのエラーは mode=continue を記録する (#737: 再送でなく継続)', async () => {
     const { dispatch, deps } = makeDeps([
       toolStep('', 'toolu_1', 'notes.create'),
       () => {
@@ -373,7 +374,11 @@ describe('retryContext (#646: write capability 二重実行防止)', () => {
 
     expect(dispatch).toHaveBeenCalledTimes(1)
     expect(outcome.status).toBe('error')
-    expect(loop.retryContext.value).toBeNull()
+    expect(loop.retryContext.value).toMatchObject({
+      sessionId: 's1',
+      userText: 'こんにちは',
+      mode: 'continue',
+    })
   })
 
   it('runSend 開始時に前回の retryContext をクリアする', async () => {
@@ -394,7 +399,7 @@ describe('retryContext (#646: write capability 二重実行防止)', () => {
 })
 
 describe('prepareRetry', () => {
-  it('失敗した user + assistant ペアを session から除去し userText を返す', async () => {
+  it('resend: 失敗した user + assistant ペアを session から除去し userText を返す', async () => {
     const { sessions, deps } = makeDeps(
       [
         () => {
@@ -413,12 +418,35 @@ describe('prepareRetry', () => {
     await loop.runSend(request())
     expect(sessions.get('s1')?.messages).toHaveLength(4)
 
-    const text = loop.prepareRetry('s1')
+    const retry = loop.prepareRetry('s1')
 
-    expect(text).toBe('こんにちは')
+    expect(retry).toEqual({ mode: 'resend', text: 'こんにちは' })
     expect(loop.retryContext.value).toBeNull()
     // 失敗ペアが消え、既存の会話だけが残る
     expect(sessions.get('s1')?.messages.map((m) => m.id)).toEqual(['u0', 'a0'])
+  })
+
+  it('continue: 失敗 placeholder のみ除去し、user と実行済み tool_use / tool_result は残す (#737)', async () => {
+    const { sessions, deps } = makeDeps([
+      toolStep('検索します', 'toolu_1', 'notes.create'),
+      () => {
+        throw new Error('boom after tool')
+      },
+    ])
+    const loop = useAiSendLoop(deps)
+
+    await loop.runSend(request())
+    // user / assistant(tool_use) / user(tool_result) / placeholder(⚠️)
+    expect(sessions.get('s1')?.messages).toHaveLength(4)
+
+    const retry = loop.prepareRetry('s1')
+
+    expect(retry).toEqual({ mode: 'continue', text: 'こんにちは' })
+    const remaining = sessions.get('s1')?.messages ?? []
+    expect(remaining).toHaveLength(3)
+    expect(remaining[0]).toMatchObject({ role: 'user', content: 'こんにちは' })
+    expect(remaining[1]).toMatchObject({ toolUseId: 'toolu_1' })
+    expect(remaining[2]).toMatchObject({ toolResultFor: 'toolu_1' })
   })
 
   it('別セッション表示中や streaming 中は何もしない', async () => {
@@ -439,6 +467,89 @@ describe('prepareRetry', () => {
     chat.isStreaming.value = false
 
     expect(sessions.get('s1')?.messages).toHaveLength(2)
+  })
+})
+
+describe('runSend: continuation (#737 tool 実行ターンの安全な再試行)', () => {
+  /** tool 実行済みターンが失敗した直後の session 状態を作る。 */
+  async function failAfterTool() {
+    const { chat, sessions, dispatch, deps } = makeDeps([
+      toolStep('実行します', 'toolu_1', 'notes.create', { text: 'hi' }),
+      () => {
+        throw new Error('切断')
+      },
+      textStep('投稿しました'),
+    ])
+    const loop = useAiSendLoop(deps)
+    await loop.runSend(request())
+    return { chat, sessions, dispatch, deps, loop }
+  }
+
+  it('user メッセージを追加せず、実行済み tool_result を含む履歴で続きを生成する', async () => {
+    const { chat, sessions, dispatch, loop } = await failAfterTool()
+    const retry = loop.prepareRetry('s1')
+    expect(retry?.mode).toBe('continue')
+
+    const outcome = await loop.runSend(
+      request({ text: retry?.text ?? '', continuation: true }),
+    )
+
+    expect(outcome).toMatchObject({ status: 'done', finalText: '投稿しました' })
+    // 継続で dispatch が再実行されていない (= 二重投稿なし)
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    const messages = sessions.get('s1')?.messages ?? []
+    // user / assistant(tool_use) / tool_result / assistant(final) — user は 1 つだけ
+    expect(
+      messages.filter((m) => m.role === 'user' && !m.toolResultFor),
+    ).toHaveLength(1)
+    expect(messages.at(-1)).toMatchObject({
+      role: 'assistant',
+      content: '投稿しました',
+    })
+
+    // 継続 round の wire history は tool_result で終わる (placeholder 除外済み)
+    const contHistory = chat.calls[2]?.history ?? []
+    expect(contHistory.at(-1)?.toolResultFor).toBe('toolu_1')
+  })
+
+  it('継続 round の system に切断通知を付与する', async () => {
+    const { chat, loop } = await failAfterTool()
+    loop.prepareRetry('s1')
+
+    await loop.runSend(request({ continuation: true }))
+
+    expect(chat.calls[2]?.system).toContain('SYSTEM')
+    expect(chat.calls[2]?.system).toContain('切断')
+  })
+
+  it('継続がさらに失敗しても mode=continue を再記録する (再継続可能)', async () => {
+    const { deps } = makeDeps([
+      toolStep('', 'toolu_1', 'notes.create'),
+      () => {
+        throw new Error('切断 1 回目')
+      },
+      () => {
+        throw new Error('切断 2 回目')
+      },
+    ])
+    const loop = useAiSendLoop(deps)
+    await loop.runSend(request())
+    expect(loop.prepareRetry('s1')?.mode).toBe('continue')
+
+    // 継続 1 round 目 (このターン内では tool 未実行) で再度切断しても、
+    // ターン全体としては実行済み tool を含むため resend に落ちてはいけない
+    const outcome = await loop.runSend(request({ continuation: true }))
+    expect(outcome.status).toBe('error')
+    expect(loop.retryContext.value?.mode).toBe('continue')
+  })
+
+  it('tool_use assistant しか無い session では wasFirstRound=true (タイトル生成が動く)', async () => {
+    const { loop } = await failAfterTool()
+    loop.prepareRetry('s1')
+
+    const outcome = await loop.runSend(request({ continuation: true }))
+    expect(outcome).toMatchObject({ status: 'done', wasFirstRound: true })
   })
 })
 

--- a/src/composables/useAiSendLoop.ts
+++ b/src/composables/useAiSendLoop.ts
@@ -48,12 +48,21 @@ export interface AiSendLoopDeps {
 
 export interface AiSendRequest {
   sessionId: string
-  /** ユーザー入力テキスト (user メッセージとして追加される) */
+  /**
+   * ユーザー入力テキスト (user メッセージとして追加される)。
+   * continuation では追加されない (元ターンの user メッセージが履歴に残っている)。
+   */
   text: string
   connectionId: string
   model: string
   /** provider 形式に変換済みの tool definition 配列 */
   tools?: unknown[]
+  /**
+   * 切断ターンの継続モード (#737)。user メッセージを追加せず、session に
+   * 残っている実行済み tool_use / tool_result を含む履歴から続きを生成する。
+   * 実行済み tool を再生成しないため write capability の二重実行が起きない。
+   */
+  continuation?: boolean
   /**
    * round ごとに wire history から system prompt を組み立てる。
    * context (memos / visible notes 等) は round 間で変わりうるため毎回呼ぶ。
@@ -72,15 +81,37 @@ export type AiSendOutcome =
 
 /**
  * ストリーム切断 (#508) で失敗したターンの再試行用コンテキスト。
- * tool を 1 つでも実行したターンは再送で write capability が二重実行される
- * 恐れがあるため記録しない (#646 §C)。
+ *
+ * - `resend` — tool 未実行のターン。user + placeholder を取り除き、同じ
+ *   text で通常送信を再走行する (#646 §C)
+ * - `continue` — tool 実行済みのターン (#737)。dispatch は sendMessage の
+ *   完了後にのみ走り、結果は次の sendMessage 前に session へ記録済みなので、
+ *   「実行済みだが未記録」の tool は存在しない。よって失敗 placeholder だけ
+ *   取り除き、実行済み tool_use / tool_result を履歴に残したまま続きを
+ *   生成すれば、write capability を再実行する経路は構造的に無い
  */
 export interface AiRetryContext {
   sessionId: string
-  userMsgId: string
+  /** resend で取り除く user メッセージ (continuation 起点では undefined) */
+  userMsgId?: string
   placeholderId: string
   userText: string
+  mode: 'resend' | 'continue'
 }
+
+export interface AiRetryPlan {
+  mode: 'resend' | 'continue'
+  /** 再送 (resend) / 継続時の trigger 再解決 (continue) に使う元の入力 */
+  text: string
+}
+
+/**
+ * 継続モードで system prompt 末尾に付ける通知 (#737)。実行済み tool の
+ * 繰り返しをモデル側でも抑止する 2 重目の防壁 (1 重目は「実行済み round を
+ * 再生成しない」という構造そのもの)。
+ */
+export const CONTINUATION_NOTICE =
+  '直前の応答は途中で切断されました。会話履歴にある tool 実行結果は既に実行済みです。同じ書き込み操作を繰り返さず、既存の結果を使って応答の続きを完成させてください。'
 
 /**
  * tool_use ループで暴走しないための上限。1 ターン中に AI が連続で tool を
@@ -115,19 +146,30 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
     retryContext.value = null
 
     const now = Date.now()
-    const userMsg: ChatMessage = {
-      id: `msg-${now}-u`,
-      role: 'user',
-      content: req.text,
-      timestamp: now,
-    }
     const before = deps.sessions.get(req.sessionId)
     if (!before) return { status: 'aborted' }
-    deps.sessions.updateMessages(req.sessionId, [...before.messages, userMsg])
-    deps.onUpdate?.()
 
-    // この round が assistant 応答のない初回かどうか (AI 生成タイトル用)
-    const wasFirstRound = !before.messages.some((m) => m.role === 'assistant')
+    // continuation (#737) では user メッセージを追加しない (失敗ターンの
+    // user + 実行済み tool_use / tool_result が session に残っている)。
+    let userMsgId: string | undefined
+    if (!req.continuation) {
+      const userMsg: ChatMessage = {
+        id: `msg-${now}-u`,
+        role: 'user',
+        content: req.text,
+        timestamp: now,
+      }
+      userMsgId = userMsg.id
+      deps.sessions.updateMessages(req.sessionId, [...before.messages, userMsg])
+      deps.onUpdate?.()
+    }
+
+    // このターンが assistant 応答のない初回かどうか (AI 生成タイトル用)。
+    // 失敗ターンの残骸 (tool_use 付き assistant) は「完了した応答」ではない
+    // ので数えない (= continuation でも初回ならタイトル生成が動く)。
+    const wasFirstRound = !before.messages.some(
+      (m) => m.role === 'assistant' && !m.toolUseId,
+    )
 
     // Pre-add empty assistant placeholder so streaming has a target slot
     const assistantMsg: ChatMessage = {
@@ -165,7 +207,13 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
             !m.heartbeat,
         )
 
-        const system = await req.buildSystem(history)
+        const base = await req.buildSystem(history)
+        // 継続モードでは切断通知を付け、実行済み tool の繰り返しを抑止する
+        const system = req.continuation
+          ? base
+            ? `${base}\n\n${CONTINUATION_NOTICE}`
+            : CONTINUATION_NOTICE
+          : base
 
         let pendingToolUse: ToolUseEvent | null = null
         const turnText = await deps.chat.sendMessage({
@@ -294,15 +342,16 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
           ])
         }
       }
-      // tool 未実行のターンだけ再試行を許可する (#508)。tool 実行後の再送は
-      // write capability (投稿/クリップ等) の二重実行につながるため出さない。
-      if (toolRound === 0) {
-        retryContext.value = {
-          sessionId: req.sessionId,
-          userMsgId: userMsg.id,
-          placeholderId,
-          userText: req.text,
-        }
+      // 再試行コンテキスト (#508 / #737)。tool 未実行の新規ターンは resend
+      // (ターン全体を再送)、tool 実行済み or 継続中のターンは continue
+      // (実行済み tool を保持して続きから生成)。再送による write capability
+      // の二重実行はこの分岐で構造的に防ぐ。
+      retryContext.value = {
+        sessionId: req.sessionId,
+        userMsgId,
+        placeholderId,
+        userText: req.text,
+        mode: toolRound === 0 && !req.continuation ? 'resend' : 'continue',
       }
       return { status: 'error', message, wasFirstRound }
     } finally {
@@ -312,25 +361,29 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
   }
 
   /**
-   * 再試行の準備: 失敗した user + assistant のペアを session から取り除き、
-   * 再送すべき userText を返す。history が失敗前と同一になるので、呼び出し側は
-   * 通常の送信経路を再走行するだけでよい。実行できない状況 (別セッション表示中 /
-   * streaming 中 / コンテキスト無し) では null を返し、状態を変えない。
+   * 再試行の準備。実行できない状況 (別セッション表示中 / streaming 中 /
+   * コンテキスト無し) では null を返し、状態を変えない。
+   *
+   * - resend: 失敗した user + placeholder を取り除く。history が失敗前と
+   *   同一になるので、呼び出し側は通常の送信経路を再走行するだけでよい
+   * - continue (#737): 失敗 placeholder のみ取り除く。user と実行済み
+   *   tool_use / tool_result は履歴に残し、呼び出し側は continuation: true
+   *   で runSend を再走行する
    */
-  function prepareRetry(currentSessionId: string | null): string | null {
+  function prepareRetry(currentSessionId: string | null): AiRetryPlan | null {
     const r = retryContext.value
     if (!r || deps.chat.isStreaming.value) return null
     if (r.sessionId !== currentSessionId) return null
     retryContext.value = null
     const cur = deps.sessions.get(r.sessionId)
     if (!cur) return null
+    const removeIds =
+      r.mode === 'resend' ? [r.userMsgId, r.placeholderId] : [r.placeholderId]
     deps.sessions.updateMessages(
       r.sessionId,
-      cur.messages.filter(
-        (m) => m.id !== r.userMsgId && m.id !== r.placeholderId,
-      ),
+      cur.messages.filter((m) => !removeIds.includes(m.id)),
     )
-    return r.userText
+    return { mode: r.mode, text: r.userText }
   }
 
   return {

--- a/src/composables/useChatThread.test.ts
+++ b/src/composables/useChatThread.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ChatMessage } from '@/adapters/types'
+import {
+  type ChatThreadDeps,
+  type ChatThreadSubscription,
+  type ChatThreadTarget,
+  chatThreadId,
+  useChatThread,
+} from './useChatThread'
+
+// ---- fakes ----
+
+function msg(id: string, createdAt = '2026-07-01T00:00:00.000Z'): ChatMessage {
+  return { id, createdAt, fromUserId: 'u-from', text: `text-${id}` }
+}
+
+function makeStore() {
+  const map = new Map<string, ChatMessage>()
+  return {
+    put: (msgs: ChatMessage[]) => {
+      for (const m of msgs) map.set(m.id, m)
+    },
+    resolve: (ids: string[]) =>
+      ids.flatMap((id) => {
+        const m = map.get(id)
+        return m ? [m] : []
+      }),
+    remove: (id: string) => {
+      map.delete(id)
+    },
+  }
+}
+
+const USER_TARGET: ChatThreadTarget = { kind: 'user', otherId: 'other-1' }
+const ROOM_TARGET: ChatThreadTarget = { kind: 'room', roomId: 'room-1' }
+
+interface DepsOverrides {
+  cached?: ChatMessage[] | (() => Promise<ChatMessage[]>)
+  fetched?: ChatMessage[] | (() => Promise<ChatMessage[]>)
+  /** resolveApi が null を返す (= adapter 不在) */
+  noApi?: boolean
+}
+
+function makeDeps(overrides: DepsOverrides = {}) {
+  const store = makeStore()
+  const subs: Array<{ disposed: boolean }> = []
+  const onIncoming = vi.fn()
+  const fetch = vi.fn(
+    async (_t: ChatThreadTarget, _opts?: { untilId?: string }) => {
+      const f = overrides.fetched ?? []
+      return typeof f === 'function' ? f() : f
+    },
+  )
+  const getCached = vi.fn(
+    async (
+      _accountId: string,
+      _threadId: string,
+      _untilId: string | null,
+      _limit: number,
+    ) => {
+      const c = overrides.cached ?? []
+      return typeof c === 'function' ? c() : c
+    },
+  )
+  const subscribe = vi.fn(
+    (
+      _accountId: string,
+      _target: ChatThreadTarget,
+      _handlers: {
+        onInsert(m: ChatMessage): void
+        onDelete(id: string): void
+      },
+    ): ChatThreadSubscription => {
+      const sub = { disposed: false }
+      subs.push(sub)
+      return {
+        dispose: () => {
+          sub.disposed = true
+        },
+      }
+    },
+  )
+  const deps: ChatThreadDeps = {
+    store,
+    getCached,
+    resolveApi: async () => (overrides.noApi ? null : { fetch }),
+    subscribe,
+    onIncoming,
+  }
+  return { deps, store, fetch, getCached, subscribe, subs, onIncoming }
+}
+
+// cache/API は newest-first で返る (Misskey API と同じ向き)
+const newestFirst = (...ids: string[]) =>
+  ids.map((id, i) => msg(id, `2026-07-0${9 - i}T00:00:00.000Z`))
+
+// ---- tests ----
+
+describe('chatThreadId', () => {
+  it('room は r: prefix、user は u: prefix', () => {
+    expect(chatThreadId(ROOM_TARGET)).toBe('r:room-1')
+    expect(chatThreadId(USER_TARGET)).toBe('u:other-1')
+  })
+})
+
+describe('open: cache hydrate → API reconcile (#460 B-2)', () => {
+  it('キャッシュがあれば先に oldest-first で表示し onHydrated を呼ぶ', async () => {
+    const hydrated: string[][] = []
+    const { deps } = makeDeps({
+      cached: newestFirst('c2', 'c1'),
+      fetched: newestFirst('a3', 'a2', 'a1'),
+    })
+    const thread = useChatThread(deps)
+
+    const outcome = await thread.open('acc-1', USER_TARGET, {
+      loggedOut: false,
+      onHydrated: () => hydrated.push(thread.messages.value.map((m) => m.id)),
+    })
+
+    expect(outcome).toBe('opened')
+    // hydrate 時点ではキャッシュの reverse (oldest-first)
+    expect(hydrated).toEqual([['c1', 'c2']])
+    // reconcile 後は API 結果で完全置換
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['a1', 'a2', 'a3'])
+  })
+
+  it('ログアウト中はキャッシュのみで API fetch も購読もしない', async () => {
+    const { deps, fetch, subscribe } = makeDeps({
+      cached: newestFirst('c2', 'c1'),
+    })
+    const thread = useChatThread(deps)
+
+    await thread.open('acc-1', USER_TARGET, { loggedOut: true })
+
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['c1', 'c2'])
+    expect(fetch).not.toHaveBeenCalled()
+    expect(subscribe).not.toHaveBeenCalled()
+  })
+
+  it('ログイン中に adapter を解決できなければ aborted (状態を変えない)', async () => {
+    const { deps, getCached } = makeDeps({ noApi: true })
+    const thread = useChatThread(deps)
+
+    const outcome = await thread.open('acc-1', USER_TARGET, {
+      loggedOut: false,
+    })
+
+    expect(outcome).toBe('aborted')
+    expect(getCached).not.toHaveBeenCalled()
+    expect(thread.target.value).toBeNull()
+  })
+
+  it('API fetch 失敗でもキャッシュ hydrate 済みなら表示を保つ', async () => {
+    const { deps } = makeDeps({
+      cached: newestFirst('c2', 'c1'),
+      fetched: () => Promise.reject(new Error('offline')),
+    })
+    const thread = useChatThread(deps)
+
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['c1', 'c2'])
+  })
+
+  it('API fetch 失敗かつキャッシュ空なら空リストで確定する', async () => {
+    const { deps } = makeDeps({
+      fetched: () => Promise.reject(new Error('offline')),
+    })
+    const thread = useChatThread(deps)
+
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+    expect(thread.messages.value).toEqual([])
+  })
+
+  it('キャッシュ読み失敗は空扱いで続行する', async () => {
+    const { deps } = makeDeps({
+      cached: () => Promise.reject(new Error('db broken')),
+      fetched: newestFirst('a1'),
+    })
+    const thread = useChatThread(deps)
+
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['a1'])
+  })
+
+  it('再 open で前の購読を dispose する', async () => {
+    const { deps, subs } = makeDeps()
+    const thread = useChatThread(deps)
+
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+    await thread.open('acc-1', ROOM_TARGET, { loggedOut: false })
+
+    expect(subs).toHaveLength(2)
+    expect(subs[0]?.disposed).toBe(true)
+    expect(subs[1]?.disposed).toBe(false)
+    expect(thread.target.value).toEqual(ROOM_TARGET)
+  })
+})
+
+describe('ライブ購読イベント', () => {
+  it('onInsert は onIncoming へ委譲し、onDelete はメッセージを取り除く', async () => {
+    const { deps, subscribe, onIncoming } = makeDeps({
+      fetched: newestFirst('a2', 'a1'),
+    })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    const handlers = subscribe.mock.calls[0]?.[2]
+    const incoming = msg('live-1')
+    handlers?.onInsert(incoming)
+    expect(onIncoming).toHaveBeenCalledExactlyOnceWith(incoming)
+
+    handlers?.onDelete('a2')
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['a1'])
+  })
+})
+
+describe('append / prepend', () => {
+  it('append は重複 id を無視する', async () => {
+    const { deps } = makeDeps({ fetched: newestFirst('a1') })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    thread.append(msg('a2'))
+    thread.append(msg('a2'))
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['a1', 'a2'])
+  })
+})
+
+describe('loadOlder (#460 過去分取得)', () => {
+  it('oldest.id を untilId に API 取得し、oldest-first で前置する', async () => {
+    const { deps, fetch } = makeDeps({ fetched: newestFirst('a2', 'a1') })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    fetch.mockResolvedValueOnce(newestFirst('o2', 'o1'))
+    const added = await thread.loadOlder('acc-1', { loggedOut: false })
+
+    expect(added).toBe(true)
+    expect(fetch).toHaveBeenLastCalledWith(USER_TARGET, { untilId: 'a1' })
+    expect(thread.messages.value.map((m) => m.id)).toEqual([
+      'o1',
+      'o2',
+      'a1',
+      'a2',
+    ])
+  })
+
+  it('API 失敗時はキャッシュへ fallback する', async () => {
+    const { deps, fetch, getCached } = makeDeps({
+      fetched: newestFirst('a1'),
+    })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    fetch.mockRejectedValueOnce(new Error('offline'))
+    getCached.mockResolvedValueOnce(newestFirst('o1'))
+    const added = await thread.loadOlder('acc-1', { loggedOut: false })
+
+    expect(added).toBe(true)
+    expect(getCached).toHaveBeenLastCalledWith('acc-1', 'u:other-1', 'a1', 50)
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['o1', 'a1'])
+  })
+
+  it('ログアウト中はキャッシュのみから取得する', async () => {
+    const { deps, fetch, getCached } = makeDeps({
+      cached: newestFirst('a1'),
+    })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: true })
+
+    getCached.mockResolvedValueOnce(newestFirst('o1'))
+    const added = await thread.loadOlder('acc-1', { loggedOut: true })
+
+    expect(added).toBe(true)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['o1', 'a1'])
+  })
+
+  it('結果が空なら false を返し状態を変えない', async () => {
+    const { deps, fetch } = makeDeps({ fetched: newestFirst('a1') })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    fetch.mockResolvedValueOnce([])
+    const added = await thread.loadOlder('acc-1', { loggedOut: false })
+    expect(added).toBe(false)
+    expect(thread.messages.value.map((m) => m.id)).toEqual(['a1'])
+  })
+
+  it('メッセージが無い / thread 未 open のときは何もしない', async () => {
+    const { deps, fetch } = makeDeps()
+    const thread = useChatThread(deps)
+    expect(await thread.loadOlder('acc-1', { loggedOut: false })).toBe(false)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})
+
+describe('close', () => {
+  it('購読を dispose し state を初期化する', async () => {
+    const { deps, subs } = makeDeps({ fetched: newestFirst('a1') })
+    const thread = useChatThread(deps)
+    await thread.open('acc-1', USER_TARGET, { loggedOut: false })
+
+    thread.close()
+
+    expect(subs[0]?.disposed).toBe(true)
+    expect(thread.messageIds.value).toEqual([])
+    expect(thread.target.value).toBeNull()
+  })
+})

--- a/src/composables/useChatThread.ts
+++ b/src/composables/useChatThread.ts
@@ -1,0 +1,231 @@
+import { computed, ref, shallowRef } from 'vue'
+import type { ChatMessage } from '@/adapters/types'
+
+/**
+ * チャット会話 thread の状態機械 (#707)。DeckChatColumn から抽出した
+ * 「cache hydrate → API reconcile → ライブ購読」ladder (#460 B-1/B-2) と
+ * message id リスト操作をここに集約する。
+ *
+ * 依存は port として注入する。view (viewMode 切替 / スクロール / 通知音 /
+ * ミュート判定 / エラー表示) は呼び出し側の責務。
+ */
+
+export type ChatThreadTarget =
+  | { kind: 'room'; roomId: string }
+  | { kind: 'user'; otherId: string }
+
+/** chat_messages_cache の thread id 形式 (`r:<roomId>` / `u:<userId>`)。 */
+export function chatThreadId(target: ChatThreadTarget): string {
+  return target.kind === 'room' ? `r:${target.roomId}` : `u:${target.otherId}`
+}
+
+/** chatMessageStore の必要最小面。 */
+export interface ChatThreadStorePort {
+  put(msgs: ChatMessage[]): void
+  resolve(ids: string[]): ChatMessage[]
+  remove(id: string): void
+}
+
+/** 解決済みの API 面 (adapter 相当)。メッセージは newest-first で返る。 */
+export interface ChatThreadApiPort {
+  fetch(
+    target: ChatThreadTarget,
+    opts?: { untilId?: string },
+  ): Promise<ChatMessage[]>
+}
+
+export interface ChatThreadSubscription {
+  dispose(): void
+}
+
+export interface ChatThreadDeps {
+  store: ChatThreadStorePort
+  /** キャッシュ thread 読み (token 不要、newest-first)。失敗は throw でよい。 */
+  getCached(
+    accountId: string,
+    threadId: string,
+    untilId: string | null,
+    limit: number,
+  ): Promise<ChatMessage[]>
+  /**
+   * アカウントの API 面を解決する。adapter を初期化できない場合は null
+   * (ログイン中なら open は中断、ログアウト中はキャッシュのみで続行)。
+   */
+  resolveApi(accountId: string): Promise<ChatThreadApiPort | null>
+  /** ライブ購読を開く。dispose 可能な handle を返す。 */
+  subscribe(
+    accountId: string,
+    target: ChatThreadTarget,
+    handlers: {
+      onInsert(msg: ChatMessage): void
+      onDelete(id: string): void
+    },
+  ): ChatThreadSubscription | Promise<ChatThreadSubscription>
+  /**
+   * WS 新着メッセージの通知。ミュート判定・通知音・スクロール・append の
+   * 判断は呼び出し側が行う (append する場合は `append()` を呼ぶ)。
+   */
+  onIncoming(msg: ChatMessage): void
+}
+
+/** キャッシュからの 1 ページ取得件数 (open hydrate / loadOlder 共通)。 */
+const CACHE_PAGE_SIZE = 50
+
+export type ChatThreadOpenOutcome = 'opened' | 'aborted'
+
+export function useChatThread(deps: ChatThreadDeps) {
+  // メッセージは store からの ID 参照のみで管理する (#460 B-5)。
+  // `messageIds` の真値を持ち、`messages` は store から resolve した derived。
+  const messageIds = ref<string[]>([])
+  const messages = computed(() => deps.store.resolve(messageIds.value))
+  const target = shallowRef<ChatThreadTarget | null>(null)
+
+  let sub: ChatThreadSubscription | null = null
+
+  function setMessages(msgs: ChatMessage[]) {
+    deps.store.put(msgs)
+    messageIds.value = msgs.map((m) => m.id)
+  }
+
+  function append(msg: ChatMessage) {
+    if (messageIds.value.includes(msg.id)) return
+    deps.store.put([msg])
+    messageIds.value = [...messageIds.value, msg.id]
+  }
+
+  /** newest-first の older ページを oldest-first に直して前置する。 */
+  function prepend(older: ChatMessage[]) {
+    if (older.length === 0) return
+    deps.store.put(older)
+    const existing = new Set(messageIds.value)
+    const newIds = older
+      .slice()
+      .reverse()
+      .map((m) => m.id)
+      .filter((id) => !existing.has(id))
+    messageIds.value = [...newIds, ...messageIds.value]
+  }
+
+  function remove(messageId: string) {
+    messageIds.value = messageIds.value.filter((id) => id !== messageId)
+    deps.store.remove(messageId)
+  }
+
+  async function loadCached(
+    accountId: string,
+    threadId: string,
+    untilId: string | null,
+  ): Promise<ChatMessage[]> {
+    try {
+      return await deps.getCached(accountId, threadId, untilId, CACHE_PAGE_SIZE)
+    } catch {
+      return []
+    }
+  }
+
+  /**
+   * thread を開く。ladder (#460):
+   *   1. キャッシュ hydrate — あれば即表示して `onHydrated` を呼ぶ
+   *   2. ログアウト中 / adapter 不在ならキャッシュのみで確定
+   *   3. API fetch で完全置換 (server is source of truth)、失敗時は
+   *      hydrate 済み表示を保つ
+   *   4. ライブ購読を開く (購読エラーは throw され呼び出し側で表示する)
+   *
+   * ログイン中に adapter を解決できない場合は 'aborted' を返し、
+   * 表示状態を変えない。
+   */
+  async function open(
+    accountId: string,
+    nextTarget: ChatThreadTarget,
+    opts: { loggedOut: boolean; onHydrated?(): void },
+  ): Promise<ChatThreadOpenOutcome> {
+    sub?.dispose()
+    sub = null
+
+    const api = await deps.resolveApi(accountId)
+    if (!api && !opts.loggedOut) return 'aborted'
+
+    target.value = nextTarget
+    const threadId = chatThreadId(nextTarget)
+
+    // 1. Cache hydrate (B-2): 即時に thread を表示する (newest-first → 表示順)
+    const cached = await loadCached(accountId, threadId, null)
+    const hydrated = cached.length > 0
+    if (hydrated) {
+      setMessages(cached.slice().reverse())
+      opts.onHydrated?.()
+    }
+
+    // 2. ログアウト中はキャッシュだけで終わり。WS 購読も貼らない (B-1)。
+    if (opts.loggedOut || !api) {
+      if (!hydrated) setMessages([])
+      return 'opened'
+    }
+
+    // 3. 並行で API fetch して reconcile
+    try {
+      const msgs = await api.fetch(nextTarget)
+      setMessages(msgs.slice().reverse())
+    } catch {
+      // cache hydrate 済みならそのまま、空ならそのまま空
+      if (!hydrated) setMessages([])
+    }
+
+    // 4. ライブ購読
+    sub = await deps.subscribe(accountId, nextTarget, {
+      onInsert: (msg) => deps.onIncoming(msg),
+      onDelete: (id) => remove(id),
+    })
+    return 'opened'
+  }
+
+  /**
+   * 過去分の取得。API → 失敗時キャッシュの fallback ladder。
+   * @returns 1 件でも前置したら true
+   */
+  async function loadOlder(
+    accountId: string,
+    opts: { loggedOut: boolean },
+  ): Promise<boolean> {
+    const t = target.value
+    const oldest = messages.value[0]
+    if (!t || !oldest) return false
+
+    const api = await deps.resolveApi(accountId)
+    if (!api && !opts.loggedOut) return false
+
+    const threadId = chatThreadId(t)
+    let older: ChatMessage[]
+    if (opts.loggedOut || !api) {
+      older = await loadCached(accountId, threadId, oldest.id)
+    } else {
+      try {
+        older = await api.fetch(t, { untilId: oldest.id })
+      } catch {
+        older = await loadCached(accountId, threadId, oldest.id)
+      }
+    }
+    if (older.length === 0) return false
+    prepend(older)
+    return true
+  }
+
+  /** 購読を閉じて state を初期化する (history view へ戻る / unmount)。 */
+  function close() {
+    sub?.dispose()
+    sub = null
+    messageIds.value = []
+    target.value = null
+  }
+
+  return {
+    messageIds,
+    messages,
+    target,
+    open,
+    loadOlder,
+    append,
+    remove,
+    close,
+  }
+}

--- a/src/composables/useHeartbeatDaemon.test.ts
+++ b/src/composables/useHeartbeatDaemon.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { AiChatSendOptions, ChatMessage } from './useAiChat'
 import { defaultConfig } from './useAiConfig'
+import { useAiSendLoop } from './useAiSendLoop'
 import {
   _internal,
   applyHeartbeatSuppression,
+  createEphemeralAiSession,
   decideCheapCheck,
+  HEARTBEAT_EPHEMERAL_SESSION_ID,
   HEARTBEAT_OK_TOKEN,
 } from './useHeartbeatDaemon'
 
@@ -90,6 +95,121 @@ describe('HEARTBEAT_INSTRUCTION', () => {
   it('mentions HEARTBEAT skill (= OpenClaw style "follow strictly")', () => {
     expect(_internal.HEARTBEAT_INSTRUCTION).toContain('HEARTBEAT')
     expect(_internal.HEARTBEAT_INSTRUCTION).toContain('過去の会話')
+  })
+})
+
+describe('createEphemeralAiSession (#707 send ループ共有)', () => {
+  it('専用 id 以外の get は undefined を返す', () => {
+    const ephemeral = createEphemeralAiSession()
+    expect(ephemeral.port.get('other-session')).toBeUndefined()
+    expect(
+      ephemeral.port.get(HEARTBEAT_EPHEMERAL_SESSION_ID)?.messages,
+    ).toEqual([])
+  })
+
+  it('updateMessages / reset で履歴を差し替え・破棄できる', () => {
+    const ephemeral = createEphemeralAiSession()
+    const m: ChatMessage = {
+      id: 'u1',
+      role: 'user',
+      content: 'x',
+      timestamp: 0,
+    }
+    ephemeral.port.updateMessages(HEARTBEAT_EPHEMERAL_SESSION_ID, [m])
+    expect(
+      ephemeral.port.get(HEARTBEAT_EPHEMERAL_SESSION_ID)?.messages,
+    ).toEqual([m])
+    // 専用 id 以外への書込は無視
+    ephemeral.port.updateMessages('other-session', [])
+    expect(
+      ephemeral.port.get(HEARTBEAT_EPHEMERAL_SESSION_ID)?.messages,
+    ).toEqual([m])
+    ephemeral.reset()
+    expect(
+      ephemeral.port.get(HEARTBEAT_EPHEMERAL_SESSION_ID)?.messages,
+    ).toEqual([])
+  })
+
+  it('useAiSendLoop と組み合わせ、tool round を経た finalText を得る (旧 runAiInference と同じ wire 形状)', async () => {
+    const ephemeral = createEphemeralAiSession()
+    const calls: AiChatSendOptions[] = []
+    const isStreaming = ref(false)
+    const currentText = ref('')
+    const script: Array<(opts: AiChatSendOptions) => string> = [
+      (opts) => {
+        opts.onToolUse?.({
+          toolUseId: 'toolu_1',
+          name: 'server.pulse',
+          input: {},
+        })
+        return ''
+      },
+      () => '重要な発見があります',
+    ]
+    const chat = {
+      isStreaming,
+      currentText,
+      sendMessage: async (opts: AiChatSendOptions) => {
+        calls.push(opts)
+        const step = script.shift()
+        if (!step) throw new Error('script exhausted')
+        return step(opts)
+      },
+    }
+    const dispatch = vi.fn(async () => ({ ok: true as const, result: 'pong' }))
+    const loop = useAiSendLoop({ chat, sessions: ephemeral.port, dispatch })
+
+    ephemeral.reset()
+    const outcome = await loop.runSend({
+      sessionId: HEARTBEAT_EPHEMERAL_SESSION_ID,
+      text: 'Heartbeat tick at 2026-07-12T00:00:00.000Z',
+      connectionId: 'conn-1',
+      model: 'model-1',
+      tools: [{ name: 'server.pulse' }],
+      buildSystem: () => 'HEARTBEAT SYSTEM',
+    })
+
+    expect(outcome).toMatchObject({
+      status: 'done',
+      finalText: '重要な発見があります',
+    })
+    expect(dispatch).toHaveBeenCalledExactlyOnceWith('server.pulse', {})
+    // system は round ごとに同一の定数が渡る (旧実装: 一度だけ組み立てて使い回し)
+    expect(calls.every((c) => c.system === 'HEARTBEAT SYSTEM')).toBe(true)
+    // round 2 の wire history に tool_use / tool_result のペアが入る
+    const round2 = calls[1]?.history ?? []
+    expect(round2.map((m) => m.toolUseId)).toContain('toolu_1')
+    expect(round2.map((m) => m.toolResultFor)).toContain('toolu_1')
+  })
+
+  it('ストリーム失敗は outcome status=error になる (daemon 側で throw に変換され連続失敗カウントに乗る)', async () => {
+    const ephemeral = createEphemeralAiSession()
+    const chat = {
+      isStreaming: ref(false),
+      currentText: ref(''),
+      sendMessage: async () => {
+        throw new Error('接続が切断されました')
+      },
+    }
+    const loop = useAiSendLoop({
+      chat,
+      sessions: ephemeral.port,
+      dispatch: vi.fn(async () => ({ ok: true as const, result: 'ok' })),
+    })
+
+    ephemeral.reset()
+    const outcome = await loop.runSend({
+      sessionId: HEARTBEAT_EPHEMERAL_SESSION_ID,
+      text: 'Heartbeat tick at 2026-07-12T00:00:00.000Z',
+      connectionId: 'conn-1',
+      model: 'model-1',
+      buildSystem: () => undefined,
+    })
+
+    expect(outcome).toMatchObject({
+      status: 'error',
+      message: '接続が切断されました',
+    })
   })
 })
 

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -39,7 +39,7 @@ import { isTauri } from '@/utils/settingsFs'
 import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 import { listenTauri } from '@/utils/tauriEvents'
 import { commands, unwrap } from '@/utils/tauriInvoke'
-import { type ChatMessage, type ToolUseEvent, useAiChat } from './useAiChat'
+import { type ChatMessage, useAiChat } from './useAiChat'
 import {
   type AiConfig,
   HEARTBEAT_ACK_MAX_CHARS,
@@ -47,6 +47,7 @@ import {
   resolveAiConnection,
   useAiConfig,
 } from './useAiConfig'
+import { type AiSendSessionPort, useAiSendLoop } from './useAiSendLoop'
 import {
   buildAiContextBlock,
   composeHeartbeatSystemPrompt,
@@ -102,7 +103,35 @@ export function applyHeartbeatSuppression(
   return body
 }
 
-const MAX_TOOL_ROUNDS = 5
+/** useAiSendLoop に渡す heartbeat 専用の使い捨てセッション id */
+export const HEARTBEAT_EPHEMERAL_SESSION_ID = 'heartbeat-ephemeral'
+
+/**
+ * heartbeat の AI 推論は永続 session を持たず、tick ごとに使い捨ての wire
+ * history で走る。send ループを DeckAiColumn と共有する (#707) ため、
+ * useAiSendLoop の session port を in-memory で満たす。
+ */
+export function createEphemeralAiSession(): {
+  port: AiSendSessionPort
+  /** tick 開始時に履歴を空へ戻す */
+  reset(): void
+} {
+  let messages: ChatMessage[] = []
+  return {
+    port: {
+      get: (id) =>
+        id === HEARTBEAT_EPHEMERAL_SESSION_ID
+          ? { title: '', messages }
+          : undefined,
+      updateMessages: (id, next) => {
+        if (id === HEARTBEAT_EPHEMERAL_SESSION_ID) messages = next
+      },
+    },
+    reset: () => {
+      messages = []
+    },
+  }
+}
 
 /**
  * AI 推論の連続失敗がこの回数に達したら daemon を自動 disable + warning toast。
@@ -345,6 +374,17 @@ export function useHeartbeatDaemon() {
   // (chat session で同じパターンを採用している)
   const titleGen = useAiChat()
   const toast = useToast()
+
+  // send ループ本体は DeckAiColumn と共有 (#707)。heartbeat の推論履歴は
+  // 永続 session に残さず tick ごとに使い捨てる (報告は target session への
+  // append で別管理)。
+  const ephemeral = createEphemeralAiSession()
+  const sendLoop = useAiSendLoop({
+    chat: aiChat,
+    sessions: ephemeral.port,
+    dispatch: (name, input) =>
+      dispatchCapability(name, input, { principal: { kind: 'ai.heartbeat' } }),
+  })
 
   const isRunning = ref(false)
   /**
@@ -704,14 +744,6 @@ export function useHeartbeatDaemon() {
       return null
     }
 
-    const initialUser: ChatMessage = {
-      id: `msg-${Date.now()}-hb-u`,
-      role: 'user',
-      content: `Heartbeat tick at ${new Date(payload.triggered_at_ms).toISOString()}`,
-      timestamp: Date.now(),
-    }
-    const history: ChatMessage[] = [initialUser]
-
     const granted = resolveForProfiled('ai.heartbeat')
     const eligibleCaps = listCapabilities().filter((c) => {
       if (!c.aiTool || !c.signature) return false
@@ -761,53 +793,21 @@ export function useHeartbeatDaemon() {
       HEARTBEAT_INSTRUCTION,
     )
 
-    let finalText = ''
-    for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
-      let pendingToolUse: ToolUseEvent | null = null
-      const turnText = await aiChat.sendMessage({
-        connectionId: resolved.connection.id,
-        model: resolved.model,
-        history,
-        system,
-        tools,
-        onToolUse: (e) => {
-          pendingToolUse = e
-        },
-      })
-
-      if (!pendingToolUse) {
-        finalText = turnText
-        break
-      }
-      const toolUse: ToolUseEvent = pendingToolUse
-      const dispatch = await dispatchCapability(toolUse.name, toolUse.input, {
-        principal: { kind: 'ai.heartbeat' },
-      })
-      const resultText = dispatch.ok
-        ? typeof dispatch.result === 'string'
-          ? dispatch.result
-          : JSON.stringify(dispatch.result)
-        : `Error (${dispatch.code}): ${dispatch.error}`
-      const ts = Date.now()
-      history.push({
-        id: `msg-${ts}-hb-a${round}`,
-        role: 'assistant',
-        content: turnText,
-        timestamp: ts,
-        toolUseId: toolUse.toolUseId,
-        toolUseName: toolUse.name,
-        toolUseInput: toolUse.input,
-      })
-      history.push({
-        id: `msg-${ts}-hb-r${round}`,
-        role: 'user',
-        content: resultText,
-        timestamp: ts,
-        toolResultFor: toolUse.toolUseId,
-      })
-    }
-
-    return finalText
+    // tool round / dispatch 結果の整形は useAiSendLoop の責務 (#707)。
+    // context は tick 開始時に一度組み立てた system を全 round で使い回す。
+    ephemeral.reset()
+    const outcome = await sendLoop.runSend({
+      sessionId: HEARTBEAT_EPHEMERAL_SESSION_ID,
+      text: `Heartbeat tick at ${new Date(payload.triggered_at_ms).toISOString()}`,
+      connectionId: resolved.connection.id,
+      model: resolved.model,
+      tools,
+      buildSystem: () => system,
+    })
+    if (outcome.status === 'aborted') return null
+    // throw に変換して呼び出し側の連続失敗カウント (auto-disable) に乗せる
+    if (outcome.status === 'error') throw new Error(outcome.message)
+    return outcome.finalText
   }
 
   // App.vue が daemon を mount するだけで使う (provide/inject なし)。

--- a/src/utils/chatHistoryEntries.test.ts
+++ b/src/utils/chatHistoryEntries.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest'
+import type { ChatMessage } from '@/adapters/types'
+import {
+  buildCrossAccountHistoryEntries,
+  buildPerAccountHistoryEntries,
+  buildPerAccountPrefetchTargets,
+  chatMessageMatchesSearch,
+  matchesChatSearch,
+} from './chatHistoryEntries'
+
+// ---- fixtures ----
+
+let seq = 0
+function dm(
+  partial: Partial<ChatMessage> & { fromUserId: string },
+): ChatMessage {
+  seq++
+  return {
+    id: `m${seq}`,
+    createdAt: `2026-07-0${(seq % 9) + 1}T00:00:00.000Z`,
+    ...partial,
+  }
+}
+
+const ME = 'me'
+const OTHER = 'other-1'
+
+describe('buildCrossAccountHistoryEntries', () => {
+  const getUserId = (accountId: string) =>
+    accountId === 'acc-a' ? ME : undefined
+
+  it('thread (room/DM) 単位で最新 1 件に dedup し、新しい順に並べる', () => {
+    const older = dm({
+      fromUserId: OTHER,
+      toUserId: ME,
+      createdAt: '2026-07-01T00:00:00.000Z',
+      text: 'old',
+    })
+    const newer = dm({
+      fromUserId: ME,
+      toUserId: OTHER,
+      createdAt: '2026-07-02T00:00:00.000Z',
+      text: 'new',
+    })
+    const room = dm({
+      fromUserId: OTHER,
+      toRoomId: 'room-1',
+      toRoom: { id: 'room-1', name: '雑談' },
+      createdAt: '2026-07-03T00:00:00.000Z',
+    })
+    const entries = buildCrossAccountHistoryEntries(
+      [older, newer, room].map((msg) => ({
+        msg,
+        accountId: 'acc-a',
+        host: 'misskey.example',
+      })),
+      getUserId,
+    )
+
+    expect(entries).toHaveLength(2)
+    // 新しい順: room が先頭、DM thread は最新の 1 件のみ
+    expect(entries[0]).toMatchObject({
+      key: 'acc-a:room:room-1',
+      isRoom: true,
+      name: '雑談',
+      hasName: true,
+      roomId: 'room-1',
+      serverHost: 'misskey.example',
+    })
+    expect(entries[1]).toMatchObject({
+      key: `acc-a:user:${OTHER}`,
+      isRoom: false,
+      otherId: OTHER,
+    })
+    expect(entries[1]?.message.text).toBe('new')
+  })
+
+  it('自分発信の DM は toUser 側を相手として表示する', () => {
+    const msg = dm({
+      fromUserId: ME,
+      toUserId: OTHER,
+      toUser: { id: OTHER, username: 'alice', name: 'アリス' },
+    })
+    const [entry] = buildCrossAccountHistoryEntries(
+      [{ msg, accountId: 'acc-a', host: 'h' }],
+      getUserId,
+    )
+    expect(entry).toMatchObject({
+      name: 'アリス',
+      hasName: true,
+      otherId: OTHER,
+    })
+  })
+
+  it('name は other.name → username → otherId の順に fallback し hasName に反映する', () => {
+    const noName = dm({
+      fromUserId: 'u1',
+      toUserId: ME,
+      fromUser: { id: 'u1', username: 'bob' },
+    })
+    const noUser = dm({ fromUserId: 'u2', toUserId: ME })
+    const entries = buildCrossAccountHistoryEntries(
+      [noName, noUser].map((msg) => ({ msg, accountId: 'acc-a', host: 'h' })),
+      getUserId,
+    )
+    const byOther = new Map(entries.map((e) => [e.otherId, e]))
+    expect(byOther.get('u1')).toMatchObject({ name: 'bob', hasName: false })
+    expect(byOther.get('u2')).toMatchObject({ name: 'u2', hasName: false })
+  })
+
+  it('room 名が無ければ "Room"、emojis/avatar は最新メッセージ送信者から借りる', () => {
+    const msg = dm({
+      fromUserId: OTHER,
+      toRoomId: 'room-x',
+      toRoom: { id: 'room-x' },
+      fromUser: {
+        id: OTHER,
+        username: 'bob',
+        avatarUrl: 'https://a/av.png',
+        emojis: { wave: 'https://a/wave.png' },
+      },
+    })
+    const [entry] = buildCrossAccountHistoryEntries(
+      [{ msg, accountId: 'acc-a', host: 'h' }],
+      getUserId,
+    )
+    expect(entry).toMatchObject({
+      name: 'Room',
+      hasName: false,
+      avatarUrl: 'https://a/av.png',
+      emojis: { wave: 'https://a/wave.png' },
+    })
+  })
+
+  it('相手を導出できない DM (toUserId 無しの自分発信) は skip する', () => {
+    const msg = dm({ fromUserId: ME })
+    expect(
+      buildCrossAccountHistoryEntries(
+        [{ msg, accountId: 'acc-a', host: 'h' }],
+        getUserId,
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('buildPerAccountHistoryEntries', () => {
+  it('room / DM を thread 単位で dedup し、入力順 (= 新しい順前提) を保つ', () => {
+    const m1 = dm({
+      fromUserId: OTHER,
+      toUserId: ME,
+      fromUser: { id: OTHER, username: 'alice' },
+    })
+    const m2 = dm({ fromUserId: OTHER, toUserId: ME })
+    const m3 = dm({
+      fromUserId: ME,
+      toRoomId: 'r1',
+      toRoom: { id: 'r1', name: 'Dev' },
+    })
+    const entries = buildPerAccountHistoryEntries([m1, m2, m3], ME)
+    expect(entries.map((e) => e.key)).toEqual([`user:${OTHER}`, 'room:r1'])
+    expect(entries[0]?.message.id).toBe(m1.id)
+  })
+
+  it('myUserId undefined でも fromUserId 側を相手として成立する', () => {
+    const msg = dm({
+      fromUserId: OTHER,
+      toUserId: ME,
+      fromUser: { id: OTHER, username: 'alice' },
+    })
+    const [entry] = buildPerAccountHistoryEntries([msg], undefined)
+    expect(entry).toMatchObject({ otherId: OTHER, name: 'alice' })
+  })
+})
+
+describe('buildPerAccountPrefetchTargets', () => {
+  it('thread 単位で dedup した PrefetchTarget を返す', () => {
+    const msgs = [
+      dm({ fromUserId: OTHER, toUserId: ME }),
+      dm({ fromUserId: ME, toUserId: OTHER }),
+      dm({ fromUserId: ME, toRoomId: 'r1' }),
+      dm({ fromUserId: OTHER, toRoomId: 'r1' }),
+    ]
+    expect(buildPerAccountPrefetchTargets('acc-a', ME, msgs)).toEqual([
+      { accountId: 'acc-a', isRoom: false, targetId: OTHER },
+      { accountId: 'acc-a', isRoom: true, targetId: 'r1' },
+    ])
+  })
+
+  it('相手を導出できないメッセージは無視する', () => {
+    expect(
+      buildPerAccountPrefetchTargets('acc-a', ME, [dm({ fromUserId: ME })]),
+    ).toEqual([])
+  })
+})
+
+describe('matchesChatSearch', () => {
+  it('空クエリは常に true', () => {
+    expect(matchesChatSearch('', 'name', null)).toBe(true)
+    expect(matchesChatSearch('  ', 'name', undefined)).toBe(true)
+  })
+
+  it('thread 名 / プレビュー本文を大文字小文字無視で substring match する', () => {
+    expect(matchesChatSearch('ali', 'Alice', null)).toBe(true)
+    expect(matchesChatSearch('ALI', 'alice', null)).toBe(true)
+    expect(matchesChatSearch('hello', 'alice', 'say HELLO world')).toBe(true)
+    expect(matchesChatSearch('xyz', 'alice', 'hello')).toBe(false)
+  })
+})
+
+describe('chatMessageMatchesSearch', () => {
+  const msg = dm({
+    fromUserId: OTHER,
+    text: 'Meeting at Noon',
+    fromUser: { id: OTHER, username: 'alice', name: 'アリス' },
+    file: {
+      id: 'f1',
+      name: 'Report.PDF',
+      type: 'application/pdf',
+      url: '',
+    } as ChatMessage['file'],
+  })
+
+  it('本文 / 送信者名 / username / ファイル名で match する', () => {
+    expect(chatMessageMatchesSearch('noon', msg)).toBe(true)
+    expect(chatMessageMatchesSearch('アリス', msg)).toBe(true)
+    expect(chatMessageMatchesSearch('ALICE', msg)).toBe(true)
+    expect(chatMessageMatchesSearch('report.pdf', msg)).toBe(true)
+    expect(chatMessageMatchesSearch('absent', msg)).toBe(false)
+  })
+})

--- a/src/utils/chatHistoryEntries.ts
+++ b/src/utils/chatHistoryEntries.ts
@@ -1,0 +1,214 @@
+import type { AvatarDecoration, ChatMessage, ChatUser } from '@/adapters/types'
+import type { PrefetchTarget } from '@/composables/useChatThreadPrefetch'
+
+/**
+ * チャット履歴 view の thread entry 構築ロジック (#707)。
+ * DeckChatColumn から抽出した純関数群。cross-account / per-account の
+ * history entry 導出と検索マッチをここに集約する。
+ */
+
+interface ChatHistoryEntryBase {
+  key: string
+  message: ChatMessage
+  isRoom: boolean
+  name: string
+  /** 表示名 (`name`) が user-defined か (false なら fallback の username/roomId を使用)。 */
+  hasName: boolean
+  /** name に含まれる `:shortcode:` を画像に解決するための辞書。 */
+  emojis?: Record<string, string>
+  avatarUrl?: string
+  avatarDecorations?: AvatarDecoration[]
+  otherId?: string
+}
+
+export interface CrossAccountChatHistoryEntry extends ChatHistoryEntryBase {
+  accountId: string
+  serverHost: string
+  roomId?: string
+}
+
+export type PerAccountChatHistoryEntry = ChatHistoryEntryBase
+
+/** DM の相手 user を導出する (自分発信なら toUser、受信なら fromUser)。 */
+function resolveOther(
+  msg: ChatMessage,
+  myUserId: string | undefined,
+): { otherId: string | undefined; other: ChatUser | undefined } {
+  const isMine = msg.fromUserId === myUserId
+  return {
+    otherId: isMine ? msg.toUserId : msg.fromUserId,
+    other: isMine ? msg.toUser : msg.fromUser,
+  }
+}
+
+/**
+ * cross-account history view の entry 構築 (#460)。
+ * 全アカウントから集めた message を thread (room/DM) 単位の最新 1 件に dedup する。
+ * cache hydrate phase / API reconcile phase の両方から呼ぶ。
+ */
+export function buildCrossAccountHistoryEntries(
+  allMessages: { msg: ChatMessage; accountId: string; host: string }[],
+  getUserId: (accountId: string) => string | undefined,
+): CrossAccountChatHistoryEntry[] {
+  const entries: CrossAccountChatHistoryEntry[] = []
+  const seen = new Set<string>()
+  const sorted = [...allMessages].sort(
+    (a, b) =>
+      new Date(b.msg.createdAt).getTime() - new Date(a.msg.createdAt).getTime(),
+  )
+
+  for (const { msg, accountId, host } of sorted) {
+    const uid = getUserId(accountId)
+    if (msg.toRoomId) {
+      const key = `${accountId}:room:${msg.toRoomId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      entries.push({
+        key,
+        accountId,
+        serverHost: host,
+        message: msg,
+        isRoom: true,
+        name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        // ChatRoom には emojis 辞書が無いので、最新メッセージ送信者の辞書で代替する
+        // (同一サーバー上の shortcode は同じ辞書で解決できる)
+        emojis: msg.fromUser?.emojis ?? undefined,
+        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
+        avatarDecorations: msg.fromUser?.avatarDecorations,
+        roomId: msg.toRoomId,
+      })
+    } else {
+      const { otherId, other } = resolveOther(msg, uid)
+      if (!otherId) continue
+      const key = `${accountId}:user:${otherId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      entries.push({
+        key,
+        accountId,
+        serverHost: host,
+        message: msg,
+        isRoom: false,
+        name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
+        avatarUrl: other?.avatarUrl ?? undefined,
+        avatarDecorations: other?.avatarDecorations,
+        otherId,
+      })
+    }
+  }
+
+  return entries
+}
+
+/**
+ * per-account history view の entry 構築。入力 (chat/history 由来) は
+ * 新しい順で来る前提で、thread 単位の最初の 1 件を採る。
+ */
+export function buildPerAccountHistoryEntries(
+  msgs: ChatMessage[],
+  myUserId: string | undefined,
+): PerAccountChatHistoryEntry[] {
+  const seen = new Set<string>()
+  const entries: PerAccountChatHistoryEntry[] = []
+
+  for (const msg of msgs) {
+    if (msg.toRoomId) {
+      if (seen.has(`room:${msg.toRoomId}`)) continue
+      seen.add(`room:${msg.toRoomId}`)
+      entries.push({
+        key: `room:${msg.toRoomId}`,
+        message: msg,
+        isRoom: true,
+        name: msg.toRoom?.name || 'Room',
+        hasName: !!msg.toRoom?.name,
+        emojis: msg.fromUser?.emojis ?? undefined,
+        avatarUrl: msg.fromUser?.avatarUrl ?? undefined,
+        avatarDecorations: msg.fromUser?.avatarDecorations,
+      })
+    } else {
+      const { otherId, other } = resolveOther(msg, myUserId)
+      if (!otherId || seen.has(`user:${otherId}`)) continue
+      seen.add(`user:${otherId}`)
+      entries.push({
+        key: `user:${otherId}`,
+        message: msg,
+        isRoom: false,
+        name: other?.name || other?.username || otherId,
+        hasName: !!other?.name,
+        emojis: other?.emojis ?? undefined,
+        avatarUrl: other?.avatarUrl ?? undefined,
+        avatarDecorations: other?.avatarDecorations,
+        otherId,
+      })
+    }
+  }
+
+  return entries
+}
+
+/**
+ * Per-account history から prefetch 対象 thread を抽出する (#460 B-6)。
+ * `fromUserId === uid` で送信側 / 受信側を判定して thread の相手
+ * (otherId or roomId) を導出する。
+ */
+export function buildPerAccountPrefetchTargets(
+  accountId: string,
+  uid: string | undefined,
+  msgs: ChatMessage[],
+): PrefetchTarget[] {
+  const seen = new Set<string>()
+  const targets: PrefetchTarget[] = []
+  for (const msg of msgs) {
+    if (msg.toRoomId) {
+      const key = `room:${msg.toRoomId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      targets.push({ accountId, isRoom: true, targetId: msg.toRoomId })
+    } else {
+      const { otherId } = resolveOther(msg, uid)
+      if (!otherId) continue
+      const key = `user:${otherId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      targets.push({ accountId, isRoom: false, targetId: otherId })
+    }
+  }
+  return targets
+}
+
+/**
+ * 履歴 view (#483) の絞り込み。thread 名 + 直近メッセージのプレビュー本文を
+ * 大文字小文字無視の substring match で判定する。空クエリは常に match。
+ */
+export function matchesChatSearch(
+  query: string,
+  name: string,
+  preview: string | null | undefined,
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  if (name.toLowerCase().includes(q)) return true
+  if (preview?.toLowerCase().includes(q)) return true
+  return false
+}
+
+/**
+ * 会話 view 内検索 (#483 v1) の message 単位 match。
+ * 本文 / 送信者名 / username / 添付ファイル名を対象にする。
+ */
+export function chatMessageMatchesSearch(
+  query: string,
+  m: ChatMessage,
+): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  if (m.text?.toLowerCase().includes(q)) return true
+  const u = m.fromUser
+  if (u?.name?.toLowerCase().includes(q)) return true
+  if (u?.username?.toLowerCase().includes(q)) return true
+  if (m.file?.name.toLowerCase().includes(q)) return true
+  return false
+}

--- a/src/utils/noteViewModel.test.ts
+++ b/src/utils/noteViewModel.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { NormalizedNote } from '@/adapters/types'
+import {
+  buildReactionsData,
+  canRenoteNote,
+  clampMenuPosition,
+  deriveActiveModeFlags,
+  deriveChannelInfo,
+  extractNoteUrls,
+  isLongNoteText,
+  isPureRenote,
+  resolveEffectiveNoteBase,
+} from './noteViewModel'
+
+function note(partial: Partial<NormalizedNote> = {}): NormalizedNote {
+  return {
+    id: 'n1',
+    _accountId: 'acc-1',
+    _serverHost: 'misskey.example',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    text: 'hello',
+    cw: null,
+    user: {
+      id: 'u1',
+      username: 'alice',
+      host: null,
+      name: 'アリス',
+      avatarUrl: null,
+    },
+    visibility: 'public',
+    emojis: {},
+    reactionEmojis: {},
+    reactions: {},
+    renoteCount: 0,
+    repliesCount: 0,
+    files: [],
+    ...partial,
+  }
+}
+
+describe('isPureRenote / resolveEffectiveNoteBase', () => {
+  it('renote があり text が null なら pure renote で、内側のノートを表示する', () => {
+    const inner = note({ id: 'inner' })
+    const n = note({ renote: inner, text: null })
+    expect(isPureRenote(n)).toBe(true)
+    expect(resolveEffectiveNoteBase(n)).toBe(inner)
+  })
+
+  it('text がある引用リノートは pure renote ではなく、自身を表示する', () => {
+    const n = note({ renote: note({ id: 'inner' }), text: '引用コメント' })
+    expect(isPureRenote(n)).toBe(false)
+    expect(resolveEffectiveNoteBase(n)).toBe(n)
+  })
+
+  it('renote が無ければ自身を表示する', () => {
+    const n = note()
+    expect(isPureRenote(n)).toBe(false)
+    expect(resolveEffectiveNoteBase(n)).toBe(n)
+  })
+})
+
+describe('extractNoteUrls', () => {
+  it('本文中の URL を抽出する', () => {
+    const n = note({ text: '見て https://example.com/a すごい' })
+    expect(extractNoteUrls(n)).toEqual(['https://example.com/a'])
+  })
+
+  it('renote の url / uri と一致する URL は除外する', () => {
+    const n = note({
+      text: 'https://example.com/a https://example.com/b',
+      renote: note({
+        id: 'inner',
+        url: 'https://example.com/a',
+        uri: 'https://example.com/b',
+      }),
+    })
+    expect(extractNoteUrls(n)).toEqual([])
+  })
+
+  it('text が null なら空配列', () => {
+    expect(extractNoteUrls(note({ text: null }))).toEqual([])
+  })
+})
+
+describe('deriveChannelInfo', () => {
+  it('channel オブジェクトがあれば name / color を使う', () => {
+    const n = note({
+      channel: { id: 'ch1', name: '雑談', color: '#ff0000' },
+    })
+    expect(deriveChannelInfo(n)).toEqual({
+      id: 'ch1',
+      name: '雑談',
+      color: '#ff0000',
+    })
+  })
+
+  it('color が無ければ id から決定論的な hsl を導出する', () => {
+    const a = deriveChannelInfo(note({ channel: { id: 'ch1', name: 'x' } }))
+    const b = deriveChannelInfo(note({ channel: { id: 'ch1', name: 'x' } }))
+    expect(a?.color).toMatch(/^hsl\(\d+, 65%, 55%\)$/)
+    expect(a?.color).toBe(b?.color)
+  })
+
+  it('channelId のみ (channel 未 hydrate) でも id で成立する', () => {
+    const info = deriveChannelInfo(note({ channelId: 'ch2' }))
+    expect(info).toMatchObject({ id: 'ch2', name: null })
+  })
+
+  it('チャンネル情報が無ければ null', () => {
+    expect(deriveChannelInfo(note())).toBeNull()
+  })
+})
+
+describe('isLongNoteText', () => {
+  it('500 文字超で true', () => {
+    expect(isLongNoteText(note({ text: 'あ'.repeat(501) }))).toBe(true)
+    expect(isLongNoteText(note({ text: 'あ'.repeat(500) }))).toBe(false)
+  })
+
+  it('8 行超で true', () => {
+    expect(isLongNoteText(note({ text: 'a\n'.repeat(9).trim() }))).toBe(true)
+    expect(isLongNoteText(note({ text: 'a\nb\nc' }))).toBe(false)
+  })
+
+  it('CW 付きは折りたたみ機構が別にあるので false', () => {
+    expect(isLongNoteText(note({ cw: '注意', text: 'あ'.repeat(600) }))).toBe(
+      false,
+    )
+  })
+
+  it('text が null なら false', () => {
+    expect(isLongNoteText(note({ text: null }))).toBe(false)
+  })
+})
+
+describe('canRenoteNote (Misskey WebUI と同じ判定)', () => {
+  it('public / home は誰でも可', () => {
+    expect(canRenoteNote(note({ visibility: 'public' }), false)).toBe(true)
+    expect(canRenoteNote(note({ visibility: 'home' }), false)).toBe(true)
+  })
+
+  it('followers は自分のノートのみ可', () => {
+    expect(canRenoteNote(note({ visibility: 'followers' }), true)).toBe(true)
+    expect(canRenoteNote(note({ visibility: 'followers' }), false)).toBe(false)
+  })
+
+  it('specified は不可', () => {
+    expect(canRenoteNote(note({ visibility: 'specified' }), true)).toBe(false)
+  })
+})
+
+describe('deriveActiveModeFlags', () => {
+  it('true のフラグのみ isNoteIn<X>Mode からラベルを導出する', () => {
+    const flags = deriveActiveModeFlags({
+      isNoteInYamiMode: true,
+      isNoteInFooMode: false,
+    })
+    expect(flags).toHaveLength(1)
+    expect(flags[0]).toMatchObject({ key: 'isNoteInYamiMode', label: 'Yami' })
+    expect(flags[0]?.icon).toBeTruthy()
+  })
+
+  it('パターン外のキーはキー名をそのままラベルにする', () => {
+    const flags = deriveActiveModeFlags({ customFlag: true })
+    expect(flags[0]).toMatchObject({ key: 'customFlag', label: 'customFlag' })
+  })
+
+  it('undefined なら空配列', () => {
+    expect(deriveActiveModeFlags(undefined)).toEqual([])
+  })
+})
+
+describe('buildReactionsData', () => {
+  it('リアクションをキー昇順に整列し、URL を resolver で解決する', () => {
+    const reactionUrl = vi.fn(
+      (reaction: string) => `https://cdn/${encodeURIComponent(reaction)}`,
+    )
+    const n = note({
+      reactions: { ':b:': 2, ':a:': 5 },
+      emojis: { x: 'u' },
+      reactionEmojis: { y: 'v' },
+    })
+    const data = buildReactionsData(n, reactionUrl)
+    expect(data.sorted).toEqual([
+      { reaction: ':a:', count: 5 },
+      { reaction: ':b:', count: 2 },
+    ])
+    expect(data.urls[':a:']).toBe('https://cdn/%3Aa%3A')
+    expect(reactionUrl).toHaveBeenCalledWith(
+      ':a:',
+      n.emojis,
+      n.reactionEmojis,
+      'misskey.example',
+    )
+  })
+
+  it('リアクションが無ければ空を返し resolver を呼ばない', () => {
+    const reactionUrl = vi.fn(() => null)
+    const data = buildReactionsData(note(), reactionUrl)
+    expect(data.sorted).toEqual([])
+    expect(data.urls).toEqual({})
+    expect(reactionUrl).not.toHaveBeenCalled()
+  })
+})
+
+describe('clampMenuPosition', () => {
+  const viewport = { width: 1000, height: 800 }
+  const size = { width: 200, height: 80 }
+
+  it('収まる場合はアンカー直下 (left, bottom+4)', () => {
+    const pos = clampMenuPosition(
+      { left: 100, top: 300, bottom: 320 },
+      size,
+      viewport,
+    )
+    expect(pos).toEqual({ x: 100, y: 324 })
+  })
+
+  it('右端からはみ出す場合は右余白 8px で clamp する', () => {
+    const pos = clampMenuPosition(
+      { left: 900, top: 300, bottom: 320 },
+      size,
+      viewport,
+    )
+    expect(pos.x).toBe(1000 - 200 - 8)
+  })
+
+  it('下端からはみ出す場合はアンカー上側へ反転する', () => {
+    const pos = clampMenuPosition(
+      { left: 100, top: 760, bottom: 780 },
+      size,
+      viewport,
+    )
+    expect(pos.y).toBe(760 - 80 - 4)
+  })
+
+  it('左上には最低 8px の余白を確保する', () => {
+    const pos = clampMenuPosition(
+      { left: -50, top: 0, bottom: 4 },
+      size,
+      viewport,
+    )
+    expect(pos.x).toBe(8)
+    expect(pos.y).toBe(8)
+  })
+})

--- a/src/utils/noteViewModel.ts
+++ b/src/utils/noteViewModel.ts
@@ -1,0 +1,170 @@
+import type { NormalizedNote, NoteVisibility } from '@/adapters/types'
+import { CUSTOM_TL_ICONS } from '@/utils/customTimelines'
+import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
+import { parseMfm } from '@/utils/mfm'
+
+/**
+ * MkNote のビューモデル導出ロジック (#707)。表示派生値の計算を
+ * コンポーネントから抽出した純関数群。
+ */
+
+/** renote のみで本文が無い「純粋リノート」か。 */
+export function isPureRenote(note: NormalizedNote): boolean {
+  return !!note.renote && note.text === null
+}
+
+/** 純粋リノートなら内側のノート、それ以外は自身を表示対象にする。 */
+export function resolveEffectiveNoteBase(note: NormalizedNote): NormalizedNote {
+  return note.renote && note.text === null ? note.renote : note
+}
+
+/** 本文から抽出した URL（renote の url/uri と一致するものは除外）。 */
+export function extractNoteUrls(note: NormalizedNote): string[] {
+  const text = note.text
+  if (!text) return []
+  const tokens = parseMfm(text)
+  const renote = note.renote
+  return extractUrlFromMfm(tokens).filter(
+    (u) => u !== renote?.url && u !== renote?.uri,
+  )
+}
+
+/** チャンネル id から決定論的な表示色を導出する (color 未設定チャンネル用)。 */
+export function hashChannelColor(id: string): string {
+  let h = 0
+  for (let i = 0; i < id.length; i++) h = (h * 31 + id.charCodeAt(i)) | 0
+  const hue = ((h % 360) + 360) % 360
+  return `hsl(${hue}, 65%, 55%)`
+}
+
+export interface NoteChannelInfo {
+  id: string
+  name: string | null
+  color: string
+}
+
+/** チャンネルバッジ表示情報。channel 未 hydrate (channelId のみ) にも対応。 */
+export function deriveChannelInfo(
+  note: NormalizedNote,
+): NoteChannelInfo | null {
+  const ch = note.channel
+  const id = ch?.id ?? note.channelId
+  if (!id) return null
+  return {
+    id,
+    name: ch?.name ?? null,
+    color: ch?.color || hashChannelColor(id),
+  }
+}
+
+export const LONG_TEXT_THRESHOLD = 500
+export const LONG_TEXT_LINES = 8
+
+/**
+ * 長文折りたたみの対象か。CW 付きは CW の折りたたみ機構が優先されるので
+ * 対象外。
+ */
+export function isLongNoteText(note: NormalizedNote): boolean {
+  const text = note.text
+  if (!text || note.cw !== null) return false
+  if (text.length > LONG_TEXT_THRESHOLD) return true
+  return text.split('\n').length > LONG_TEXT_LINES
+}
+
+/**
+ * リノート可否（Misskey WebUI と同じ判定）。
+ * public/home は誰でも可、followers は自分のノートのみ、specified は不可。
+ */
+export function canRenoteNote(
+  note: NormalizedNote,
+  isOwnNote: boolean,
+): boolean {
+  const v: NoteVisibility = note.visibility
+  return v === 'public' || v === 'home' || (v === 'followers' && isOwnNote)
+}
+
+const DEFAULT_MODE_ICON = 'M12 2a10 10 0 100 20 10 10 0 000-20z'
+
+export interface ActiveModeFlag {
+  key: string
+  label: string
+  icon: string
+}
+
+/** フォーク固有 modeFlags (`isNoteIn<X>Mode`) のうち有効なものをバッジ化する。 */
+export function deriveActiveModeFlags(
+  modeFlags: Record<string, boolean> | undefined,
+): ActiveModeFlag[] {
+  if (!modeFlags) return []
+  return Object.entries(modeFlags)
+    .filter(([, v]) => v)
+    .map(([key]) => {
+      const match = key.match(/^isNoteIn(.+)Mode$/)
+      const label = match?.[1] ?? key
+      return {
+        key,
+        label,
+        icon: CUSTOM_TL_ICONS[label.toLowerCase()] ?? DEFAULT_MODE_ICON,
+      }
+    })
+}
+
+export interface ReactionsData {
+  sorted: { reaction: string; count: number }[]
+  urls: Record<string, string | null>
+}
+
+/**
+ * リアクション一覧の表示データ。キー昇順に整列し、カスタム絵文字 URL を
+ * 注入された resolver (useEmojiResolver.reactionUrl) で解決する。
+ */
+export function buildReactionsData(
+  note: NormalizedNote,
+  reactionUrl: (
+    reaction: string,
+    emojis: Record<string, string>,
+    reactionEmojis: Record<string, string>,
+    serverHost: string,
+  ) => string | null,
+): ReactionsData {
+  const reactions = note.reactions
+  const keys = Object.keys(reactions)
+  if (keys.length === 0) {
+    return { sorted: [], urls: {} }
+  }
+  keys.sort()
+  const sorted: { reaction: string; count: number }[] = new Array(keys.length)
+  const urls: Record<string, string | null> = {}
+  for (let i = 0; i < keys.length; i++) {
+    const reaction = keys[i] as string
+    sorted[i] = { reaction, count: reactions[reaction] as number }
+    urls[reaction] = reactionUrl(
+      reaction,
+      note.emojis,
+      note.reactionEmojis,
+      note._serverHost,
+    )
+  }
+  return { sorted, urls }
+}
+
+/**
+ * アンカー要素直下にポップアップメニューを出すときの位置決め。
+ * 右端は 8px 余白で clamp、下端からはみ出す場合はアンカー上側へ反転、
+ * 左上は最低 8px を確保する。
+ */
+export function clampMenuPosition(
+  anchor: { left: number; top: number; bottom: number },
+  menu: { width: number; height: number },
+  viewport: { width: number; height: number },
+): { x: number; y: number } {
+  let x = anchor.left
+  let y = anchor.bottom + 4
+  if (x + menu.width > viewport.width) x = viewport.width - menu.width - 8
+  if (y + menu.height > viewport.height) {
+    y = Math.max(8, anchor.top - menu.height - 4)
+  }
+  x = Math.max(8, x)
+  y = Math.max(8, y)
+  return { x, y }
+}

--- a/src/utils/replyMentions.test.ts
+++ b/src/utils/replyMentions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { NormalizedNote } from '@/adapters/types'
+import { buildReplyMentions } from './replyMentions'
+
+function replyTarget(
+  partial: Omit<Partial<NormalizedNote>, 'user'> & {
+    user?: Partial<NormalizedNote['user']>
+  } = {},
+): NormalizedNote {
+  return {
+    id: 'n1',
+    _accountId: 'acc-1',
+    _serverHost: 'misskey.example',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    text: null,
+    cw: null,
+    visibility: 'public',
+    emojis: {},
+    reactionEmojis: {},
+    reactions: {},
+    renoteCount: 0,
+    repliesCount: 0,
+    files: [],
+    ...partial,
+    user: {
+      id: 'u-alice',
+      username: 'alice',
+      host: null,
+      name: null,
+      avatarUrl: null,
+      ...partial.user,
+    },
+  }
+}
+
+const me = { userId: 'u-me', username: 'me', host: 'misskey.example' }
+
+describe('buildReplyMentions', () => {
+  it('リプライ先ユーザーへのメンションを先頭に付ける (ローカルは host なし)', () => {
+    expect(buildReplyMentions(replyTarget(), me)).toEqual(['@alice'])
+  })
+
+  it('リモートユーザーは @user@host 形式', () => {
+    const target = replyTarget({ user: { host: 'remote.example' } })
+    expect(buildReplyMentions(target, me)).toEqual(['@alice@remote.example'])
+  })
+
+  it('自分自身へのリプライではメンションを付けない', () => {
+    const target = replyTarget({ user: { id: 'u-me', username: 'me' } })
+    expect(buildReplyMentions(target, me)).toEqual([])
+  })
+
+  it('リプライ先本文中のメンション (会話参加者) を重複なしで引き継ぐ', () => {
+    const target = replyTarget({
+      text: '@bob @carol@remote.example @alice こんにちは',
+    })
+    expect(buildReplyMentions(target, me)).toEqual([
+      '@alice',
+      '@bob',
+      '@carol@remote.example',
+    ])
+  })
+
+  it('本文中の自分へのメンションは引き継がない (ローカル/リモート表記の両方)', () => {
+    const target = replyTarget({
+      text: '@me @me@misskey.example @bob やあ',
+    })
+    expect(buildReplyMentions(target, me)).toEqual(['@alice', '@bob'])
+  })
+
+  it('大文字小文字違いは同一メンションとして dedup する', () => {
+    const target = replyTarget({ text: '@Alice @BOB @bob' })
+    expect(buildReplyMentions(target, me)).toEqual(['@alice', '@BOB'])
+  })
+
+  it('自分のアカウント情報が無くても成立する', () => {
+    expect(buildReplyMentions(replyTarget(), null)).toEqual(['@alice'])
+  })
+})

--- a/src/utils/replyMentions.ts
+++ b/src/utils/replyMentions.ts
@@ -1,0 +1,49 @@
+import type { NormalizedNote } from '@/adapters/types'
+import { parseMfm } from '@/utils/mfm'
+
+/**
+ * リプライ開始時に投稿フォームへ prefill するメンション列を組み立てる (#707)。
+ * Misskey WebUI と同じく「リプライ先ユーザー + リプライ先本文中のメンション
+ * (= 会話参加者)」を、自分を除外しつつ重複なしで引き継ぐ。
+ */
+export function buildReplyMentions(
+  replyTo: NormalizedNote,
+  me: {
+    userId?: string | null
+    username?: string | null
+    host?: string | null
+  } | null,
+): string[] {
+  const mentions: string[] = []
+  const seen = new Set<string>()
+
+  // 1. Reply target user
+  const replyUser = replyTo.user
+  if (replyUser.id !== me?.userId) {
+    const acct = replyUser.host
+      ? `@${replyUser.username}@${replyUser.host}`
+      : `@${replyUser.username}`
+    mentions.push(acct)
+    seen.add(acct.toLowerCase())
+  }
+
+  // 2. Mentions in the reply target's text (reply chain participants)
+  if (replyTo.text) {
+    for (const token of parseMfm(replyTo.text)) {
+      if (token.type !== 'mention') continue
+      const acct = token.acct
+      const lower = acct.toLowerCase()
+      if (seen.has(lower)) continue
+      // Skip self
+      const isSelf = token.host
+        ? token.username.toLowerCase() === me?.username?.toLowerCase() &&
+          token.host.toLowerCase() === me?.host?.toLowerCase()
+        : token.username.toLowerCase() === me?.username?.toLowerCase()
+      if (isSelf) continue
+      seen.add(lower)
+      mentions.push(acct)
+    }
+  }
+
+  return mentions
+}


### PR DESCRIPTION
## v1.7.0

### Features

- feat(ai): tool 実行ターンの再試行を継続モードで安全に開放 (#737)
  - 再送 (regenerate) ではなく継続 (continue) にすることで write capability の二重実行を構造的に防止。実行済み tool_use / tool_result を履歴に残したまま失敗セグメントだけを再生成する

### Refactor (#707 アーキテクチャ整理)

- refactor(ai): useHeartbeatDaemon の AI 推論ループを useAiSendLoop に統合
- refactor(chat): 履歴 entry 構築ロジックを純関数モジュールへ抽出
- refactor(chat): 会話 thread の状態機械を useChatThread に抽出 (DeckChatColumn 1932→1635 行)
- refactor(note): MkNote のビューモデル導出を純関数モジュールへ抽出
- refactor(post-form): MkPostForm の分離可能ブロックを子コンポーネント化 (2214→1996 行)
  - 下書き復元時にアンケート選択肢のキーが desync する潜在バグも解消

### Chore

- chore: bump version to 1.7.0
- chore: regenerate openapi.json for 1.7.0

### 検証

- unit 1375 pass (1277 から +98、TDD 先行で追加) / typecheck / biome / E2E (#702) 13 pass

Closes #737
Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)