### PR TITLE
Release v1.9.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -735,7 +735,7 @@ AiScript / AI / プラグインが**任意の外部サービス** (GitHub / Line
 #### AI 統合
 
 - `vault.fetch` は capability registry に登録 (`aiTool: true`, permission `vault.use`, `requiresConfirmation: true`)。AI / AiScript / コマンドパレットから呼べる
-- 開示は principal クラス別 (#712 §6.1): `exposedTo: ('ai' | 'external')[]` (接続単位、default 空 = 非開示)。「AI に見せる」「外部アプリに見せる」は別の同意で、`vault.fetch` capability は呼び出し principal のクラスに開示された接続のみ `connectionRef` (name / id) で解決。plugin principal は恒久拒否 (`vault_not_exposed_to_plugins`)
+- 開示は principal クラス別 (#712 §6.1 / #759): `exposedTo: ('ai' | 'plugin' | 'external')[]` (接続単位、default 空 = 非開示)。「AI に見せる」「プラグイン・ウィジェットに見せる」「外部アプリに見せる」は別の同意で、`vault.fetch` capability は呼び出し principal のクラスに開示された接続のみ `connectionRef` (name / id) で解決。plugin クラスは接続ごとの明示 opt-in (#759 — secret 自体は Rust 側注入のまま AiScript に露出しない)
 - 「今後確認なし」(`trustedFor`) もクラス別 — 外部アプリでの確認同意が AI の trust に化けない
 - AI の system prompt に `<available-connections>` ブロックを注入 (Ai クラスに開示された接続の name / baseUrl / auth のみ、secret / id は出さない)
 - permission `vault.use` は preset readonly/safe = false、full = true。HIGH_RISK 指定

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.9.0"
+version = "1.9.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.9.0"
+    "version": "1.9.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/vault/model.rs
+++ b/src-tauri/src/vault/model.rs
@@ -60,17 +60,16 @@ pub enum ConnectionOrigin {
 }
 
 /// 接続を開示する先の principal クラス (#712 §6.1)。
-/// principal そのものより粗い 2 クラス — 接続ごとに 4 principal 分のトグルを
-/// 並べるのは Apple 式に反する。「AI に見せる」「外部アプリに見せる」の
-/// 2 つの同意が、ユーザーのメンタルモデルの実際の粒度。
-///
-/// plugin クラスは存在しない — プラグインへの vault 開示は恒久不可
-/// (プラグインに secret を渡す同意設計が必要になったとき別途)。
+/// principal そのものより粗いクラス — 接続ごとに全 principal 分のトグルを
+/// 並べるのは Apple 式に反する。「AI に見せる」「プラグインに見せる」
+/// 「外部アプリに見せる」の 3 つの同意が、ユーザーのメンタルモデルの実際の粒度。
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PrincipalClass {
     /// ai.chat + ai.heartbeat
     Ai,
+    /// AiScript プラグイン / ウィジェット (#759 — per-connection opt-in、default 非開示)
+    Plugin,
     /// HTTP API 経由の外部アプリ (全永続トークン)
     External,
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2667,18 +2667,19 @@ export type PerformanceConfig = { memory_cache_max_total: number; memory_cache_m
 export type Player = { url: string; width: number | null; height: number | null; allow?: string[] }
 /**
  * 接続を開示する先の principal クラス (#712 §6.1)。
- * principal そのものより粗い 2 クラス — 接続ごとに 4 principal 分のトグルを
- * 並べるのは Apple 式に反する。「AI に見せる」「外部アプリに見せる」の
- * 2 つの同意が、ユーザーのメンタルモデルの実際の粒度。
- * 
- * plugin クラスは存在しない — プラグインへの vault 開示は恒久不可
- * (プラグインに secret を渡す同意設計が必要になったとき別途)。
+ * principal そのものより粗いクラス — 接続ごとに全 principal 分のトグルを
+ * 並べるのは Apple 式に反する。「AI に見せる」「プラグインに見せる」
+ * 「外部アプリに見せる」の 3 つの同意が、ユーザーのメンタルモデルの実際の粒度。
  */
 export type PrincipalClass = 
 /**
  * ai.chat + ai.heartbeat
  */
 "ai" | 
+/**
+ * AiScript プラグイン / ウィジェット (#759 — per-connection opt-in、default 非開示)
+ */
+"plugin" | 
 /**
  * HTTP API 経由の外部アプリ (全永続トークン)
  */

--- a/src/capabilities/builtins/vault.test.ts
+++ b/src/capabilities/builtins/vault.test.ts
@@ -137,6 +137,15 @@ describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () 
     expect(result).toBeNull()
   })
 
+  it('plugin の rememberLabel は同意の及ぶ範囲 (全プラグイン) を明示する (#759)', async () => {
+    setConnections([makeConnection({ exposedTo: ['plugin'] })])
+    const result = await requiresConfirmation(
+      { connectionRef: 'Habitica' },
+      PLUGIN_CTX,
+    )
+    expect(result?.rememberLabel).toContain('すべてのプラグイン')
+  })
+
   it('Ai クラスの trust は plugin には効かない (同意のクラス分離)', async () => {
     setConnections([
       makeConnection({ exposedTo: ['ai', 'plugin'], trustedFor: ['ai'] }),

--- a/src/capabilities/builtins/vault.test.ts
+++ b/src/capabilities/builtins/vault.test.ts
@@ -1,10 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Connection } from '@/bindings'
 import type { CapabilityContext } from '@/capabilities/types'
-import {
-  _clearPluginDenialsForTest,
-  getPluginDenial,
-} from '@/permissions/pluginDenials'
 
 // `commands.*` をモックして実 Tauri invoke を回避する。`unwrap` は実物を使う
 // (ok-Result をそのまま剥がすだけ)。接続一覧はテストごとに差し替える。
@@ -55,7 +51,7 @@ function setConnections(conns: Connection[]) {
 const AI_CTX: CapabilityContext = { principal: { kind: 'ai.chat' } }
 const EXTERNAL_CTX: CapabilityContext = { principal: { kind: 'external' } }
 const PLUGIN_CTX: CapabilityContext = {
-  principal: { kind: 'plugin', pluginId: 'evil-widget' },
+  principal: { kind: 'plugin', pluginId: 'widget:habitica-status' },
 }
 
 /** vaultFetchCapability.requiresConfirmation は関数形。型を絞って呼ぶ。 */
@@ -67,7 +63,6 @@ const requiresConfirmation = vaultFetchCapability.requiresConfirmation as (
 beforeEach(() => {
   listConnections.mockReset()
   setTrusted.mockClear()
-  _clearPluginDenialsForTest()
 })
 
 describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () => {
@@ -131,12 +126,26 @@ describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () 
     expect(result?.rememberLabel).toBeUndefined()
   })
 
-  it('plugin principal は vault_not_exposed_to_plugins で恒久拒否 + バッジ記録', async () => {
-    setConnections([makeConnection({ exposedTo: ['ai', 'external'] })])
-    await expect(
-      requiresConfirmation({ connectionRef: 'Habitica' }, PLUGIN_CTX),
-    ).rejects.toThrow(/vault_not_exposed_to_plugins/)
-    expect(getPluginDenial('evil-widget')?.lastTarget).toBe('vault.fetch')
+  it('Plugin クラスで信頼済みの接続は plugin principal から確認スキップ (#759)', async () => {
+    setConnections([
+      makeConnection({ exposedTo: ['plugin'], trustedFor: ['plugin'] }),
+    ])
+    const result = await requiresConfirmation(
+      { connectionRef: 'Habitica' },
+      PLUGIN_CTX,
+    )
+    expect(result).toBeNull()
+  })
+
+  it('Ai クラスの trust は plugin には効かない (同意のクラス分離)', async () => {
+    setConnections([
+      makeConnection({ exposedTo: ['ai', 'plugin'], trustedFor: ['ai'] }),
+    ])
+    const result = await requiresConfirmation(
+      { connectionRef: 'Habitica' },
+      PLUGIN_CTX,
+    )
+    expect(result).not.toBeNull()
   })
 })
 
@@ -161,6 +170,17 @@ describe('vaultFetchCapability.onConfirmRemember', () => {
     expect(setTrusted).toHaveBeenCalledWith('conn-habitica', 'external', true)
   })
 
+  it('plugin の同意は Plugin クラスにだけ効く (#759)', async () => {
+    setConnections([
+      makeConnection({ id: 'conn-habitica', exposedTo: ['plugin'] }),
+    ])
+    await vaultFetchCapability.onConfirmRemember?.(
+      { connectionRef: 'Habitica' },
+      PLUGIN_CTX,
+    )
+    expect(setTrusted).toHaveBeenCalledWith('conn-habitica', 'plugin', true)
+  })
+
   it('does nothing when connectionRef does not resolve', async () => {
     setConnections([makeConnection()])
     await vaultFetchCapability.onConfirmRemember?.(
@@ -182,14 +202,24 @@ describe('vaultFetchCapability.execute — 開示クラスのフィルタ (#712 
     ).rejects.toThrow(/利用できません/)
   })
 
-  it('plugin principal は execute でも恒久拒否', async () => {
+  it('plugin principal は Plugin 開示の無い接続に到達できない (default 非開示 #759)', async () => {
     setConnections([makeConnection({ exposedTo: ['ai', 'external'] })])
     await expect(
       vaultFetchCapability.execute(
         { connectionRef: 'Habitica', path: '/status' },
         PLUGIN_CTX,
       ),
-    ).rejects.toThrow(/vault_not_exposed_to_plugins/)
+    ).rejects.toThrow(/利用できません/)
+  })
+
+  it('Plugin 開示 opt-in された接続は plugin principal から解決できる (#759)', async () => {
+    setConnections([makeConnection({ exposedTo: ['plugin'] })])
+    await expect(
+      vaultFetchCapability.execute(
+        { connectionRef: 'Habitica', path: '/status' },
+        PLUGIN_CTX,
+      ),
+    ).resolves.toBeDefined()
   })
 
   it('user principal は開示に関わらず全接続を扱える (本人操作)', async () => {

--- a/src/capabilities/builtins/vault.ts
+++ b/src/capabilities/builtins/vault.ts
@@ -100,9 +100,16 @@ export const vaultFetchCapability: Command = {
       okLabel: '許可',
       cancelLabel: 'やめる',
       type: 'danger',
-      // 接続が解決できた + remember の同意先クラスが確定しているときだけ出す
+      // 接続が解決できた + remember の同意先クラスが確定しているときだけ出す。
+      // trust はクラス単位 — plugin はダイアログに個体名が出るぶん「この個体
+      // だけ」への誤認が起きやすいので、同意の及ぶ範囲を文言で明示する (#759)
       ...(conn && cls !== 'user'
-        ? { rememberLabel: '今後この接続を確認なしで使う' }
+        ? {
+            rememberLabel:
+              cls === 'plugin'
+                ? '今後すべてのプラグイン・ウィジェットからこの接続を確認なしで使う'
+                : '今後この接続を確認なしで使う',
+          }
         : {}),
     }
   },

--- a/src/capabilities/builtins/vault.ts
+++ b/src/capabilities/builtins/vault.ts
@@ -1,28 +1,27 @@
 import type { Connection, PrincipalClass } from '@/bindings'
 import type { CapabilityContext } from '@/capabilities/types'
 import type { Command } from '@/commands/registry'
-import { recordPluginDenial } from '@/permissions/pluginDenials'
 import type { Principal } from '@/permissions/principal'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /**
- * principal → 開示先クラスのマッピング (#712 §6.1)。
+ * principal → 開示先クラスのマッピング (#712 §6.1 / #759)。
  * - ai.chat / ai.heartbeat → 'ai'
+ * - plugin → 'plugin' (接続ごとの opt-in 開示 — default 非開示)
  * - external → 'external'
- * - user → null を返すが全開示 (本人は常に全接続を扱える)
- * - plugin → 恒久拒否 (プラグインに secret は渡さない — 復旧トグルも無い)
+ * - user → 'user' を返すが全開示 (本人は常に全接続を扱える)
  */
-function classOf(principal: Principal): PrincipalClass | 'user' | null {
+function classOf(principal: Principal): PrincipalClass | 'user' {
   switch (principal.kind) {
     case 'user':
       return 'user'
     case 'ai.chat':
     case 'ai.heartbeat':
       return 'ai'
+    case 'plugin':
+      return 'plugin'
     case 'external':
       return 'external'
-    case 'plugin':
-      return null
   }
 }
 
@@ -37,22 +36,6 @@ function requirePrincipal(ctx: CapabilityContext | undefined): Principal {
 }
 
 /**
- * plugin principal なら専用エラーで拒否する (#712 §6.1)。
- * エラーコード `vault_not_exposed_to_plugins` はプラグイン作者向け —
- * 破壊的変更 (旧 aiVisible 接続はプラグインからも見えていた) なので、
- * 復旧方法 (プラグイン設定値としての入力) まで文言で案内する。
- */
-function rejectPlugin(principal: Principal): void {
-  if (principal.kind !== 'plugin') return
-  recordPluginDenial(principal.pluginId, 'vault.fetch', ['vault.use'])
-  throw new Error(
-    'vault_not_exposed_to_plugins: Secret Vault はプラグインには開示されません' +
-      ' (NoteDeck のセキュリティ設計)。外部 API キーが必要な場合はユーザーに' +
-      'プラグイン設定値としての入力を求めてください',
-  )
-}
-
-/**
  * `connectionRef` (接続名 — 大文字小文字無視 — または id) を、principal の
  * クラスに開示された接続に解決する。見つからなければ `null`。`execute` と
  * `requiresConfirmation` / `onConfirmRemember` で同じ解決ロジックを共有する。
@@ -62,7 +45,6 @@ async function resolveVisibleConnection(
   principal: Principal,
 ): Promise<Connection | null> {
   const cls = classOf(principal)
-  if (cls === null) return null
   const all = unwrap(await commands.vaultListConnections())
   const visible =
     cls === 'user' ? all : all.filter((c) => c.exposedTo?.includes(cls))
@@ -80,8 +62,8 @@ async function resolveVisibleConnection(
  * 渡らない。
  *
  * この capability から到達できるのは **呼び出し principal のクラスに開示された
- * 接続のみ** (#712 §6.1)。「AI に見せる」「外部アプリに見せる」は別の同意で、
- * 片方への開示がもう片方に波及しない。plugin principal は恒久拒否。
+ * 接続のみ** (#712 §6.1 / #759)。「AI に見せる」「プラグインに見せる」
+ * 「外部アプリに見せる」は別の同意で、片方への開示が他方に波及しない。
  *
  * confirmation は接続の per-class 信頼状態で決まる (#712 §6.2):
  * - `trustedFor` に呼び出しクラスが含まれる接続 → 確認なし
@@ -99,19 +81,13 @@ export const vaultFetchCapability: Command = {
   permissions: ['vault.use'],
   requiresConfirmation: async (params, ctx) => {
     const principal = requirePrincipal(ctx)
-    rejectPlugin(principal)
     const cls = classOf(principal)
     const ref =
       typeof params?.connectionRef === 'string' ? params.connectionRef : ''
     const conn = ref ? await resolveVisibleConnection(ref, principal) : null
     // 呼び出しクラスで信頼済みの接続は確認なしで通す (user は常に確認あり —
     // 本人操作の confirm は削らない)
-    if (
-      conn &&
-      cls !== 'user' &&
-      cls !== null &&
-      conn.trustedFor?.includes(cls)
-    ) {
+    if (conn && cls !== 'user' && conn.trustedFor?.includes(cls)) {
       return null
     }
     return {
@@ -125,7 +101,7 @@ export const vaultFetchCapability: Command = {
       cancelLabel: 'やめる',
       type: 'danger',
       // 接続が解決できた + remember の同意先クラスが確定しているときだけ出す
-      ...(conn && cls !== 'user' && cls !== null
+      ...(conn && cls !== 'user'
         ? { rememberLabel: '今後この接続を確認なしで使う' }
         : {}),
     }
@@ -134,7 +110,7 @@ export const vaultFetchCapability: Command = {
     const principal = requirePrincipal(ctx)
     const cls = classOf(principal)
     // 昇格は呼び出しクラスだけに効かせる (#712 §6.2)
-    if (cls === 'user' || cls === null) return
+    if (cls === 'user') return
     const ref =
       typeof params?.connectionRef === 'string' ? params.connectionRef : ''
     const conn = ref ? await resolveVisibleConnection(ref, principal) : null
@@ -187,7 +163,6 @@ export const vaultFetchCapability: Command = {
   visible: false,
   execute: async (params, ctx) => {
     const principal = requirePrincipal(ctx)
-    rejectPlugin(principal)
     const ref =
       typeof params?.connectionRef === 'string' ? params.connectionRef : ''
     if (!ref) throw new Error('connectionRef is required')

--- a/src/capabilities/dispatcher.test.ts
+++ b/src/capabilities/dispatcher.test.ts
@@ -1541,7 +1541,7 @@ describe('dispatchCapability — 第三者 deny floor と external read floor (#
     expect(tasks).toEqual({ ok: true, result: 'ran' })
   })
 
-  it('plugin は vault.use が floor で常時拒否される', async () => {
+  it('plugin の vault.use は preset に従う (#759 — 接続側の開示が gate)', async () => {
     registerCapability(
       makeCapability({
         id: 'vault.fetch',
@@ -1549,11 +1549,18 @@ describe('dispatchCapability — 第三者 deny floor と external read floor (#
         execute: () => 'secret-op',
       }),
     )
-    setPrincipalPreset('plugin', 'full')
-    const r = await dispatchCapability('vault.fetch', undefined, {
+    // default (readonly) では拒否
+    const denied = await dispatchCapability('vault.fetch', undefined, {
       principal: { kind: 'plugin', pluginId: 'p1' },
     })
-    expect(r.ok).toBe(false)
+    expect(denied.ok).toBe(false)
+
+    // full にすれば permission 層は通る (接続の開示は vault.fetch 側で判定)
+    setPrincipalPreset('plugin', 'full')
+    const allowed = await dispatchCapability('vault.fetch', undefined, {
+      principal: { kind: 'plugin', pluginId: 'p1' },
+    })
+    expect(allowed).toEqual({ ok: true, result: 'secret-op' })
   })
 
   it('external は custom で Misskey read 4 キーを全 OFF にしても read が通る (下限)', async () => {

--- a/src/components/window/ConnectionEditContent.vue
+++ b/src/components/window/ConnectionEditContent.vue
@@ -45,15 +45,22 @@ const aiVaultUseEnabled = computed(() => {
     resolveForProfiled('ai.heartbeat')['vault.use']
   )
 })
+const pluginVaultUseEnabled = computed(() => {
+  void permissionsFile.value
+  return resolveForProfiled('plugin')['vault.use']
+})
 const externalVaultUseEnabled = computed(() => {
   void permissionsFile.value
   return resolveForProfiled('external')['vault.use']
 })
 
-// 開示先クラス別トグル (#712 §6.1)。「AI に見せる」「外部アプリに見せる」は
-// 別の同意 — 片方への開示がもう片方に波及しない。trusted は開示が前提。
+// 開示先クラス別トグル (#712 §6.1 / #759)。「AI に見せる」「プラグインに見せる」
+// 「外部アプリに見せる」は別の同意 — 片方への開示が他方に波及しない。
+// trusted は開示が前提。
 const exposedAi = ref(false)
 const trustedAi = ref(false)
+const exposedPlugin = ref(false)
+const trustedPlugin = ref(false)
 const exposedExternal = ref(false)
 const trustedExternal = ref(false)
 // テンプレ由来 / AI プロバイダー接続のメタデータ。フォームには出さず、
@@ -116,6 +123,8 @@ onMounted(async () => {
       notes.value = conn.notes ?? ''
       exposedAi.value = conn.exposedTo?.includes('ai') ?? false
       trustedAi.value = conn.trustedFor?.includes('ai') ?? false
+      exposedPlugin.value = conn.exposedTo?.includes('plugin') ?? false
+      trustedPlugin.value = conn.trustedFor?.includes('plugin') ?? false
       exposedExternal.value = conn.exposedTo?.includes('external') ?? false
       trustedExternal.value = conn.trustedFor?.includes('external') ?? false
       hasSecret.value = (conn.slots ?? []).length > 0
@@ -221,6 +230,12 @@ async function save() {
     if (connId) {
       await vault.setExposed(connId, 'ai', exposedAi.value)
       await vault.setTrusted(connId, 'ai', exposedAi.value && trustedAi.value)
+      await vault.setExposed(connId, 'plugin', exposedPlugin.value)
+      await vault.setTrusted(
+        connId,
+        'plugin',
+        exposedPlugin.value && trustedPlugin.value,
+      )
       await vault.setExposed(connId, 'external', exposedExternal.value)
       await vault.setTrusted(
         connId,
@@ -444,6 +459,28 @@ const testResultText = computed(() => {
           </span>
         </label>
         <label :class="$style.toggleRow">
+          <input v-model="exposedPlugin" type="checkbox" />
+          <span>
+            <span :class="$style.toggleLabel">プラグイン・ウィジェットに見せる</span>
+            <span :class="$style.toggleHint">
+              AiScript プラグイン / ウィジェットからこの接続を使えるようにします
+            </span>
+          </span>
+        </label>
+        <div v-if="exposedPlugin && !pluginVaultUseEnabled" :class="$style.gateChip">
+          <i class="ti ti-info-circle" />
+          プラグインの vault.use が無効のため、この接続はまだ見えません — 権限ウィンドウを開いて許可してください
+        </div>
+        <label :class="[$style.toggleRow, $style.toggleSub, !exposedPlugin && $style.toggleDisabled]">
+          <input v-model="trustedPlugin" type="checkbox" :disabled="!exposedPlugin" />
+          <span>
+            <span :class="$style.toggleLabel">確認なしで使う (プラグイン)</span>
+            <span :class="$style.toggleHint">
+              プラグイン / ウィジェットがこの接続を使うとき確認ダイアログを出しません
+            </span>
+          </span>
+        </label>
+        <label :class="$style.toggleRow">
           <input v-model="exposedExternal" type="checkbox" />
           <span>
             <span :class="$style.toggleLabel">外部アプリに見せる</span>
@@ -465,10 +502,6 @@ const testResultText = computed(() => {
             </span>
           </span>
         </label>
-        <div :class="$style.gateChip">
-          <i class="ti ti-shield-x" />
-          プラグインには開示されません (NoteDeck のセキュリティ設計)
-        </div>
       </div>
     </details>
 
@@ -665,7 +698,7 @@ const testResultText = computed(() => {
   opacity: 0.45;
 }
 
-// 二段 gate / plugin 恒久拒否の受動表示 chip (#712 §6.3)
+// 二段 gate の受動表示 chip (#712 §6.3)
 .gateChip {
   display: flex;
   align-items: center;

--- a/src/components/window/ConnectionsContent.vue
+++ b/src/components/window/ConnectionsContent.vue
@@ -41,7 +41,7 @@ function classBadge(
     cls === 'ai'
       ? resolveForProfiled('ai.chat')['vault.use'] ||
         resolveForProfiled('ai.heartbeat')['vault.use']
-      : resolveForProfiled('external')['vault.use']
+      : resolveForProfiled(cls)['vault.use']
   if (!vaultUse || (conn.slots?.length ?? 0) === 0) return 'inactive'
   return 'active'
 }
@@ -104,6 +104,17 @@ function classBadge(
             "
           >
             <i class="ti ti-robot" />
+          </span>
+          <span
+            v-if="classBadge(conn, 'plugin') !== 'hidden'"
+            :class="[$style.connBadge, $style[`cls_${classBadge(conn, 'plugin')}`]]"
+            :title="
+              classBadge(conn, 'plugin') === 'active'
+                ? 'プラグイン・ウィジェットから利用可能'
+                : 'プラグインに開示中 (vault.use が無効か secret 未設定でまだ使えません)'
+            "
+          >
+            <i class="ti ti-puzzle" />
           </span>
           <span
             v-if="classBadge(conn, 'external') !== 'hidden'"

--- a/src/components/window/PermissionsContent.vue
+++ b/src/components/window/PermissionsContent.vue
@@ -162,11 +162,6 @@ const TASKS_RULE = {
   reason: 'タスクは本人と AI のみが実行できます',
   fixedValue: false,
 } as const
-const PLUGIN_VAULT_RULE = {
-  keys: ['vault.use'],
-  reason: 'Secret Vault はプラグインには開示されません',
-  fixedValue: false,
-} as const
 const EXTERNAL_FLOOR_RULE = {
   keys: EXTERNAL_READ_FLOOR,
   reason:
@@ -174,7 +169,7 @@ const EXTERNAL_FLOOR_RULE = {
   fixedValue: true,
 } as const
 
-const PLUGIN_DISABLED = [INSTRUCTION_RULE, TASKS_RULE, PLUGIN_VAULT_RULE]
+const PLUGIN_DISABLED = [INSTRUCTION_RULE, TASKS_RULE]
 const EXTERNAL_DISABLED = [INSTRUCTION_RULE, TASKS_RULE, EXTERNAL_FLOOR_RULE]
 
 // --- 状態依存 chip: vault.use 実効 ON かつ開示接続 0 件 (#712 §6.3) ---
@@ -186,6 +181,11 @@ const aiVaultChip = computed(() => {
     resolveForProfiled('ai.heartbeat')['vault.use']
   if (!vaultUse) return false
   return !vault.connections.value.some((c) => c.exposedTo?.includes('ai'))
+})
+const pluginVaultChip = computed(() => {
+  void permissionsFile.value
+  if (!resolveForProfiled('plugin')['vault.use']) return false
+  return !vault.connections.value.some((c) => c.exposedTo?.includes('plugin'))
 })
 const externalVaultChip = computed(() => {
   void permissionsFile.value
@@ -409,7 +409,7 @@ function handleReset() {
         <p :class="$style.hint">{{ row.hint }}</p>
 
         <div
-          v-if="(row.id === 'ai.chat' && aiVaultChip) || (row.id === 'external' && externalVaultChip)"
+          v-if="(row.id === 'ai.chat' && aiVaultChip) || (row.id === 'plugin' && pluginVaultChip) || (row.id === 'external' && externalVaultChip)"
           :class="$style.stateChip"
         >
           <i class="ti ti-info-circle" />

--- a/src/permissions/store.test.ts
+++ b/src/permissions/store.test.ts
@@ -255,10 +255,10 @@ describe('resolveForProfiled — principal 別 clamp (#712 PR 1c)', () => {
     _resetPermissionsForTest()
   })
 
-  it('plugin は vault.use も clamp、external は Misskey read 4 キーが常時 true', () => {
+  it('plugin の vault.use は clamp されない (#759 — 接続側の開示が gate)、external は Misskey read 4 キーが常時 true', () => {
     const { file } = usePermissionsConfig()
     file.value.principals.plugin = { preset: 'full', custom: {} as never }
-    expect(resolveForProfiled('plugin')['vault.use']).toBe(false)
+    expect(resolveForProfiled('plugin')['vault.use']).toBe(true)
 
     const allOff = Object.fromEntries(
       PERMISSION_KEYS.map((k) => [k, false]),

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -76,8 +76,9 @@ function safeFallbackFile(): PermissionsFileConfig {
  *   vault.use 等) は据え置き opt-in
  * - `plugin`: safe + `network.external` (PLUGIN_DEFAULT_PROFILE #714 followup)
  *   — 外部 API 連携ウィジェットを初期状態で妨げない (http.fetch の都度確認は
- *   残る)。危険権限 (skills.write / tasks.run / vault.use) は preset に
- *   関わらず clampForPrincipal が恒久 deny する
+ *   残る)。危険権限 (skills.write / tasks.run) は preset に関わらず
+ *   clampForPrincipal が恒久 deny する。vault.use は safe で OFF (opt-in) —
+ *   接続側の per-connection 開示と合わせた二段 gate (#759)
  * - `ai.heartbeat`: `readonly` — 無人実行は安全側 (#712 §4.4)
  * - `external`: 縮小 custom (#712 §4.4 — 「トークン発行 = Misskey read の
  *   同意」にローカル私的データを含めない)

--- a/src/permissions/store.ts
+++ b/src/permissions/store.ts
@@ -426,8 +426,10 @@ export function profileFor(principal: Principal): PermissionsConfig | null {
  *
  * - plugin / external: THIRD_PARTY_DENY_KEYS (AI 指示チャネル + tasks.run) を
  *   恒久 OFF。full preset でも拒否 (「同意しても成立させない」構造的禁止)
- * - plugin: vault.use も恒久 OFF (Secret Vault はプラグインに開示しない)
  * - external: EXTERNAL_READ_FLOOR (Misskey コンテンツ read 4 キー) を常時 ON
+ *
+ * plugin の vault.use はここで clamp しない (#759) — Secret Vault 側の
+ * per-connection 開示 (`exposedTo: ['plugin']`, default 非開示) が gate になる。
  */
 function clampForPrincipal(
   map: Record<PermissionKey, boolean>,
@@ -435,9 +437,6 @@ function clampForPrincipal(
 ): Record<PermissionKey, boolean> {
   if (id === 'plugin' || id === 'external') {
     for (const key of THIRD_PARTY_DENY_KEYS) map[key] = false
-  }
-  if (id === 'plugin') {
-    map['vault.use'] = false
   }
   if (id === 'external') {
     for (const key of EXTERNAL_READ_FLOOR) map[key] = true


### PR DESCRIPTION
## v1.9.1 — vault regression 修正リリース

#712 PR 3 の plugin principal 恒久拒否で、misstore 配信中の Vault 依存ウィジェット 7 本 (todoist / wakatime / steam / clickup / habitica-status / hackerone / mewk) が全壊した regression の修正。

### 変更一覧

- fix(vault): プラグイン/ウィジェットに per-connection opt-in 開示を実装 (#759)
- fix(vault): plugin の「今後確認なし」同意が全プラグインに及ぶことを文言で明示 (#759)

### 内容 (issue #759 案 B)

- `PrincipalClass` に `plugin` を追加し、`vault.fetch` は `exposedTo: ['plugin']` な接続のみ plugin principal に解決 (default 非開示 = 従来と同じ安全側)
- secret は引き続き Rust 側注入で AiScript に露出しない
- 接続編集 UI に「プラグイン・ウィジェットに見せる」「確認なしで使う」トグル、接続一覧に plugin バッジ、権限ウィンドウに開示 0 件 chip
- plugin プロファイルの vault.use 恒久 clamp を撤廃 (default readonly = OFF は維持、二段 gate の一段目)

利用には ①権限ウィンドウで plugin の vault.use 有効化 ②各接続で「プラグイン・ウィジェットに見せる」ON の 2 段 opt-in が必要。

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)