### PR TITLE
feat(site): βテスター応募に Issue Form テンプレートを導入

### DIFF
--- a/.github/ISSUE_TEMPLATE/beta_tester.yml
+++ b/.github/ISSUE_TEMPLATE/beta_tester.yml
@@ -1,0 +1,45 @@
+name: ベータテスター応募
+description: ストア配布 (Google Play / App Store) のクローズドテストに参加する
+title: "[Beta] ストア配布ベータテスト応募"
+labels: ["beta-test"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ご協力ありがとうございます！ 応募は下の 2 項目を埋めるだけで完了です。
+
+        テスター登録に必要な連絡先 (Google アカウントのメールアドレス等) をこの Issue に公開で書く必要はありません。
+        登録の準備が整い次第、こちらからこの Issue 上で共有方法をご案内します。
+        応募後のキャンセルもいつでも可能です。お気軽にどうぞ。
+  - type: dropdown
+    id: platform
+    attributes:
+      label: テストできるプラットフォーム
+      description: 複数選択できます
+      multiple: true
+      options:
+        - Android (Google Play)
+        - iOS (TestFlight)
+    validations:
+      required: true
+  - type: input
+    id: device
+    attributes:
+      label: 端末と OS バージョン
+      placeholder: "例: Pixel 8 / Android 15"
+    validations:
+      required: true
+  - type: input
+    id: server
+    attributes:
+      label: 普段使っている Misskey サーバー (任意)
+      placeholder: "例: misskey.io"
+    validations:
+      required: false
+  - type: textarea
+    id: note
+    attributes:
+      label: ひとこと (任意)
+      description: 意気込みや質問など、あれば自由にどうぞ
+    validations:
+      required: false

--- a/site/index.html
+++ b/site/index.html
@@ -422,7 +422,7 @@
             </div>
             <h4>ベータテスター募集</h4>
             <p>Google Play では配布前に最低 12 名・14 日間のクローズドテストが必要です。実機での動作確認やフィードバックにご協力いただける方を募集しています。</p>
-            <a href="https://github.com/hitalin/notedeck/issues/new?title=%5BBeta%5D+%E3%82%B9%E3%83%88%E3%82%A2%E9%85%8D%E5%B8%83%E3%83%99%E3%83%BC%E3%82%BF%E3%83%86%E3%82%B9%E3%83%88%E5%BF%9C%E5%8B%9F" class="btn btn-secondary">テスターに応募</a>
+            <a href="https://github.com/hitalin/notedeck/issues/new?template=beta_tester.yml" class="btn btn-secondary">テスターに応募</a>
           </div>
           <div class="store-cta glass fade-in" data-direction="up">
             <div class="store-cta-icon">


### PR DESCRIPTION
## 概要

ランディングページの「テスターに応募」ボタンの遷移先を、title 付きの素の new issue URL から GitHub Issue Forms (`beta_tester.yml`) に変更。

## 変更内容

- `.github/ISSUE_TEMPLATE/beta_tester.yml` を新規作成
  - 必須はプラットフォーム選択 (Android / iOS) と端末・OS バージョンの 2 項目のみ
  - 連絡先の公開が不要なこと・キャンセル自由を冒頭に明記し応募の心理的ハードルを低減
- `site/index.html` の応募ボタンを `issues/new?template=beta_tester.yml` に差し替え
- `beta-test` ラベルは作成済み

マージで Cloudflare Pages がランディングページを再デプロイし、Issue テンプレートも main 反映で有効になる。リリース (タグ) は行わない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)