### PR TITLE
Release v1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting",
   "private": true,
-  "version": "1.7.1",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.7.1"
+version = "1.8.0"
 description = "Misskey IDE — integrated deck environment for browsing, posting, searching, and connecting"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.7.1"
+    "version": "1.8.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -142,7 +142,7 @@ type HandlerType =
   | 'user_action'
   | 'page_view_interruptor'
 
-interface PluginHandler {
+export interface PluginHandler {
   pluginInstallId: string
   type: HandlerType
   title?: string

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -3,6 +3,10 @@ import type { Value, VFn } from '@syuilo/aiscript/interpreter/value.js'
 import type { JsonValue } from '@/bindings'
 import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
 import {
+  type AiScriptRunLogger,
+  useAiScriptLogsStore,
+} from '@/stores/aiscriptLogs'
+import {
   type PluginConfigDef,
   type PluginMeta,
   usePluginsStore,
@@ -451,14 +455,9 @@ export function applyNotePostInterruptors<T>(
 // Launch / Abort
 // ---------------------------------------------------------------------------
 
-const MAX_PLUGIN_LOGS = 200
-const pluginLogs = new Map<string, { text: string; isError: boolean }[]>()
-
-export function getPluginLogs(
-  installId: string,
-): { text: string; isError: boolean }[] {
-  return pluginLogs.get(installId) ?? []
-}
+// 実行ログは useAiScriptLogsStore に集約する (#710)。実行中の書き込み口を
+// installId ごとに保持し、abort 時の system イベント記録に使う。
+const pluginRunLoggers = new Map<string, AiScriptRunLogger>()
 
 export async function launchPlugin(plugin: PluginMeta): Promise<void> {
   if (!plugin.src || !plugin.active) return
@@ -466,8 +465,12 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
   // Abort existing instance if re-launching
   abortPlugin(plugin.installId)
 
-  const logs: { text: string; isError: boolean }[] = []
-  pluginLogs.set(plugin.installId, logs)
+  const runLog = useAiScriptLogsStore().beginRun(
+    'plugin',
+    plugin.installId,
+    plugin.name,
+  )
+  pluginRunLoggers.set(plugin.installId, runLog)
 
   const ctx = { accountId: null as string | null }
   pluginAccountContext.set(plugin.installId, ctx)
@@ -506,13 +509,8 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
   const env = { ...baseEnv, ...pluginEnv, ...ndEnv }
 
   const ioOpts = createInterpreterOptions({
-    onOutput: (text) => {
-      if (logs.length < MAX_PLUGIN_LOGS) logs.push({ text, isError: false })
-    },
-    onError: (err) => {
-      if (logs.length < MAX_PLUGIN_LOGS)
-        logs.push({ text: err.message, isError: true })
-    },
+    onOutput: (text) => runLog.print(text),
+    onError: (err) => runLog.error(err.message),
   })
 
   const code = sanitizeCode(plugin.src)
@@ -524,10 +522,7 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
     ast = result.ast
     legacy = result.legacy
   } catch (e) {
-    logs.push({
-      text: `Parse error: ${e instanceof Error ? e.message : String(e)}`,
-      isError: true,
-    })
+    runLog.system(`parse error: ${e instanceof Error ? e.message : String(e)}`)
     return
   }
 
@@ -535,11 +530,9 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
   ndCtx.interpreter = interpreter
   try {
     await execAiScript(interpreter, ast, legacy)
+    runLog.system('run completed')
   } catch (e) {
-    logs.push({
-      text: `Runtime error: ${e instanceof Error ? e.message : String(e)}`,
-      isError: true,
-    })
+    runLog.system(`run aborted: ${e instanceof Error ? e.message : String(e)}`)
   }
   pluginContexts.set(plugin.installId, interpreter)
 }
@@ -549,6 +542,7 @@ export function abortPlugin(installId: string): void {
   if (interp) {
     interp.abort()
     pluginContexts.delete(installId)
+    pluginRunLoggers.get(installId)?.system('aborted')
   }
   const ndCtx = pluginNdContexts.get(installId)
   if (ndCtx) {
@@ -556,7 +550,7 @@ export function abortPlugin(installId: string): void {
     pluginNdContexts.delete(installId)
   }
   pluginAccountContext.delete(installId)
-  pluginLogs.delete(installId)
+  pluginRunLoggers.delete(installId)
   removePluginHandlers(installId)
 }
 

--- a/src/capabilities/builtins/aiscript.test.ts
+++ b/src/capabilities/builtins/aiscript.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import {
   AISCRIPT_BUILTIN_CAPABILITIES,
+  aiscriptLogsCapability,
   aiscriptValidateCapability,
   preflightValidateSrc,
 } from './aiscript'
@@ -50,6 +53,70 @@ describe('aiscript.validate capability — execute', () => {
       entryPoint: 'plugin',
     }) as { ok: boolean }
     expect(r.ok).toBe(true)
+  })
+})
+
+describe('aiscript.logs capability — declaration', () => {
+  it('reuses logs.read permission and exposes the expected metadata', () => {
+    expect(aiscriptLogsCapability.id).toBe('aiscript.logs')
+    expect(aiscriptLogsCapability.aiTool).toBe(true)
+    expect(aiscriptLogsCapability.permissions).toEqual(['logs.read'])
+    expect(aiscriptLogsCapability.signature?.cheap).toBe(true)
+    expect(aiscriptLogsCapability.signature?.params?.source?.optional).toBe(
+      true,
+    )
+    expect(aiscriptLogsCapability.signature?.params?.level?.optional).toBe(true)
+  })
+
+  it('is included in AISCRIPT_BUILTIN_CAPABILITIES', () => {
+    expect(AISCRIPT_BUILTIN_CAPABILITIES.map((c) => c.id)).toContain(
+      'aiscript.logs',
+    )
+  })
+})
+
+describe('aiscript.logs capability — execute', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns entries newest-first with filters applied', () => {
+    const store = useAiScriptLogsStore()
+    const run = store.beginRun('plugin', 'p1', 'My Plugin')
+    run.print('out')
+    run.error('boom')
+    store.beginRun('widget', 'w1').print('w-out')
+
+    const all = aiscriptLogsCapability.execute({}) as Array<{
+      message: string
+    }>
+    expect(all[0]?.message).toBe('w-out')
+
+    const errors = aiscriptLogsCapability.execute({
+      level: 'error',
+    }) as Array<{ message: string }>
+    expect(errors.map((e) => e.message)).toEqual(['boom'])
+
+    const pluginOnly = aiscriptLogsCapability.execute({
+      source: 'plugin',
+      sourceId: 'p1',
+      limit: 2,
+    }) as Array<{ source: string; sourceId: string }>
+    expect(pluginOnly).toHaveLength(2)
+    expect(
+      pluginOnly.every((e) => e.source === 'plugin' && e.sourceId === 'p1'),
+    ).toBe(true)
+  })
+
+  it('ignores invalid params and falls back to defaults', () => {
+    const store = useAiScriptLogsStore()
+    store.beginRun('play', 'f1').print('x')
+    const r = aiscriptLogsCapability.execute({
+      source: 'bogus',
+      level: 42,
+      limit: 'many',
+    }) as unknown[]
+    expect(r.length).toBeGreaterThan(0)
   })
 })
 

--- a/src/capabilities/builtins/aiscript.ts
+++ b/src/capabilities/builtins/aiscript.ts
@@ -1,5 +1,10 @@
 import { validateAiScript } from '@/aiscript/validate'
 import type { Command, PreflightFailure } from '@/commands/registry'
+import {
+  type AiScriptLogLevel,
+  type AiScriptSourceKind,
+  useAiScriptLogsStore,
+} from '@/stores/aiscriptLogs'
 
 /**
  * AiScript 系 capability — AI が生成した AiScript ソースを構文検証する
@@ -56,8 +61,93 @@ export const aiscriptValidateCapability: Command = {
   },
 }
 
+const LOG_SOURCE_KINDS: readonly AiScriptSourceKind[] = [
+  'plugin',
+  'widget',
+  'play',
+  'page',
+  'playground',
+]
+const LOG_LEVELS: readonly AiScriptLogLevel[] = ['print', 'error', 'system']
+
+/**
+ * `aiscript.logs` — 全 AiScript 実行文脈の実行結果 (print / エラー /
+ * ライフサイクル) を AI が読み取る (#710)。#553 の構文 validate ループの
+ * 実行時版で、「AI が書く → 保存で実行 → 結果を読んで修正」を閉じる。
+ */
+export const aiscriptLogsCapability: Command = {
+  id: 'aiscript.logs',
+  label: 'AiScript 実行ログを取得',
+  icon: 'ti-bug',
+  category: 'general',
+  shortcuts: [],
+  aiTool: true,
+  permissions: ['logs.read'],
+  signature: {
+    description:
+      'AiScript (プラグイン/ウィジェット/Play/Page/スクラッチパッド) の実行ログ' +
+      'を新しい順に返す。print 出力は level "print"、実行時エラーは "error"、' +
+      '起動 (started)・正常終了 (run completed)・parse 失敗・runtime abort は' +
+      ' "system"。プラグイン/ウィジェットを保存して実行された後は必ずこれを' +
+      ' source / sourceId で絞って確認し、error や parse 失敗があれば src を' +
+      '修正して再保存するループを回すこと。3 回試して直らないならログを' +
+      'ユーザーに見せて相談する。',
+    params: {
+      source: {
+        type: 'string',
+        description:
+          '"plugin" | "widget" | "play" | "page" | "playground" | "all" (default: "all")',
+        enum: [...LOG_SOURCE_KINDS, 'all'],
+        optional: true,
+      },
+      sourceId: {
+        type: 'string',
+        description:
+          'installId (plugin/widget) や Play/Page の id で絞り込む (省略可)',
+        optional: true,
+      },
+      level: {
+        type: 'string',
+        description: '"print" | "error" | "system" | "all" (default: "all")',
+        enum: [...LOG_LEVELS, 'all'],
+        optional: true,
+      },
+      limit: {
+        type: 'number',
+        description: '最大返却数 (default: 50)',
+        optional: true,
+      },
+    },
+    returns: {
+      type: 'array',
+      description:
+        '{ at, source, sourceId, name?, runId, level, message } の配列 (新しい順)。' +
+        'runId は実行ごとの通し番号で、同じ runId = 同じ実行。',
+    },
+    cheap: true,
+  },
+  visible: false,
+  execute: (params) => {
+    const source = LOG_SOURCE_KINDS.includes(
+      params?.source as AiScriptSourceKind,
+    )
+      ? (params?.source as AiScriptSourceKind)
+      : 'all'
+    const sourceId =
+      typeof params?.sourceId === 'string' && params.sourceId.length > 0
+        ? params.sourceId
+        : undefined
+    const level = LOG_LEVELS.includes(params?.level as AiScriptLogLevel)
+      ? (params?.level as AiScriptLogLevel)
+      : 'all'
+    const limit = typeof params?.limit === 'number' ? params.limit : 50
+    return useAiScriptLogsStore().recent({ source, sourceId, level, limit })
+  },
+}
+
 export const AISCRIPT_BUILTIN_CAPABILITIES: readonly Command[] = [
   aiscriptValidateCapability,
+  aiscriptLogsCapability,
 ]
 
 /**

--- a/src/capabilities/builtins/index.test.ts
+++ b/src/capabilities/builtins/index.test.ts
@@ -15,6 +15,7 @@ describe('ALL_BUILTIN_CAPABILITIES', () => {
         'ai.sessions.read',
         'ai.sessions.search',
         'ai.setPersona',
+        'aiscript.logs',
         'aiscript.validate',
         'announcements.list',
         'antenna.list',

--- a/src/capabilities/builtins/plugins.test.ts
+++ b/src/capabilities/builtins/plugins.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { launchPlugin } from '@/aiscript/plugin-api'
+import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
 import {
   PLUGINS_BUILTIN_CAPABILITIES,
   pluginsCreateCapability,
@@ -10,6 +13,19 @@ import {
   pluginsUninstallCapability,
   pluginsUpdateCapability,
 } from './plugins'
+
+vi.mock('@/aiscript/plugin-api', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/aiscript/plugin-api')>()
+  return { ...actual, launchPlugin: vi.fn().mockResolvedValue(undefined) }
+})
+
+// unit プロジェクトは node 環境のため localStorage を stub する (deck.test.ts と同じ)
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+})
 
 // Note: execute は usePluginsStore (Pinia) に依存するため store mock 抜きでは
 // 走らない。capability 定義 (id / permissions / aiTool / requiresConfirmation)
@@ -69,17 +85,17 @@ describe('plugin capabilities — declaration', () => {
     expect(opts?.codeLanguage).toBe('is')
   })
 
-  it('plugins.update: write permission, aiTool:true, install preview confirmation', () => {
+  it('plugins.update: write permission, aiTool:true, install preview confirmation', async () => {
     expect(pluginsUpdateCapability.id).toBe('plugins.update')
     expect(pluginsUpdateCapability.permissions).toEqual(['plugins.write'])
     expect(pluginsUpdateCapability.aiTool).toBe(true)
     expect(typeof pluginsUpdateCapability.requiresConfirmation).toBe('function')
-    expect(() => pluginsUpdateCapability.execute({})).toThrow(
+    await expect(pluginsUpdateCapability.execute({})).rejects.toThrow(
       /installId is required/,
     )
-    expect(() => pluginsUpdateCapability.execute({ installId: 'x' })).toThrow(
-      /src is required/,
-    )
+    await expect(
+      pluginsUpdateCapability.execute({ installId: 'x' }),
+    ).rejects.toThrow(/src is required/)
   })
 
   it('plugins.setActive: write permission, aiTool:true, install preview confirmation (有効化時のみ)', () => {
@@ -236,5 +252,48 @@ describe('PLUGINS_BUILTIN_CAPABILITIES', () => {
     for (const cap of readCaps) {
       expect(cap.aiTool, `${cap.id} should be aiTool:true`).toBe(true)
     }
+  })
+})
+
+describe('plugins.update — アクティブなら再起動する (#744)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(launchPlugin).mockClear()
+  })
+
+  function addPlugin(active: boolean): PluginMeta {
+    const plugin: PluginMeta = {
+      installId: `p-test-${active}`,
+      name: 'test-plugin',
+      version: '1.0.0',
+      configData: {},
+      src: 'let x = 1',
+      active,
+    }
+    usePluginsStore().addPlugin(plugin)
+    return plugin
+  }
+
+  it('非アクティブなプラグインは再起動せず relaunched: false', async () => {
+    const plugin = addPlugin(false)
+    const r = (await pluginsUpdateCapability.execute({
+      installId: plugin.installId,
+      src: 'let y = 2',
+    })) as { relaunched: boolean }
+    expect(r.relaunched).toBe(false)
+    expect(launchPlugin).not.toHaveBeenCalled()
+  })
+
+  it('アクティブなプラグインは新 src で再起動し relaunched: true', async () => {
+    const plugin = addPlugin(true)
+    const r = (await pluginsUpdateCapability.execute({
+      installId: plugin.installId,
+      src: 'let y = 2',
+    })) as { relaunched: boolean }
+    expect(r.relaunched).toBe(true)
+    expect(launchPlugin).toHaveBeenCalledTimes(1)
+    const arg = vi.mocked(launchPlugin).mock.calls[0]?.[0]
+    expect(arg?.src).toBe('let y = 2')
+    expect(arg?.active).toBe(true)
   })
 })

--- a/src/capabilities/builtins/plugins.test.ts
+++ b/src/capabilities/builtins/plugins.test.ts
@@ -296,4 +296,23 @@ describe('plugins.update — アクティブなら再起動する (#744)', () =>
     expect(arg?.src).toBe('let y = 2')
     expect(arg?.active).toBe(true)
   })
+
+  it('確認ダイアログはアクティブ時のみ再起動を予告する', async () => {
+    if (typeof pluginsUpdateCapability.requiresConfirmation !== 'function') {
+      throw new Error('requiresConfirmation must be a function')
+    }
+    const active = addPlugin(true)
+    const oActive = await pluginsUpdateCapability.requiresConfirmation(
+      { installId: active.installId, src: 'let y = 2' },
+      {},
+    )
+    expect(oActive?.message).toContain('再起動されます')
+
+    const inactive = addPlugin(false)
+    const oInactive = await pluginsUpdateCapability.requiresConfirmation(
+      { installId: inactive.installId, src: 'let y = 2' },
+      {},
+    )
+    expect(oInactive?.message).not.toContain('再起動されます')
+  })
 })

--- a/src/capabilities/builtins/plugins.test.ts
+++ b/src/capabilities/builtins/plugins.test.ts
@@ -316,3 +316,48 @@ describe('plugins.update — アクティブなら再起動する (#744)', () =>
     expect(oInactive?.message).not.toContain('再起動されます')
   })
 })
+
+describe('plugins.setActive — 有効化で起動 / 無効化で停止する', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.mocked(launchPlugin).mockClear()
+  })
+
+  function addPlugin(active: boolean): PluginMeta {
+    const plugin: PluginMeta = {
+      installId: `p-setactive-${active}`,
+      name: 'test-plugin',
+      version: '1.0.0',
+      configData: {},
+      src: 'let x = 1',
+      active,
+    }
+    usePluginsStore().addPlugin(plugin)
+    return plugin
+  }
+
+  it('active: true でフラグ更新に加えて launchPlugin を呼ぶ', async () => {
+    const plugin = addPlugin(false)
+    const r = (await pluginsSetActiveCapability.execute({
+      installId: plugin.installId,
+      active: true,
+    })) as { active: boolean }
+    expect(r.active).toBe(true)
+    expect(usePluginsStore().getPlugin(plugin.installId)?.active).toBe(true)
+    expect(launchPlugin).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(launchPlugin).mock.calls[0]?.[0]?.installId).toBe(
+      plugin.installId,
+    )
+  })
+
+  it('active: false では launchPlugin を呼ばない (abort のみ)', async () => {
+    const plugin = addPlugin(true)
+    const r = (await pluginsSetActiveCapability.execute({
+      installId: plugin.installId,
+      active: false,
+    })) as { active: boolean }
+    expect(r.active).toBe(false)
+    expect(usePluginsStore().getPlugin(plugin.installId)?.active).toBe(false)
+    expect(launchPlugin).not.toHaveBeenCalled()
+  })
+})

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -1,4 +1,4 @@
-import { parsePluginMeta } from '@/aiscript/plugin-api'
+import { launchPlugin, parsePluginMeta } from '@/aiscript/plugin-api'
 import type { Command } from '@/commands/registry'
 import { useAccountsStore } from '@/stores/accounts'
 import { useMisStoreStore } from '@/stores/misstore'
@@ -248,18 +248,22 @@ export const pluginsUpdateCapability: Command = {
     description:
       'プラグインの AiScript ソースを全文置換する。' +
       'plugins.read で現状を取得してから差分判断する運用を推奨。' +
-      '実行後の print / エラーは `aiscript.logs` で確認できる。',
+      'アクティブなプラグインは保存後に新 src で自動再起動されるので、' +
+      '`aiscript.logs` で実行結果 (起動 / print / エラー) を確認し、' +
+      'エラーがあれば修正して再保存するループを回すこと。',
     params: {
       installId: { type: 'string', description: '対象プラグインの installId' },
       src: { type: 'string', description: '新しい AiScript ソース全文' },
     },
     returns: {
       type: 'object',
-      description: '{ installId, length: 新 src の文字数 }',
+      description:
+        '{ installId, length: 新 src の文字数, relaunched: boolean }。' +
+        'relaunched=true ならアクティブなプラグインを新 src で再起動済み。',
     },
   },
   visible: false,
-  execute: (params) => {
+  execute: async (params) => {
     const installId =
       typeof params?.installId === 'string' ? params.installId : ''
     const src = typeof params?.src === 'string' ? params.src : ''
@@ -270,7 +274,15 @@ export const pluginsUpdateCapability: Command = {
       throw new Error(`plugins.update: plugin "${installId}" not found`)
     }
     store.updateSrc(installId, src)
-    return { installId, length: src.length }
+    // アクティブなら UI の保存と同様に新 src で再起動する (#744)。
+    // launchPlugin は内部で既存インスタンスを abort する。
+    const updated = store.getPlugin(installId)
+    let relaunched = false
+    if (updated?.active) {
+      await launchPlugin(updated)
+      relaunched = true
+    }
+    return { installId, length: src.length, relaunched }
   },
 }
 

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -228,7 +228,11 @@ export const pluginsUpdateCapability: Command = {
     const newMeta = parsePluginMeta(src)
     return {
       title: 'プラグインを更新',
-      message: `${cur.name} の AiScript を ${cur.src.length} → ${src.length} 文字に置換します。`,
+      message:
+        `${cur.name} の AiScript を ${cur.src.length} → ${src.length} 文字に置換します。` +
+        (cur.active
+          ? 'アクティブなため、保存後すぐ新しいコードで再起動されます。'
+          : ''),
       installPreview: {
         kind: 'plugin',
         name: newMeta?.name ?? cur.name,

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -247,7 +247,8 @@ export const pluginsUpdateCapability: Command = {
   signature: {
     description:
       'プラグインの AiScript ソースを全文置換する。' +
-      'plugins.read で現状を取得してから差分判断する運用を推奨。',
+      'plugins.read で現状を取得してから差分判断する運用を推奨。' +
+      '実行後の print / エラーは `aiscript.logs` で確認できる。',
     params: {
       installId: { type: 'string', description: '対象プラグインの installId' },
       src: { type: 'string', description: '新しい AiScript ソース全文' },

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -1,4 +1,8 @@
-import { launchPlugin, parsePluginMeta } from '@/aiscript/plugin-api'
+import {
+  abortPlugin,
+  launchPlugin,
+  parsePluginMeta,
+} from '@/aiscript/plugin-api'
 import type { Command } from '@/commands/registry'
 import { useAccountsStore } from '@/stores/accounts'
 import { useMisStoreStore } from '@/stores/misstore'
@@ -331,7 +335,8 @@ export const pluginsSetActiveCapability: Command = {
       'プラグインの active 状態を切り替える。有効化 (true) すると ' +
       'handler が起動して Misskey API 介入の副作用が走り得るので、AI が ' +
       '呼ぶときは確認ダイアログでユーザー承認を取る。無効化 (false) は ' +
-      '即実行 (= 可逆な停止操作)。',
+      '即実行 (= 可逆な停止操作)。有効化後は aiscript.logs (source: plugin) ' +
+      'に "started" が記録されるので起動確認に使える。',
     params: {
       installId: { type: 'string', description: '対象プラグインの installId' },
       active: {
@@ -345,7 +350,7 @@ export const pluginsSetActiveCapability: Command = {
     },
   },
   visible: false,
-  execute: (params) => {
+  execute: async (params) => {
     const installId =
       typeof params?.installId === 'string' ? params.installId : ''
     if (!installId) {
@@ -357,6 +362,13 @@ export const pluginsSetActiveCapability: Command = {
       throw new Error(`plugins.setActive: plugin "${installId}" not found`)
     }
     store.setActive(installId, active)
+    // フラグ更新だけでは handler は起動しない (UI トグルと同じく launch/abort が必要)
+    const updated = store.getPlugin(installId)
+    if (active && updated) {
+      await launchPlugin(updated)
+    } else {
+      abortPlugin(installId)
+    }
     return { installId, active }
   },
 }

--- a/src/capabilities/builtins/widgets.test.ts
+++ b/src/capabilities/builtins/widgets.test.ts
@@ -213,4 +213,23 @@ describe('widgets.update — 表示中なら再実行を要求する (#744)', ()
     expect(store.rerunSignal(widget.installId)).toBe(1)
     expect(store.getWidget(widget.installId)?.src).toBe('let y = 2')
   })
+
+  it('確認ダイアログは表示中のときのみ再実行を予告する', async () => {
+    if (typeof widgetsUpdateCapability.requiresConfirmation !== 'function') {
+      throw new Error('requiresConfirmation must be a function')
+    }
+    const widget = addWidget()
+    const before = await widgetsUpdateCapability.requiresConfirmation(
+      { installId: widget.installId, src: 'let y = 2' },
+      {},
+    )
+    expect(before?.message).not.toContain('再実行されます')
+
+    useWidgetsStore().registerMounted(widget.installId)
+    const after = await widgetsUpdateCapability.requiresConfirmation(
+      { installId: widget.installId, src: 'let y = 2' },
+      {},
+    )
+    expect(after?.message).toContain('再実行されます')
+  })
 })

--- a/src/capabilities/builtins/widgets.test.ts
+++ b/src/capabilities/builtins/widgets.test.ts
@@ -1,4 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useWidgetsStore, type WidgetMeta } from '@/stores/widgets'
+
+// unit プロジェクトは node 環境のため localStorage を stub する (deck.test.ts と同じ)
+const storage = new Map<string, string>()
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+})
+
 import {
   WIDGETS_BUILTIN_CAPABILITIES,
   widgetsCreateCapability,
@@ -160,5 +171,46 @@ describe('WIDGETS_BUILTIN_CAPABILITIES', () => {
       'widgets.uninstall',
       'widgets.update',
     ])
+  })
+})
+
+describe('widgets.update — 表示中なら再実行を要求する (#744)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  function addWidget(): WidgetMeta {
+    const widget: WidgetMeta = {
+      installId: 'w-test-1',
+      name: 'test-widget',
+      src: 'let x = 1',
+      autoRun: false,
+      createdAt: 0,
+      updatedAt: 0,
+    }
+    useWidgetsStore().addWidget(widget)
+    return widget
+  }
+
+  it('未マウントなら rerunning: false', () => {
+    const widget = addWidget()
+    const r = widgetsUpdateCapability.execute({
+      installId: widget.installId,
+      src: 'let y = 2',
+    }) as { rerunning: boolean }
+    expect(r.rerunning).toBe(false)
+  })
+
+  it('マウント中なら rerunning: true でシグナルが進む', () => {
+    const widget = addWidget()
+    const store = useWidgetsStore()
+    store.registerMounted(widget.installId)
+    const r = widgetsUpdateCapability.execute({
+      installId: widget.installId,
+      src: 'let y = 2',
+    }) as { rerunning: boolean }
+    expect(r.rerunning).toBe(true)
+    expect(store.rerunSignal(widget.installId)).toBe(1)
+    expect(store.getWidget(widget.installId)?.src).toBe('let y = 2')
   })
 })

--- a/src/capabilities/builtins/widgets.ts
+++ b/src/capabilities/builtins/widgets.ts
@@ -211,8 +211,10 @@ export const widgetsUpdateCapability: Command = {
     description:
       'ウィジェットの AiScript ソースを全文置換する。意図しない上書きを' +
       '防ぐため、事前に widgets.read で現状を取得してから差分判断して' +
-      'から渡すことを推奨。実行後の print / エラーは `aiscript.logs` で' +
-      '確認できる。',
+      'から渡すことを推奨。表示中のウィジェットは保存後に新 src で自動' +
+      '再実行されるので、`aiscript.logs` で実行結果 (print / エラー) を' +
+      '確認し、エラーがあれば修正して再保存するループを回すこと。' +
+      '表示されていないウィジェットは実行されない (rerunning=false)。',
     params: {
       installId: {
         type: 'string',
@@ -222,7 +224,9 @@ export const widgetsUpdateCapability: Command = {
     },
     returns: {
       type: 'object',
-      description: '{ installId, length: 新 src の文字数 }',
+      description:
+        '{ installId, length: 新 src の文字数, rerunning: boolean }。' +
+        'rerunning=true なら表示中インスタンスが新 src で再実行される。',
     },
   },
   visible: false,
@@ -237,7 +241,10 @@ export const widgetsUpdateCapability: Command = {
       throw new Error(`widgets.update: widget "${installId}" not found`)
     }
     store.updateSrc(installId, src)
-    return { installId, length: src.length }
+    // 表示中のインスタンスに再実行を要求する (#744)。ユーザーのエディタ編集
+    // (debounce 自動保存) と違い、AI 経由の保存だけがこのシグナルを発火する。
+    const rerunning = store.requestRerun(installId) > 0
+    return { installId, length: src.length, rerunning }
   },
 }
 

--- a/src/capabilities/builtins/widgets.ts
+++ b/src/capabilities/builtins/widgets.ts
@@ -195,7 +195,11 @@ export const widgetsUpdateCapability: Command = {
     if (!cur) return null
     return {
       title: 'ウィジェットを更新',
-      message: `${cur.name} の AiScript を ${cur.src.length} → ${src.length} 文字に置換します。`,
+      message:
+        `${cur.name} の AiScript を ${cur.src.length} → ${src.length} 文字に置換します。` +
+        (useWidgetsStore().mountedCount(installId) > 0
+          ? '表示中のウィジェットは保存後すぐ新しいコードで再実行されます。'
+          : ''),
       installPreview: {
         kind: 'widget',
         name: cur.name,

--- a/src/capabilities/builtins/widgets.ts
+++ b/src/capabilities/builtins/widgets.ts
@@ -211,7 +211,8 @@ export const widgetsUpdateCapability: Command = {
     description:
       'ウィジェットの AiScript ソースを全文置換する。意図しない上書きを' +
       '防ぐため、事前に widgets.read で現状を取得してから差分判断して' +
-      'から渡すことを推奨。',
+      'から渡すことを推奨。実行後の print / エラーは `aiscript.logs` で' +
+      '確認できる。',
     params: {
       installId: {
         type: 'string',

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -8,6 +8,11 @@ import {
   watch,
 } from 'vue'
 import type { NormalizedDriveFile, NormalizedNote } from '@/adapters/types'
+import {
+  getPluginHandlers,
+  type PluginHandler,
+  setPluginAccountContext,
+} from '@/aiscript/plugin-api'
 import { useAutocomplete } from '@/composables/useAutocomplete'
 import type { StoredDraft } from '@/composables/useDrafts'
 import { showLoginPrompt } from '@/composables/useLoginPrompt'
@@ -286,6 +291,42 @@ function pickEmoji(reaction: string) {
 // --- Hashtag ---
 function insertHashtag() {
   insertAtCursor(textareaRef.value, '#')
+}
+
+// --- Plugin post_form_action (#731) ---
+const showPluginActionsMenu = popups.register()
+
+const postFormActions = computed(() =>
+  getPluginHandlers('post_form_action', activeAccountId.value),
+)
+
+function togglePluginActionsMenu() {
+  popups.toggle(showPluginActionsMenu)
+}
+
+function runPostFormAction(action: PluginHandler) {
+  showPluginActionsMenu.value = false
+  if (activeAccountId.value) {
+    setPluginAccountContext(action.pluginInstallId, activeAccountId.value)
+  }
+  // handler は (form, update) の 2 引数 (plugin-api.ts の register_post_form_action)。
+  // update は 'text' / 'cw' キーに対応し、cw: null は CW 解除。
+  action.handler(
+    { text: text.value, cw: showCw.value ? cw.value : null },
+    (key: unknown, value: unknown) => {
+      if (key === 'text' && typeof value === 'string') {
+        text.value = value
+      } else if (key === 'cw') {
+        if (value == null) {
+          showCw.value = false
+          cw.value = ''
+        } else if (typeof value === 'string') {
+          showCw.value = true
+          cw.value = value
+        }
+      }
+    },
+  )
 }
 
 // --- MFM menu ---
@@ -898,6 +939,24 @@ function onKeydown(e: KeyboardEvent) {
               <i class="ti ti-trash" />
             </button>
           </template>
+
+          <!-- Plugin post_form_action (#731) — 登録があるときだけ表示 -->
+          <div v-if="postFormActions.length > 0" :class="$style.footerPopupWrapper">
+            <button class="_button" :class="$style.footerBtn" title="プラグイン" @click.stop="togglePluginActionsMenu">
+              <i class="ti ti-plug" />
+            </button>
+            <div v-if="showPluginActionsMenu" :class="[$style.footerPopup, $style.mfmMenu]" @click.stop>
+              <button
+                v-for="action in postFormActions"
+                :key="action.pluginInstallId + action.title"
+                class="_button"
+                :class="$style.mfmMenuItem"
+                @click="runPostFormAction(action)"
+              >
+                {{ action.title }}
+              </button>
+            </div>
+          </div>
         </div>
         <div v-if="!props.inline" :class="$style.footerRight">
           <!-- Post form editor -->

--- a/src/components/deck/DeckAiScriptColumn.vue
+++ b/src/components/deck/DeckAiScriptColumn.vue
@@ -29,6 +29,7 @@ import { usePortal } from '@/composables/usePortal'
 import { useSwipeTab } from '@/composables/useSwipeTab'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { useVerticalResize } from '@/composables/useVerticalResize'
+import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
@@ -199,12 +200,19 @@ async function run() {
       }
     : undefined
 
+  const runLog = useAiScriptLogsStore().beginRun(
+    'playground',
+    props.column.id,
+    props.column.name ?? undefined,
+  )
+
   const parser = new Parser()
   let ast: Ast.Node[]
   try {
     ast = parser.parse(sanitizeCode(code.value))
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`parse error: ${error.value}`)
     running.value = false
     return
   }
@@ -249,9 +257,13 @@ async function run() {
   })
 
   const ioOpts = createInterpreterOptions({
-    onOutput: (text) => output.value.push({ text, isError: false }),
+    onOutput: (text) => {
+      output.value.push({ text, isError: false })
+      runLog.print(text)
+    },
     onError: (err) => {
       error.value = err.message
+      runLog.error(err.message)
     },
   })
 
@@ -269,8 +281,10 @@ async function run() {
 
   try {
     await interp.exec(ast)
+    runLog.system('run completed')
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`run aborted: ${error.value}`)
   }
   running.value = false
 }

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -128,7 +128,23 @@ function stop() {
 onBeforeUnmount(() => {
   flushPendingSave()
   stop()
+  widgetsStore.unregisterMounted(props.widget.installId)
 })
+
+// AI 経由の widgets.update (#744): 新しい src を反映して再実行する。
+// pending の自動保存が古いコードで上書き返さないよう先にキャンセルする。
+watch(
+  () => widgetsStore.rerunSignal(props.widget.installId),
+  (sig, prev) => {
+    if (sig <= (prev ?? 0)) return
+    if (saveTimer) {
+      clearTimeout(saveTimer)
+      saveTimer = null
+    }
+    code.value = props.widget.src ?? ''
+    run()
+  },
+)
 
 async function run() {
   if (running.value) return
@@ -247,6 +263,7 @@ async function run() {
 // autoRun=true な widget は mount のたびに自動実行する。
 // (フラグを下げない: カラム再表示・ナビバートグル・他カラム参照のたびに UI を出すため)
 onMounted(() => {
+  widgetsStore.registerMounted(props.widget.installId)
   if (props.widget.autoRun && code.value) {
     run()
   }

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -33,6 +33,7 @@ const MkPostForm = defineAsyncComponent(
 )
 
 import { useAccountsStore } from '@/stores/accounts'
+import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useWidgetsStore, type WidgetMeta } from '@/stores/widgets'
 import AiScriptEditor from './AiScriptEditor.vue'
 import type { PostFormRequest } from './AiScriptUiRenderer.vue'
@@ -145,12 +146,19 @@ async function run() {
       }
     : undefined
 
+  const runLog = useAiScriptLogsStore().beginRun(
+    'widget',
+    props.widget.installId,
+    props.widget.name,
+  )
+
   const parser = new Parser()
   let ast: Ast.Node[]
   try {
     ast = parser.parse(sanitizeCode(code.value))
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`parse error: ${error.value}`)
     running.value = false
     return
   }
@@ -192,10 +200,12 @@ async function run() {
   const ioOpts = createInterpreterOptions({
     onOutput: (text) => {
       output.value.push({ text, isError: false })
+      runLog.print(text)
     },
     onError: (err) => {
       error.value = err.message
       output.value.push({ text: err.message, isError: true })
+      runLog.error(err.message)
     },
   })
 
@@ -225,8 +235,10 @@ async function run() {
 
   try {
     await interp.exec(ast)
+    runLog.system('run completed')
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`run aborted: ${error.value}`)
   }
 
   running.value = false

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -2,7 +2,6 @@
 import { computed, reactive, ref, watch } from 'vue'
 import {
   abortPlugin,
-  getPluginLogs,
   launchPlugin,
   parsePluginMeta,
 } from '@/aiscript/plugin-api'
@@ -12,6 +11,7 @@ import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
+import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
 import { pluginSrcFilename } from '@/utils/settingsFs'
 
@@ -36,8 +36,11 @@ const plugin = computed(() =>
     : undefined,
 )
 
+const aiscriptLogsStore = useAiScriptLogsStore()
 const pluginLogs = computed(() =>
-  editingPluginId.value ? getPluginLogs(editingPluginId.value) : [],
+  editingPluginId.value
+    ? aiscriptLogsStore.entriesFor('plugin', editingPluginId.value)
+    : [],
 )
 
 // 新規インストールモード
@@ -400,11 +403,17 @@ async function importPlugin() {
     <div v-if="!isNewInstall && tab === 'logs'" :class="$style.logsPanel">
       <div v-if="pluginLogs.length > 0" :class="$style.logsList">
         <div
-          v-for="(log, i) in pluginLogs"
-          :key="i"
-          :class="[$style.logLine, { [$style.logError]: log.isError }]"
+          v-for="log in pluginLogs"
+          :key="log.seq"
+          :class="[
+            $style.logLine,
+            {
+              [$style.logError]: log.level === 'error',
+              [$style.logSystem]: log.level === 'system',
+            },
+          ]"
         >
-          {{ log.text }}
+          {{ log.message }}
         </div>
       </div>
       <div v-else :class="$style.logsEmpty">
@@ -755,6 +764,11 @@ async function importPlugin() {
 
   &.logError {
     color: var(--nd-love);
+  }
+
+  &.logSystem {
+    opacity: 0.6;
+    font-style: italic;
   }
 }
 

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -33,6 +33,7 @@ import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePortal } from '@/composables/usePortal'
 import { useWindowEditAction } from '@/composables/useWindowEditAction'
 import { useAccountsStore } from '@/stores/accounts'
+import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { useWidgetsStore } from '@/stores/widgets'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -135,12 +136,19 @@ async function run() {
         unwrap(await commands.apiRequest(accId, endpoint, params as JsonValue))
     : undefined
 
+  const runLog = useAiScriptLogsStore().beginRun(
+    'widget',
+    props.widgetId,
+    widget.value.name,
+  )
+
   const parser = new Parser()
   let ast: Ast.Node[]
   try {
     ast = parser.parse(sanitizeCode(code.value))
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`parse error: ${error.value}`)
     running.value = false
     return
   }
@@ -182,10 +190,12 @@ async function run() {
   const ioOpts = createInterpreterOptions({
     onOutput: (text) => {
       output.value.push({ text, isError: false })
+      runLog.print(text)
     },
     onError: (err) => {
       error.value = err.message
       output.value.push({ text: err.message, isError: true })
+      runLog.error(err.message)
     },
   })
 
@@ -214,8 +224,10 @@ async function run() {
 
   try {
     await interp.exec(ast)
+    runLog.system('run completed')
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e)
+    runLog.system(`run aborted: ${error.value}`)
   }
 
   running.value = false

--- a/src/components/window/user-profile/UserProfileMenu.vue
+++ b/src/components/window/user-profile/UserProfileMenu.vue
@@ -7,6 +7,10 @@ import type {
   UserList,
   UserRelation,
 } from '@/adapters/types'
+import {
+  getPluginHandlers,
+  setPluginAccountContext,
+} from '@/aiscript/plugin-api'
 import PopupMenu from '@/components/common/PopupMenu.vue'
 import { useDeckStore } from '@/stores/deck'
 import { useMutesStore } from '@/stores/mutes'
@@ -92,6 +96,11 @@ function open(event: MouseEvent) {
 }
 
 defineExpose({ open })
+
+// プラグインの user_action (#731) — note_action (NoteMoreMenu) と同じ発火パターン
+const userActions = computed(() =>
+  getPluginHandlers('user_action', props.accountId),
+)
 
 function closeUserMenu() {
   userMenuRef.value?.close()
@@ -474,6 +483,18 @@ async function addToAntenna(antenna: Antenna) {
             "
           />
           投稿を通知
+        </button>
+      </template>
+      <template v-if="user && userActions.length > 0">
+        <div class="_popupDivider" />
+        <button
+          v-for="action in userActions"
+          :key="action.pluginInstallId + action.title"
+          class="_popupItem"
+          @click="setPluginAccountContext(action.pluginInstallId, accountId); action.handler(user); closeUserMenu()"
+        >
+          <i class="ti ti-plug" />
+          {{ action.title }}
         </button>
       </template>
       <div class="_popupDivider" />

--- a/src/composables/useAiScriptRunner.ts
+++ b/src/composables/useAiScriptRunner.ts
@@ -18,6 +18,10 @@ import type { JsonValue } from '@/bindings'
 import { useCommandStore } from '@/commands/registry'
 import type AiScriptDialog from '@/components/common/AiScriptDialog.vue'
 import type { Principal } from '@/permissions/principal'
+import {
+  logSourceOfPrincipal,
+  useAiScriptLogsStore,
+} from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -70,6 +74,13 @@ export function useAiScriptRunner() {
     reset()
     running.value = true
 
+    const logSource = logSourceOfPrincipal(options.principal)
+    const runLog = useAiScriptLogsStore().beginRun(
+      logSource.source,
+      logSource.sourceId,
+      logSource.name,
+    )
+
     const sanitized = sanitizeCode(code)
 
     let ast: Ast.Node[]
@@ -80,6 +91,7 @@ export function useAiScriptRunner() {
       legacy = result.legacy
     } catch (e) {
       runError.value = AppError.from(e).message
+      runLog.system(`parse error: ${AppError.from(e).message}`)
       running.value = false
       return
     }
@@ -120,9 +132,13 @@ export function useAiScriptRunner() {
     })
 
     const ioOpts = createInterpreterOptions({
-      onOutput: (text) => consoleOutput.value.push({ text, isError: false }),
+      onOutput: (text) => {
+        consoleOutput.value.push({ text, isError: false })
+        runLog.print(text)
+      },
       onError: (err) => {
         runError.value = err.message
+        runLog.error(err.message)
       },
     })
 
@@ -145,8 +161,10 @@ export function useAiScriptRunner() {
     interpreter.value = interp
     try {
       await execAiScript(interp, ast, legacy)
+      runLog.system('run completed')
     } catch (e) {
       runError.value = AppError.from(e).message
+      runLog.system(`run aborted: ${AppError.from(e).message}`)
     }
     running.value = false
   }

--- a/src/stores/aiscriptLogs.test.ts
+++ b/src/stores/aiscriptLogs.test.ts
@@ -1,0 +1,105 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAiScriptLogsStore } from './aiscriptLogs'
+
+describe('useAiScriptLogsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('beginRun は system "started" を記録し runId を採番する', () => {
+    const store = useAiScriptLogsStore()
+    const a = store.beginRun('plugin', 'p1', 'My Plugin')
+    const b = store.beginRun('widget', 'w1')
+    expect(b.runId).toBeGreaterThan(a.runId)
+
+    const entries = store.entriesFor('plugin', 'p1')
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      source: 'plugin',
+      sourceId: 'p1',
+      name: 'My Plugin',
+      runId: a.runId,
+      level: 'system',
+      message: 'started',
+    })
+  })
+
+  it('print / error / system がそれぞれの level で記録される', () => {
+    const store = useAiScriptLogsStore()
+    const run = store.beginRun('play', 'f1')
+    run.print('hello')
+    run.error('boom')
+    run.system('run completed')
+
+    const levels = store.entriesFor('play', 'f1').map((e) => e.level)
+    expect(levels).toEqual(['system', 'print', 'error', 'system'])
+  })
+
+  it('リング上限を超えたら古い方から破棄する (新しい方は必ず残る)', () => {
+    const store = useAiScriptLogsStore()
+    const run = store.beginRun('plugin', 'p1')
+    for (let i = 0; i < 300; i++) run.print(`msg ${i}`)
+
+    const entries = store.entriesFor('plugin', 'p1')
+    expect(entries).toHaveLength(200)
+    // 最新は残り、最古 (started と序盤の print) は破棄されている
+    expect(entries.at(-1)?.message).toBe('msg 299')
+    expect(entries[0]?.message).toBe('msg 100')
+  })
+
+  it('リングは source ごとに独立している', () => {
+    const store = useAiScriptLogsStore()
+    const a = store.beginRun('plugin', 'p1')
+    const b = store.beginRun('plugin', 'p2')
+    for (let i = 0; i < 300; i++) a.print(`a${i}`)
+    b.print('b0')
+
+    expect(store.entriesFor('plugin', 'p1')).toHaveLength(200)
+    // p2 は started + b0 のみ
+    expect(store.entriesFor('plugin', 'p2')).toHaveLength(2)
+  })
+
+  it('長文メッセージは truncate される', () => {
+    const store = useAiScriptLogsStore()
+    const run = store.beginRun('playground', 'col1')
+    run.print('x'.repeat(5000))
+
+    const entry = store.entriesFor('playground', 'col1').at(-1)
+    expect(entry?.message.length).toBeLessThan(1100)
+    expect(entry?.message.endsWith('… (truncated)')).toBe(true)
+  })
+
+  it('recent は新しい順で source / level / limit フィルタが効く', () => {
+    const store = useAiScriptLogsStore()
+    const p = store.beginRun('plugin', 'p1')
+    p.print('p-out')
+    p.error('p-err')
+    const w = store.beginRun('widget', 'w1')
+    w.print('w-out')
+
+    const all = store.recent({})
+    expect(all[0]?.message).toBe('w-out')
+    expect(all.at(-1)?.message).toBe('started')
+
+    const errorsOnly = store.recent({ level: 'error' })
+    expect(errorsOnly.map((e) => e.message)).toEqual(['p-err'])
+
+    const widgetOnly = store.recent({ source: 'widget' })
+    expect(widgetOnly.every((e) => e.source === 'widget')).toBe(true)
+
+    const limited = store.recent({ limit: 2 })
+    expect(limited).toHaveLength(2)
+    expect(limited[0]?.message).toBe('w-out')
+  })
+
+  it('recent は sourceId で絞り込める', () => {
+    const store = useAiScriptLogsStore()
+    store.beginRun('plugin', 'p1').print('one')
+    store.beginRun('plugin', 'p2').print('two')
+
+    const p2 = store.recent({ source: 'plugin', sourceId: 'p2' })
+    expect(p2.every((e) => e.sourceId === 'p2')).toBe(true)
+    expect(p2.map((e) => e.message)).toContain('two')
+  })
+})

--- a/src/stores/aiscriptLogs.ts
+++ b/src/stores/aiscriptLogs.ts
@@ -1,0 +1,164 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import type { Principal } from '@/permissions/principal'
+
+/**
+ * AiScript 実行ログ集約 (#710)。
+ *
+ * 全実行文脈 (プラグイン / ウィジェット / Play / Page / スクラッチパッド) の
+ * print 出力・実行時エラー・ライフサイクルイベントを source 別の in-memory
+ * リングに集約する (永続化しない)。capability `aiscript.logs` から AI が
+ * 読み取り、「書く → 保存で実行 → 結果を読んで修正」のループを閉じる。
+ * プラグイン管理 UI の Logs タブもここを読む (読み口の一本化)。
+ */
+
+export type AiScriptSourceKind =
+  | 'plugin'
+  | 'widget'
+  | 'play'
+  | 'page'
+  | 'playground'
+
+export type AiScriptLogLevel = 'print' | 'error' | 'system'
+
+export interface AiScriptLogEntry {
+  /** Unix ms */
+  at: number
+  /** 全 source 横断の単調増加連番 (recent のマージ順序に使う) */
+  seq: number
+  source: AiScriptSourceKind
+  /** installId / Play・Page の id / スクラッチパッドのカラム id */
+  sourceId: string
+  /** 表示名 (プラグイン名等、分かる範囲で) */
+  name?: string
+  /** 実行ごとの通し番号 (beginRun で採番) */
+  runId: number
+  level: AiScriptLogLevel
+  message: string
+}
+
+/** 1 実行分の書き込み口。配線側は onOutput/onError からこれに tee する */
+export interface AiScriptRunLogger {
+  runId: number
+  print: (text: string) => void
+  error: (text: string) => void
+  system: (text: string) => void
+}
+
+export interface AiScriptLogFilter {
+  source?: AiScriptSourceKind | 'all'
+  sourceId?: string
+  level?: AiScriptLogLevel | 'all'
+  limit?: number
+}
+
+/** source 別リング上限。超えたら古い方から破棄する */
+const RING_SIZE = 200
+const MAX_MESSAGE_LENGTH = 1000
+
+/**
+ * principal から log source を導出する。principal の pluginId は
+ * `widget:<id>` / `play:<id>` / `page:<id>` / 素の installId (プラグイン)
+ * という既存規約 (principal.ts) をそのまま流用する。
+ */
+export function logSourceOfPrincipal(principal: Principal): {
+  source: AiScriptSourceKind
+  sourceId: string
+  name?: string
+} {
+  if (principal.kind !== 'plugin') return { source: 'playground', sourceId: '' }
+  const { pluginId, name } = principal
+  const m = pluginId.match(/^(widget|play|page):(.*)$/)
+  if (m)
+    return {
+      source: m[1] as AiScriptSourceKind,
+      sourceId: m[2] ?? '',
+      ...(name ? { name } : {}),
+    }
+  return { source: 'plugin', sourceId: pluginId, ...(name ? { name } : {}) }
+}
+
+export const useAiScriptLogsStore = defineStore('aiscriptLogs', () => {
+  const rings = ref<Map<string, AiScriptLogEntry[]>>(new Map())
+  let seqCounter = 0
+  let runCounter = 0
+
+  function record(
+    source: AiScriptSourceKind,
+    sourceId: string,
+    name: string | undefined,
+    runId: number,
+    level: AiScriptLogLevel,
+    message: string,
+  ) {
+    const key = `${source}:${sourceId}`
+    let ring = rings.value.get(key)
+    if (!ring) {
+      ring = []
+      rings.value.set(key, ring)
+    }
+    ring.push({
+      at: Date.now(),
+      seq: ++seqCounter,
+      source,
+      sourceId,
+      runId,
+      level,
+      message:
+        message.length > MAX_MESSAGE_LENGTH
+          ? `${message.slice(0, MAX_MESSAGE_LENGTH)}… (truncated)`
+          : message,
+      ...(name ? { name } : {}),
+    })
+    if (ring.length > RING_SIZE) ring.splice(0, ring.length - RING_SIZE)
+  }
+
+  /** 実行開始を宣言して runId を採番し、system "started" を記録する */
+  function beginRun(
+    source: AiScriptSourceKind,
+    sourceId: string,
+    name?: string,
+  ): AiScriptRunLogger {
+    const runId = ++runCounter
+    const logger: AiScriptRunLogger = {
+      runId,
+      print: (text) => record(source, sourceId, name, runId, 'print', text),
+      error: (text) => record(source, sourceId, name, runId, 'error', text),
+      system: (text) => record(source, sourceId, name, runId, 'system', text),
+    }
+    logger.system('started')
+    return logger
+  }
+
+  /** UI 表示用: 指定 source の全エントリ (古い順) */
+  function entriesFor(
+    source: AiScriptSourceKind,
+    sourceId: string,
+  ): AiScriptLogEntry[] {
+    return rings.value.get(`${source}:${sourceId}`) ?? []
+  }
+
+  /** capability 用: フィルタして新しい順に返す */
+  function recent(filter: AiScriptLogFilter = {}): AiScriptLogEntry[] {
+    const source = filter.source ?? 'all'
+    const level = filter.level ?? 'all'
+    const limit = Math.max(1, Math.min(filter.limit ?? 50, RING_SIZE))
+    const matched: AiScriptLogEntry[] = []
+    for (const ring of rings.value.values()) {
+      for (const e of ring) {
+        if (source !== 'all' && e.source !== source) continue
+        if (filter.sourceId && e.sourceId !== filter.sourceId) continue
+        if (level !== 'all' && e.level !== level) continue
+        matched.push(e)
+      }
+    }
+    matched.sort((a, b) => b.seq - a.seq)
+    return matched.slice(0, limit)
+  }
+
+  function clear() {
+    rings.value = new Map()
+  }
+
+  return { beginRun, entriesFor, recent, clear }
+})

--- a/src/stores/widgets.test.ts
+++ b/src/stores/widgets.test.ts
@@ -1,0 +1,36 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useWidgetsStore } from './widgets'
+
+describe('useWidgetsStore — 再実行シグナル (#744)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('未マウントなら requestRerun は発火せず 0 を返す', () => {
+    const store = useWidgetsStore()
+    expect(store.requestRerun('w1')).toBe(0)
+    expect(store.rerunSignal('w1')).toBe(0)
+  })
+
+  it('マウント中はインスタンス数を返しシグナルが進む', () => {
+    const store = useWidgetsStore()
+    store.registerMounted('w1')
+    store.registerMounted('w1')
+
+    expect(store.requestRerun('w1')).toBe(2)
+    expect(store.rerunSignal('w1')).toBe(1)
+    expect(store.requestRerun('w1')).toBe(2)
+    expect(store.rerunSignal('w1')).toBe(2)
+    // 別 widget には影響しない
+    expect(store.rerunSignal('w2')).toBe(0)
+  })
+
+  it('unregisterMounted で 0 に戻ったら発火しない', () => {
+    const store = useWidgetsStore()
+    store.registerMounted('w1')
+    store.unregisterMounted('w1')
+    expect(store.requestRerun('w1')).toBe(0)
+    expect(store.rerunSignal('w1')).toBe(0)
+  })
+})

--- a/src/stores/widgets.ts
+++ b/src/stores/widgets.ts
@@ -251,6 +251,43 @@ export const useWidgetsStore = defineStore('widgets', () => {
     saveSidebarOrderToStorage(ids)
   }
 
+  // --- AI 経由の再実行シグナル (#744) ---
+  // widgets.update capability だけが requestRerun を発火し、マウント中の
+  // WidgetAiScript が rerunSignal を watch して新 src で再実行する。
+  // ユーザーのウィジェット内エディタ編集 (debounce 自動保存) では発火しない。
+  const rerunSignals = ref<Map<string, number>>(new Map())
+  const mountedCounts = ref<Map<string, number>>(new Map())
+
+  function registerMounted(installId: string) {
+    mountedCounts.value.set(
+      installId,
+      (mountedCounts.value.get(installId) ?? 0) + 1,
+    )
+  }
+
+  function unregisterMounted(installId: string) {
+    const n = (mountedCounts.value.get(installId) ?? 0) - 1
+    if (n > 0) mountedCounts.value.set(installId, n)
+    else mountedCounts.value.delete(installId)
+  }
+
+  /** マウント中インスタンスに再実行を要求する。返り値は対象インスタンス数 (0 = 発火なし) */
+  function requestRerun(installId: string): number {
+    const mounted = mountedCounts.value.get(installId) ?? 0
+    if (mounted > 0) {
+      rerunSignals.value.set(
+        installId,
+        (rerunSignals.value.get(installId) ?? 0) + 1,
+      )
+    }
+    return mounted
+  }
+
+  /** WidgetAiScript が watch する再実行シグナル (単調増加カウンタ) */
+  function rerunSignal(installId: string): number {
+    return rerunSignals.value.get(installId) ?? 0
+  }
+
   function updateSrc(installId: string, src: string) {
     ensureLoaded()
     const widget = widgets.value.find((w) => w.installId === installId)
@@ -324,5 +361,9 @@ export const useWidgetsStore = defineStore('widgets', () => {
     addToSidebar,
     removeFromSidebar,
     reorderSidebar,
+    registerMounted,
+    unregisterMounted,
+    requestRerun,
+    rerunSignal,
   }
 })

--- a/src/stores/widgets.ts
+++ b/src/stores/widgets.ts
@@ -288,6 +288,11 @@ export const useWidgetsStore = defineStore('widgets', () => {
     return rerunSignals.value.get(installId) ?? 0
   }
 
+  /** マウント中インスタンス数 (シグナルを発火しない read-only 版) */
+  function mountedCount(installId: string): number {
+    return mountedCounts.value.get(installId) ?? 0
+  }
+
   function updateSrc(installId: string, src: string) {
     ensureLoaded()
     const widget = widgets.value.find((w) => w.installId === installId)
@@ -365,5 +370,6 @@ export const useWidgetsStore = defineStore('widgets', () => {
     unregisterMounted,
     requestRerun,
     rerunSignal,
+    mountedCount,
   }
 })


### PR DESCRIPTION
## Release v1.8.0

AI 自己拡張ループの完成がテーマのリリース。AiScript を書く → 保存で即実行 → 実行結果を AI 自身が読んで直す、の一周が実機で回るようになった。

### 変更一覧

- feat(aiscript): 実行結果を AI が読める aiscript.logs capability を追加 (#710)
- feat(capability): AI 経由の保存でプラグイン/ウィジェットを再実行する (#744)
- fix(capability): 更新確認ダイアログで保存後の再実行を予告する (#744)
- fix(capability): plugins.setActive で handler を起動/停止する (#744)
- feat(plugin): user_action / post_form_action フックを UI に配線 (#731)
- feat(site): ベータテスター応募に Issue Form テンプレートを導入
- chore: bump version to 1.8.0 / regenerate openapi.json

### 実機確認済み

- validate 自己修正 → plugins.create → setActive → フック登録 (started が aiscript.logs に記録)
- user_action / post_form_action がユーザーメニュー・投稿フォームに表示され発火
- plugins.update で relaunched: true → 新コードの print 出力を AI が aiscript.logs で確認

Closes #710
Closes #744
Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)