### PR TITLE
Release v1.10.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -736,7 +736,7 @@ AiScript / AI / プラグインが**任意の外部サービス** (GitHub / Line
 
 - `vault.fetch` は capability registry に登録 (`aiTool: true`, permission `vault.use`, `requiresConfirmation: true`)。AI / AiScript / コマンドパレットから呼べる
 - 開示は principal クラス別 (#712 §6.1 / #759): `exposedTo: ('ai' | 'plugin' | 'external')[]` (接続単位、default 空 = 非開示)。「AI に見せる」「プラグイン・ウィジェットに見せる」「外部アプリに見せる」は別の同意で、`vault.fetch` capability は呼び出し principal のクラスに開示された接続のみ `connectionRef` (name / id) で解決。plugin クラスは接続ごとの明示 opt-in (#759 — secret 自体は Rust 側注入のまま AiScript に露出しない)
-- 「今後確認なし」(`trustedFor`) もクラス別 — 外部アプリでの確認同意が AI の trust に化けない
+- 「今後確認なし」(`trustedFor`) もクラス別 — 外部アプリでの確認同意が AI の trust に化けない。plugin クラスのみクラス一括ではなく**個体単位** (`trustedPlugins: {id, name}[]`) — 1 ウィジェットへの同意が全プラグイン / Play / Page に波及しない。取り消しは接続編集の信頼済み一覧から
 - AI の system prompt に `<available-connections>` ブロックを注入 (Ai クラスに開示された接続の name / baseUrl / auth のみ、secret / id は出さない)
 - permission `vault.use` は preset readonly/safe = false、full = true。HIGH_RISK 指定
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.9.1",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.9.1"
+version = "1.10.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.9.1"
+    "version": "1.10.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/vault.rs
+++ b/src-tauri/src/commands/vault.rs
@@ -181,6 +181,7 @@ fn upsert_metadata(
                 protocol: input.protocol,
                 exposed_to: vec![],
                 trusted_for: vec![],
+                trusted_plugins: vec![],
                 legacy_ai_visible: None,
                 legacy_ai_trusted: None,
                 slots: Vec::new(),
@@ -425,6 +426,9 @@ pub async fn vault_set_exposed(
         connection.exposed_to.retain(|c| *c != principal_class);
         // 開示を外したクラスの trust も意味を失うので同時に外す
         connection.trusted_for.retain(|c| *c != principal_class);
+        if principal_class == crate::vault::model::PrincipalClass::Plugin {
+            connection.trusted_plugins.clear();
+        }
     }
     connection.updated_at = now_millis();
     connections_store::save(&app, &file)?;
@@ -458,6 +462,44 @@ pub async fn vault_set_trusted(
         }
     } else {
         connection.trusted_for.retain(|c| *c != principal_class);
+    }
+    connection.updated_at = now_millis();
+    connections_store::save(&app, &file)?;
+    Ok(())
+}
+
+/// 接続を「信頼済み」にするプラグイン個体を切り替える。
+///
+/// plugin クラスの trust はクラス一括 (`trusted_for`) にせず個体単位で持つ —
+/// 1 つのウィジェットの確認同意が全プラグイン / Play / Page に波及しない。
+/// `name` は帰属表示用スナップショット (再信頼で最新の名前に更新される)。
+#[tauri::command]
+#[specta::specta]
+pub async fn vault_set_trusted_plugin(
+    app: tauri::AppHandle,
+    window: tauri::Window,
+    id: String,
+    plugin_id: String,
+    name: Option<String>,
+    trusted: bool,
+) -> VaultResult<()> {
+    assert_main_window(&window)?;
+    validate_connection_id(&id)?;
+
+    let mut file = connections_store::load(&app)?;
+    let connection = file
+        .connections
+        .iter_mut()
+        .find(|c| c.id == id)
+        .ok_or(VaultError::ConnectionNotFound)?;
+    connection.trusted_plugins.retain(|p| p.id != plugin_id);
+    if trusted {
+        connection
+            .trusted_plugins
+            .push(crate::vault::model::TrustedPlugin {
+                id: plugin_id,
+                name,
+            });
     }
     connection.updated_at = now_millis();
     connections_store::save(&app, &file)?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -754,6 +754,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::vault_delete_connection,
             commands::vault_set_exposed,
             commands::vault_set_trusted,
+            commands::vault_set_trusted_plugin,
             commands::vault_fetch,
             commands::vault_test_connection,
             commands::ai_migrate_provider_to_vault,

--- a/src-tauri/src/vault/connections_store.rs
+++ b/src-tauri/src/vault/connections_store.rs
@@ -1,7 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
 
-
 use super::error::{VaultError, VaultResult};
 use super::model::{ConnectionsFile, PrincipalClass, SCHEMA_VERSION};
 
@@ -52,21 +51,24 @@ pub fn load(app: &tauri::AppHandle) -> VaultResult<ConnectionsFile> {
 fn migrate_legacy_exposure(file: &mut ConnectionsFile) -> bool {
     let mut migrated = false;
     for conn in &mut file.connections {
-        if conn.legacy_ai_visible == Some(true)
-            && !conn.exposed_to.contains(&PrincipalClass::Ai)
-        {
+        if conn.legacy_ai_visible == Some(true) && !conn.exposed_to.contains(&PrincipalClass::Ai) {
             conn.exposed_to.push(PrincipalClass::Ai);
             migrated = true;
         }
-        if conn.legacy_ai_trusted == Some(true)
-            && !conn.trusted_for.contains(&PrincipalClass::Ai)
-        {
+        if conn.legacy_ai_trusted == Some(true) && !conn.trusted_for.contains(&PrincipalClass::Ai) {
             conn.trusted_for.push(PrincipalClass::Ai);
             migrated = true;
         }
         if conn.legacy_ai_visible.is_some() || conn.legacy_ai_trusted.is_some() {
             conn.legacy_ai_visible = None;
             conn.legacy_ai_trusted = None;
+            migrated = true;
+        }
+        // v1.9.1 の plugin クラス一括 trust は個体単位 (trusted_plugins) に移行
+        // したため除去する。個体の対応関係は復元できないので単に落とす
+        // (= 次回利用時に確認が出る安全側)。
+        if conn.trusted_for.contains(&PrincipalClass::Plugin) {
+            conn.trusted_for.retain(|c| *c != PrincipalClass::Plugin);
             migrated = true;
         }
     }
@@ -111,7 +113,6 @@ pub fn check_schema_version(file: &ConnectionsFile) -> VaultResult<()> {
     }
     Ok(())
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -166,7 +167,10 @@ mod tests {
         }"#,
         );
         assert!(!migrate_legacy_exposure(&mut file));
-        assert_eq!(file.connections[0].exposed_to, vec![PrincipalClass::External]);
+        assert_eq!(
+            file.connections[0].exposed_to,
+            vec![PrincipalClass::External]
+        );
     }
 
     #[test]

--- a/src-tauri/src/vault/model.rs
+++ b/src-tauri/src/vault/model.rs
@@ -74,6 +74,22 @@ pub enum PrincipalClass {
     External,
 }
 
+/// 「確認なしで使う」のプラグイン個体単位の記憶。
+///
+/// 開示 (`exposed_to`) はクラス単位だが、plugin クラスは多数の第三者コード個体が
+/// 同居するため、trust だけはクラス一括 (`trusted_for`) にせず個体単位で持つ —
+/// 1 つのウィジェットへの同意が全プラグイン / Play / Page に波及しない。
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TrustedPlugin {
+    /// principal の pluginId (`widget:<installId>` / `play:<id>` / `page:<id>` /
+    /// プラグインは installId 素)。
+    pub id: String,
+    /// 帰属表示用の配布名スナップショット (記憶時点の名前)。
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
 /// 接続メタデータ。secret 本体は含まない (OS キーチェーンに別管理)。
 ///
 /// `Debug` を derive してよい — secret を持たないため。
@@ -110,10 +126,15 @@ pub struct Connection {
     /// External は誰も自動付与しない — 外部アプリへの開示は必ず明示 opt-in。
     #[serde(default)]
     pub exposed_to: Vec<PrincipalClass>,
-    /// 確認ダイアログなしで vault.fetch を許可するクラス。
+    /// 確認ダイアログなしで vault.fetch を許可するクラス (Ai / External のみ —
+    /// Plugin の trust は個体単位の `trusted_plugins` で持つ)。
     /// `exposed_to` に含まれるクラスにのみ意味を持つ。
     #[serde(default)]
     pub trusted_for: Vec<PrincipalClass>,
+    /// 確認ダイアログなしで vault.fetch を許可するプラグイン個体。
+    /// `exposed_to` に Plugin が含まれるときのみ意味を持つ。
+    #[serde(default)]
+    pub trusted_plugins: Vec<TrustedPlugin>,
     /// 旧 `aiVisible` (移行読込専用 #712)。load 時に `exposed_to: [Ai]` へ
     /// 変換され、次回保存で消える (serialize しない)。
     #[serde(default, rename = "aiVisible", skip_serializing)]
@@ -247,6 +268,10 @@ mod tests {
             protocol: None,
             exposed_to: vec![PrincipalClass::Ai],
             trusted_for: vec![PrincipalClass::Ai],
+            trusted_plugins: vec![TrustedPlugin {
+                id: "widget:01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+                name: Some("Todoist".to_string()),
+            }],
             legacy_ai_visible: Some(true),
             legacy_ai_trusted: Some(true),
             slots: vec![],
@@ -261,11 +286,14 @@ mod tests {
         let json = serde_json::to_string(&conn).unwrap();
         assert!(json.contains("\"exposedTo\":[\"ai\"]"));
         assert!(json.contains("\"trustedFor\":[\"ai\"]"));
+        assert!(json.contains("\"trustedPlugins\""));
+        assert!(json.contains("\"name\":\"Todoist\""));
         // 旧フィールドは serialize されない (= 次回保存で消える)
         assert!(!json.contains("aiVisible"));
         assert!(!json.contains("aiTrusted"));
         let back: Connection = serde_json::from_str(&json).unwrap();
         assert_eq!(back.exposed_to, vec![PrincipalClass::Ai]);
+        assert_eq!(back.trusted_plugins, conn.trusted_plugins);
         assert_eq!(back.legacy_ai_visible, None);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2036,6 +2036,21 @@ async vaultSetTrusted(id: string, principalClass: PrincipalClass, trusted: boole
 }
 },
 /**
+ * 接続を「信頼済み」にするプラグイン個体を切り替える。
+ * 
+ * plugin クラスの trust はクラス一括 (`trusted_for`) にせず個体単位で持つ —
+ * 1 つのウィジェットの確認同意が全プラグイン / Play / Page に波及しない。
+ * `name` は帰属表示用スナップショット (再信頼で最新の名前に更新される)。
+ */
+async vaultSetTrustedPlugin(id: string, pluginId: string, name: string | null, trusted: boolean) : Promise<Result<null, VaultError>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("vault_set_trusted_plugin", { id, pluginId, name, trusted }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * 登録済み接続を使って HTTP リクエストを実行する。
  * 
  * secret は Rust 側で注入され、フロントエンドには渡らない。SSRF 防御
@@ -2429,10 +2444,16 @@ protocol?: ConnectionProtocol | null;
  */
 exposedTo?: PrincipalClass[]; 
 /**
- * 確認ダイアログなしで vault.fetch を許可するクラス。
+ * 確認ダイアログなしで vault.fetch を許可するクラス (Ai / External のみ —
+ * Plugin の trust は個体単位の `trusted_plugins` で持つ)。
  * `exposed_to` に含まれるクラスにのみ意味を持つ。
  */
 trustedFor?: PrincipalClass[]; 
+/**
+ * 確認ダイアログなしで vault.fetch を許可するプラグイン個体。
+ * `exposed_to` に Plugin が含まれるときのみ意味を持つ。
+ */
+trustedPlugins?: TrustedPlugin[]; 
 /**
  * secret が設定済みの slot 名一覧。keychain 列挙 API がないため metadata 側が source of truth。
  */
@@ -2742,6 +2763,23 @@ export type SummaryData = { title: string | null; description: string | null; ic
 export type TimelineFilter = { withRenotes: boolean | null; withReplies: boolean | null; withFiles: boolean | null; withBots: boolean | null; withSensitive: boolean | null }
 export type TimelineOptions = { limit?: number; sinceId: string | null; untilId: string | null; filters?: TimelineFilter | null; listId: string | null }
 export type TimelineType = string
+/**
+ * 「確認なしで使う」のプラグイン個体単位の記憶。
+ * 
+ * 開示 (`exposed_to`) はクラス単位だが、plugin クラスは多数の第三者コード個体が
+ * 同居するため、trust だけはクラス一括 (`trusted_for`) にせず個体単位で持つ —
+ * 1 つのウィジェットへの同意が全プラグイン / Play / Page に波及しない。
+ */
+export type TrustedPlugin = { 
+/**
+ * principal の pluginId (`widget:<installId>` / `play:<id>` / `page:<id>` /
+ * プラグインは installId 素)。
+ */
+id: string; 
+/**
+ * 帰属表示用の配布名スナップショット (記憶時点の名前)。
+ */
+name?: string | null }
 export type UserField = { name: string; value: string }
 /**
  * `charts/user/following`

--- a/src/capabilities/builtins/vault.test.ts
+++ b/src/capabilities/builtins/vault.test.ts
@@ -11,6 +11,14 @@ const setTrusted = vi.fn(
     data: null,
   }),
 )
+const setTrustedPlugin = vi.fn(
+  async (
+    _id: string,
+    _pluginId: string,
+    _name: string | null,
+    _trusted: boolean,
+  ) => ({ status: 'ok', data: null }),
+)
 
 vi.mock('@/utils/tauriInvoke', async () => {
   const actual = await vi.importActual<typeof import('@/utils/tauriInvoke')>(
@@ -22,6 +30,12 @@ vi.mock('@/utils/tauriInvoke', async () => {
       vaultListConnections: () => listConnections(),
       vaultSetTrusted: (id: string, cls: string, trusted: boolean) =>
         setTrusted(id, cls, trusted),
+      vaultSetTrustedPlugin: (
+        id: string,
+        pluginId: string,
+        name: string | null,
+        trusted: boolean,
+      ) => setTrustedPlugin(id, pluginId, name, trusted),
       vaultFetch: vi.fn(async () => ({ status: 'ok', data: {} })),
     },
   }
@@ -63,6 +77,7 @@ const requiresConfirmation = vaultFetchCapability.requiresConfirmation as (
 beforeEach(() => {
   listConnections.mockReset()
   setTrusted.mockClear()
+  setTrustedPlugin.mockClear()
 })
 
 describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () => {
@@ -126,9 +141,12 @@ describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () 
     expect(result?.rememberLabel).toBeUndefined()
   })
 
-  it('Plugin クラスで信頼済みの接続は plugin principal から確認スキップ (#759)', async () => {
+  it('trustedPlugins に載っている個体は確認スキップ (per-plugin trust)', async () => {
     setConnections([
-      makeConnection({ exposedTo: ['plugin'], trustedFor: ['plugin'] }),
+      makeConnection({
+        exposedTo: ['plugin'],
+        trustedPlugins: [{ id: 'widget:habitica-status', name: 'Habitica' }],
+      }),
     ])
     const result = await requiresConfirmation(
       { connectionRef: 'Habitica' },
@@ -137,13 +155,27 @@ describe('vaultFetchCapability.requiresConfirmation (per-class #712 §6.2)', () 
     expect(result).toBeNull()
   })
 
-  it('plugin の rememberLabel は同意の及ぶ範囲 (全プラグイン) を明示する (#759)', async () => {
+  it('別個体の trust は効かない (個体単位の同意分離)', async () => {
+    setConnections([
+      makeConnection({
+        exposedTo: ['plugin'],
+        trustedPlugins: [{ id: 'widget:other-widget', name: null }],
+      }),
+    ])
+    const result = await requiresConfirmation(
+      { connectionRef: 'Habitica' },
+      PLUGIN_CTX,
+    )
+    expect(result).not.toBeNull()
+  })
+
+  it('plugin の rememberLabel は同意の主体 (個体名) を明示する', async () => {
     setConnections([makeConnection({ exposedTo: ['plugin'] })])
     const result = await requiresConfirmation(
       { connectionRef: 'Habitica' },
       PLUGIN_CTX,
     )
-    expect(result?.rememberLabel).toContain('すべてのプラグイン')
+    expect(result?.rememberLabel).toContain('habitica-status')
   })
 
   it('Ai クラスの trust は plugin には効かない (同意のクラス分離)', async () => {
@@ -179,7 +211,7 @@ describe('vaultFetchCapability.onConfirmRemember', () => {
     expect(setTrusted).toHaveBeenCalledWith('conn-habitica', 'external', true)
   })
 
-  it('plugin の同意は Plugin クラスにだけ効く (#759)', async () => {
+  it('plugin の同意は呼び出し個体にだけ積まれる (per-plugin trust)', async () => {
     setConnections([
       makeConnection({ id: 'conn-habitica', exposedTo: ['plugin'] }),
     ])
@@ -187,7 +219,13 @@ describe('vaultFetchCapability.onConfirmRemember', () => {
       { connectionRef: 'Habitica' },
       PLUGIN_CTX,
     )
-    expect(setTrusted).toHaveBeenCalledWith('conn-habitica', 'plugin', true)
+    expect(setTrustedPlugin).toHaveBeenCalledWith(
+      'conn-habitica',
+      'widget:habitica-status',
+      null,
+      true,
+    )
+    expect(setTrusted).not.toHaveBeenCalled()
   })
 
   it('does nothing when connectionRef does not resolve', async () => {

--- a/src/capabilities/builtins/vault.ts
+++ b/src/capabilities/builtins/vault.ts
@@ -1,7 +1,7 @@
 import type { Connection, PrincipalClass } from '@/bindings'
 import type { CapabilityContext } from '@/capabilities/types'
 import type { Command } from '@/commands/registry'
-import type { Principal } from '@/permissions/principal'
+import { type Principal, principalActorLabel } from '@/permissions/principal'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 /**
@@ -56,6 +56,18 @@ async function resolveVisibleConnection(
   )
 }
 
+/** principal がこの接続を確認なしで使えるか (#712 §6.2 / per-plugin trust)。 */
+function isTrusted(conn: Connection, principal: Principal): boolean {
+  if (principal.kind === 'plugin') {
+    return (
+      conn.trustedPlugins?.some((p) => p.id === principal.pluginId) ?? false
+    )
+  }
+  const cls = classOf(principal)
+  if (cls === 'user') return false
+  return conn.trustedFor?.includes(cls) ?? false
+}
+
 /**
  * `vault.fetch` — 登録済みの外部サービス接続 (Secret Vault, #564) を使って
  * HTTP リクエストを送る。secret は Rust 側で注入され、AI / AiScript には
@@ -65,11 +77,14 @@ async function resolveVisibleConnection(
  * 接続のみ** (#712 §6.1 / #759)。「AI に見せる」「プラグインに見せる」
  * 「外部アプリに見せる」は別の同意で、片方への開示が他方に波及しない。
  *
- * confirmation は接続の per-class 信頼状態で決まる (#712 §6.2):
- * - `trustedFor` に呼び出しクラスが含まれる接続 → 確認なし
+ * confirmation は接続の信頼状態で決まる (#712 §6.2):
+ * - ai / external: `trustedFor` に呼び出しクラスが含まれる接続 → 確認なし
+ * - plugin: クラス一括ではなく **個体単位** (`trustedPlugins` に pluginId が
+ *   含まれる接続 → 確認なし)。1 つのウィジェットへの同意が全プラグイン /
+ *   Play / Page に波及しない
  * - それ以外 → 都度確認。「今後この接続を確認なしで使う」ON で許可されたら
- *   `onConfirmRemember` が **呼び出しクラスだけ** を `trustedFor` に追加する
- *   — 外部アプリでの同意が AI の trust に化けない。
+ *   `onConfirmRemember` が **呼び出しクラス (plugin は呼び出し個体) だけ** に
+ *   記憶する — 外部アプリでの同意が AI の trust に化けない。
  */
 export const vaultFetchCapability: Command = {
   id: 'vault.fetch',
@@ -85,9 +100,9 @@ export const vaultFetchCapability: Command = {
     const ref =
       typeof params?.connectionRef === 'string' ? params.connectionRef : ''
     const conn = ref ? await resolveVisibleConnection(ref, principal) : null
-    // 呼び出しクラスで信頼済みの接続は確認なしで通す (user は常に確認あり —
-    // 本人操作の confirm は削らない)
-    if (conn && cls !== 'user' && conn.trustedFor?.includes(cls)) {
+    // 信頼済みの接続は確認なしで通す (user は常に確認あり — 本人操作の
+    // confirm は削らない)
+    if (conn && isTrusted(conn, principal)) {
       return null
     }
     return {
@@ -100,14 +115,13 @@ export const vaultFetchCapability: Command = {
       okLabel: '許可',
       cancelLabel: 'やめる',
       type: 'danger',
-      // 接続が解決できた + remember の同意先クラスが確定しているときだけ出す。
-      // trust はクラス単位 — plugin はダイアログに個体名が出るぶん「この個体
-      // だけ」への誤認が起きやすいので、同意の及ぶ範囲を文言で明示する (#759)
+      // 接続が解決できた + remember の同意先が確定しているときだけ出す。
+      // plugin は個体単位の記憶なので、同意の主体を文言でも明示する
       ...(conn && cls !== 'user'
         ? {
             rememberLabel:
-              cls === 'plugin'
-                ? '今後すべてのプラグイン・ウィジェットからこの接続を確認なしで使う'
+              principal.kind === 'plugin'
+                ? `今後${principalActorLabel(principal)}からこの接続を確認なしで使う`
                 : '今後この接続を確認なしで使う',
           }
         : {}),
@@ -116,12 +130,24 @@ export const vaultFetchCapability: Command = {
   onConfirmRemember: async (params, ctx) => {
     const principal = requirePrincipal(ctx)
     const cls = classOf(principal)
-    // 昇格は呼び出しクラスだけに効かせる (#712 §6.2)
+    // 昇格は呼び出しクラス (plugin は呼び出し個体) だけに効かせる (#712 §6.2)
     if (cls === 'user') return
     const ref =
       typeof params?.connectionRef === 'string' ? params.connectionRef : ''
     const conn = ref ? await resolveVisibleConnection(ref, principal) : null
-    if (conn) unwrap(await commands.vaultSetTrusted(conn.id, cls, true))
+    if (!conn) return
+    if (principal.kind === 'plugin') {
+      unwrap(
+        await commands.vaultSetTrustedPlugin(
+          conn.id,
+          principal.pluginId,
+          principal.name ?? null,
+          true,
+        ),
+      )
+    } else {
+      unwrap(await commands.vaultSetTrusted(conn.id, cls, true))
+    }
   },
   signature: {
     description:

--- a/src/components/window/ConnectionEditContent.vue
+++ b/src/components/window/ConnectionEditContent.vue
@@ -4,6 +4,7 @@ import type {
   AuthType,
   ConnectionProtocol,
   ConnectionUpsert,
+  TrustedPlugin,
   VaultTestResult,
 } from '@/bindings'
 import { useVault } from '@/composables/useVault'
@@ -56,11 +57,13 @@ const externalVaultUseEnabled = computed(() => {
 
 // 開示先クラス別トグル (#712 §6.1 / #759)。「AI に見せる」「プラグインに見せる」
 // 「外部アプリに見せる」は別の同意 — 片方への開示が他方に波及しない。
-// trusted は開示が前提。
+// trusted は開示が前提。plugin の trust はクラス一括ではなく個体単位
+// (trustedPlugins) — 確認ダイアログの「今後確認なし」で積まれ、ここでは
+// 一覧表示と個別取り消しのみ行う。
 const exposedAi = ref(false)
 const trustedAi = ref(false)
 const exposedPlugin = ref(false)
-const trustedPlugin = ref(false)
+const trustedPlugins = ref<TrustedPlugin[]>([])
 const exposedExternal = ref(false)
 const trustedExternal = ref(false)
 // テンプレ由来 / AI プロバイダー接続のメタデータ。フォームには出さず、
@@ -124,7 +127,7 @@ onMounted(async () => {
       exposedAi.value = conn.exposedTo?.includes('ai') ?? false
       trustedAi.value = conn.trustedFor?.includes('ai') ?? false
       exposedPlugin.value = conn.exposedTo?.includes('plugin') ?? false
-      trustedPlugin.value = conn.trustedFor?.includes('plugin') ?? false
+      trustedPlugins.value = [...(conn.trustedPlugins ?? [])]
       exposedExternal.value = conn.exposedTo?.includes('external') ?? false
       trustedExternal.value = conn.trustedFor?.includes('external') ?? false
       hasSecret.value = (conn.slots ?? []).length > 0
@@ -230,12 +233,9 @@ async function save() {
     if (connId) {
       await vault.setExposed(connId, 'ai', exposedAi.value)
       await vault.setTrusted(connId, 'ai', exposedAi.value && trustedAi.value)
+      // plugin の trust (個体単位) は確認ダイアログ側で積まれる。開示 OFF に
+      // すると Rust 側 (vault_set_exposed) が trustedPlugins をまとめて外す。
       await vault.setExposed(connId, 'plugin', exposedPlugin.value)
-      await vault.setTrusted(
-        connId,
-        'plugin',
-        exposedPlugin.value && trustedPlugin.value,
-      )
       await vault.setExposed(connId, 'external', exposedExternal.value)
       await vault.setTrusted(
         connId,
@@ -249,6 +249,17 @@ async function save() {
     errorMessage.value = formatError(e)
   } finally {
     saving.value = false
+  }
+}
+
+/** 信頼済みプラグイン個体の取り消し (即時反映 — save を待たない)。 */
+async function revokeTrustedPlugin(pluginId: string) {
+  if (!props.connectionId) return
+  try {
+    await vault.setTrustedPlugin(props.connectionId, pluginId, null, false)
+    trustedPlugins.value = trustedPlugins.value.filter((p) => p.id !== pluginId)
+  } catch (e) {
+    errorMessage.value = formatError(e)
   }
 }
 
@@ -471,15 +482,30 @@ const testResultText = computed(() => {
           <i class="ti ti-info-circle" />
           プラグインの vault.use が無効のため、この接続はまだ見えません — 権限ウィンドウを開いて許可してください
         </div>
-        <label :class="[$style.toggleRow, $style.toggleSub, !exposedPlugin && $style.toggleDisabled]">
-          <input v-model="trustedPlugin" type="checkbox" :disabled="!exposedPlugin" />
-          <span>
-            <span :class="$style.toggleLabel">確認なしで使う (プラグイン)</span>
-            <span :class="$style.toggleHint">
-              プラグイン / ウィジェットがこの接続を使うとき確認ダイアログを出しません
-            </span>
+        <div
+          v-if="exposedPlugin && trustedPlugins.length > 0"
+          :class="$style.trustedPluginList"
+        >
+          <span :class="$style.toggleHint">
+            確認なしで使えるプラグイン・ウィジェット (確認ダイアログの「今後確認なし」で追加されます)
           </span>
-        </label>
+          <div
+            v-for="tp in trustedPlugins"
+            :key="tp.id"
+            :class="$style.trustedPluginRow"
+          >
+            <i class="ti ti-puzzle" />
+            <span :class="$style.trustedPluginName">{{ tp.name || tp.id }}</span>
+            <button
+              class="_button"
+              :class="$style.revokeBtn"
+              title="信頼を取り消す (次回から確認ダイアログが出ます)"
+              @click="revokeTrustedPlugin(tp.id)"
+            >
+              <i class="ti ti-x" />
+            </button>
+          </div>
+        </div>
         <label :class="$style.toggleRow">
           <input v-model="exposedExternal" type="checkbox" />
           <span>
@@ -691,6 +717,47 @@ const testResultText = computed(() => {
 .toggleSub {
   margin-top: 8px;
   padding-left: 22px;
+}
+
+// 信頼済みプラグイン個体の一覧 (開示トグルの下にぶら下がる)
+.trustedPluginList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+  padding-left: 22px;
+}
+
+.trustedPluginRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.83em;
+  color: var(--nd-fg);
+
+  i {
+    color: var(--nd-fgMuted);
+  }
+}
+
+.trustedPluginName {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.revokeBtn {
+  display: flex;
+  align-items: center;
+  padding: 2px 4px;
+  border-radius: var(--nd-radius-sm);
+  color: var(--nd-fgMuted);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--nd-love);
+  }
 }
 
 .toggleDisabled {

--- a/src/composables/useVault.ts
+++ b/src/composables/useVault.ts
@@ -102,6 +102,20 @@ async function setTrusted(
   await refresh()
 }
 
+/**
+ * 接続を「信頼済み」にするプラグイン個体を切り替える。plugin クラスの trust は
+ * クラス一括にせず個体単位 — 1 ウィジェットへの同意が全プラグインに波及しない。
+ */
+async function setTrustedPlugin(
+  id: string,
+  pluginId: string,
+  name: string | null,
+  trusted: boolean,
+): Promise<void> {
+  unwrap(await commands.vaultSetTrustedPlugin(id, pluginId, name, trusted))
+  await refresh()
+}
+
 /** 接続の疎通テストを実行する。 */
 async function testConnection(
   id: string,
@@ -146,6 +160,7 @@ export function useVault() {
     deleteConnection,
     setExposed,
     setTrusted,
+    setTrustedPlugin,
     testConnection,
     fetch,
   }


### PR DESCRIPTION
## v1.10.0 — プラグインの接続信頼を個体単位に分離

v1.9.1 (#759) で導入したプラグイン・ウィジェットへの Secret Vault 接続開示について、「今後この接続を確認なしで使う」の同意を plugin クラス一括から **(接続 × プラグイン個体) 単位**に分離する。1 つのウィジェットへの同意が全プラグイン / Play / Page に波及しなくなり、汎用 capability 確認 (#714 confirmSkips) が既に持っていた per-plugin 粒度に vault の trust が揃う。

### 変更一覧

- feat(vault): プラグインの接続信頼をクラス一括から個体単位に分離

### 内容

- `Connection` に `trustedPlugins: {id, name}[]` を追加 (name は帰属表示用スナップショット)、`vault_set_trusted_plugin` コマンドを新設
- `vault.fetch` の確認スキップ判定は plugin principal なら `trustedPlugins` を参照。remember は呼び出し個体にだけ積まれ、rememberLabel に個体名を明示
- 接続編集 UI: 「確認なしで使う (プラグイン)」クラストグルを廃止し、信頼済み個体の一覧 + 個別取り消しに置換 (追加は確認ダイアログ経由のみ)
- plugin 開示 OFF で `trustedPlugins` も同時クリア (Rust 側)
- v1.9.1 の `trusted_for: ['plugin']` は load 時 migration で除去 (次回利用時に確認が出る安全側)

🤖 Generated with [Claude Code](https://claude.com/claude-code)