### PR TITLE
ci: リリース時に @notedeck@misskey.io へ自動投稿

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,3 +416,25 @@ jobs:
           installers-regex: '-windows-x64-setup\.exe$'
           version: ${{ steps.version.outputs.version }}
           token: ${{ secrets.WINGET_TOKEN }}
+
+  announce:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Post to Misskey
+        env:
+          MISSKEY_TOKEN: ${{ secrets.MISSKEY_TOKEN }}
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          TEXT="🚀 NoteDeck v${VERSION} をリリースしました
+
+          https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+          jq -n --arg i "$MISSKEY_TOKEN" --arg text "$TEXT" \
+            '{i: $i, text: $text, visibility: "public"}' \
+            | curl -sf https://misskey.io/api/notes/create \
+              -H "Content-Type: application/json" \
+              -d @-


### PR DESCRIPTION
## 概要

リリース公開後に @notedeck@misskey.io へリリース告知を自動投稿する `announce` ジョブを release.yml に追加。

## なぜ

サポート/宣伝アカウントの手動運用をやめて Bot 化するため。リリース情報の発生源が release.yml なので、AUR/winget 更新と同列の「リリース後処理」として同居させた。GITHUB_TOKEN による draft 解除は `release: published` イベントで別ワークフローをトリガーしないため、`needs: publish` の後続ジョブ方式が必須。

## 前提

- repo secret `MISSKEY_TOKEN` (write:notes) — 設定済み
- secret 欠落時は announce のみ失敗し、リリース本体・AUR・winget には影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)