### PR TITLE
Release v1.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.10.0",
+  "version": "1.11.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=f1931af84a384c749efa2cd5b9aa478d22d19393#f1931af84a384c749efa2cd5b9aa478d22d19393"
+source = "git+https://github.com/hitalin/notecli?rev=cb0a7f388c621965e1465e72f67f6cba60e76ca2#cb0a7f388c621965e1465e72f67f6cba60e76ca2"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.10.0"
+version = "1.11.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.10.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "f1931af84a384c749efa2cd5b9aa478d22d19393", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "cb0a7f388c621965e1465e72f67f6cba60e76ca2", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
@@ -83,4 +83,3 @@ panic = "abort"
 [lib]
 name = "notedeck_lib"
 crate-type = ["lib", "cdylib", "staticlib"]
-

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.10.0"
+    "version": "1.11.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -263,6 +263,20 @@ pub async fn api_get_follow_requests(
         .await
 }
 
+#[tauri::command]
+#[specta::specta]
+pub async fn api_get_sent_follow_requests(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    limit: Option<i64>,
+) -> Result<serde_json::Value> {
+    let (db, client) = app_state.ready().await;
+    let (host, token) = get_credentials(&db, &account_id)?;
+    client
+        .get_sent_follow_requests(&host, &token, limit.unwrap_or(30).clamp(1, 100))
+        .await
+}
+
 // --- Follow list & relations ---
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -613,6 +613,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_get_drive_files,
             commands::api_delete_drive_file,
             commands::api_get_follow_requests,
+            commands::api_get_sent_follow_requests,
             commands::api_search_users,
             commands::api_get_roles,
             commands::api_get_role_users,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/api.ts
+++ b/src/aiscript/api.ts
@@ -4,38 +4,12 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
 import type { Principal } from '@/permissions/principal'
 import { useConfirm } from '@/stores/confirm'
+import { nyaize } from '@/utils/nyaize'
 import {
   getStorageString,
   removeStorage,
   setStorageJson,
 } from '@/utils/storage'
-
-// Misskey 本家の nyaize 実装 (misskey-js/src/nyaize.ts)
-const enRegex1 = /(?<=n)a/gi
-const enRegex2 = /(?<=morn)ing/gi
-const enRegex3 = /(?<=every)one/gi
-const koRegex1 = /[나-낳]/g
-const koRegex2 = /(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm
-const koRegex3 = /(야(?=\?))|(야$)|(야(?= ))/gm
-
-function nyaize(text: string): string {
-  return text
-    .replaceAll('な', 'にゃ')
-    .replaceAll('ナ', 'ニャ')
-    .replaceAll('ﾅ', 'ﾆｬ')
-    .replace(enRegex1, (x) => (x === 'A' ? 'YA' : 'ya'))
-    .replace(enRegex2, (x) => (x === 'ING' ? 'YAN' : 'yan'))
-    .replace(enRegex3, (x) => (x === 'ONE' ? 'NYAN' : 'nyan'))
-    .replace(koRegex1, (match) =>
-      !Number.isNaN(match.charCodeAt(0))
-        ? String.fromCharCode(
-            match.charCodeAt(0) + '냐'.charCodeAt(0) - '나'.charCodeAt(0),
-          )
-        : match,
-    )
-    .replace(koRegex2, '다냥')
-    .replace(koRegex3, '냥')
-}
 
 export interface AiScriptEnvOptions {
   /**

--- a/src/aiscript/api.ts
+++ b/src/aiscript/api.ts
@@ -1,6 +1,5 @@
 import { utils, values } from '@syuilo/aiscript'
 import type { Value } from '@syuilo/aiscript/interpreter/value.js'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
 import type { Principal } from '@/permissions/principal'
 import { useConfirm } from '@/stores/confirm'
@@ -10,6 +9,7 @@ import {
   removeStorage,
   setStorageJson,
 } from '@/utils/storage'
+import { openSafeUrl } from '@/utils/url'
 
 export interface AiScriptEnvOptions {
   /**
@@ -159,7 +159,7 @@ export function createAiScriptEnv(
   // --- Mk:url ---
   consts['Mk:url'] = values.FN_NATIVE(async ([urlVal]) => {
     const url = urlVal?.type === 'str' ? urlVal.value : ''
-    if (url) await openUrl(url)
+    if (url) await openSafeUrl(url)
     return values.NULL
   })
 

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -12,6 +12,7 @@ import {
   usePluginsStore,
 } from '@/stores/plugins'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { openSafeUrl } from '@/utils/url'
 import { createAiScriptEnv } from './api'
 import {
   createAiScriptInterpreter,
@@ -341,8 +342,7 @@ function createPluginSpecificEnv(
   consts['Plugin:open_url'] = values.FN_NATIVE(
     async ([urlVal]): Promise<Value> => {
       if (urlVal?.type !== 'str') return values.NULL
-      const { openUrl } = await import('@tauri-apps/plugin-opener')
-      await openUrl(urlVal.value)
+      await openSafeUrl(urlVal.value)
       return values.NULL
     },
   )

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -877,6 +877,14 @@ async apiGetFollowRequests(accountId: string, limit: number | null) : Promise<Re
     else return { status: "error", error: e  as any };
 }
 },
+async apiGetSentFollowRequests(accountId: string, limit: number | null) : Promise<Result<JsonValue, { code: string; message: string }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_get_sent_follow_requests", { accountId, limit }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async apiSearchUsers(accountId: string, query: string | null, origin: string | null, sort: string | null, state: string | null, limit: number | null, offset: number | null) : Promise<Result<JsonValue, { code: string; message: string }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_search_users", { accountId, query, origin, sort, state, limit, offset }) };

--- a/src/components/common/MkAd.vue
+++ b/src/components/common/MkAd.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { ref } from 'vue'
 import type { ServerAd } from '@/adapters/types'
-import { isSafeUrl } from '@/utils/url'
+import { openSafeUrl } from '@/utils/url'
 
 const props = withDefaults(
   defineProps<{
@@ -20,9 +19,7 @@ const emit = defineEmits<{
 const showMenu = ref(false)
 
 function onClick() {
-  if (props.ad.url && isSafeUrl(props.ad.url)) {
-    openUrl(props.ad.url)
-  }
+  openSafeUrl(props.ad.url)
 }
 
 function reduceFrequency() {

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -6,6 +6,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyUrl } from '@/utils/imageProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
+import { nyaizeTokens } from '@/utils/nyaize'
 import { isMemoUrl, isSafeUrl } from '@/utils/url'
 import MkEmoji from './MkEmoji.vue'
 
@@ -23,6 +24,11 @@ const props = defineProps<{
    * ノート本文には影響しないので Misskey 互換性は保たれる。
    */
   markdown?: boolean
+  /**
+   * cat ユーザーの本文を text ノード単位で にゃ化する (#763)。
+   * 再帰呼び出しには変換済み children が渡るので prop の伝播は不要。
+   */
+  nyaize?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -49,8 +55,9 @@ function isMentionMe(username: string, host: string | null): boolean {
 }
 
 const resolvedTokens = computed(() => {
-  if (props.tokens) return props.tokens
-  return parseMfm(props.text ?? '', { markdown: props.markdown })
+  const tokens =
+    props.tokens ?? parseMfm(props.text ?? '', { markdown: props.markdown })
+  return props.nyaize ? nyaizeTokens(tokens) : tokens
 })
 
 const emojiUrls = computed(() => {

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, useCssModule } from 'vue'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
@@ -7,7 +6,7 @@ import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyUrl } from '@/utils/imageProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
 import { nyaizeTokens } from '@/utils/nyaize'
-import { isMemoUrl, isSafeUrl } from '@/utils/url'
+import { isMemoUrl, isSafeUrl, openSafeUrl } from '@/utils/url'
 import MkEmoji from './MkEmoji.vue'
 
 const props = defineProps<{
@@ -86,7 +85,7 @@ function handleLinkClick(e: MouseEvent, url: string) {
     emit('memoLinkClick', memo.id)
     return
   }
-  if (isSafeUrl(url)) openUrl(url)
+  openSafeUrl(url)
 }
 
 function escapeHtml(text: string): string {
@@ -447,7 +446,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Center --><span v-else-if="token.type === 'center'" :class="$style.mfmCenter"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></span><!--
     --><!-- Plain --><span v-else-if="token.type === 'plain'">{{ token.value }}</span><!--
     --><!-- Quote --><blockquote v-else-if="token.type === 'quote'" :class="$style.mfmQuote"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></blockquote><!--
-    --><!-- Search --><div v-else-if="token.type === 'search'" :class="$style.mfmSearch"><input :class="$style.mfmSearchInput" type="text" :value="token.query" readonly /><button :class="$style.mfmSearchButton" @click.stop="openUrl(`https://www.google.com/search?q=${encodeURIComponent(token.query)}`)">検索</button></div><!--
+    --><!-- Search --><div v-else-if="token.type === 'search'" :class="$style.mfmSearch"><input :class="$style.mfmSearchInput" type="text" :value="token.query" readonly /><button :class="$style.mfmSearchButton" @click.stop="openSafeUrl(`https://www.google.com/search?q=${encodeURIComponent(token.query)}`)">検索</button></div><!--
     --><!-- Math Inline --><span v-else-if="token.type === 'mathInline'" :class="$style.mfmMath" v-html="renderKatex(token.value, false)"></span><!--
     --><!-- Math Block --><div v-else-if="token.type === 'mathBlock'" :class="$style.mfmMathBlock" v-html="renderKatex(token.value, true)"></div><!--
     --><!-- Heading (Markdown 拡張) --><h1 v-else-if="token.type === 'heading' && token.level === 1" :class="[$style.mfmHeading, $style.mfmHeading1]"><MkMfm :tokens="token.children" :emojis="emojis" :reaction-emojis="reactionEmojis" :server-host="serverHost" :my-username="myUsername" :my-host="myHost" @mention-click="(u, h) => emit('mentionClick', u, h)" @mention-hover="(e, u, h) => emit('mentionHover', e, u, h)" @mention-leave="emit('mentionLeave')" @memo-link-click="(id) => emit('memoLinkClick', id)" /></h1><!--

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -23,6 +23,7 @@ import {
   useVaporTransitionGroup,
 } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
+import { useSettingsStore } from '@/stores/settings'
 import { formatTime } from '@/utils/formatTime'
 import { proxyThumbUrl, proxyUrl } from '@/utils/imageProxy'
 import {
@@ -87,6 +88,16 @@ const allEmojis = computed(() => ({
   ...effectiveNote.value.emojis,
   ...effectiveNote.value.user.emojis,
 }))
+
+// cat ユーザーの本文にゃ化 (#763)。interruptor 適用後の isCat で判定するので、
+// プラグインが isCat を折れば原文表示に戻せる (デにゃいざー)。表示専用で、
+// コピー・検索は原文 (effectiveNote.text) のまま。
+const settingsStore = useSettingsStore()
+const shouldNyaize = computed(
+  () =>
+    effectiveNote.value.user.isCat === true &&
+    settingsStore.get('note.nyaize') !== false,
+)
 const isPureRenote = computed(() => isPureRenoteNote(props.note))
 
 /** 本文から抽出した URL（renote の url/uri と一致するものは除外） */
@@ -687,6 +698,7 @@ function handlePickerReaction(reaction: string) {
             <p :class="$style.text">
               <MkMfm
                 :text="effectiveNote.text"
+                :nyaize="shouldNyaize"
                 :emojis="effectiveNote.emojis"
                 :reaction-emojis="effectiveNote.reactionEmojis"
                 :server-host="effectiveNote._serverHost"

--- a/src/components/common/MkUrlPreview.vue
+++ b/src/components/common/MkUrlPreview.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import {
   computed,
   defineAsyncComponent,
@@ -15,7 +14,7 @@ import { useOgpPreview } from '@/composables/useOgpPreview'
 import { usePerformanceStore } from '@/stores/performance'
 import { proxyUrl } from '@/utils/imageProxy'
 import { parseNoteUrl } from '@/utils/noteUrl'
-import { isSafeUrl } from '@/utils/url'
+import { isSafeUrl, openSafeUrl } from '@/utils/url'
 
 const perfStore = usePerformanceStore()
 
@@ -109,7 +108,7 @@ function handleClick(e: MouseEvent) {
   e.preventDefault()
   e.stopPropagation()
   const targetUrl = data.value?.url || props.url
-  if (isSafeUrl(targetUrl)) openUrl(targetUrl)
+  openSafeUrl(targetUrl)
 }
 
 function hostname(url: string): string {

--- a/src/components/common/MkUserPopup.vue
+++ b/src/components/common/MkUserPopup.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import { initAdapterFor } from '@/adapters/factory'
 import type { NormalizedUserDetail } from '@/adapters/types'
@@ -167,10 +166,6 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
           リモートユーザー
         </div>
 
-        <button class="_popupItem" @click.stop="openUrl(`https://${account?.host}/@${user.username}${user.host ? `@${user.host}` : ''}`)">
-          <i class="ti ti-external-link" />
-          Web UIで開く
-        </button>
       </div>
     </template>
   </div>

--- a/src/components/common/NoteMoreMenu.vue
+++ b/src/components/common/NoteMoreMenu.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, ref, watch } from 'vue'
 import type { Clip, NormalizedNote } from '@/adapters/types'
 import {
@@ -17,7 +16,6 @@ import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
-import { isSafeUrl } from '@/utils/url'
 import PopupMenu from './PopupMenu.vue'
 
 const props = defineProps<{
@@ -99,11 +97,6 @@ function resetSubViews() {
 
 function backToMain() {
   resetSubViews()
-}
-
-function openInWebUI() {
-  const url = noteWebUrl.value
-  if (url && isSafeUrl(url)) openUrl(url)
 }
 
 function openInspector() {
@@ -322,10 +315,6 @@ defineExpose({ open })
       <button v-if="!isGuest" class="_popupItem" @click="canInteract ? openClipQuickPick() : (showLoginPrompt(), close())">
         <i class="ti ti-paperclip" />
         クリップに追加
-      </button>
-      <button class="_popupItem" @click="openInWebUI(); close()">
-        <i class="ti ti-external-link" />
-        Web UIで開く
       </button>
       <button class="_popupItem" @click="openInspector">
         <i class="ti ti-code" />

--- a/src/components/common/PopupMenu.dom.test.ts
+++ b/src/components/common/PopupMenu.dom.test.ts
@@ -1,0 +1,98 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type App, createApp, defineComponent, h, nextTick, ref } from 'vue'
+import PopupMenu from './PopupMenu.vue'
+
+describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)', () => {
+  let app: App | null = null
+  let container: HTMLElement | null = null
+
+  afterEach(() => {
+    app?.unmount()
+    app = null
+    container?.remove()
+    container = null
+  })
+
+  // テストハーネス: ref 経由の命令的 open() が必要なため h() で最小構成を組む
+  // (アプリ本体の Vapor 制約はテストコードには適用しない)
+  function mountMenu(viewportWidth: number, onClose?: () => void) {
+    // useUiStore は store 初期化時に innerWidth を読むため、pinia 作成前に設定する
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: viewportWidth,
+    })
+    const pinia = createPinia()
+    setActivePinia(pinia)
+
+    const menuRef = ref<InstanceType<typeof PopupMenu> | null>(null)
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(
+            PopupMenu,
+            { ref: menuRef, onClose },
+            { default: () => h('button', null, 'アイテム') },
+          )
+      },
+    })
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(Parent)
+    app.use(pinia)
+    app.mount(container)
+    return menuRef
+  }
+
+  function openEvent() {
+    return new MouseEvent('click', { clientX: 100, clientY: 50 })
+  }
+
+  it('狭いビューポートでは座標配置されないシートとしてネスト描画される', async () => {
+    const menuRef = mountMenu(375)
+    menuRef.value?.open(openEvent())
+    await nextTick()
+
+    const root = container?.querySelector('[popover]') as HTMLElement
+    expect(root).toBeTruthy()
+    // シート branch: root は backdrop で、押下点への座標配置をしない
+    expect(root.style.top).toBe('')
+    expect(root.style.left).toBe('')
+    // メニュー本体は backdrop の子としてネストされる
+    const sheet = root.querySelector('.popup-menu')
+    expect(sheet).toBeTruthy()
+    expect(sheet?.textContent).toContain('アイテム')
+  })
+
+  it('広いビューポートでは従来どおり押下点にアンカーされる', async () => {
+    const menuRef = mountMenu(1280)
+    menuRef.value?.open(openEvent())
+    await nextTick()
+
+    const root = container?.querySelector('[popover]') as HTMLElement
+    expect(root).toBeTruthy()
+    // popup branch: root 自身がメニューで、clientX+4 / clientY+10 に配置
+    expect(root.classList.contains('popup-menu')).toBe(true)
+    expect(root.style.left).toBe('104px')
+    expect(root.style.top).toBe('60px')
+  })
+
+  it('シートの backdrop タップで閉じ、メニュー項目タップでは閉じない', async () => {
+    const onClose = vi.fn()
+    const menuRef = mountMenu(375, onClose)
+    menuRef.value?.open(openEvent())
+    await nextTick()
+
+    const root = container?.querySelector('[popover]') as HTMLElement
+    const item = root.querySelector('button') as HTMLElement
+
+    // 項目タップ (click.self 不成立) では閉じない
+    item.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(onClose).not.toHaveBeenCalled()
+
+    // backdrop 自身のタップで閉じる
+    root.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/common/PopupMenu.vue
+++ b/src/components/common/PopupMenu.vue
@@ -1,14 +1,18 @@
 <script setup lang="ts">
 import { nextTick, ref, watch } from 'vue'
 
+import { useBackButton } from '@/composables/useBackButton'
 import { useMenuKeyboard } from '@/composables/useMenuKeyboard'
 import { useNativePopover } from '@/composables/useNativePopover'
 import { useVaporTransition } from '@/composables/useVaporTransition'
+import { useIsCompactLayout } from '@/stores/ui'
 import { COLUMN_SELECTOR, extractThemeVars } from '@/utils/themeVars'
 
 const emit = defineEmits<{
   close: []
 }>()
+
+const isCompact = useIsCompactLayout()
 
 const showMenu = ref(false)
 const menuPos = ref({ x: 0, y: 0 })
@@ -40,6 +44,9 @@ useNativePopover(menuRef, visible, {
   ignoreOutsideClickFor: triggerRef,
 })
 
+// Android back button / gesture でシートを閉じる
+useBackButton(showMenu, () => close())
+
 function open(e: MouseEvent) {
   const el = e.currentTarget as HTMLElement | null
   triggerRef.value = el
@@ -53,9 +60,13 @@ function open(e: MouseEvent) {
   ) as HTMLElement | null
   if (column) menuTheme.value = extractThemeVars(column)
 
+  showMenu.value = true
+
+  // ボトムシート (compact) は下端固定なので位置計算不要
+  if (isCompact.value) return
+
   // 押下点に被ると最初のメニュー項目を誤タップしやすいので少し下にずらす
   menuPos.value = { x: e.clientX + 4, y: e.clientY + 10 }
-  showMenu.value = true
 
   nextTick(() => {
     const menu = menuRef.value
@@ -79,8 +90,27 @@ defineExpose({ open, close, activateKeyboard })
 </script>
 
 <template>
+    <!-- compact: 画面下からスライドするボトムシート -->
+    <!-- inset はインライン必須: global.css の [popover]:popover-open リセット (0,2,0) がクラス指定に勝つ -->
     <div
-      v-if="visible"
+      v-if="visible && isCompact"
+      ref="menuRef"
+      popover="manual"
+      style="inset: 0"
+      :class="[$style.sheetBackdrop, entering && $style.enter, leaving && $style.leave]"
+      @click.self="close()"
+    >
+      <div
+        :class="[$style.sheet, entering && $style.sheetEnter, leaving && $style.sheetLeave]"
+        class="_popup nd-popup-content popup-menu"
+        :style="menuTheme"
+      >
+        <slot />
+      </div>
+    </div>
+    <!-- desktop: 押下点アンカーのポップアップ -->
+    <div
+      v-else-if="visible"
       ref="menuRef"
       popover="manual"
       :class="[$style.popupMenu, entering && $style.contentEnter, leaving && $style.contentLeave]"
@@ -99,6 +129,45 @@ defineExpose({ open, close, activateKeyboard })
   min-width: 200px;
   max-width: 300px;
   padding: 6px 0;
+}
+
+.sheetBackdrop {
+  position: fixed;
+  // inset: 0 はテンプレート側のインライン style で指定 (popover リセットとの特異度競合回避)
+  width: auto;
+  height: auto;
+  background: rgb(0 0 0 / 0.4);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  // slide 中のシートが viewport 下にはみ出てもスクロールバーを出さない
+  overflow: hidden;
+}
+
+.sheet {
+  width: 100%;
+  max-height: 70vh;
+  max-height: 70dvh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  border-radius: var(--nd-radius) var(--nd-radius) 0 0;
+  padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
+}
+
+.sheetEnter {
+  animation: sheetIn 0.25s var(--nd-ease-decel);
+}
+
+.sheetLeave {
+  animation: sheetOut var(--nd-duration-base) ease-out forwards;
+}
+
+@keyframes sheetIn {
+  from { transform: translateY(100%); }
+}
+
+@keyframes sheetOut {
+  to { transform: translateY(100%); }
 }
 
 </style>

--- a/src/components/common/PopupMenu.vue
+++ b/src/components/common/PopupMenu.vue
@@ -136,7 +136,7 @@ defineExpose({ open, close, activateKeyboard })
   // inset: 0 はテンプレート側のインライン style で指定 (popover リセットとの特異度競合回避)
   width: auto;
   height: auto;
-  background: rgb(0 0 0 / 0.4);
+  background: var(--nd-modalBg);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/src/components/deck/DeckAboutMisskeyColumn.vue
+++ b/src/components/deck/DeckAboutMisskeyColumn.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import {
   computed,
   defineAsyncComponent,
@@ -20,7 +19,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
-import { isSafeUrl } from '@/utils/url'
+import { openSafeUrl } from '@/utils/url'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
 
@@ -142,7 +141,7 @@ const sponsors = [
 ]
 
 function openLink(url: string) {
-  if (isSafeUrl(url)) openUrl(url)
+  openSafeUrl(url)
 }
 
 async function fetchMeta() {

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, inject, provide, ref, watch } from 'vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import {
@@ -17,6 +16,7 @@ import { useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { useToast } from '@/stores/toast'
 import { useIsCompactLayout, useUiStore } from '@/stores/ui'
+import { openSafeUrl } from '@/utils/url'
 
 const props = defineProps<{
   columnId: string
@@ -196,7 +196,7 @@ function toggleMute() {
 
 function onOpenWebUi() {
   closeMenu()
-  if (props.webUiUrl) openUrl(props.webUiUrl)
+  if (props.webUiUrl) openSafeUrl(props.webUiUrl)
 }
 
 /** Open this column as a PiP window, then remove from deck */

--- a/src/components/deck/DeckFollowRequestsColumn.vue
+++ b/src/components/deck/DeckFollowRequestsColumn.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { NormalizedUser } from '@/adapters/types'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import MkAvatar from '@/components/common/MkAvatar.vue'
@@ -8,21 +8,26 @@ import { useColumnPullScroller } from '@/composables/useColumnPullScroller'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useNavigation } from '@/composables/useNavigation'
 import { useServerImages } from '@/composables/useServerImages'
-import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
+import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { AppError, AUTH_ERROR_MESSAGE } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import type { ColumnTabDef } from './ColumnTabs.vue'
+import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
 
 interface FollowRequest {
   id: string
   follower: NormalizedUser
-  /** Account that received this request (set in cross-account mode) */
+  followee: NormalizedUser
+  /** Account this request belongs to (set in cross-account mode) */
   _accountId?: string
 }
+
+type TabValue = 'received' | 'sent'
 
 const props = defineProps<{
   column: DeckColumnType
@@ -44,12 +49,37 @@ const serverIconUrl = ref<string | undefined>()
 const isLoading = ref(false)
 const error = ref<AppError | null>(null)
 const requests = ref<FollowRequest[]>([])
-const actionStates = ref<Record<string, 'accepted' | 'rejected'>>({})
+const actionStates = ref<Record<string, 'accepted' | 'rejected' | 'canceled'>>(
+  {},
+)
 const scrollContainer = ref<HTMLElement | null>(null)
 useColumnPullScroller(scrollContainer)
 
+const activeTab = ref<TabValue>('received')
+const tabDefs: ColumnTabDef[] = [
+  { value: 'received', label: '受け取った申請', icon: 'download' },
+  { value: 'sent', label: '送った申請', icon: 'upload' },
+]
+
+/** 受信タブは相手=follower、送信タブは相手=followee */
+function requestUser(req: FollowRequest): NormalizedUser {
+  return activeTab.value === 'sent' ? req.followee : req.follower
+}
+
+const emptyMessage = computed(() =>
+  activeTab.value === 'sent'
+    ? '送信中のフォローリクエストはありません'
+    : 'フォローリクエストはありません',
+)
+
 function scrollToTop() {
   scrollContainer.value?.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+function fetchForAccount(accountId: string, tab: TabValue) {
+  return tab === 'sent'
+    ? commands.apiGetSentFollowRequests(accountId, 30)
+    : commands.apiGetFollowRequests(accountId, 30)
 }
 
 async function fetchRequests() {
@@ -64,6 +94,7 @@ async function fetchRequestsPerAccount() {
   const acc = account.value
   if (!acc) return
 
+  const tab = activeTab.value
   isLoading.value = true
   error.value = null
 
@@ -71,17 +102,22 @@ async function fetchRequestsPerAccount() {
     const info = await serversStore.getServerInfo(acc.host)
     serverIconUrl.value = info.iconUrl
 
-    requests.value = unwrap(
-      await commands.apiGetFollowRequests(acc.id, 30),
+    const reqs = unwrap(
+      await fetchForAccount(acc.id, tab),
     ) as unknown as FollowRequest[]
+    if (activeTab.value !== tab) return
+    requests.value = reqs
   } catch (e) {
+    if (activeTab.value !== tab) return
     error.value = AppError.from(e)
   } finally {
-    isLoading.value = false
+    // タブ切替で新しい fetch が走っている場合はそちらの isLoading を保つ
+    if (activeTab.value === tab) isLoading.value = false
   }
 }
 
 async function fetchRequestsCrossAccount() {
+  const tab = activeTab.value
   isLoading.value = true
   error.value = null
   const accounts = accountsStore.accounts.filter((a) => a.hasToken)
@@ -90,11 +126,12 @@ async function fetchRequestsCrossAccount() {
     const results = await Promise.allSettled(
       accounts.map(async (acc) => {
         const reqs = unwrap(
-          await commands.apiGetFollowRequests(acc.id, 30),
+          await fetchForAccount(acc.id, tab),
         ) as unknown as FollowRequest[]
         return reqs.map((r) => ({ ...r, _accountId: acc.id }))
       }),
     )
+    if (activeTab.value !== tab) return
 
     const allRequests: FollowRequest[] = []
     for (const r of results) {
@@ -105,15 +142,16 @@ async function fetchRequestsCrossAccount() {
 
     requests.value = allRequests
   } catch (e) {
+    if (activeTab.value !== tab) return
     error.value = AppError.from(e)
   } finally {
-    isLoading.value = false
+    if (activeTab.value === tab) isLoading.value = false
   }
 }
 
 async function handleAction(
   req: FollowRequest,
-  action: 'accepted' | 'rejected',
+  action: 'accepted' | 'rejected' | 'canceled',
 ) {
   const accountId = isCrossAccount.value ? req._accountId : account.value?.id
   if (!accountId) return
@@ -121,13 +159,18 @@ async function handleAction(
   try {
     if (action === 'accepted') {
       unwrap(await commands.apiAcceptFollowRequest(accountId, req.follower.id))
-    } else {
+    } else if (action === 'rejected') {
       unwrap(await commands.apiRejectFollowRequest(accountId, req.follower.id))
+    } else {
+      unwrap(await commands.apiCancelFollowRequest(accountId, req.followee.id))
     }
     actionStates.value = { ...actionStates.value, [req.id]: action }
   } catch (e) {
     const appErr = AppError.from(e)
-    if (appErr.message.includes('NO_SUCH_FOLLOW_REQUEST')) {
+    if (
+      appErr.message.includes('NO_SUCH_FOLLOW_REQUEST') ||
+      appErr.message.includes('FOLLOW_REQUEST_NOT_FOUND')
+    ) {
       actionStates.value = { ...actionStates.value, [req.id]: action }
     } else {
       toast.show(appErr.message, 'error')
@@ -141,17 +184,47 @@ function getRequestAccountId(req: FollowRequest): string | undefined {
     : (props.column.accountId ?? undefined)
 }
 
+/** Resolve the account that owns a request (for cross-account support) */
+function resolveReqAccount(req: FollowRequest) {
+  if (!isCrossAccount.value) return account.value
+  return accountsStore.accounts.find((a) => a.id === req._accountId)
+}
+
 function getRequestServerHost(req: FollowRequest): string | undefined {
-  if (isCrossAccount.value && req._accountId) {
-    return accountsStore.accounts.find((a) => a.id === req._accountId)?.host
-  }
-  return account.value?.host
+  return resolveReqAccount(req)?.host
+}
+
+/** Get the server favicon URL for a request's account */
+function resolveReqServerIcon(req: FollowRequest): string | null {
+  const acc = resolveReqAccount(req)
+  if (!acc) return null
+  const info = serversStore.servers.get(acc.host)
+  return info?.iconUrl || `https://${acc.host}/favicon.ico`
+}
+
+/** Whether to show the server badge on a request (cross-account columns with 2+ accounts) */
+function shouldShowServerBadge(req: FollowRequest): boolean {
+  if (!isCrossAccount.value) return false
+  if (accountsStore.accounts.length < 2) return false
+  return resolveReqAccount(req) != null
+}
+
+/** Tooltip shown on the server badge: `@username@host` */
+function reqBadgeTitle(req: FollowRequest): string | undefined {
+  const acc = resolveReqAccount(req)
+  if (!acc) return undefined
+  return `@${acc.username}@${acc.host}`
 }
 
 function displayName(user: NormalizedUser): string {
   if (user.host) return `@${user.username}@${user.host}`
   return `@${user.username}`
 }
+
+watch(activeTab, () => {
+  requests.value = []
+  fetchRequests()
+})
 
 onMounted(() => {
   fetchRequests()
@@ -176,6 +249,14 @@ onMounted(() => {
       <DeckHeaderAccount v-if="!isCrossAccount" :account="account" :server-icon-url="serverIconUrl" />
     </template>
 
+    <template #header-extra>
+      <ColumnTabs
+        v-model="activeTab"
+        :tabs="tabDefs"
+        :swipe-target="scrollContainer"
+      />
+    </template>
+
     <ColumnEmptyState
       v-if="error && !isLoggedOut"
       :message="error.isAuth ? AUTH_ERROR_MESSAGE : error.message"
@@ -186,7 +267,7 @@ onMounted(() => {
     <div v-else :class="$style.frBody">
       <ColumnEmptyState
         v-if="requests.length === 0 && !isLoading"
-        message="フォローリクエストはありません"
+        :message="emptyMessage"
         :image-url="serverInfoImageUrl"
       />
 
@@ -196,42 +277,46 @@ onMounted(() => {
           :key="req.id"
           :class="$style.frItem"
         >
-          <div :class="$style.frUser" role="button" tabindex="0" @click="getRequestAccountId(req) && navToUser(getRequestAccountId(req)!, req.follower.id)" @keydown.enter="getRequestAccountId(req) && navToUser(getRequestAccountId(req)!, req.follower.id)">
-            <MkAvatar
-              :avatar-url="req.follower.avatarUrl"
-              :decorations="req.follower.avatarDecorations"
-              :size="42"
-              :is-cat="req.follower.isCat"
-            />
+          <div :class="$style.frUser" role="button" tabindex="0" @click="getRequestAccountId(req) && navToUser(getRequestAccountId(req)!, requestUser(req).id)" @keydown.enter="getRequestAccountId(req) && navToUser(getRequestAccountId(req)!, requestUser(req).id)">
+            <div :class="$style.frAvatarWrap">
+              <MkAvatar
+                :avatar-url="requestUser(req).avatarUrl"
+                :decorations="requestUser(req).avatarDecorations"
+                :size="42"
+                :is-cat="requestUser(req).isCat"
+              />
+              <img
+                v-if="shouldShowServerBadge(req) && resolveReqServerIcon(req)"
+                :src="resolveReqServerIcon(req)!"
+                :class="$style.frServerBadge"
+                :title="reqBadgeTitle(req)"
+              />
+            </div>
             <div :class="$style.frUserInfo">
               <span :class="$style.frDisplayName">
                 <MkMfm
-                  v-if="req.follower.name"
-                  :text="req.follower.name"
+                  v-if="requestUser(req).name"
+                  :text="requestUser(req).name!"
                   :server-host="getRequestServerHost(req)"
-                  :emojis="req.follower.emojis"
+                  :emojis="requestUser(req).emojis"
                   plain
                 />
-                <template v-else>{{ req.follower.username }}</template>
+                <template v-else>{{ requestUser(req).username }}</template>
               </span>
-              <span :class="$style.frAcct">{{ displayName(req.follower) }}</span>
+              <span :class="$style.frAcct">{{ displayName(requestUser(req)) }}</span>
             </div>
-          </div>
-
-          <!-- Cross-account: show which account this request is for -->
-          <div v-if="isCrossAccount && req._accountId" :class="$style.frAccountBadge">
-            <img
-              :src="getAccountAvatarUrl(accountsStore.accounts.find((a) => a.id === req._accountId)!)"
-              :class="$style.frAccountAvatar"
-            />
-            <span :class="$style.frAccountHost">{{ accountsStore.accounts.find((a) => a.id === req._accountId)?.host }}</span>
           </div>
 
           <div :class="$style.frActions">
             <template v-if="actionStates[req.id]">
               <span :class="$style.frDone">
-                {{ actionStates[req.id] === 'accepted' ? '承認済み' : '拒否済み' }}
+                {{ actionStates[req.id] === 'accepted' ? '承認済み' : actionStates[req.id] === 'rejected' ? '拒否済み' : '取り消し済み' }}
               </span>
+            </template>
+            <template v-else-if="activeTab === 'sent'">
+              <button :class="[$style.frBtn, $style.cancelBtn]" @click="handleAction(req, 'canceled')">
+                <i class="ti ti-x" /> 取り消し
+              </button>
             </template>
             <template v-else>
               <button :class="[$style.frBtn, $style.acceptBtn]" @click="handleAction(req, 'accepted')">
@@ -303,27 +388,25 @@ onMounted(() => {
   white-space: nowrap;
 }
 
-.frAccountBadge {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 6px;
-  padding-left: 52px;
-  font-size: 0.75em;
-  opacity: 0.6;
+.frAvatarWrap {
+  position: relative;
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
 }
 
-.frAccountAvatar {
-  width: 16px;
-  height: 16px;
+.frServerBadge {
+  position: absolute;
+  top: -2px;
+  right: -4px;
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
-  object-fit: cover;
-}
-
-.frAccountHost {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  object-fit: contain;
+  background: var(--nd-panel);
+  box-shadow: 0 0 0 3px var(--nd-panel);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .frActions {
@@ -331,6 +414,9 @@ onMounted(() => {
   gap: 8px;
   margin-top: 10px;
   padding-left: 52px;
+  /* ボタン部は通知カラムの followRequestActions と同じ 300px 幅。単独
+     ボタン (送信タブの取り消し) がカラム全幅へ間延びするのを防ぐ。 */
+  max-width: 352px; /* 300px + padding-left 52px */
 }
 
 .frBtn {
@@ -346,7 +432,9 @@ onMounted(() => {
   border: none;
   border-radius: var(--nd-radius-full);
   cursor: pointer;
-  transition: filter var(--nd-duration-base);
+  transition:
+    filter var(--nd-duration-base),
+    background var(--nd-duration-base);
 }
 
 .acceptBtn {
@@ -364,6 +452,16 @@ onMounted(() => {
 
   &:hover {
     background: var(--nd-love-subtle);
+  }
+}
+
+/* 本家 MkButton rounded danger 相当: buttonBg 地 + error 色の太字 */
+.cancelBtn {
+  background: var(--nd-buttonBg);
+  color: var(--nd-error);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
   }
 }
 

--- a/src/components/deck/DeckLayout.vue
+++ b/src/components/deck/DeckLayout.vue
@@ -459,7 +459,7 @@ function acceptCrossWindowDrop() {
   position: fixed;
   inset: 0;
   z-index: var(--nd-z-navbar);
-  background: rgb(0 0 0 / 0.5);
+  background: var(--nd-modalBg);
 }
 
 .fileDropOverlay {

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -23,6 +23,7 @@ import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { useRealtimeModeStore } from '@/stores/realtimeMode'
 import { useToast } from '@/stores/toast'
+import { webUiUrl as buildWebUiUrl } from '@/utils/url'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
 
@@ -112,7 +113,7 @@ function showOfflineDetail(): void {
 
 const webUiUrl = computed(() => {
   if (!props.webUiPath || !account.value) return undefined
-  return `https://${account.value.host}${props.webUiPath}`
+  return buildWebUiUrl(account.value.host, props.webUiPath)
 })
 
 const postFormPortalRef = useTemplateRef<HTMLElement>('postFormPortalRef')

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -12,6 +12,7 @@ import {
   WINDOW_SIZES,
 } from '@/stores/windows'
 import { isTauri, openSettingsFileInEditor } from '@/utils/settingsFs'
+import { openSafeUrl } from '@/utils/url'
 import { WINDOW_LABELS } from './windowLabels'
 
 const props = defineProps<{
@@ -50,8 +51,7 @@ async function openExternalLink() {
   const t = externalLink.value
   if (!t || t.disabled) return
   try {
-    const { openUrl } = await import('@tauri-apps/plugin-opener')
-    await openUrl(t.url)
+    await openSafeUrl(t.url)
   } catch (e) {
     console.warn('[DeckWindow] openExternalLink failed:', e)
   }
@@ -358,7 +358,7 @@ onBeforeUnmount(() => {
         class="_button"
         :class="$style.windowBtn"
         :disabled="externalLink.disabled"
-        :title="externalLink.title ?? 'Web で開く'"
+        :title="externalLink.title ?? 'Web UIで開く'"
         @click="openExternalLink"
       >
         <i :class="`ti ti-${externalLink.icon ?? 'world'}`" />

--- a/src/components/deck/DeckWindowLayer.vue
+++ b/src/components/deck/DeckWindowLayer.vue
@@ -192,6 +192,8 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
         v-if="win.type === 'follow-list'"
         :account-id="(win.props.accountId as string)"
         :user-id="(win.props.userId as string)"
+        :username="(win.props.username as string | undefined)"
+        :user-host="(win.props.userHost as string | null | undefined)"
         :initial-tab="(win.props.initialTab as 'following' | 'followers' | undefined)"
       />
       <LoginContent

--- a/src/components/deck/NavAccountMenu.vue
+++ b/src/components/deck/NavAccountMenu.vue
@@ -6,11 +6,7 @@ import { useVaporTransition } from '@/composables/useVaporTransition'
 import { type Account, isGuestAccount } from '@/stores/accounts'
 import { modeIcon, modeLabel } from '@/utils/customTimelines'
 import { hapticSelection } from '@/utils/haptics'
-
-const openUrl = async (url: string) => {
-  const { openUrl: open } = await import('@tauri-apps/plugin-opener')
-  return open(url)
-}
+import { openSafeUrl, webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   show: boolean
@@ -90,12 +86,12 @@ const hasUpperSection = computed(
           <i class="ti ti-user" />
         </button>
         <div :class="$style.navAccountMenuDivider" />
-        <button class="_button" :class="$style.navAccountMenuItem" @click="openUrl(`https://${account.host}/settings`)">
+        <button class="_button" :class="$style.navAccountMenuItem" @click="openSafeUrl(webUiUrl(account.host, '/settings'))">
           <span>設定</span>
           <i class="ti ti-external-link" />
         </button>
       </template>
-      <button v-if="isAdmin" class="_button" :class="$style.navAccountMenuItem" @click="openUrl(`https://${account.host}/admin`)">
+      <button v-if="isAdmin" class="_button" :class="$style.navAccountMenuItem" @click="openSafeUrl(webUiUrl(account.host, '/admin'))">
         <span>コントロールパネル</span>
         <i class="ti ti-external-link" />
       </button>

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -35,7 +35,7 @@ const MkPostForm = defineAsyncComponent(
 import { useAccountsStore } from '@/stores/accounts'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useWidgetsStore, type WidgetMeta } from '@/stores/widgets'
-import AiScriptEditor from './AiScriptEditor.vue'
+import { useWindowsStore } from '@/stores/windows'
 import type { PostFormRequest } from './AiScriptUiRenderer.vue'
 import AiScriptUiRenderer from './AiScriptUiRenderer.vue'
 
@@ -65,14 +65,12 @@ const serverUrl = computed(() => {
   const account = accountsStore.accounts.find((a) => a.id === props.accountId)
   return account ? `https://${account.host}` : ''
 })
-const code = ref(props.widget.src ?? '')
+// src の正本は widgetsStore (widget-edit window / AI 経由で更新される)。
+const code = computed(() => props.widget.src ?? '')
 const uiComponents = ref<UiComponent[]>([])
 const output = ref<{ text: string; isError: boolean }[]>([])
 const error = ref<string | null>(null)
 const running = ref(false)
-/** カラム内エディタ表示フラグ。新規作成は widget-edit window で行う前提のため、
- *  既存 widget の src 確認/微修正用に on/off できるが、初期は閉じておく。 */
-const showEditor = ref(false)
 const interpreter = ref<Interpreter | null>(null)
 const { show: showToast } = useToast()
 const dialogRef = ref<InstanceType<typeof AiScriptDialog> | null>(null)
@@ -95,22 +93,14 @@ function closePostForm() {
   postFormData.value = {}
 }
 
-// Persist code on change (debounce + アンマウント時 flush で取りこぼし防止)
-let saveTimer: ReturnType<typeof setTimeout> | null = null
-function flushPendingSave() {
-  if (saveTimer) {
-    clearTimeout(saveTimer)
-    saveTimer = null
-    widgetsStore.updateSrc(props.widget.installId, code.value)
-  }
+// コード編集は widget-edit ウィンドウで行う (#765)
+const windowsStore = useWindowsStore()
+function openEditor() {
+  windowsStore.open('widget-edit', {
+    widgetId: props.widget.installId,
+    accountId: props.accountId,
+  })
 }
-watch(code, (val) => {
-  if (saveTimer) clearTimeout(saveTimer)
-  saveTimer = setTimeout(() => {
-    saveTimer = null
-    widgetsStore.updateSrc(props.widget.installId, val)
-  }, 500)
-})
 
 // 走っているインタプリタ (＝Async:interval などのタイマー) を止め、
 // Nd:* で登録したコマンド/購読も解放する。再実行前とアンマウント時に呼ぶ。
@@ -126,22 +116,15 @@ function stop() {
 }
 
 onBeforeUnmount(() => {
-  flushPendingSave()
   stop()
   widgetsStore.unregisterMounted(props.widget.installId)
 })
 
-// AI 経由の widgets.update (#744): 新しい src を反映して再実行する。
-// pending の自動保存が古いコードで上書き返さないよう先にキャンセルする。
+// AI 経由の widgets.update (#744): 新しい src で再実行する。
 watch(
   () => widgetsStore.rerunSignal(props.widget.installId),
   (sig, prev) => {
     if (sig <= (prev ?? 0)) return
-    if (saveTimer) {
-      clearTimeout(saveTimer)
-      saveTimer = null
-    }
-    code.value = props.widget.src ?? ''
     run()
   },
 )
@@ -280,10 +263,10 @@ onMounted(() => {
       <div :class="$style.headerActions">
         <button
           :class="$style.toolBtn"
-          :title="showEditor ? 'エディタを閉じる' : 'コードを編集'"
-          @click="showEditor = !showEditor"
+          title="コードを編集"
+          @click="openEditor"
         >
-          <i :class="showEditor ? 'ti ti-chevron-up' : 'ti ti-code'" />
+          <i class="ti ti-code" />
         </button>
         <button
           :class="[$style.toolBtn, $style.run]"
@@ -313,34 +296,26 @@ onMounted(() => {
     <div :class="$style.widgetBody">
       <AiScriptDialog ref="dialogRef" />
 
-      <AiScriptEditor
-        v-if="showEditor"
-        v-model="code"
-        placeholder="AiScript App code..."
+      <div v-if="error" :class="$style.appError">{{ error }}</div>
+
+      <AiScriptUiRenderer
+        v-if="uiComponents.length"
+        :components="uiComponents"
+        :interpreter="(interpreter as Interpreter | null)"
+        :server-url="serverUrl"
+        @post="handlePost"
       />
 
-      <template v-else>
-        <div v-if="error" :class="$style.appError">{{ error }}</div>
-
-        <AiScriptUiRenderer
-          v-if="uiComponents.length"
-          :components="uiComponents"
-          :interpreter="(interpreter as Interpreter | null)"
-          :server-url="serverUrl"
-          @post="handlePost"
-        />
-
-        <details v-if="output.length" :class="$style.outputPanel">
-          <summary>出力 ({{ output.length }})</summary>
-          <div
-            v-for="(line, i) in output"
-            :key="i"
-            :class="[$style.outputLine, { [$style.error]: line.isError }]"
-          >
-            {{ line.text }}
-          </div>
-        </details>
-      </template>
+      <details v-if="output.length" :class="$style.outputPanel">
+        <summary>出力 ({{ output.length }})</summary>
+        <div
+          v-for="(line, i) in output"
+          :key="i"
+          :class="[$style.outputLine, { [$style.error]: line.isError }]"
+        >
+          {{ line.text }}
+        </div>
+      </details>
     </div>
   </div>
 

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { getTauriVersion } from '@tauri-apps/api/app'
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, onMounted, ref, shallowRef } from 'vue'
 import type { Check, HealthReport, Status } from '@/bindings'
 import { useTutorialStore } from '@/composables/useTutorial'
@@ -12,6 +11,7 @@ import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { openSafeUrl } from '@/utils/url'
 import { version as appVersion } from '../../../package.json'
 
 const emit = defineEmits<{
@@ -222,7 +222,7 @@ function reportBug() {
   const diagSection = diag ? `\n\n## 診断\n\n\`\`\`\n${diag}\n\`\`\`` : ''
   const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}${diagSection}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
   const url = `${REPO_URL}/issues/new?labels=bug&body=${encodeURIComponent(body)}`
-  openUrl(url)
+  openSafeUrl(url)
 }
 </script>
 
@@ -243,7 +243,7 @@ function reportBug() {
         class="_button"
         :class="$style.aboutTitle"
         title="公式サイトを開く"
-        @click="openUrl(SITE_URL)"
+        @click="openSafeUrl(SITE_URL)"
       >
         NoteDeck
       </button>
@@ -300,7 +300,7 @@ function reportBug() {
     <div :class="$style.formSection">
       <div :class="$style.formSectionLabel">開発者</div>
       <div :class="$style.sectionBody">
-        <button type="button" class="_button" :class="$style.formLink" @click="openUrl(SPONSOR_URL)">
+        <button type="button" class="_button" :class="$style.formLink" @click="openSafeUrl(SPONSOR_URL)">
           <img src="https://github.com/hitalin.png?size=48" :class="$style.devAvatar" alt="" />
           <span>@hitalin</span>
           <span :class="$style.formLinkSuffix">GitHub Sponsors <i class="ti ti-external-link" /></span>

--- a/src/components/window/AppearanceEditorContent.vue
+++ b/src/components/window/AppearanceEditorContent.vue
@@ -4,6 +4,7 @@ import { computed, ref, watch } from 'vue'
 import EditorTabs from '@/components/common/EditorTabs.vue'
 import DayNightToggle from '@/components/deck/DayNightToggle.vue'
 import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
+import AiSwitchRow from '@/components/window/ai-settings/AiSwitchRow.vue'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { CURRENT_SCHEMA_VERSION, parseSettings } from '@/settings/schema'
@@ -71,6 +72,14 @@ function onFileSelected(e: Event) {
 
 function removeWallpaper() {
   deckStore.clearWallpaper()
+}
+
+// ── Visual tab: note view settings ──
+const nyaizeEnabled = computed(() => settingsStore.get('note.nyaize') !== false)
+
+function toggleNyaize() {
+  hapticSelection()
+  settingsStore.set('note.nyaize', !nyaizeEnabled.value)
 }
 
 // ── Code tab: raw JSON editor ──
@@ -184,6 +193,17 @@ const statusClass = computed(() => {
           <i class="ti ti-photo-off" />
           <span>壁紙を削除</span>
         </button>
+      </div>
+
+      <!-- Note view -->
+      <div :class="$style.section">
+        <AiSwitchRow
+          label="Catユーザーの語尾をにゃ化"
+          sub-label="本家 Web UI と同じ表示。コピー・検索は原文のまま"
+          icon="ti-cat"
+          :on="nyaizeEnabled"
+          @toggle="toggleNyaize"
+        />
       </div>
 
       <input

--- a/src/components/window/ClipDetailContent.vue
+++ b/src/components/window/ClipDetailContent.vue
@@ -12,6 +12,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -56,7 +57,7 @@ const isOwnClip = computed(
 
 const clipWebUrl = computed(() => {
   if (!clip.value || !account.value?.host) return undefined
-  return `https://${account.value.host}/clips/${clip.value.id}`
+  return webUiUrl(account.value.host, `/clips/${clip.value.id}`)
 })
 
 useWindowExternalLink(() =>

--- a/src/components/window/FollowListContent.vue
+++ b/src/components/window/FollowListContent.vue
@@ -12,14 +12,19 @@ import MkMfm from '@/components/common/MkMfm.vue'
 import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useNavigation } from '@/composables/useNavigation'
 import { usePaginatedList } from '@/composables/usePaginatedList'
+import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { isGuestAccount, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
+import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
   userId: string
+  /** WebUI の /@acct/(following|followers) を開くヘッダーボタン用。deep link 経由では未指定 */
+  username?: string
+  userHost?: string | null
   initialTab?: 'following' | 'followers'
 }>()
 
@@ -38,6 +43,13 @@ const hoveredFollowId = ref<string | null>(null)
 
 const account = accountsStore.accounts.find((a) => a.id === props.accountId)
 const isOwnProfile = computed(() => account?.userId === props.userId)
+
+// ヘッダー「Web UIで開く」— 表示中タブに対応する WebUI ページを開く
+useWindowExternalLink(() => {
+  if (!account || !props.username) return null
+  const acct = `@${props.username}${props.userHost ? `@${props.userHost}` : ''}`
+  return { url: webUiUrl(account.host, `/${acct}/${activeTab.value}`) }
+})
 const isGuest = account ? isGuestAccount(account) : false
 let adapter: ServerAdapter | null = null
 

--- a/src/components/window/GalleryDetailContent.vue
+++ b/src/components/window/GalleryDetailContent.vue
@@ -5,6 +5,7 @@ import { safeUrl } from '@/composables/useDriveFolder'
 import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 interface GalleryFile {
   id: string
@@ -46,7 +47,7 @@ const account = computed(
   () => accountsStore.accounts.find((a) => a.id === props.accountId) ?? null,
 )
 const serverUrl = computed(() =>
-  account.value ? `https://${account.value.host}` : '',
+  account.value ? webUiUrl(account.value.host) : '',
 )
 
 const detailPost = ref<GalleryPost>({ ...props.post })

--- a/src/components/window/InstanceProfileContent.vue
+++ b/src/components/window/InstanceProfileContent.vue
@@ -12,7 +12,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { AppError } from '@/utils/errors'
 import { formatCount, formatDate } from '@/utils/format'
 import { commands, unwrap } from '@/utils/tauriInvoke'
-import { safeCssUrl } from '@/utils/url'
+import { safeCssUrl, webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -80,12 +80,8 @@ onMounted(() => {
   loadRemoteMeta()
 })
 
-// DeckWindow ヘッダーに「Web で開く」ボタンを登録 (UserProfile と同じ導線)。
-useWindowExternalLink(() => ({
-  url: `https://${props.host}`,
-  title: 'Web UI で開く',
-  icon: 'world',
-}))
+// DeckWindow ヘッダーに「Web UIで開く」ボタンを登録 (UserProfile と同じ導線)。
+useWindowExternalLink(() => ({ url: webUiUrl(props.host) }))
 
 const rawJson = computed(() =>
   instance.value ? JSON.stringify(instance.value, null, 2) : '',

--- a/src/components/window/ListDetailContent.vue
+++ b/src/components/window/ListDetailContent.vue
@@ -10,6 +10,7 @@ import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -55,7 +56,7 @@ const isOwnList = computed(
 
 const listWebUrl = computed(() => {
   if (!list.value || !account.value?.host) return undefined
-  return `https://${account.value.host}/my/lists/${list.value.id}`
+  return webUiUrl(account.value.host, `/my/lists/${list.value.id}`)
 })
 
 useWindowExternalLink(() =>

--- a/src/components/window/LoginContent.vue
+++ b/src/components/window/LoginContent.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { openUrl } from '@tauri-apps/plugin-opener'
 import { computed, onMounted, ref } from 'vue'
 import { MisskeyAuth } from '@/adapters/misskey/auth'
 import type { AuthSession } from '@/adapters/types'
@@ -13,6 +12,7 @@ import { useServersStore } from '@/stores/servers'
 import { useIsCompactLayout } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { openSafeUrl } from '@/utils/url'
 
 const props = defineProps<{
   initialHost?: string
@@ -66,7 +66,7 @@ async function startLogin() {
   try {
     step.value = 'waiting'
     currentSession = await auth.startAuth(trimmedHost)
-    await openUrl(currentSession.url)
+    await openSafeUrl(currentSession.url)
   } catch (e) {
     step.value = 'error'
     errorMessage.value = AppError.from(e).message

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -40,6 +40,7 @@ import { useIsCompactLayout } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { proxyUrl } from '@/utils/imageProxy'
 import { toggleReaction } from '@/utils/toggleReaction'
+import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -73,7 +74,7 @@ const noteWebUrl = computed(() => {
   const host = accountsStore.accounts.find(
     (a) => a.id === props.accountId,
   )?.host
-  return host ? `https://${host}/notes/${props.noteId}` : undefined
+  return host ? webUiUrl(host, `/notes/${props.noteId}`) : undefined
 })
 
 useWindowExternalLink(() =>

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -33,6 +33,7 @@ import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
 import { useNoteCapture } from '@/composables/useNoteCapture'
 import { usePortal } from '@/composables/usePortal'
+import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
 import { useIsCompactLayout } from '@/stores/ui'
@@ -66,6 +67,18 @@ const reactionTypes = computed(() =>
 const isLoading = ref(true)
 const error = ref<AppError | null>(null)
 const myUserId = ref<string | undefined>()
+
+// ヘッダー「Web で開く」— 委譲目的 (自アカウントで操作できる) なので所属サーバーで開く
+const noteWebUrl = computed(() => {
+  const host = accountsStore.accounts.find(
+    (a) => a.id === props.accountId,
+  )?.host
+  return host ? `https://${host}/notes/${props.noteId}` : undefined
+})
+
+useWindowExternalLink(() =>
+  noteWebUrl.value ? { url: noteWebUrl.value } : null,
+)
 
 // Note Capture: 投票・リアクション等の pollVoted/reacted イベントを受けて
 // 表示中のノートをリアルタイム更新する。カラムと違い詳細ウィンドウは

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -69,7 +69,7 @@ const isLoading = ref(true)
 const error = ref<AppError | null>(null)
 const myUserId = ref<string | undefined>()
 
-// ヘッダー「Web で開く」— 委譲目的 (自アカウントで操作できる) なので所属サーバーで開く
+// ヘッダー「Web UIで開く」— 委譲目的 (自アカウントで操作できる) なので所属サーバーで開く
 const noteWebUrl = computed(() => {
   const host = accountsStore.accounts.find(
     (a) => a.id === props.accountId,

--- a/src/components/window/PageDetailContent.vue
+++ b/src/components/window/PageDetailContent.vue
@@ -24,6 +24,7 @@ import { AppError } from '@/utils/errors'
 import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
 import { parseMfm } from '@/utils/mfm'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const MkPostForm = defineAsyncComponent(
   () => import('@/components/common/MkPostForm.vue'),
@@ -43,7 +44,7 @@ const account = computed(
   () => accountsStore.accounts.find((a) => a.id === props.accountId) ?? null,
 )
 const serverUrl = computed(() =>
-  account.value ? `https://${account.value.host}` : '',
+  account.value ? webUiUrl(account.value.host) : '',
 )
 
 interface PageContent {

--- a/src/components/window/PageEditContent.vue
+++ b/src/components/window/PageEditContent.vue
@@ -11,6 +11,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -22,7 +23,7 @@ const account = computed(
   () => accountsStore.accounts.find((a) => a.id === props.accountId) ?? null,
 )
 const serverUrl = computed(() =>
-  account.value ? `https://${account.value.host}` : '',
+  account.value ? webUiUrl(account.value.host) : '',
 )
 const toast = useToast()
 

--- a/src/components/window/PlayDetailContent.vue
+++ b/src/components/window/PlayDetailContent.vue
@@ -21,6 +21,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const MkPostForm = defineAsyncComponent(
   () => import('@/components/common/MkPostForm.vue'),
@@ -42,7 +43,7 @@ const account = computed(
   () => accountsStore.accounts.find((a) => a.id === props.accountId) ?? null,
 )
 const serverUrl = computed(() =>
-  account.value ? `https://${account.value.host}` : '',
+  account.value ? webUiUrl(account.value.host) : '',
 )
 
 interface FlashDetail {

--- a/src/components/window/PlayEditContent.vue
+++ b/src/components/window/PlayEditContent.vue
@@ -11,6 +11,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { webUiUrl } from '@/utils/url'
 
 const AiScriptEditor = defineAsyncComponent(
   () => import('@/components/deck/widgets/AiScriptEditor.vue'),
@@ -26,7 +27,7 @@ const account = computed(
   () => accountsStore.accounts.find((a) => a.id === props.accountId) ?? null,
 )
 const serverUrl = computed(() =>
-  account.value ? `https://${account.value.host}` : '',
+  account.value ? webUiUrl(account.value.host) : '',
 )
 const toast = useToast()
 

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -67,7 +67,7 @@ import { formatDate } from '@/utils/format'
 import { proxyUrl } from '@/utils/imageProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { toggleReaction } from '@/utils/toggleReaction'
-import { openSafeUrl } from '@/utils/url'
+import { openSafeUrl, webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
   accountId: string
@@ -164,17 +164,13 @@ useWindowExternalLink(() => {
   if (!u || !host) return null
   if (isOwnProfile.value) {
     return {
-      url: `https://${host}/settings/profile`,
+      url: webUiUrl(host, '/settings/profile'),
       title: 'プロフィールを編集',
       icon: 'pencil',
     }
   }
   const suffix = u.host ? `@${u.host}` : ''
-  return {
-    url: `https://${host}/@${u.username}${suffix}`,
-    title: 'Web UIで開く',
-    icon: 'world',
-  }
+  return { url: webUiUrl(host, `/@${u.username}${suffix}`) }
 })
 
 const MAX_PROFILE_NOTES = 500

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -59,6 +59,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { usePaginatedList } from '@/composables/usePaginatedList'
 import { usePortal } from '@/composables/usePortal'
 import { useSensitiveMask } from '@/composables/useSensitiveMask'
+import { useWindowEditAction } from '@/composables/useWindowEditAction'
 import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
@@ -157,20 +158,23 @@ function handleMemoSaved(memo: string) {
   if (user.value) user.value.memo = memo
 }
 
-// ヘッダー「Web UIで開く」ボタンの登録 — 自プロフィールは編集画面、他は公開ページ
+// ヘッダー「Web UIで開く」— 自他問わず公開ページ (Page/Play detail と同じ 2 ボタン構成)
 useWindowExternalLink(() => {
   const u = user.value
   const host = account.value?.host
   if (!u || !host) return null
-  if (isOwnProfile.value) {
-    return {
-      url: webUiUrl(host, '/settings/profile'),
-      title: 'プロフィールを編集',
-      icon: 'pencil',
-    }
-  }
   const suffix = u.host ? `@${u.host}` : ''
   return { url: webUiUrl(host, `/@${u.username}${suffix}`) }
+})
+
+// 自プロフィールの編集ボタン — アプリ内編集は非サポートなので WebUI 設定に委譲
+useWindowEditAction(() => {
+  const host = account.value?.host
+  if (!isOwnProfile.value || !host) return null
+  return {
+    onClick: () => openSafeUrl(webUiUrl(host, '/settings/profile')),
+    title: 'プロフィールを編集',
+  }
 })
 
 const MAX_PROFILE_NOTES = 500

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -284,7 +284,13 @@ function toggleAutoRun() {
     <!-- Header (= PluginsContent と同型) -->
     <div v-if="widget" :class="$style.header">
       <div :class="$style.headerIcon">
-        <i class="ti ti-layout-dashboard" />
+        <span
+          v-if="widget.iconUrl"
+          :class="$style.headerIconImg"
+          :style="{ '--icon-url': `url('${widget.iconUrl}')` }"
+          aria-hidden="true"
+        />
+        <i v-else class="ti ti-layout-dashboard" />
       </div>
       <div :class="$style.headerMeta">
         <div v-if="isRenaming" :class="$style.renameRow">
@@ -412,6 +418,14 @@ function toggleAutoRun() {
   background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
   color: var(--nd-accent);
   font-size: 24px;
+}
+
+.headerIconImg {
+  width: 1em;
+  height: 1em;
+  background-color: currentColor;
+  -webkit-mask: var(--icon-url) center / contain no-repeat;
+  mask: var(--icon-url) center / contain no-repeat;
 }
 
 .headerMeta {

--- a/src/components/window/user-profile/UserProfileHero.vue
+++ b/src/components/window/user-profile/UserProfileHero.vue
@@ -98,6 +98,7 @@ function openFollowList(type: 'following' | 'followers') {
     accountId: props.accountId,
     userId: props.user.id,
     username: props.user.username,
+    userHost: props.user.host,
     initialTab: type,
   })
 }

--- a/src/composables/useAccountActions.ts
+++ b/src/composables/useAccountActions.ts
@@ -11,6 +11,7 @@ import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
 import { purgeNotificationCacheForAccount } from '@/utils/notificationCache'
 import { removeStorage, STORAGE_KEYS } from '@/utils/storage'
+import { openSafeUrl, webUiUrl } from '@/utils/url'
 
 export function useAccountActions() {
   const accountsStore = useAccountsStore()
@@ -23,16 +24,14 @@ export function useAccountActions() {
     windowsStore.open('user-profile', { accountId: acc.id, userId: acc.userId })
   }
 
-  async function openSettings(acc: Account) {
+  function openSettings(acc: Account) {
     // Misskey Web UI の設定ページを外部ブラウザで開くだけなので、
     // ログアウト中でもリンクとして機能させる。
-    const { openUrl } = await import('@tauri-apps/plugin-opener')
-    openUrl(`https://${acc.host}/settings`)
+    openSafeUrl(webUiUrl(acc.host, '/settings'))
   }
 
-  async function openAdmin(acc: Account) {
-    const { openUrl } = await import('@tauri-apps/plugin-opener')
-    openUrl(`https://${acc.host}/admin`)
+  function openAdmin(acc: Account) {
+    openSafeUrl(webUiUrl(acc.host, '/admin'))
   }
 
   /** トークンを無効化し、ローカルデータは保持する */

--- a/src/composables/useWindowExternalLink.ts
+++ b/src/composables/useWindowExternalLink.ts
@@ -10,7 +10,7 @@ import {
 
 export interface WindowExternalLink {
   url: string
-  /** title 属性。省略時は 'Web で開く' */
+  /** title 属性。省略時は 'Web UIで開く' */
   title?: string
   /** tabler アイコン名 (ti- 接頭辞なし)。省略時は 'world' */
   icon?: string

--- a/src/settings/schema.ts
+++ b/src/settings/schema.ts
@@ -26,6 +26,13 @@ export interface NotedeckSettings {
   'modes.realtime'?: boolean
   'modes.offline'?: boolean
 
+  // --- Note view ---
+  /**
+   * cat ユーザーのノート本文を描画時に にゃ化する (#763、本家 Web UI 準拠)。
+   * 表示専用でコピー・検索は原文のまま。false で原文表示。
+   */
+  'note.nyaize'?: boolean
+
   // --- Post form ---
   'postForm.preview'?: boolean
   'postForm.autoSaveDraft'?: boolean
@@ -110,6 +117,8 @@ export const DEFAULT_SETTINGS: NotedeckSettings = {
   // 体験を変えない)
   'modes.realtime': true,
   'modes.offline': false,
+  // 本家 Web UI と同じ表示を基準にするため default ON (#763)
+  'note.nyaize': true,
   // notedeck の差別化要素「過去ノートを一瞬でローカル全文検索」を尊重し、
   // デフォルトは notecli の `EvictionConfig::default()` (= per-account 1M cap、
   // TTL なし) と同等のバランスプリセット。

--- a/src/stores/widgets.ts
+++ b/src/stores/widgets.ts
@@ -254,7 +254,7 @@ export const useWidgetsStore = defineStore('widgets', () => {
   // --- AI 経由の再実行シグナル (#744) ---
   // widgets.update capability だけが requestRerun を発火し、マウント中の
   // WidgetAiScript が rerunSignal を watch して新 src で再実行する。
-  // ユーザーのウィジェット内エディタ編集 (debounce 自動保存) では発火しない。
+  // ユーザーの widget-edit ウィンドウでの編集 (debounce 自動保存) では発火しない。
   const rerunSignals = ref<Map<string, number>>(new Map())
   const mountedCounts = ref<Map<string, number>>(new Map())
 

--- a/src/utils/nyaize.test.ts
+++ b/src/utils/nyaize.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { MfmToken } from './mfmParser'
+import { nyaize, nyaizeTokens } from './nyaize'
+
+describe('nyaize', () => {
+  it('日本語の な / ナ / ﾅ を にゃ化する', () => {
+    expect(nyaize('なんと')).toBe('にゃんと')
+    expect(nyaize('ナナ')).toBe('ニャニャ')
+    expect(nyaize('ﾅﾝﾃﾞ')).toBe('ﾆｬﾝﾃﾞ')
+  })
+
+  it('英語の na / morning / everyone を変換する', () => {
+    expect(nyaize('banana')).toBe('banyanya')
+    expect(nyaize('good morning')).toBe('good mornyan')
+    expect(nyaize('everyone')).toBe('everynyan')
+    expect(nyaize('BANANA')).toBe('BANYANYA')
+  })
+
+  it('韓国語の 나 行 / 語尾 다 / 야 を変換する', () => {
+    expect(nyaize('나')).toBe('냐')
+    expect(nyaize('합니다.')).toBe('합니다냥.')
+    expect(nyaize('뭐야?')).toBe('뭐냥?')
+  })
+
+  it('対象文字を含まないテキストはそのまま返す', () => {
+    expect(nyaize('hello world')).toBe('hello world')
+  })
+})
+
+describe('nyaizeTokens', () => {
+  it('text ノードの値を にゃ化する', () => {
+    const tokens: MfmToken[] = [{ type: 'text', value: 'なんと' }]
+    expect(nyaizeTokens(tokens)).toEqual([{ type: 'text', value: 'にゃんと' }])
+  })
+
+  it('URL / コード / メンション / カスタム絵文字 / plain は変換しない', () => {
+    const tokens: MfmToken[] = [
+      { type: 'url', value: 'https://nano.example/' },
+      { type: 'inlineCode', value: 'なんと' },
+      { type: 'codeBlock', lang: null, value: 'なんと' },
+      { type: 'mention', username: 'nana', host: null, acct: '@nana' },
+      { type: 'customEmoji', shortcode: 'nande' },
+      { type: 'plain', value: 'なんと' },
+    ]
+    expect(nyaizeTokens(tokens)).toEqual(tokens)
+  })
+
+  it('bold / fn などの子ノード内の text も変換する', () => {
+    const tokens: MfmToken[] = [
+      { type: 'bold', children: [{ type: 'text', value: 'な' }] },
+      {
+        type: 'fn',
+        name: 'shake',
+        args: {},
+        children: [{ type: 'text', value: 'ナ' }],
+      },
+    ]
+    expect(nyaizeTokens(tokens)).toEqual([
+      { type: 'bold', children: [{ type: 'text', value: 'にゃ' }] },
+      {
+        type: 'fn',
+        name: 'shake',
+        args: {},
+        children: [{ type: 'text', value: 'ニャ' }],
+      },
+    ])
+  })
+
+  it('入力のトークンツリーを破壊しない (parseMfm キャッシュ保護)', () => {
+    const child: MfmToken = { type: 'text', value: 'な' }
+    const tokens: MfmToken[] = [{ type: 'bold', children: [child] }]
+    nyaizeTokens(tokens)
+    expect(child.value).toBe('な')
+  })
+})

--- a/src/utils/nyaize.ts
+++ b/src/utils/nyaize.ts
@@ -1,0 +1,65 @@
+/**
+ * nyaize — cat ユーザーのノート本文の語尾を にゃ化する (#763)。
+ * Misskey 本家は v13.13.0 以降、保存時ではなく描画時に適用する方式。
+ * 変換ロジックは misskey-js/src/nyaize.ts と同一。
+ */
+import type { MfmToken } from './mfmParser'
+
+const enRegex1 = /(?<=n)a/gi
+const enRegex2 = /(?<=morn)ing/gi
+const enRegex3 = /(?<=every)one/gi
+const koRegex1 = /[나-낳]/g
+const koRegex2 = /(다$)|(다(?=\.))|(다(?= ))|(다(?=!))|(다(?=\?))/gm
+const koRegex3 = /(야(?=\?))|(야$)|(야(?= ))/gm
+
+export function nyaize(text: string): string {
+  return text
+    .replaceAll('な', 'にゃ')
+    .replaceAll('ナ', 'ニャ')
+    .replaceAll('ﾅ', 'ﾆｬ')
+    .replace(enRegex1, (x) => (x === 'A' ? 'YA' : 'ya'))
+    .replace(enRegex2, (x) => (x === 'ING' ? 'YAN' : 'yan'))
+    .replace(enRegex3, (x) => (x === 'ONE' ? 'NYAN' : 'nyan'))
+    .replace(koRegex1, (match) =>
+      !Number.isNaN(match.charCodeAt(0))
+        ? String.fromCharCode(
+            match.charCodeAt(0) + '냐'.charCodeAt(0) - '나'.charCodeAt(0),
+          )
+        : match,
+    )
+    .replace(koRegex2, '다냥')
+    .replace(koRegex3, '냥')
+}
+
+/**
+ * parse 済み MFM トークンツリーの text ノードだけ にゃ化した新しいツリーを返す
+ * (本家 frontend の `nyaize: 'respect'` 相当)。URL・コード・メンション・
+ * カスタム絵文字・`<plain>` は変換しない。
+ * parseMfm の LRU キャッシュを汚染しないよう、入力は変更せずコピーを返す。
+ */
+export function nyaizeTokens(tokens: MfmToken[]): MfmToken[] {
+  return tokens.map((token) => {
+    switch (token.type) {
+      case 'text':
+        return { ...token, value: nyaize(token.value) }
+      case 'bold':
+      case 'italic':
+      case 'strike':
+      case 'small':
+      case 'center':
+      case 'quote':
+      case 'heading':
+      case 'fn':
+        return { ...token, children: nyaizeTokens(token.children) }
+      case 'link':
+        return { ...token, label: nyaizeTokens(token.label) }
+      case 'list':
+        return {
+          ...token,
+          items: token.items.map((item) => nyaizeTokens(item)),
+        }
+      default:
+        return token
+    }
+  })
+}

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -17,6 +17,11 @@ export async function openSafeUrl(
   await openUrl(url)
 }
 
+/** Misskey WebUI (`https://<host>`) の URL を組み立てる。委譲導線は全てここを通す。 */
+export function webUiUrl(host: string, path = ''): string {
+  return `https://${host}${path}`
+}
+
 /**
  * Match `memo:<id>` link scheme. id は Zettelkasten 形式 (`YYYYMMDDHHmmss`、14 桁数字)。
  * `useMemos.generateMemoKey` 形式に合わせる。

--- a/src/views/PipPage.vue
+++ b/src/views/PipPage.vue
@@ -268,6 +268,8 @@ onMounted(async () => {
           v-else-if="windowPayload.type === 'follow-list'"
           :account-id="(windowPayload.props.accountId as string)"
           :user-id="(windowPayload.props.userId as string)"
+          :username="(windowPayload.props.username as string | undefined)"
+          :user-host="(windowPayload.props.userHost as string | null | undefined)"
           :initial-tab="(windowPayload.props.initialTab as 'following' | 'followers' | undefined)"
         />
         <LoginContent


### PR DESCRIPTION
## Changes

- feat: フォロリクカラムを「受け取った申請」「送った申請」のタブ構成に (#767)
- chore: コメントの旧ラベル表記「Web で開く」を「Web UIで開く」に揃える
- refactor: 自プロフィールのヘッダーを編集ボタン + Web UIで開くの 2 ボタン構成に分離
- refactor: WebUI 導線の任意改善 4 点をあるべき仕様に統一
- feat: note-detail ヘッダーに「Web で開く」ボタンを追加し、メニューの WebUI 導線をプラグインへ委譲
- feat: widget-edit ウィンドウのヘッダーに設定済みアイコン (iconUrl) を表示
- refactor: ウィジットのコードボタンで widget-edit ウィンドウを開くよう変更 (#765)
- feat: cat ユーザーのノート本文を描画時に nyaize する (#763)
- fix: ボトムシート/ナビドロワーの暗幕を --nd-modalBg トークンに統一
- feat: スマホサイズ表示で…メニュー展開をボトムシートに変更
- ci: リリース時に @notedeck@misskey.io へ自動投稿する announce ジョブを追加
- chore: bump version to 1.11.0

Closes #763
Closes #764
Closes #765
Closes #766
Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)