### PR TITLE
Release v1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.11.0"
+version = "1.11.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.11.0"
+version = "1.11.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.11.0"
+    "version": "1.11.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/PopupMenu.dom.test.ts
+++ b/src/components/common/PopupMenu.dom.test.ts
@@ -49,20 +49,23 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
     return new MouseEvent('click', { clientX: 100, clientY: 50 })
   }
 
-  it('狭いビューポートでは座標配置されないシートとしてネスト描画される', async () => {
+  it('狭いビューポートでは設定メニューと同じ dialog ホストのシートとして描画される', async () => {
     const menuRef = mountMenu(375)
     menuRef.value?.open(openEvent())
     await nextTick()
 
-    const root = container?.querySelector('[popover]') as HTMLElement
-    expect(root).toBeTruthy()
-    // シート branch: root は backdrop で、押下点への座標配置をしない
-    expect(root.style.top).toBe('')
-    expect(root.style.left).toBe('')
-    // メニュー本体は backdrop の子としてネストされる
-    const sheet = root.querySelector('.popup-menu')
+    // シート branch: dialog._nativeDialog ホスト (::backdrop の暗転を共有)
+    const dialog = container?.querySelector(
+      'dialog._nativeDialog',
+    ) as HTMLDialogElement
+    expect(dialog).toBeTruthy()
+    // メニュー本体は dialog の子としてネストされ、押下点への座標配置をしない
+    const sheet = dialog.querySelector('.popup-menu') as HTMLElement
     expect(sheet).toBeTruthy()
-    expect(sheet?.textContent).toContain('アイテム')
+    expect(sheet.style.top).toBe('')
+    expect(sheet.textContent).toContain('アイテム')
+    // popover 用の座標アンカー版は描画されない
+    expect(container?.querySelector('[popover]')).toBeNull()
   })
 
   it('広いビューポートでは従来どおり押下点にアンカーされる', async () => {
@@ -76,6 +79,7 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
     expect(root.classList.contains('popup-menu')).toBe(true)
     expect(root.style.left).toBe('104px')
     expect(root.style.top).toBe('60px')
+    expect(container?.querySelector('dialog')).toBeNull()
   })
 
   it('シートの backdrop タップで閉じ、メニュー項目タップでは閉じない', async () => {
@@ -84,15 +88,17 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
     menuRef.value?.open(openEvent())
     await nextTick()
 
-    const root = container?.querySelector('[popover]') as HTMLElement
-    const item = root.querySelector('button') as HTMLElement
+    const dialog = container?.querySelector(
+      'dialog._nativeDialog',
+    ) as HTMLDialogElement
+    const item = dialog.querySelector('button') as HTMLElement
 
-    // 項目タップ (click.self 不成立) では閉じない
+    // 項目タップ (target が dialog 自身でない) では閉じない
     item.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(onClose).not.toHaveBeenCalled()
 
-    // backdrop 自身のタップで閉じる
-    root.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    // backdrop タップ (target === dialog) で閉じる
+    dialog.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/common/PopupMenu.vue
+++ b/src/components/common/PopupMenu.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from 'vue'
+import { computed, nextTick, ref, watch } from 'vue'
 
 import { useBackButton } from '@/composables/useBackButton'
 import { useMenuKeyboard } from '@/composables/useMenuKeyboard'
+import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNativePopover } from '@/composables/useNativePopover'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { useIsCompactLayout } from '@/stores/ui'
@@ -17,7 +18,9 @@ const isCompact = useIsCompactLayout()
 const showMenu = ref(false)
 const menuPos = ref({ x: 0, y: 0 })
 const menuTheme = ref<Record<string, string>>({})
+// desktop: popover 要素 = メニュー本体 / compact: シート本体 (dialog の子)
 const menuRef = ref<HTMLElement | null>(null)
+const dialogRef = ref<HTMLDialogElement | null>(null)
 const triggerRef = ref<HTMLElement | null>(null)
 
 const { visible, entering, leaving } = useVaporTransition(showMenu, {
@@ -37,12 +40,27 @@ watch(visible, (v) => {
   else deactivateKeyboard()
 })
 
-useNativePopover(menuRef, visible, {
-  onClose: () => close(),
-  leaveDuration: 200,
-  dismissOnOutsideClick: true,
-  ignoreOutsideClickFor: triggerRef,
-})
+useNativePopover(
+  menuRef,
+  computed(() => visible.value && !isCompact.value),
+  {
+    onClose: () => close(),
+    leaveDuration: 200,
+    dismissOnOutsideClick: true,
+    ignoreOutsideClickFor: triggerRef,
+  },
+)
+
+// compact のボトムシートは設定メニュー等と同じ dialog ホスト
+// (::backdrop の暗転 + navMenu.scss のスライドをそのまま共有)
+useNativeDialog(
+  dialogRef,
+  computed(() => visible.value && isCompact.value),
+  {
+    onCancel: () => close(),
+    leaveDuration: 200,
+  },
+)
 
 // Android back button / gesture でシートを閉じる
 useBackButton(showMenu, () => close())
@@ -90,24 +108,23 @@ defineExpose({ open, close, activateKeyboard })
 </script>
 
 <template>
-    <!-- compact: 画面下からスライドするボトムシート -->
-    <!-- inset はインライン必須: global.css の [popover]:popover-open リセット (0,2,0) がクラス指定に勝つ -->
-    <div
+    <!-- compact: 画面下からスライドするボトムシート (設定メニュー等と同じ dialog + navMenu.scss パターン) -->
+    <dialog
       v-if="visible && isCompact"
-      ref="menuRef"
-      popover="manual"
-      style="inset: 0"
-      :class="[$style.sheetBackdrop, entering && $style.enter, leaving && $style.leave]"
-      @click.self="close()"
+      ref="dialogRef"
+      class="_nativeDialog"
+      :class="[$style.mobileBackdrop, leaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
     >
       <div
-        :class="[$style.sheet, entering && $style.sheetEnter, leaving && $style.sheetLeave]"
+        ref="menuRef"
+        :class="[$style.sheet, leaving ? $style.sheetContentLeave : $style.sheetContentEnter]"
         class="_popup nd-popup-content popup-menu"
         :style="menuTheme"
+        @pointerdown.stop
       >
         <slot />
       </div>
-    </div>
+    </dialog>
     <!-- desktop: 押下点アンカーのポップアップ -->
     <div
       v-else-if="visible"
@@ -123,6 +140,7 @@ defineExpose({ open, close, activateKeyboard })
 
 <style lang="scss" module>
 @use '@/styles/popup';
+@use '@/styles/navMenu';
 
 .popupMenu {
   position: fixed;
@@ -131,43 +149,14 @@ defineExpose({ open, close, activateKeyboard })
   padding: 6px 0;
 }
 
-.sheetBackdrop {
-  position: fixed;
-  // inset: 0 はテンプレート側のインライン style で指定 (popover リセットとの特異度競合回避)
-  width: auto;
-  height: auto;
-  background: var(--nd-modalBg);
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  // slide 中のシートが viewport 下にはみ出てもスクロールバーを出さない
-  overflow: hidden;
-}
-
 .sheet {
   width: 100%;
   max-height: 70vh;
   max-height: 70dvh;
   overflow-y: auto;
   overscroll-behavior: contain;
-  border-radius: var(--nd-radius) var(--nd-radius) 0 0;
-  padding: 8px 0 calc(8px + env(safe-area-inset-bottom));
-}
-
-.sheetEnter {
-  animation: sheetIn 0.25s var(--nd-ease-decel);
-}
-
-.sheetLeave {
-  animation: sheetOut var(--nd-duration-base) ease-out forwards;
-}
-
-@keyframes sheetIn {
-  from { transform: translateY(100%); }
-}
-
-@keyframes sheetOut {
-  to { transform: translateY(100%); }
+  border-radius: 16px 16px 0 0;
+  padding: 8px 0 calc(8px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
 }
 
 </style>

--- a/src/components/deck/DeckFollowRequestsColumn.vue
+++ b/src/components/deck/DeckFollowRequestsColumn.vue
@@ -8,6 +8,7 @@ import { useColumnPullScroller } from '@/composables/useColumnPullScroller'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useNavigation } from '@/composables/useNavigation'
 import { useServerImages } from '@/composables/useServerImages'
+import { useTabSlide } from '@/composables/useTabSlide'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
@@ -54,12 +55,18 @@ const actionStates = ref<Record<string, 'accepted' | 'rejected' | 'canceled'>>(
 )
 const scrollContainer = ref<HTMLElement | null>(null)
 useColumnPullScroller(scrollContainer)
+/** スワイプ対象は空表示でも常に存在する body 側 (scroller は条件付き描画) */
+const bodyRef = ref<HTMLElement | null>(null)
 
 const activeTab = ref<TabValue>('received')
 const tabDefs: ColumnTabDef[] = [
   { value: 'received', label: '受け取った申請', icon: 'download' },
   { value: 'sent', label: '送った申請', icon: 'upload' },
 ]
+const frTabIndex = computed(() =>
+  tabDefs.findIndex((t) => t.value === activeTab.value),
+)
+useTabSlide(frTabIndex, bodyRef)
 
 /** 受信タブは相手=follower、送信タブは相手=followee */
 function requestUser(req: FollowRequest): NormalizedUser {
@@ -253,7 +260,7 @@ onMounted(() => {
       <ColumnTabs
         v-model="activeTab"
         :tabs="tabDefs"
-        :swipe-target="scrollContainer"
+        :swipe-target="bodyRef"
       />
     </template>
 
@@ -264,7 +271,7 @@ onMounted(() => {
       :image-url="serverErrorImageUrl"
     />
 
-    <div v-else :class="$style.frBody">
+    <div v-else ref="bodyRef" :class="$style.frBody">
       <ColumnEmptyState
         v-if="requests.length === 0 && !isLoading"
         :message="emptyMessage"


### PR DESCRIPTION
## Changes

- fix: フォロリクカラムのタブが横スワイプ/横スクロールで切り替わらない
- fix: …メニューのボトムシートを設定メニューと同じ dialog パターンに統一
- chore: bump version to 1.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)