### PR TITLE
Release v1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.11.1"
+version = "1.12.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.11.1"
+version = "1.12.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.11.1"
+    "version": "1.12.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -2,11 +2,13 @@ import { type Ast, type Interpreter, utils, values } from '@syuilo/aiscript'
 import type { Value, VFn } from '@syuilo/aiscript/interpreter/value.js'
 import type { JsonValue } from '@/bindings'
 import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
+import { accountScopeKey, useAccountsStore } from '@/stores/accounts'
 import {
   type AiScriptRunLogger,
   useAiScriptLogsStore,
 } from '@/stores/aiscriptLogs'
 import {
+  isPluginEffectiveFor,
   type PluginConfigDef,
   type PluginMeta,
   usePluginsStore,
@@ -157,26 +159,26 @@ const pluginAccountContext = new Map<string, { accountId: string | null }>()
 const pluginNdContexts = new Map<string, NoteDeckEnvContext>()
 
 /**
- * type に該当する handler を返す。accountId が指定されていれば、各 handler の
- * 提供元 plugin の `installedFor` で per-account 有効/無効を判定する:
- *   - installedFor 未設定 / 空配列 → 旧仕様で全 account に有効 (backward compat)
- *   - 1 つ以上の id がセット → 該当 accountId が含まれる場合のみ有効
- * accountId が null/undefined の場合 (グローバル context など) は filter しない。
+ * type に該当する handler をスコープ評価 (#771) して返す。
+ * 有効 = 提供元 plugin が全体スコープ (global) OR 対象アカウントの
+ * アカウント別スコープ (installedFor に安定キー一致)。
+ * accountId (内部 UUID) は accounts store 経由で安定キーに解決する。
+ * accountId が null/undefined (アカウント文脈なし) の場合は全体スコープのみ。
  */
 export function getPluginHandlers<T extends HandlerType>(
   type: T,
   accountId?: string | null,
 ): PluginHandler[] {
   const matched = pluginHandlers.filter((h) => h.type === type)
-  if (!accountId) return matched
-  // installId → installedFor の lookup を都度作る (handler 数 / plugin 数とも
-  // 通常 一桁〜十数で十分)
+  if (matched.length === 0) return matched
+  const account = accountId
+    ? useAccountsStore().accounts.find((a) => a.id === accountId)
+    : undefined
+  const scopeKey = account ? accountScopeKey(account) : null
   const plugins = usePluginsStore().plugins
   return matched.filter((h) => {
     const plugin = plugins.find((p) => p.installId === h.pluginInstallId)
-    const installedFor = plugin?.installedFor
-    if (!installedFor || installedFor.length === 0) return true
-    return installedFor.includes(accountId)
+    return plugin ? isPluginEffectiveFor(plugin, scopeKey) : false
   })
 }
 
@@ -389,7 +391,7 @@ function createPluginSpecificEnv(
 
 /**
  * Apply all note_view_interruptors to a note object (sync).
- * accountId が渡されれば installedFor で per-account 有効/無効が判定される。
+ * accountId が渡されればスコープ評価 (#771) で有効/無効が判定される。
  */
 export function applyNoteViewInterruptors<T>(
   note: T,

--- a/src/capabilities/builtins/plugins.ts
+++ b/src/capabilities/builtins/plugins.ts
@@ -4,7 +4,6 @@ import {
   parsePluginMeta,
 } from '@/aiscript/plugin-api'
 import type { Command } from '@/commands/registry'
-import { useAccountsStore } from '@/stores/accounts'
 import { useMisStoreStore } from '@/stores/misstore'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
 import { getSnapshotAt, listSnapshots } from '@/utils/historyFs'
@@ -207,6 +206,8 @@ export const pluginsCreateCapability: Command = {
       configData: {},
       src,
       active: false,
+      // AI 経由はカラム文脈を持たないため全体スコープで作成 (#771)
+      global: true,
     }
     const store = usePluginsStore()
     store.addPlugin(plugin)
@@ -547,11 +548,12 @@ export const pluginsRevertCapability: Command = {
  * plugins store に追加する。AI が「○○の機能ない？」のように推薦から install
  * まで一気通貫で実行できるようにするためのラッパ。
  *
- * 内部実装は `useMisStoreStore.installPlugin(entry, forAccountIds)` を呼ぶだけ。
- * sha512 検証・parsePluginMeta・既存 storeId への installedFor union は
- * misstore store 側で実装済 (= 同 storeId のプラグインがあれば再インストール
- * せず installedFor に accountIds を追加するだけ)。インストール後は active=true で
- * 自動起動される (misstore.ts installPlugin の挙動)。
+ * 内部実装は `useMisStoreStore.installPlugin(entry, scope)` を呼ぶだけ。
+ * sha512 検証・parsePluginMeta・既存 storeId へのスコープ追加は misstore
+ * store 側で実装済 (= 同 storeId のプラグインがあれば再インストールせず
+ * scope 参照を追加するだけ)。AI 経由はカラム文脈を持たないため全体スコープ
+ * (全アカウント対象、後から追加した分も含む #771) で入れる。インストール後は
+ * active=true で自動起動される (misstore.ts installPlugin の挙動)。
  */
 export const pluginsInstallCapability: Command = {
   id: 'plugins.install',
@@ -591,8 +593,8 @@ export const pluginsInstallCapability: Command = {
     description:
       'MisStore (misstore.hital.in) の既製プラグインをインストールする。' +
       ' id は `misstore.search` で取得した値を渡す。sha512 検証付き。' +
-      ' 既に同 storeId のプラグインがあれば再インストールせず installedFor を' +
-      ' 全 logged-in account で union 更新するだけ。',
+      ' 全体スコープ (全アカウント対象) でインストールされ、既に同 storeId の' +
+      ' プラグインがあれば再インストールせず全体スコープへ追加するだけ。',
     params: {
       id: {
         type: 'string',
@@ -616,9 +618,7 @@ export const pluginsInstallCapability: Command = {
         `plugins.install: plugin "${id}" not found in MisStore (try misstore.search first)`,
       )
     }
-    const accounts = useAccountsStore()
-    const forAccountIds = accounts.accounts.map((a) => a.id)
-    await misStore.installPlugin(entry, forAccountIds)
+    await misStore.installPlugin(entry, { kind: 'global' })
     return { id: entry.id, name: entry.name, installed: true }
   },
 }

--- a/src/components/deck/ColumnSection.vue
+++ b/src/components/deck/ColumnSection.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+defineProps<{
+  label: string
+  count: number
+}>()
+
+// アコーディオン開閉。デフォルト展開、状態はカラムインスタンス内のみ
+// (永続化しない)。
+const collapsed = ref(false)
+</script>
+
+<template>
+  <section :class="$style.section">
+    <button
+      class="_button"
+      :class="$style.header"
+      :aria-expanded="!collapsed"
+      @click="collapsed = !collapsed"
+    >
+      <i
+        class="ti"
+        :class="[collapsed ? 'ti-chevron-right' : 'ti-chevron-down', $style.chevron]"
+      />
+      <span>{{ label }}</span>
+      <span :class="$style.count">{{ count }}</span>
+    </button>
+    <div v-show="!collapsed">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<style module lang="scss">
+.section {
+  &:not(:first-child) {
+    margin-top: 8px;
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 8px 12px 4px;
+  font-size: 0.75em;
+  font-weight: 600;
+  color: var(--nd-fg);
+  opacity: 0.55;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: opacity 0.1s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
+.chevron {
+  font-size: 1.1em;
+}
+
+.count {
+  font-weight: 400;
+  opacity: 0.7;
+}
+</style>

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -166,7 +166,7 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
 /**
  * インストール済みタブのセクション分け (上流の有無):
  *   - オリジナル: storeId 無し。手元が原本 (エディタ/AI 作成・import・同梱 seed)
- *   - フォーク: storeId 持ち。MisStore に上流がある複製 (改造も自由)
+ *   - ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<PluginSection[]>(() => {
@@ -174,7 +174,7 @@ const installedSections = computed<PluginSection[]>(() => {
   const store = visiblePlugins.value.filter((p) => !!p.storeId)
   const sections: PluginSection[] = [
     { key: 'local', label: 'オリジナル', items: local },
-    { key: 'store', label: 'フォーク', items: store },
+    { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)
 })

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -165,7 +165,7 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
 
 /**
  * インストール済みタブのセクション分け (上流の有無):
- *   - オリジナル: storeId 無し。手元が原本 (エディタ/AI 作成・import・同梱 seed)
+ *   - ビルドイン: storeId 無し。手元が原本 (エディタ/AI 作成・import・同梱 seed)
  *   - ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
  * 0 件のセクションは表示しない。
  */
@@ -173,7 +173,7 @@ const installedSections = computed<PluginSection[]>(() => {
   const local = visiblePlugins.value.filter((p) => !p.storeId)
   const store = visiblePlugins.value.filter((p) => !!p.storeId)
   const sections: PluginSection[] = [
-    { key: 'local', label: 'オリジナル', items: local },
+    { key: 'local', label: 'ビルドイン', items: local },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -25,6 +25,7 @@ import {
 } from '@/stores/plugins'
 import { useWindowsStore } from '@/stores/windows'
 import { openSafeUrl } from '@/utils/url'
+import ColumnSection from './ColumnSection.vue'
 import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
@@ -163,17 +164,17 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
 })
 
 /**
- * インストール済みタブのセクション分け:
- *   - ローカル: storeId 無し (NoteDeck エディタで作成 / import)
- *   - ストア: storeId 持ち (MisStore からインストール)
+ * インストール済みタブのセクション分け (上流の有無):
+ *   - オリジナル: storeId 無し。手元が原本 (エディタ/AI 作成・import・同梱 seed)
+ *   - フォーク: storeId 持ち。MisStore に上流がある複製 (改造も自由)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<PluginSection[]>(() => {
   const local = visiblePlugins.value.filter((p) => !p.storeId)
   const store = visiblePlugins.value.filter((p) => !!p.storeId)
   const sections: PluginSection[] = [
-    { key: 'local', label: 'ローカル', items: local },
-    { key: 'store', label: 'ストア', items: store },
+    { key: 'local', label: 'オリジナル', items: local },
+    { key: 'store', label: 'フォーク', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)
 })
@@ -377,12 +378,12 @@ async function deleteFromLibrary(plugin: PluginMeta) {
       <!-- ===== Installed tab ===== -->
       <template v-if="viewTab === 'installed'">
         <div :class="$style.list">
-          <div
+          <ColumnSection
             v-for="section in installedSections"
             :key="section.key"
-            :class="$style.section"
+            :label="section.label"
+            :count="section.items.length"
           >
-            <h3 :class="$style.sectionTitle">{{ section.label }}</h3>
             <PluginCard
               v-for="plugin in section.items"
               :key="plugin.installId"
@@ -403,7 +404,7 @@ async function deleteFromLibrary(plugin: PluginMeta) {
               @settings="openPluginDetail(plugin.installId)"
               @denied-click="openPermissionSettings()"
             />
-          </div>
+          </ColumnSection>
 
           <div v-if="visiblePluginCount === 0" :class="$style.empty">
             <template v-if="textQuery || activeFilter !== 'all'">
@@ -607,22 +608,6 @@ async function deleteFromLibrary(plugin: PluginMeta) {
   overflow-y: auto;
   scrollbar-color: var(--nd-scrollbarHandle) transparent;
   scrollbar-width: thin;
-}
-
-.section {
-  &:not(:first-child) {
-    margin-top: 8px;
-  }
-}
-
-.sectionTitle {
-  margin: 0;
-  padding: 8px 12px 4px;
-  font-size: 0.75em;
-  font-weight: 600;
-  color: var(--nd-fg);
-  opacity: 0.55;
-  letter-spacing: 0.04em;
 }
 
 // --- Library picker (ウィジェットカラムのピッカーと同型) ---

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -5,7 +5,12 @@ import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getPluginDenial } from '@/permissions/pluginDenials'
-import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
+import {
+  accountScopeKey,
+  getAccountAvatarUrl,
+  useAccountsStore,
+} from '@/stores/accounts'
+import { useConfirm } from '@/stores/confirm'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import {
   getPluginDetailUrl,
@@ -13,7 +18,11 @@ import {
   type StorePluginEntry,
   useMisStoreStore,
 } from '@/stores/misstore'
-import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
+import {
+  type PluginMeta,
+  type PluginScope,
+  usePluginsStore,
+} from '@/stores/plugins'
 import { useWindowsStore } from '@/stores/windows'
 import { openSafeUrl } from '@/utils/url'
 import type { ColumnTabDef } from './ColumnTabs.vue'
@@ -55,33 +64,28 @@ const account = computed(() =>
     : (accountsStore.accounts.find((a) => a.id === props.column.accountId) ??
       null),
 )
-const accountId = computed(() => props.column.accountId)
-
-/** カラムの context (per-account / 全アカウント) に応じた installedFor 対象 ids。 */
-function contextAccountIds(): string[] {
-  if (isCrossAccount.value) {
-    return accountsStore.accounts.map((a) => a.id)
-  }
-  return accountId.value ? [accountId.value] : []
-}
-
-const loggedInIds = computed(
-  () => new Set(accountsStore.accounts.map((a) => a.id)),
-)
+/**
+ * このカラムが管理するスコープ (#771)。
+ * - 全アカウントカラム: 全体スコープ (global)
+ * - per-account カラム: 当該アカウントのスコープ (accountScopeKey で紐付け)
+ * per-account カラムでアカウントが見つからない (ログアウト済) 場合は null。
+ */
+const columnScope = computed<PluginScope | null>(() => {
+  if (isCrossAccount.value) return { kind: 'global' }
+  if (!account.value) return null
+  return { kind: 'account', key: accountScopeKey(account.value) }
+})
 
 /**
- * カラム context に該当するか判定する。
- * - per-account カラム: installedFor が当該 account を含む or installedFor 未設定
- *   (旧プラグイン後方互換で全 account 対象扱い)
- * - 全アカウントカラム: installedFor が少なくとも 1 つ logged-in account を含む or 未設定
+ * カラムのスコープに参加しているか。全アカウントカラムは全体スコープ参加分
+ * のみ、per-account カラムは当該アカウントのスコープ参加分のみを表示する
+ * (ウィジェットの「カラム別プール」に対応する「スコープ別プール」)。
  */
 function matchesContext(plugin: PluginMeta): boolean {
-  const installedFor = plugin.installedFor
-  if (!installedFor || installedFor.length === 0) return true
-  if (isCrossAccount.value) {
-    return installedFor.some((id) => loggedInIds.value.has(id))
-  }
-  return installedFor.includes(accountId.value as string)
+  const scope = columnScope.value
+  if (!scope) return false
+  if (scope.kind === 'global') return plugin.global === true
+  return plugin.installedFor?.includes(scope.key) ?? false
 }
 
 // --- View mode ---
@@ -90,10 +94,14 @@ const viewTabs: ViewTab[] = ['installed', 'store']
 const viewTab = ref<ViewTab>('installed')
 const columnContentRef = ref<HTMLElement | null>(null)
 
+const scopeCount = computed(
+  () => pluginsStore.plugins.filter((p) => matchesContext(p)).length,
+)
+
 const tabDefs = computed<ColumnTabDef[]>(() => [
   {
     value: 'installed',
-    label: `インストール済み ${pluginsStore.plugins.length}`,
+    label: `インストール済み ${scopeCount.value}`,
   },
   { value: 'store', label: 'ストア' },
 ])
@@ -158,8 +166,7 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
  * インストール済みタブのセクション分け:
  *   - ローカル: storeId 無し (NoteDeck エディタで作成 / import)
  *   - ストア: storeId 持ち (MisStore からインストール)
- * 検索なし時は空セクションもラベルを出して状態が一目で分かるようにする。
- * 検索 / フィルタ適用時は該当 0 件のセクションは非表示にする。
+ * 0 件のセクションは表示しない。
  */
 const installedSections = computed<PluginSection[]>(() => {
   const local = visiblePlugins.value.filter((p) => !p.storeId)
@@ -168,9 +175,7 @@ const installedSections = computed<PluginSection[]>(() => {
     { key: 'local', label: 'ローカル', items: local },
     { key: 'store', label: 'ストア', items: store },
   ]
-  const isFiltering = textQuery.value.length > 0 || activeFilter.value !== 'all'
-  if (isFiltering) return sections.filter((s) => s.items.length > 0)
-  return sections
+  return sections.filter((s) => s.items.length > 0)
 })
 
 const visiblePluginCount = computed(() => visiblePlugins.value.length)
@@ -202,14 +207,22 @@ const filteredStorePlugins = computed(() => {
 const installError = ref<string | null>(null)
 
 async function handleStoreInstall(entry: StorePluginEntry) {
+  const scope = columnScope.value
+  if (!scope) return
   installError.value = null
   try {
-    // per-account: 当該アカウントの installedFor に追加
-    // 全アカウント: 全 logged-in account の installedFor に追加 (集約 viewer)
-    await misStore.installPlugin(entry, contextAccountIds())
+    // 本体はライブラリに 1 つ。既にあればこのカラムのスコープへ参照追加、
+    // 無ければ取得してこのスコープで有効化 (#771)
+    await misStore.installPlugin(entry, scope)
   } catch (e) {
     installError.value = e instanceof Error ? e.message : 'インストール失敗'
   }
+}
+
+/** ストアエントリがこのカラムのスコープに参加済みか (「インストール済み」表示基準)。 */
+function isEntryInScope(entry: StorePluginEntry): boolean {
+  const plugin = pluginsStore.plugins.find((p) => p.storeId === entry.id)
+  return plugin ? matchesContext(plugin) : false
 }
 
 function handleOpenStoreDetail(entry: StorePluginEntry) {
@@ -230,48 +243,59 @@ async function toggleActive(plugin: PluginMeta) {
 function openPluginDetail(pluginId: string) {
   windowsStore.open('plugins', {
     initialPluginId: pluginId,
-    initialAccountIds: contextAccountIds(),
+    ...(columnScope.value ? { initialScope: columnScope.value } : {}),
   })
 }
 
 function openNewPlugin() {
   windowsStore.open('plugins', {
-    initialAccountIds: contextAccountIds(),
+    ...(columnScope.value ? { initialScope: columnScope.value } : {}),
   })
 }
 
-// 1 クリック目で trash ボタンを赤くアーム、2 クリック目で実行 (PluginCard の
-// confirmingUninstall 表示に対応する armed 状態をカラム側で管理)
-const confirmingUninstallId = ref<string | null>(null)
-let uninstallArmTimer: ReturnType<typeof setTimeout> | null = null
-
-function requestUninstall(plugin: PluginMeta) {
-  if (uninstallArmTimer) clearTimeout(uninstallArmTimer)
-  if (confirmingUninstallId.value === plugin.installId) {
-    confirmingUninstallId.value = null
-    handleUninstall(plugin)
-    return
-  }
-  confirmingUninstallId.value = plugin.installId
-  uninstallArmTimer = setTimeout(() => {
-    confirmingUninstallId.value = null
-  }, 3000)
+/**
+ * カード trash = このカラムのスコープから外す (widgets の detach と同型)。
+ * 本体はライブラリに残り、ピッカーから再追加/完全削除できる。
+ */
+function detachFromScope(plugin: PluginMeta) {
+  const scope = columnScope.value
+  if (!scope) return
+  pluginsStore.unlinkScope(plugin.installId, scope)
 }
 
-function handleUninstall(plugin: PluginMeta) {
-  if (!isCrossAccount.value && accountId.value) {
-    // per-account: このアカウントから外す (installedFor から除外)
-    // installedFor が空になれば完全削除 (= abort も走る経路)
-    const remaining = (plugin.installedFor ?? []).filter(
-      (id) => id !== accountId.value,
-    )
-    pluginsStore.unlinkAccountFromPlugin(plugin.installId, accountId.value)
-    if (remaining.length === 0) abortPlugin(plugin.installId)
-  } else {
-    // 全アカウント: 完全削除
-    abortPlugin(plugin.installId)
-    pluginsStore.removePlugin(plugin.installId)
-  }
+const detachTitle = computed(() =>
+  isCrossAccount.value ? '全アカウント対象から外す' : 'このアカウントから外す',
+)
+
+// --- Library picker (スコープ未参加のライブラリ本体の追加/削除) ---
+// ウィジェットカラムのライブラリピッカーと同型 (#771)。
+const showLibraryPicker = ref(false)
+
+/** このカラムのスコープに未参加のライブラリ本体 (= 追加可能候補)。 */
+const libraryCandidates = computed<PluginMeta[]>(() =>
+  pluginsStore.plugins.filter((p) => !matchesContext(p)),
+)
+
+function placeFromLibrary(plugin: PluginMeta) {
+  const scope = columnScope.value
+  if (!scope) return
+  pluginsStore.linkScope(plugin.installId, scope)
+  showLibraryPicker.value = false
+}
+
+const { confirm } = useConfirm()
+
+/** ライブラリから本体ごと削除 (コードも消える)。 */
+async function deleteFromLibrary(plugin: PluginMeta) {
+  const ok = await confirm({
+    title: 'プラグインを削除',
+    message: `「${plugin.name}」をライブラリから削除しますか？プラグインのコードも消えます。この操作は取り消せません。`,
+    okLabel: '削除',
+    type: 'danger',
+  })
+  if (!ok) return
+  abortPlugin(plugin.installId)
+  pluginsStore.removePlugin(plugin.installId)
 }
 </script>
 
@@ -359,9 +383,6 @@ function handleUninstall(plugin: PluginMeta) {
             :class="$style.section"
           >
             <h3 :class="$style.sectionTitle">{{ section.label }}</h3>
-            <div v-if="section.items.length === 0" :class="$style.sectionEmpty">
-              未設定
-            </div>
             <PluginCard
               v-for="plugin in section.items"
               :key="plugin.installId"
@@ -373,12 +394,12 @@ function handleUninstall(plugin: PluginMeta) {
               :category="storeByName.get(plugin.name)?.category"
               :category-label="storeByName.get(plugin.name)?.category ? PLUGIN_CATEGORY_LABELS[storeByName.get(plugin.name)!.category] : undefined"
               :active="plugin.active"
-              :confirming-uninstall="confirmingUninstallId === plugin.installId"
+              :uninstall-title="detachTitle"
               :icon-url="plugin.iconUrl ?? storeByName.get(plugin.name)?.iconUrl"
               :denied-badge="getPluginDenial(plugin.installId)"
               @click="openPluginDetail(plugin.installId)"
               @toggle="toggleActive(plugin)"
-              @uninstall="requestUninstall(plugin)"
+              @uninstall="detachFromScope(plugin)"
               @settings="openPluginDetail(plugin.installId)"
               @denied-click="openPermissionSettings()"
             />
@@ -390,11 +411,41 @@ function handleUninstall(plugin: PluginMeta) {
             </template>
             <template v-else>
               <i class="ti ti-puzzle" :class="$style.emptyIcon" />
-              <span>プラグインがインストールされていません</span>
+              <span>このカラムに追加されたプラグインはありません</span>
               <button class="_button" :class="$style.emptyLink" @click="viewTab = 'store'">
                 ストアからインストール...
               </button>
             </template>
+          </div>
+
+          <!-- Library picker: スコープ未参加のライブラリ本体を追加/削除 -->
+          <div :class="$style.addPluginArea">
+            <button
+              :class="[$style.addPluginBtn, showLibraryPicker && $style.addPluginBtnActive]"
+              @click="showLibraryPicker = !showLibraryPicker"
+            >
+              <i :class="showLibraryPicker ? 'ti ti-chevron-up' : 'ti ti-plus'" />
+              {{ showLibraryPicker ? '閉じる' : 'ライブラリから追加' }}
+            </button>
+          </div>
+
+          <div v-if="showLibraryPicker" :class="$style.pickerWrap">
+            <div v-if="libraryCandidates.length === 0" :class="$style.pickerEmpty">
+              ライブラリに追加可能なプラグインがありません。
+            </div>
+            <PluginCard
+              v-for="plugin in libraryCandidates"
+              :key="plugin.installId"
+              mode="library"
+              :name="plugin.name"
+              :description="storeByName.get(plugin.name)?.description ?? plugin.description"
+              :author="storeByName.get(plugin.name)?.author ?? plugin.author"
+              :version="plugin.version"
+              :icon-url="plugin.iconUrl ?? storeByName.get(plugin.name)?.iconUrl"
+              @click="openPluginDetail(plugin.installId)"
+              @place="placeFromLibrary(plugin)"
+              @delete="deleteFromLibrary(plugin)"
+            />
           </div>
         </div>
       </template>
@@ -435,7 +486,7 @@ function handleUninstall(plugin: PluginMeta) {
             :category="entry.category"
             :category-label="entry.category ? PLUGIN_CATEGORY_LABELS[entry.category] : undefined"
             :installing="misStore.installing === entry.id"
-            :already-installed="misStore.installedNames.has(entry.name)"
+            :already-installed="isEntryInScope(entry)"
             :icon-url="entry.iconUrl"
             @install="handleStoreInstall(entry)"
             @open-detail="handleOpenStoreDetail(entry)"
@@ -574,11 +625,55 @@ function handleUninstall(plugin: PluginMeta) {
   letter-spacing: 0.04em;
 }
 
-.sectionEmpty {
-  padding: 6px 12px 10px;
-  font-size: 0.8em;
+// --- Library picker (ウィジェットカラムのピッカーと同型) ---
+.addPluginArea {
+  display: flex;
+  justify-content: center;
+  padding: 6px;
+}
+
+.addPluginBtn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  border: 1px dashed var(--nd-divider);
+  border-radius: var(--nd-radius-md);
+  background: none;
   color: var(--nd-fg);
+  cursor: pointer;
+  font-size: 0.85em;
   opacity: 0.5;
+  transition: opacity var(--nd-duration-base), border-color var(--nd-duration-base);
+
+  &:hover {
+    opacity: 1;
+    border-color: var(--nd-accent);
+    color: var(--nd-accent);
+  }
+}
+
+.addPluginBtnActive {
+  opacity: 1;
+  border-color: var(--nd-accent);
+  color: var(--nd-accent);
+}
+
+.pickerWrap {
+  display: flex;
+  flex-direction: column;
+  padding: 4px 0 8px;
+}
+
+.pickerEmpty {
+  margin: 4px 10px;
+  padding: 12px;
+  border: 1px dashed var(--nd-divider);
+  border-radius: var(--nd-radius-md);
+  color: var(--nd-fg);
+  opacity: 0.6;
+  font-size: 11.5px;
+  text-align: center;
 }
 
 // --- Store states ---

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -19,6 +19,7 @@ import {
   useMisStoreStore,
 } from '@/stores/misstore'
 import {
+  isBuiltInPlugin,
   type PluginMeta,
   type PluginScope,
   usePluginsStore,
@@ -138,7 +139,7 @@ const textQuery = computed(() => {
 })
 
 interface PluginSection {
-  key: 'local' | 'store'
+  key: 'builtin' | 'selfmade' | 'store'
   label: string
   items: PluginMeta[]
 }
@@ -164,16 +165,24 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
 })
 
 /**
- * インストール済みタブのセクション分け (上流の有無):
- *   - ビルドイン: storeId 無し。手元が原本 (エディタ/AI 作成・import・同梱 seed)
- *   - ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
+ * インストール済みタブのセクション分け (出自 3 分類):
+ *   - ビルドイン: アプリ同梱 seed
+ *   - 自作: ＋ボタン手書き・AI 生成・インポート (storeId 無し、同梱以外)
+ *   - ストア配布: storeId 持ち。MisStore に上流がある複製 (手で書き換えても
+ *     storeId が残る限りここ)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<PluginSection[]>(() => {
-  const local = visiblePlugins.value.filter((p) => !p.storeId)
+  const builtin = visiblePlugins.value.filter(
+    (p) => !p.storeId && isBuiltInPlugin(p.installId),
+  )
+  const selfMade = visiblePlugins.value.filter(
+    (p) => !p.storeId && !isBuiltInPlugin(p.installId),
+  )
   const store = visiblePlugins.value.filter((p) => !!p.storeId)
   const sections: PluginSection[] = [
-    { key: 'local', label: 'ビルドイン', items: local },
+    { key: 'builtin', label: 'ビルドイン', items: builtin },
+    { key: 'selfmade', label: '自作', items: selfMade },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -139,7 +139,7 @@ const textQuery = computed(() => {
 })
 
 interface PluginSection {
-  key: 'builtin' | 'selfmade' | 'store'
+  key: 'builtin' | 'sideload' | 'store'
   label: string
   items: PluginMeta[]
 }
@@ -167,7 +167,7 @@ const visiblePlugins = computed<PluginMeta[]>(() => {
 /**
  * インストール済みタブのセクション分け (出自 3 分類):
  *   - ビルドイン: アプリ同梱 seed
- *   - 自作: ＋ボタン手書き・AI 生成・インポート (storeId 無し、同梱以外)
+ *   - サイドロード: ＋ボタン手書き・AI 生成・インポート (storeId 無し、同梱以外)
  *   - ストア配布: storeId 持ち。MisStore に上流がある複製 (手で書き換えても
  *     storeId が残る限りここ)
  * 0 件のセクションは表示しない。
@@ -176,13 +176,13 @@ const installedSections = computed<PluginSection[]>(() => {
   const builtin = visiblePlugins.value.filter(
     (p) => !p.storeId && isBuiltInPlugin(p.installId),
   )
-  const selfMade = visiblePlugins.value.filter(
+  const sideloaded = visiblePlugins.value.filter(
     (p) => !p.storeId && !isBuiltInPlugin(p.installId),
   )
   const store = visiblePlugins.value.filter((p) => !!p.storeId)
   const sections: PluginSection[] = [
     { key: 'builtin', label: 'ビルドイン', items: builtin },
-    { key: 'selfmade', label: '自作', items: selfMade },
+    { key: 'sideload', label: 'サイドロード', items: sideloaded },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -17,6 +17,7 @@ import {
 } from '@/stores/skills'
 import { useWindowsStore } from '@/stores/windows'
 import { openSafeUrl } from '@/utils/url'
+import ColumnSection from './ColumnSection.vue'
 import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
@@ -85,21 +86,19 @@ interface SkillSection {
 }
 
 /**
- * インストール済みタブのセクション分け (プラグインと同形):
- *   ローカル: storeId 無し (内蔵 / ユーザー手書き)
- *   ストア:   storeId 持ち (MisStore からインストール)
- * 検索なし時は空セクションもラベルを表示。検索適用時は 0 件セクションを隠す。
+ * インストール済みタブのセクション分け (プラグインと同形 / 上流の有無):
+ *   オリジナル: storeId 無し。手元が原本 (内蔵 / ユーザー手書き)
+ *   フォーク:   storeId 持ち。MisStore に上流がある複製 (改造も自由)
+ * 0 件のセクションは表示しない。
  */
 const installedSections = computed<SkillSection[]>(() => {
   const local = visibleSkills.value.filter((s) => !s.storeId)
   const store = visibleSkills.value.filter((s) => !!s.storeId)
   const sections: SkillSection[] = [
-    { key: 'local', label: 'ローカル', items: local },
-    { key: 'store', label: 'ストア', items: store },
+    { key: 'local', label: 'オリジナル', items: local },
+    { key: 'store', label: 'フォーク', items: store },
   ]
-  if (searchQuery.value.trim())
-    return sections.filter((s) => s.items.length > 0)
-  return sections
+  return sections.filter((s) => s.items.length > 0)
 })
 
 function isToggleable(skill: SkillMeta): boolean {
@@ -241,15 +240,12 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
       <!-- ===== Installed tab ===== -->
       <template v-if="viewTab === 'installed'">
         <div :class="$style.list">
-          <div
+          <ColumnSection
             v-for="section in installedSections"
             :key="section.key"
-            :class="$style.section"
+            :label="section.label"
+            :count="section.items.length"
           >
-            <h3 :class="$style.sectionTitle">{{ section.label }}</h3>
-            <div v-if="section.items.length === 0" :class="$style.sectionEmpty">
-              未設定
-            </div>
             <div
               v-for="skill in section.items"
               :key="skill.id"
@@ -327,7 +323,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
                 </div>
               </div>
             </div>
-          </div>
+          </ColumnSection>
 
           <div v-if="visibleSkills.length === 0" :class="$style.empty">
             <i class="ti ti-sparkles" :class="$style.emptyIcon" />
@@ -511,29 +507,6 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
   overflow-y: auto;
   scrollbar-color: var(--nd-scrollbarHandle) transparent;
   scrollbar-width: thin;
-}
-
-.section {
-  &:not(:first-child) {
-    margin-top: 8px;
-  }
-}
-
-.sectionTitle {
-  margin: 0;
-  padding: 8px 12px 4px;
-  font-size: 0.75em;
-  font-weight: 600;
-  color: var(--nd-fg);
-  opacity: 0.55;
-  letter-spacing: 0.04em;
-}
-
-.sectionEmpty {
-  padding: 6px 12px 10px;
-  font-size: 0.8em;
-  color: var(--nd-fg);
-  opacity: 0.5;
 }
 
 .card {

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -87,7 +87,7 @@ interface SkillSection {
 
 /**
  * インストール済みタブのセクション分け (プラグインと同形 / 上流の有無):
- *   オリジナル: storeId 無し。手元が原本 (内蔵 / ユーザー手書き)
+ *   ビルドイン: storeId 無し。手元が原本 (内蔵 / ユーザー手書き)
  *   ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
  * 0 件のセクションは表示しない。
  */
@@ -95,7 +95,7 @@ const installedSections = computed<SkillSection[]>(() => {
   const local = visibleSkills.value.filter((s) => !s.storeId)
   const store = visibleSkills.value.filter((s) => !!s.storeId)
   const sections: SkillSection[] = [
-    { key: 'local', label: 'オリジナル', items: local },
+    { key: 'local', label: 'ビルドイン', items: local },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -88,7 +88,7 @@ interface SkillSection {
 /**
  * インストール済みタブのセクション分け (プラグインと同形 / 上流の有無):
  *   オリジナル: storeId 無し。手元が原本 (内蔵 / ユーザー手書き)
- *   フォーク:   storeId 持ち。MisStore に上流がある複製 (改造も自由)
+ *   ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<SkillSection[]>(() => {
@@ -96,7 +96,7 @@ const installedSections = computed<SkillSection[]>(() => {
   const store = visibleSkills.value.filter((s) => !!s.storeId)
   const sections: SkillSection[] = [
     { key: 'local', label: 'オリジナル', items: local },
-    { key: 'store', label: 'フォーク', items: store },
+    { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)
 })

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -80,22 +80,25 @@ const visibleSkills = computed(() => {
 })
 
 interface SkillSection {
-  key: 'local' | 'store'
+  key: 'builtin' | 'selfmade' | 'store'
   label: string
   items: SkillMeta[]
 }
 
 /**
- * インストール済みタブのセクション分け (プラグインと同形 / 上流の有無):
- *   ビルドイン: storeId 無し。手元が原本 (内蔵 / ユーザー手書き)
- *   ストア配布: storeId 持ち。MisStore に上流がある複製 (改造も自由)
+ * インストール済みタブのセクション分け (プラグインと同形 / 出自 3 分類):
+ *   ビルドイン: アプリ同梱 (builtIn フラグ)
+ *   自作: ユーザー手書き・AI 生成 (storeId 無し、同梱以外)
+ *   ストア配布: storeId 持ち。MisStore に上流がある複製 (改造しても残留)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<SkillSection[]>(() => {
-  const local = visibleSkills.value.filter((s) => !s.storeId)
+  const builtin = visibleSkills.value.filter((s) => !s.storeId && s.builtIn)
+  const selfMade = visibleSkills.value.filter((s) => !s.storeId && !s.builtIn)
   const store = visibleSkills.value.filter((s) => !!s.storeId)
   const sections: SkillSection[] = [
-    { key: 'local', label: 'ビルドイン', items: local },
+    { key: 'builtin', label: 'ビルドイン', items: builtin },
+    { key: 'selfmade', label: '自作', items: selfMade },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -80,7 +80,7 @@ const visibleSkills = computed(() => {
 })
 
 interface SkillSection {
-  key: 'builtin' | 'selfmade' | 'store'
+  key: 'builtin' | 'sideload' | 'store'
   label: string
   items: SkillMeta[]
 }
@@ -88,17 +88,17 @@ interface SkillSection {
 /**
  * インストール済みタブのセクション分け (プラグインと同形 / 出自 3 分類):
  *   ビルドイン: アプリ同梱 (builtIn フラグ)
- *   自作: ユーザー手書き・AI 生成 (storeId 無し、同梱以外)
+ *   サイドロード: ユーザー手書き・AI 生成 (storeId 無し、同梱以外)
  *   ストア配布: storeId 持ち。MisStore に上流がある複製 (改造しても残留)
  * 0 件のセクションは表示しない。
  */
 const installedSections = computed<SkillSection[]>(() => {
   const builtin = visibleSkills.value.filter((s) => !s.storeId && s.builtIn)
-  const selfMade = visibleSkills.value.filter((s) => !s.storeId && !s.builtIn)
+  const sideloaded = visibleSkills.value.filter((s) => !s.storeId && !s.builtIn)
   const store = visibleSkills.value.filter((s) => !!s.storeId)
   const sections: SkillSection[] = [
     { key: 'builtin', label: 'ビルドイン', items: builtin },
-    { key: 'selfmade', label: '自作', items: selfMade },
+    { key: 'sideload', label: 'サイドロード', items: sideloaded },
     { key: 'store', label: 'ストア配布', items: store },
   ]
   return sections.filter((s) => s.items.length > 0)

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -91,8 +91,8 @@ interface ThemeSection {
 }
 
 // インストール済みタブのセクション構成。モードで責務が変わる:
-//   per-account: オリジナル + ストア配布 (MisStore 由来) + サーバー (admin Branding)
-//   cross-account (Global): オリジナル (同梱含む) + ストア配布 — アプリ全体管理
+//   per-account: ビルドイン + ストア配布 (MisStore 由来) + サーバー (admin Branding)
+//   cross-account (Global): ビルドイン (同梱含む) + ストア配布 — アプリ全体管理
 //
 // 「Web UI で選択中のテーマ」(本家 darkTheme/lightTheme Pref) はサーバーに保存
 // されないため、NoteDeck 側でも介入しない。ユーザーが MisStore から取り込んだ
@@ -104,7 +104,7 @@ const themeSections = computed<ThemeSection[]>(() => {
   // logged-in account id 集合 (cross-account = 全アカウント集約 viewer の判定用)。
   const loggedInIds = new Set(accountsStore.accounts.map((a) => a.id))
 
-  // 「オリジナル」 (NoteDeck エディタ作成 / import / storeId 無し)。
+  // 「ビルドイン」 (NoteDeck エディタ作成 / import / storeId 無し)。
   // - per-account: installedFor に該当アカウントを含むもののみ
   // - 全アカウント: installedFor に少なくとも 1 つの logged-in account を含む
   //   もの (集約 viewer の semantics) + アプリ同梱 (Mi Dark / Mi Light)
@@ -124,7 +124,7 @@ const themeSections = computed<ThemeSection[]>(() => {
       removable: true,
     }))
   // 同梱テーマ (Mi Dark / Mi Light、削除/編集不可) は独立セクションにせず
-  // オリジナルへ混ぜる (プラグイン/スキルカラムの同梱アイテムと同じ扱い)
+  // ビルドインへ混ぜる (プラグイン/スキルカラムの同梱アイテムと同じ扱い)
   if (isCrossAccount.value) {
     localThemes.push({
       theme: mode === 'dark' ? MI_DARK : MI_LIGHT,
@@ -134,7 +134,7 @@ const themeSections = computed<ThemeSection[]>(() => {
   }
   sections.push({
     key: 'local',
-    label: 'オリジナル',
+    label: 'ビルドイン',
     items: localThemes,
   })
 

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -91,8 +91,8 @@ interface ThemeSection {
 }
 
 // インストール済みタブのセクション構成。モードで責務が変わる:
-//   per-account: オリジナル + フォーク (MisStore 由来) + サーバー (admin Branding)
-//   cross-account (Global): オリジナル (同梱含む) + フォーク — アプリ全体管理
+//   per-account: オリジナル + ストア配布 (MisStore 由来) + サーバー (admin Branding)
+//   cross-account (Global): オリジナル (同梱含む) + ストア配布 — アプリ全体管理
 //
 // 「Web UI で選択中のテーマ」(本家 darkTheme/lightTheme Pref) はサーバーに保存
 // されないため、NoteDeck 側でも介入しない。ユーザーが MisStore から取り込んだ
@@ -139,7 +139,7 @@ const themeSections = computed<ThemeSection[]>(() => {
   })
 
   if (!isCrossAccount.value && accountId.value) {
-    // フォーク (MisStore 由来、このアカウントが installedFor に登録されている
+    // ストア配布 (MisStore 由来、このアカウントが installedFor に登録されている
     // もののみ) → サーバーのテーマ (admin Branding) の順で表示。
     const cached = themeStore.accountThemeCache.get(accountId.value)
     const metaTheme = mode === 'dark' ? cached?.metaDark : cached?.metaLight
@@ -158,7 +158,7 @@ const themeSections = computed<ThemeSection[]>(() => {
       }))
     sections.push({
       key: 'store',
-      label: 'フォーク',
+      label: 'ストア配布',
       items: storeThemes,
     })
 
@@ -170,7 +170,7 @@ const themeSections = computed<ThemeSection[]>(() => {
         : [],
     })
   } else {
-    // 全アカウントカラム: フォーク (installedFor が少なくとも 1 つの
+    // 全アカウントカラム: ストア配布 (installedFor が少なくとも 1 つの
     // logged-in account を含むもの)
     const storeThemes = themeStore.installedThemes
       .filter((t) => {
@@ -186,7 +186,7 @@ const themeSections = computed<ThemeSection[]>(() => {
       }))
     sections.push({
       key: 'store',
-      label: 'フォーク',
+      label: 'ストア配布',
       items: storeThemes,
     })
   }

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -15,6 +15,7 @@ import { useWindowsStore } from '@/stores/windows'
 import { MI_DARK, MI_LIGHT } from '@/theme/builtinThemes'
 import type { MisskeyTheme } from '@/theme/types'
 import { openSafeUrl } from '@/utils/url'
+import ColumnSection from './ColumnSection.vue'
 import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
@@ -28,9 +29,7 @@ const themeStore = useThemeStore()
 const misStore = useMisStoreStore()
 const windowsStore = useWindowsStore()
 const accountsStore = useAccountsStore()
-const { serverIconUrl, serverInfoImageUrl } = useServerImages(
-  () => props.column,
-)
+const { serverIconUrl } = useServerImages(() => props.column)
 const { columnThemeVars } = useColumnTheme(() => props.column)
 
 misStore.fetchThemes()
@@ -92,15 +91,12 @@ interface ThemeSection {
 }
 
 // インストール済みタブのセクション構成。モードで責務が変わる:
-//   per-account: サーバー (admin Branding) + ストア (MisStore 由来 installedThemes)
-//   cross-account (Global): ローカル (NoteDeck 独自 installedThemes) — アプリ全体管理
+//   per-account: オリジナル + フォーク (MisStore 由来) + サーバー (admin Branding)
+//   cross-account (Global): オリジナル (同梱含む) + フォーク — アプリ全体管理
 //
 // 「Web UI で選択中のテーマ」(本家 darkTheme/lightTheme Pref) はサーバーに保存
 // されないため、NoteDeck 側でも介入しない。ユーザーが MisStore から取り込んだ
 // テーマを per-column 適用する UX に集中する。
-//
-// NoteDeck builtin (Mi Dark / Mi Light) は内部 fallback としてのみ残し
-// UI には出さない。Misskey 本家の builtin は MisStore 配布予定。
 const themeSections = computed<ThemeSection[]>(() => {
   const mode = currentMode.value
   const sections: ThemeSection[] = []
@@ -108,11 +104,10 @@ const themeSections = computed<ThemeSection[]>(() => {
   // logged-in account id 集合 (cross-account = 全アカウント集約 viewer の判定用)。
   const loggedInIds = new Set(accountsStore.accounts.map((a) => a.id))
 
-  // 「ローカルのテーマ」 (NoteDeck エディタ作成 / import / storeId 無し)。
+  // 「オリジナル」 (NoteDeck エディタ作成 / import / storeId 無し)。
   // - per-account: installedFor に該当アカウントを含むもののみ
-  // - 全アカウント: installedFor に少なくとも 1 つの logged-in account を含むもの
-  //   (集約 viewer の semantics; どこにも紐付かない孤児テーマは隠す)
-  // 空でもセクション ラベルは出す。
+  // - 全アカウント: installedFor に少なくとも 1 つの logged-in account を含む
+  //   もの (集約 viewer の semantics) + アプリ同梱 (Mi Dark / Mi Light)
   const localThemes = themeStore.installedThemes
     .filter((t) => {
       if (t.$notedeck?.storeId) return false
@@ -128,15 +123,24 @@ const themeSections = computed<ThemeSection[]>(() => {
       source: 'local',
       removable: true,
     }))
+  // 同梱テーマ (Mi Dark / Mi Light、削除/編集不可) は独立セクションにせず
+  // オリジナルへ混ぜる (プラグイン/スキルカラムの同梱アイテムと同じ扱い)
+  if (isCrossAccount.value) {
+    localThemes.push({
+      theme: mode === 'dark' ? MI_DARK : MI_LIGHT,
+      source: 'builtin',
+      removable: false,
+    })
+  }
   sections.push({
     key: 'local',
-    label: 'ローカル',
+    label: 'オリジナル',
     items: localThemes,
   })
 
   if (!isCrossAccount.value && accountId.value) {
-    // ストアのテーマ (このアカウントが installedFor に登録されているもののみ)
-    // → サーバーのテーマ (admin Branding) の順で表示。
+    // フォーク (MisStore 由来、このアカウントが installedFor に登録されている
+    // もののみ) → サーバーのテーマ (admin Branding) の順で表示。
     const cached = themeStore.accountThemeCache.get(accountId.value)
     const metaTheme = mode === 'dark' ? cached?.metaDark : cached?.metaLight
 
@@ -154,7 +158,7 @@ const themeSections = computed<ThemeSection[]>(() => {
       }))
     sections.push({
       key: 'store',
-      label: 'ストア',
+      label: 'フォーク',
       items: storeThemes,
     })
 
@@ -166,8 +170,8 @@ const themeSections = computed<ThemeSection[]>(() => {
         : [],
     })
   } else {
-    // 全アカウントカラム: ストア (installedFor が少なくとも 1 つの logged-in
-    // account を含むもの) → ビルトインの順。空でもセクション ラベルは出す。
+    // 全アカウントカラム: フォーク (installedFor が少なくとも 1 つの
+    // logged-in account を含むもの)
     const storeThemes = themeStore.installedThemes
       .filter((t) => {
         if (!t.$notedeck?.storeId) return false
@@ -182,24 +186,13 @@ const themeSections = computed<ThemeSection[]>(() => {
       }))
     sections.push({
       key: 'store',
-      label: 'ストア',
+      label: 'フォーク',
       items: storeThemes,
-    })
-    // builtin (Mi Dark / Mi Light) はアプリ内蔵で削除/編集不可
-    sections.push({
-      key: 'builtin',
-      label: 'ビルトイン',
-      items: [
-        {
-          theme: mode === 'dark' ? MI_DARK : MI_LIGHT,
-          source: 'builtin',
-          removable: false,
-        },
-      ],
     })
   }
 
-  return sections
+  // 0 件のセクションは表示しない
+  return sections.filter((s) => s.items.length > 0)
 })
 
 const installedTotalCount = computed(() =>
@@ -420,24 +413,13 @@ function storeEntryToTheme(entry: StoreThemeEntry): MisskeyTheme {
       <!-- ===== Installed tab ===== -->
       <template v-if="viewTab === 'installed'">
         <div :class="$style.scroll">
-          <div
+          <ColumnSection
             v-for="section in filteredSections"
             :key="section.key"
-            :class="$style.section"
+            :label="section.label"
+            :count="section.items.length"
           >
-            <h3 :class="$style.sectionTitle">{{ section.label }}</h3>
-            <div v-if="section.items.length === 0" :class="$style.sectionEmpty">
-              <div :class="$style.sectionEmptyCard">
-                <img
-                  v-if="serverInfoImageUrl"
-                  :src="serverInfoImageUrl"
-                  :class="$style.sectionEmptyImage"
-                  alt=""
-                />
-                <span :class="$style.sectionEmptyText">未設定</span>
-              </div>
-            </div>
-            <div v-else :class="$style.grid">
+            <div :class="$style.grid">
               <ThemeCard
                 v-for="entry in section.items"
                 :key="`${entry.source}:${entry.theme.id}`"
@@ -455,7 +437,7 @@ function storeEntryToTheme(entry: StoreThemeEntry): MisskeyTheme {
                 @remove="removeTheme(entry)"
               />
             </div>
-          </div>
+          </ColumnSection>
 
           <div v-if="totalFilteredCount === 0" :class="$style.empty">
             <template v-if="searchQuery">
@@ -585,64 +567,11 @@ function storeEntryToTheme(entry: StoreThemeEntry): MisskeyTheme {
   scrollbar-width: thin;
 }
 
-.section {
-  & + & {
-    margin-top: 4px;
-  }
-}
-
-.sectionTitle {
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--nd-fg);
-  opacity: 0.55;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: 8px 12px 2px;
-  margin: 0;
-}
-
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 8px;
   padding: 4px 10px 8px;
-}
-
-.sectionEmpty {
-  // grid と同じレイアウト (2 列) で、1 列目に空状態画像 + 名前風テキストを
-  // テーマカードと同じ位置に配置する
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
-  padding: 4px 10px 8px;
-}
-
-.sectionEmptyCard {
-  display: flex;
-  flex-direction: column;
-  border: 2px dashed var(--nd-divider);
-  border-radius: var(--nd-radius-sm);
-  overflow: hidden;
-  opacity: 0.6;
-}
-
-.sectionEmptyImage {
-  display: block;
-  width: 100%;
-  aspect-ratio: 200 / 150;
-  object-fit: contain;
-  background: color-mix(in srgb, var(--nd-fg) 4%, transparent);
-}
-
-.sectionEmptyText {
-  padding: 4px 6px;
-  text-align: center;
-  font-size: 0.75em;
-  color: var(--nd-fg);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .storeLoading {

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -91,8 +91,8 @@ interface ThemeSection {
 }
 
 // インストール済みタブのセクション構成 (出自 3 分類 + サーバー):
-//   per-account: 自作 + ストア配布 (MisStore 由来) + サーバー (admin Branding)
-//   cross-account (Global): ビルドイン (同梱) + 自作 + ストア配布 — アプリ全体管理
+//   per-account: サイドロード + ストア配布 (MisStore 由来) + サーバー (admin Branding)
+//   cross-account (Global): ビルドイン (同梱) + サイドロード + ストア配布 — アプリ全体管理
 //
 // 「Web UI で選択中のテーマ」(本家 darkTheme/lightTheme Pref) はサーバーに保存
 // されないため、NoteDeck 側でも介入しない。ユーザーが MisStore から取り込んだ
@@ -120,11 +120,11 @@ const themeSections = computed<ThemeSection[]>(() => {
     })
   }
 
-  // 「自作」 (NoteDeck エディタ作成 / import / storeId 無し)。
+  // 「サイドロード」 (NoteDeck エディタ作成 / import / storeId 無し)。
   // - per-account: installedFor に該当アカウントを含むもののみ
   // - 全アカウント: installedFor に少なくとも 1 つの logged-in account を含む
   //   もの (集約 viewer の semantics)
-  const selfMadeThemes = themeStore.installedThemes
+  const sideloadedThemes = themeStore.installedThemes
     .filter((t) => {
       if (t.$notedeck?.storeId) return false
       if ((t.base ?? 'dark') !== mode) return false
@@ -140,9 +140,9 @@ const themeSections = computed<ThemeSection[]>(() => {
       removable: true,
     }))
   sections.push({
-    key: 'selfmade',
-    label: '自作',
-    items: selfMadeThemes,
+    key: 'sideload',
+    label: 'サイドロード',
+    items: sideloadedThemes,
   })
 
   if (!isCrossAccount.value && accountId.value) {

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -90,9 +90,9 @@ interface ThemeSection {
   items: ThemeEntry[]
 }
 
-// インストール済みタブのセクション構成。モードで責務が変わる:
-//   per-account: ビルドイン + ストア配布 (MisStore 由来) + サーバー (admin Branding)
-//   cross-account (Global): ビルドイン (同梱含む) + ストア配布 — アプリ全体管理
+// インストール済みタブのセクション構成 (出自 3 分類 + サーバー):
+//   per-account: 自作 + ストア配布 (MisStore 由来) + サーバー (admin Branding)
+//   cross-account (Global): ビルドイン (同梱) + 自作 + ストア配布 — アプリ全体管理
 //
 // 「Web UI で選択中のテーマ」(本家 darkTheme/lightTheme Pref) はサーバーに保存
 // されないため、NoteDeck 側でも介入しない。ユーザーが MisStore から取り込んだ
@@ -104,11 +104,27 @@ const themeSections = computed<ThemeSection[]>(() => {
   // logged-in account id 集合 (cross-account = 全アカウント集約 viewer の判定用)。
   const loggedInIds = new Set(accountsStore.accounts.map((a) => a.id))
 
-  // 「ビルドイン」 (NoteDeck エディタ作成 / import / storeId 無し)。
+  // 「ビルドイン」= アプリ同梱 (Mi Dark / Mi Light、削除/編集不可)。
+  // プラグイン/スキルカラムの同梱セクションと同じ扱いで全アカウントカラムのみ。
+  if (isCrossAccount.value) {
+    sections.push({
+      key: 'builtin',
+      label: 'ビルドイン',
+      items: [
+        {
+          theme: mode === 'dark' ? MI_DARK : MI_LIGHT,
+          source: 'builtin',
+          removable: false,
+        },
+      ],
+    })
+  }
+
+  // 「自作」 (NoteDeck エディタ作成 / import / storeId 無し)。
   // - per-account: installedFor に該当アカウントを含むもののみ
   // - 全アカウント: installedFor に少なくとも 1 つの logged-in account を含む
-  //   もの (集約 viewer の semantics) + アプリ同梱 (Mi Dark / Mi Light)
-  const localThemes = themeStore.installedThemes
+  //   もの (集約 viewer の semantics)
+  const selfMadeThemes = themeStore.installedThemes
     .filter((t) => {
       if (t.$notedeck?.storeId) return false
       if ((t.base ?? 'dark') !== mode) return false
@@ -123,19 +139,10 @@ const themeSections = computed<ThemeSection[]>(() => {
       source: 'local',
       removable: true,
     }))
-  // 同梱テーマ (Mi Dark / Mi Light、削除/編集不可) は独立セクションにせず
-  // ビルドインへ混ぜる (プラグイン/スキルカラムの同梱アイテムと同じ扱い)
-  if (isCrossAccount.value) {
-    localThemes.push({
-      theme: mode === 'dark' ? MI_DARK : MI_LIGHT,
-      source: 'builtin',
-      removable: false,
-    })
-  }
   sections.push({
-    key: 'local',
-    label: 'ビルドイン',
-    items: localThemes,
+    key: 'selfmade',
+    label: '自作',
+    items: selfMadeThemes,
   })
 
   if (!isCrossAccount.value && accountId.value) {

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-type Mode = 'installed' | 'store'
+type Mode = 'installed' | 'store' | 'library'
 
 const props = defineProps<{
   mode: Mode
@@ -15,6 +15,8 @@ const props = defineProps<{
   installing?: boolean
   alreadyInstalled?: boolean
   confirmingUninstall?: boolean
+  /** installed mode: trash ボタンの title (スコープ文脈で言い換える) */
+  uninstallTitle?: string
   iconUrl?: string
   /**
    * 権限拒否バッジ (#712 §8.4)。plugin principal の permission_denied が
@@ -31,6 +33,8 @@ const emit = defineEmits<{
   (e: 'settings'): void
   (e: 'open-detail'): void
   (e: 'denied-click'): void
+  (e: 'place'): void
+  (e: 'delete'): void
 }>()
 
 const disabled = computed(
@@ -84,7 +88,7 @@ const disabled = computed(
             <button
               class="_button"
               :class="[$style.iconBtn, confirmingUninstall && $style.iconBtnDanger]"
-              :title="confirmingUninstall ? 'もう一度クリックで削除' : 'アンインストール'"
+              :title="confirmingUninstall ? 'もう一度クリックで実行' : (uninstallTitle ?? 'アンインストール')"
               @click.stop="emit('uninstall')"
             >
               <i class="ti ti-trash" />
@@ -103,6 +107,26 @@ const disabled = computed(
               @click.stop="emit('toggle')"
             >
               {{ active ? '無効にする' : '有効にする' }}
+            </button>
+          </template>
+
+          <!-- Library mode: スコープ未参加のライブラリ本体 (place / 本体削除) -->
+          <template v-else-if="mode === 'library'">
+            <button
+              class="_button"
+              :class="$style.iconBtn"
+              title="ライブラリから削除 (コードも消える)"
+              @click.stop="emit('delete')"
+            >
+              <i class="ti ti-trash" />
+            </button>
+            <button
+              class="_button"
+              :class="$style.primaryBtn"
+              @click.stop="emit('place')"
+            >
+              <i class="ti ti-plus" />
+              追加
             </button>
           </template>
 

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -12,17 +12,21 @@ import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
-import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
+import {
+  type PluginMeta,
+  type PluginScope,
+  usePluginsStore,
+} from '@/stores/plugins'
 import { pluginSrcFilename } from '@/utils/settingsFs'
 
 const props = defineProps<{
   initialPluginId?: string
   initialTab?: string
-  /** プラグインカラム経由で開いた場合の紐付け対象 account id 一覧。
-   *  - per-account カラム: [accountId]
-   *  - 全アカウントカラム: 全 logged-in account の id
-   *  保存時 installedFor に追加される。 */
-  initialAccountIds?: string[]
+  /** プラグインカラム経由で開いた場合のインストール先スコープ (#771)。
+   *  - per-account カラム: { kind: 'account', key: accountScopeKey }
+   *  - 全アカウントカラム: { kind: 'global' }
+   *  未指定 (カラム外から開いた場合) は全体スコープ扱い。 */
+  initialScope?: PluginScope
 }>()
 
 const pluginsStore = usePluginsStore()
@@ -166,7 +170,7 @@ async function doInstall() {
     }
   }
 
-  const ids = props.initialAccountIds ?? []
+  const scope = props.initialScope ?? { kind: 'global' }
   const newPlugin: PluginMeta = {
     installId: `p-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     name: meta.name,
@@ -178,7 +182,9 @@ async function doInstall() {
     configData,
     src: code,
     active: true,
-    ...(ids.length > 0 ? { installedFor: ids } : {}),
+    ...(scope.kind === 'global'
+      ? { global: true }
+      : { installedFor: [scope.key] }),
   }
 
   pluginsStore.addPlugin(newPlugin)

--- a/src/composables/useDeepLink.ts
+++ b/src/composables/useDeepLink.ts
@@ -227,7 +227,8 @@ async function handleInstallPlugin(pluginId: string): Promise<void> {
     console.info('[deep-link] plugin already installed:', pluginId)
     return
   }
-  await misStore.installPlugin(entry)
+  // deep link はカラム文脈を持たないため全体スコープでインストールする
+  await misStore.installPlugin(entry, { kind: 'global' })
 }
 
 async function handleInstallTheme(themeId: string): Promise<void> {

--- a/src/defaults/plugins/ai-actions.meta.json5
+++ b/src/defaults/plugins/ai-actions.meta.json5
@@ -7,4 +7,5 @@
   permissions: ['ai.invoke', 'clipboard', 'notifications'],
   configData: {},
   active: true,
+  global: true,
 }

--- a/src/stores/accounts.ts
+++ b/src/stores/accounts.ts
@@ -20,6 +20,18 @@ export interface Account {
 
 const GUEST_USER_ID = '__guest__'
 
+/**
+ * per-account 紐付けに使う安定キー。内部 UUID (`Account.id`) はログインの
+ * たびに再生成されるため永続データの紐付けには使えない (#771)。
+ * host + サーバー側 userId は再ログインしても変わらない。
+ */
+export function accountScopeKey(account: {
+  host: string
+  userId: string
+}): string {
+  return `${account.host}:${account.userId}`
+}
+
 export function isGuestAccount(account: Account): boolean {
   return account.userId === GUEST_USER_ID && !account.hasToken
 }

--- a/src/stores/misstore.ts
+++ b/src/stores/misstore.ts
@@ -1,7 +1,11 @@
 import { defineStore } from 'pinia'
-import { computed, ref, shallowRef } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { launchPlugin, parsePluginMeta } from '@/aiscript/plugin-api'
-import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
+import {
+  type PluginMeta,
+  type PluginScope,
+  usePluginsStore,
+} from '@/stores/plugins'
 import { type SkillMeta, useSkillsStore } from '@/stores/skills'
 import { useThemeStore } from '@/stores/theme'
 import {
@@ -374,22 +378,22 @@ export const useMisStoreStore = defineStore('misstore', () => {
   // --- Install ---
 
   /**
-   * MisStore からプラグインをインストール / 紐付け追加する。
-   * - 同じ storeId の既存プラグインがあれば installedFor に accountIds を union 追加
-   *   (重複インストールは避ける)
-   * - 無ければ新規追加 (installedFor に forAccountIds をセット、storeId 紐付け)
+   * MisStore からプラグインをインストール / スコープ追加する (#771)。
+   * - 同じ storeId の既存プラグインがあればライブラリ本体は再取得せず、
+   *   指定 scope への参照を追加するだけ (重複インストールは避ける)
+   * - 無ければ新規追加 (指定 scope で有効化、storeId 紐付け)
    */
   async function installPlugin(
     entry: StorePluginEntry,
-    forAccountIds: string[] = [],
+    scope: PluginScope,
   ): Promise<void> {
     installing.value = entry.id
     try {
       const pluginsStore = usePluginsStore()
-      // 既に同 storeId でインストール済みなら installedFor を追加するだけ
+      // 既に同 storeId でインストール済みなら scope 参照を追加するだけ
       const existing = pluginsStore.plugins.find((p) => p.storeId === entry.id)
       if (existing) {
-        pluginsStore.linkAccountToPlugin(existing.installId, forAccountIds)
+        pluginsStore.linkScope(existing.installId, scope)
         return
       }
 
@@ -433,7 +437,9 @@ export const useMisStoreStore = defineStore('misstore', () => {
         active: true,
         storeId: entry.id,
         ...(entry.iconUrl ? { iconUrl: entry.iconUrl } : {}),
-        ...(forAccountIds.length > 0 ? { installedFor: forAccountIds } : {}),
+        ...(scope.kind === 'global'
+          ? { global: true }
+          : { installedFor: [scope.key] }),
       }
 
       pluginsStore.addPlugin(newPlugin)
@@ -560,11 +566,6 @@ export const useMisStoreStore = defineStore('misstore', () => {
     )
   }
 
-  const installedNames = computed(() => {
-    const pluginsStore = usePluginsStore()
-    return new Set(pluginsStore.plugins.map((p) => p.name))
-  })
-
   return {
     plugins,
     loading,
@@ -599,6 +600,5 @@ export const useMisStoreStore = defineStore('misstore', () => {
     isThemeInstalled,
     isWidgetInstalled,
     isSkillInstalled,
-    installedNames,
   }
 })

--- a/src/stores/plugins.test.ts
+++ b/src/stores/plugins.test.ts
@@ -1,0 +1,259 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/utils/settingsFs', () => ({
+  isTauri: false,
+  pluginSrcFilename: (n: string) => `${n}.is`,
+  pluginMetaFilename: (n: string) => `${n}.meta.json5`,
+  writePluginFile: vi.fn(async () => undefined),
+  deletePluginFile: vi.fn(async () => undefined),
+  listPluginFiles: vi.fn(async () => []),
+  readPluginFile: vi.fn(async () => ''),
+}))
+
+vi.mock('@/utils/storage', () => {
+  const mem = new Map<string, unknown>()
+  return {
+    STORAGE_KEYS: {
+      plugins: 'nd:plugins',
+      pluginsSeededBuiltins: 'nd:plugins-seeded',
+      aiscriptPlugin: (id: string) => `nd:aiscript-plugin:${id}`,
+    },
+    getStorageJson: (key: string, fallback: unknown) =>
+      mem.has(key) ? mem.get(key) : fallback,
+    setStorageJson: (key: string, value: unknown) => {
+      mem.set(key, value)
+    },
+    removeStorageByPrefix: vi.fn(),
+    __mem: mem,
+  }
+})
+
+vi.mock('@/utils/historyFs', () => ({
+  pushSnapshot: vi.fn(async () => undefined),
+}))
+
+import { accountScopeKey, useAccountsStore } from '@/stores/accounts'
+import {
+  isPluginEffectiveFor,
+  type PluginMeta,
+  usePluginsStore,
+} from '@/stores/plugins'
+import { STORAGE_KEYS, setStorageJson } from '@/utils/storage'
+
+function makePlugin(partial: Partial<PluginMeta>): PluginMeta {
+  return {
+    installId: partial.installId ?? `p-${Math.random().toString(36).slice(2)}`,
+    name: partial.name ?? 'test-plugin',
+    version: '1.0.0',
+    configData: {},
+    src: '### {}',
+    active: true,
+    ...partial,
+  }
+}
+
+const yami = {
+  id: 'uuid-yami',
+  host: 'yami.ski',
+  userId: 'u1',
+  username: 'hitalin',
+  displayName: null,
+  avatarUrl: null,
+  software: 'misskey-dev/misskey' as const,
+  hasToken: true,
+}
+const cloud = {
+  id: 'uuid-cloud',
+  host: 'misskey.cloud',
+  userId: 'u2',
+  username: 'hitalin',
+  displayName: null,
+  avatarUrl: null,
+  software: 'misskey-dev/misskey' as const,
+  hasToken: true,
+}
+
+function setupAccounts() {
+  const accounts = useAccountsStore()
+  accounts.accounts = [yami, cloud]
+  accounts.isLoaded = true
+  return accounts
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  // seed 済み扱いにして built-in seed がテストを汚さないようにする
+  setStorageJson(STORAGE_KEYS.pluginsSeededBuiltins, ['ai-actions-builtin'])
+  setStorageJson(STORAGE_KEYS.plugins, [])
+})
+
+describe('accountScopeKey', () => {
+  it('host と userId から安定キーを作る (内部 UUID 非依存)', () => {
+    expect(accountScopeKey(yami)).toBe('yami.ski:u1')
+  })
+})
+
+describe('isPluginEffectiveFor', () => {
+  it('global プラグインはどのアカウントにも効く', () => {
+    const p = makePlugin({ global: true })
+    expect(isPluginEffectiveFor(p, 'yami.ski:u1')).toBe(true)
+    expect(isPluginEffectiveFor(p, null)).toBe(true)
+  })
+
+  it('アカウント別スコープはキー一致時のみ効く', () => {
+    const p = makePlugin({ installedFor: ['yami.ski:u1'] })
+    expect(isPluginEffectiveFor(p, 'yami.ski:u1')).toBe(true)
+    expect(isPluginEffectiveFor(p, 'misskey.cloud:u2')).toBe(false)
+    expect(isPluginEffectiveFor(p, null)).toBe(false)
+  })
+
+  it('スコープなし (どちらも無い) はどこにも効かない (ライブラリのみ)', () => {
+    const p = makePlugin({})
+    expect(isPluginEffectiveFor(p, 'yami.ski:u1')).toBe(false)
+    expect(isPluginEffectiveFor(p, null)).toBe(false)
+  })
+})
+
+describe('scope link/unlink', () => {
+  it('linkGlobalScope / unlinkGlobalScope で全体スコープを付け外しできる', () => {
+    setupAccounts()
+    const store = usePluginsStore()
+    const p = makePlugin({ installId: 'p1' })
+    store.addPlugin(p)
+
+    store.linkGlobalScope('p1')
+    expect(store.getPlugin('p1')?.global).toBe(true)
+
+    store.unlinkGlobalScope('p1')
+    expect(store.getPlugin('p1')?.global).toBeUndefined()
+    // 本体はライブラリに残る (widgets の detach と同じ)
+    expect(store.getPlugin('p1')).toBeTruthy()
+  })
+
+  it('linkAccountScope / unlinkAccountScope で安定キーを付け外しできる', () => {
+    setupAccounts()
+    const store = usePluginsStore()
+    store.addPlugin(makePlugin({ installId: 'p1' }))
+
+    store.linkAccountScope('p1', 'yami.ski:u1')
+    store.linkAccountScope('p1', 'yami.ski:u1') // 重複 union
+    store.linkAccountScope('p1', 'misskey.cloud:u2')
+    expect(store.getPlugin('p1')?.installedFor).toEqual([
+      'yami.ski:u1',
+      'misskey.cloud:u2',
+    ])
+
+    store.unlinkAccountScope('p1', 'yami.ski:u1')
+    expect(store.getPlugin('p1')?.installedFor).toEqual(['misskey.cloud:u2'])
+
+    // 最後のスコープを外しても本体は残る
+    store.unlinkAccountScope('p1', 'misskey.cloud:u2')
+    expect(store.getPlugin('p1')).toBeTruthy()
+    expect(
+      isPluginEffectiveFor(store.getPlugin('p1') as PluginMeta, 'yami.ski:u1'),
+    ).toBe(false)
+  })
+})
+
+describe('レガシーデータ移行 (#771)', () => {
+  it('installedFor なし (旧: 全アカウント) → global: true', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [makePlugin({ installId: 'p1' })])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    expect(store.getPlugin('p1')?.global).toBe(true)
+  })
+
+  it('現行アカウント UUID → 安定キーに置換', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({ installId: 'p1', installedFor: ['uuid-yami'] }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    const p = store.getPlugin('p1')
+    expect(p?.installedFor).toEqual(['yami.ski:u1'])
+    expect(p?.global).toBeUndefined()
+  })
+
+  it('紐付け先が全て現存しない UUID → global: true (ゾンビ救済)', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({
+        installId: 'p1',
+        installedFor: ['uuid-dead-1', 'uuid-dead-2'],
+      }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    const p = store.getPlugin('p1')
+    expect(p?.global).toBe(true)
+    expect(p?.installedFor).toBeUndefined()
+  })
+
+  it('全現行アカウントをカバーする旧スナップショット → global: true (全アカウント相当)', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({
+        installId: 'p1',
+        installedFor: ['uuid-yami', 'uuid-cloud', 'uuid-dead'],
+      }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    const p = store.getPlugin('p1')
+    expect(p?.global).toBe(true)
+    expect(p?.installedFor).toBeUndefined()
+  })
+
+  it('一部アカウントのみの旧スナップショット → 安定キー化して per-account 維持', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({
+        installId: 'p1',
+        installedFor: ['uuid-yami', 'uuid-dead'],
+      }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    const p = store.getPlugin('p1')
+    expect(p?.global).toBeUndefined()
+    expect(p?.installedFor).toEqual(['yami.ski:u1'])
+  })
+
+  it('移行済み (安定キーのみ) には再実行しても触れない (冪等)', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({ installId: 'p1', installedFor: ['yami.ski:u1'] }),
+      makePlugin({ installId: 'p2', global: true }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    expect(store.getPlugin('p1')?.installedFor).toEqual(['yami.ski:u1'])
+    expect(store.getPlugin('p1')?.global).toBeUndefined()
+    expect(store.getPlugin('p2')?.global).toBe(true)
+  })
+
+  it('意図的に全アカウントへ個別紐付けした安定キーは global へ昇格しない', () => {
+    setupAccounts()
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({
+        installId: 'p1',
+        installedFor: ['yami.ski:u1', 'misskey.cloud:u2'],
+      }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    store.migrateScopes()
+    const p = store.getPlugin('p1')
+    expect(p?.global).toBeUndefined()
+    expect(p?.installedFor).toEqual(['yami.ski:u1', 'misskey.cloud:u2'])
+  })
+})

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -1,7 +1,8 @@
 import JSON5 from 'json5'
 import { defineStore } from 'pinia'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 
+import { accountScopeKey, useAccountsStore } from '@/stores/accounts'
 import { pushSnapshot } from '@/utils/historyFs'
 import * as settingsFs from '@/utils/settingsFs'
 import {
@@ -68,6 +69,7 @@ function pluginMetaToFullMeta(tpl: BuiltInPluginTemplate): PluginMeta {
     configData: tpl.meta.configData || {},
     src: tpl.src,
     active: tpl.meta.active ?? true,
+    global: tpl.meta.global,
     installedFor: tpl.meta.installedFor,
     storeId: tpl.meta.storeId,
     iconUrl: tpl.meta.iconUrl,
@@ -92,14 +94,33 @@ export interface PluginMeta {
   configData: Record<string, unknown>
   src: string
   active: boolean
-  /** どの account の per-account プラグインカラム / handler 発火対象に含めるか。
-   *  - 空 / undefined: 後方互換で全 account 対象 (旧プラグイン)
-   *  - 1 つ以上: 該当 account のみで handler 発火 (per-account 有効化) */
+  /** 全体スコープ参加 (#771)。true なら全アカウント (後から追加した分も含む) で
+   *  有効。全アカウントカラムで追加したプラグインはこちら。 */
+  global?: boolean
+  /** アカウント別スコープ参加 (#771)。`accountScopeKey` (host:userId) の配列。
+   *  再ログインで再生成される内部 UUID ではなく安定キーで持つ。
+   *  global と installedFor の両方が無いものはどこにも効かない (ライブラリのみ)。 */
   installedFor?: string[]
   /** misstore 由来の追跡 ID (将来の自動更新用) */
   storeId?: string
   /** 個別アイコン URL (MisStore registry の iconUrl 互換) */
   iconUrl?: string
+}
+
+/** インストール/追加先スコープ (#771)。カラムの文脈から決まる。 */
+export type PluginScope = { kind: 'global' } | { kind: 'account'; key: string }
+
+/**
+ * plugin が scopeKey (`accountScopeKey`) のアカウントに効くか。
+ * scopeKey=null は「アカウント文脈なし」= 全体スコープのみ有効。
+ */
+export function isPluginEffectiveFor(
+  plugin: PluginMeta,
+  scopeKey: string | null,
+): boolean {
+  if (plugin.global) return true
+  if (!scopeKey) return false
+  return plugin.installedFor?.includes(scopeKey) ?? false
 }
 
 /** Metadata fields stored in *.meta.json5 (everything except src). */
@@ -113,6 +134,7 @@ interface PluginFileMeta {
   config?: Record<string, PluginConfigDef>
   configData: Record<string, unknown>
   active: boolean
+  global?: boolean
   installedFor?: string[]
   storeId?: string
   iconUrl?: string
@@ -145,9 +167,9 @@ export const usePluginsStore = defineStore('plugins', () => {
       initialized.value = true
       // ブラウザ環境 (ファイル I/O なし) でも built-in を seed して
       // 動作確認ができるようにする
-      seedMissingBuiltIns().catch((e) =>
-        console.warn('[plugins] built-in seed failed:', e),
-      )
+      seedMissingBuiltIns()
+        .then(() => scheduleScopeMigration())
+        .catch((e) => console.warn('[plugins] built-in seed failed:', e))
     }
   }
 
@@ -184,6 +206,7 @@ export const usePluginsStore = defineStore('plugins', () => {
       ...(plugin.config ? { config: plugin.config } : {}),
       configData: plugin.configData,
       active: plugin.active,
+      ...(plugin.global ? { global: true } : {}),
       ...(plugin.installedFor?.length
         ? { installedFor: plugin.installedFor }
         : {}),
@@ -238,6 +261,7 @@ export const usePluginsStore = defineStore('plugins', () => {
               configData: meta.configData || {},
               src,
               active: meta.active ?? false,
+              global: meta.global,
               installedFor: meta.installedFor,
               storeId: meta.storeId,
               iconUrl: meta.iconUrl,
@@ -267,6 +291,10 @@ export const usePluginsStore = defineStore('plugins', () => {
 
     // Seed built-in plugins (初回起動 + 後追い追加に対応)。
     await seedMissingBuiltIns()
+
+    // レガシー紐付けのスコープ移行 (#771)。files が source of truth に
+    // なった後で走らせる。
+    scheduleScopeMigration()
   }
 
   /**
@@ -341,40 +369,127 @@ export const usePluginsStore = defineStore('plugins', () => {
     }
   }
 
-  /**
-   * プラグインの `installedFor` に accountIds を追加 (union)。
-   * misstore.installPlugin / per-account エディタ保存等で使う。
-   */
-  function linkAccountToPlugin(installId: string, accountIds: string[]) {
-    if (accountIds.length === 0) return
+  /** 全体スコープに参加させる。全アカウントカラムからのインストール/追加用。 */
+  function linkGlobalScope(installId: string) {
+    ensureLoaded()
+    const plugin = plugins.value.find((p) => p.installId === installId)
+    if (!plugin || plugin.global) return
+    plugin.global = true
+    persist(plugin)
+  }
+
+  /** 全体スコープから外す。本体はライブラリに残る (widgets の detach と同型)。 */
+  function unlinkGlobalScope(installId: string) {
+    ensureLoaded()
+    const plugin = plugins.value.find((p) => p.installId === installId)
+    if (!plugin?.global) return
+    plugin.global = undefined
+    persist(plugin)
+  }
+
+  /** アカウント別スコープ (`accountScopeKey`) に参加させる (union)。 */
+  function linkAccountScope(installId: string, scopeKey: string) {
     ensureLoaded()
     const plugin = plugins.value.find((p) => p.installId === installId)
     if (!plugin) return
     const existing = plugin.installedFor ?? []
-    plugin.installedFor = Array.from(new Set([...existing, ...accountIds]))
+    if (existing.includes(scopeKey)) return
+    plugin.installedFor = [...existing, scopeKey]
     persist(plugin)
   }
 
-  /**
-   * プラグインの per-account 紐付け (`installedFor`) から accountId を外す。
-   * installedFor が空になれば plugins から完全削除する。
-   * per-account プラグインカラムでの「× ボタン」=「このアカウントから外す」用。
-   */
-  function unlinkAccountFromPlugin(installId: string, accountId: string) {
+  /** アカウント別スコープから外す。本体はライブラリに残る。 */
+  function unlinkAccountScope(installId: string, scopeKey: string) {
     ensureLoaded()
     const plugin = plugins.value.find((p) => p.installId === installId)
-    if (!plugin || !plugin.installedFor) {
-      // installedFor が無い (= 全 account 対象 / 旧プラグイン) は per-account
-      // 単独除去の対象外。完全削除は cross-account カラムから行う想定。
-      return
-    }
-    const remaining = plugin.installedFor.filter((id) => id !== accountId)
-    if (remaining.length === 0) {
-      removePlugin(installId)
-      return
-    }
-    plugin.installedFor = remaining
+    if (!plugin?.installedFor) return
+    const remaining = plugin.installedFor.filter((k) => k !== scopeKey)
+    plugin.installedFor = remaining.length > 0 ? remaining : undefined
     persist(plugin)
+  }
+
+  /** scope に応じて linkGlobalScope / linkAccountScope へ振り分ける。 */
+  function linkScope(installId: string, scope: PluginScope) {
+    if (scope.kind === 'global') linkGlobalScope(installId)
+    else linkAccountScope(installId, scope.key)
+  }
+
+  /** scope に応じて unlinkGlobalScope / unlinkAccountScope へ振り分ける。 */
+  function unlinkScope(installId: string, scope: PluginScope) {
+    if (scope.kind === 'global') unlinkGlobalScope(installId)
+    else unlinkAccountScope(installId, scope.key)
+  }
+
+  /** 安定キーは host:userId 形式で必ず ':' を含む。旧 UUID には含まれない。 */
+  const isScopeKey = (v: string) => v.includes(':')
+
+  let scopesMigrated = false
+
+  /**
+   * レガシー紐付けの一括移行 (#771)。アカウント一覧が必要なので
+   * accounts ロード後に 1 回だけ走る。
+   * - global / installedFor とも無し (旧: 全アカウント対象) → global: true
+   * - installedFor の旧 UUID → 現行アカウントに該当すれば安定キーへ置換、
+   *   該当しなければ破棄 (再ログインで UUID が変わった痕跡)
+   * - 置換の結果 空 (紐付け先が全滅したゾンビ) → global: true で救済
+   * - 置換の結果 全現行アカウントをカバー (旧 全アカウントカラムの
+   *   スナップショット) → global: true に昇格
+   * 安定キーのみのプラグインには触れない (冪等)。
+   */
+  function migrateScopes() {
+    const accountsStore = useAccountsStore()
+    if (!accountsStore.isLoaded || scopesMigrated) return
+    scopesMigrated = true
+    ensureLoaded()
+
+    const uuidToKey = new Map(
+      accountsStore.accounts.map((a) => [a.id, accountScopeKey(a)]),
+    )
+    const allKeys = accountsStore.accounts.map((a) => accountScopeKey(a))
+
+    for (const plugin of plugins.value) {
+      if (plugin.global) continue
+      const list = plugin.installedFor ?? []
+      if (list.length === 0) {
+        if (plugin.installedFor !== undefined) plugin.installedFor = undefined
+        plugin.global = true
+        persist(plugin)
+        continue
+      }
+      if (list.every(isScopeKey)) continue // 移行済み
+
+      const mapped = Array.from(
+        new Set(list.map((v) => (isScopeKey(v) ? v : uuidToKey.get(v)))),
+      ).filter((v): v is string => !!v)
+
+      if (
+        mapped.length === 0 ||
+        (allKeys.length > 0 && allKeys.every((k) => mapped.includes(k)))
+      ) {
+        plugin.global = true
+        plugin.installedFor = undefined
+      } else {
+        plugin.installedFor = mapped
+      }
+      persist(plugin)
+    }
+  }
+
+  /** accounts のロード完了を待って migrateScopes を 1 回だけ実行する。 */
+  function scheduleScopeMigration() {
+    const accountsStore = useAccountsStore()
+    if (accountsStore.isLoaded) {
+      migrateScopes()
+      return
+    }
+    const stop = watch(
+      () => accountsStore.isLoaded,
+      (ready) => {
+        if (!ready) return
+        stop()
+        migrateScopes()
+      },
+    )
   }
 
   function setActive(installId: string, active: boolean) {
@@ -446,8 +561,13 @@ export const usePluginsStore = defineStore('plugins', () => {
     ensureLoaded,
     addPlugin,
     removePlugin,
-    linkAccountToPlugin,
-    unlinkAccountFromPlugin,
+    linkGlobalScope,
+    unlinkGlobalScope,
+    linkAccountScope,
+    unlinkAccountScope,
+    linkScope,
+    unlinkScope,
+    migrateScopes,
     renamePlugin,
     setActive,
     updateConfigData,

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -110,6 +110,18 @@ export interface PluginMeta {
 /** インストール/追加先スコープ (#771)。カラムの文脈から決まる。 */
 export type PluginScope = { kind: 'global' } | { kind: 'account'; key: string }
 
+let builtInIdCache: Set<string> | null = null
+
+/** アプリ同梱 (defaults/plugins seed) 由来のプラグインか。セクション分類用。 */
+export function isBuiltInPlugin(installId: string): boolean {
+  if (!builtInIdCache) {
+    builtInIdCache = new Set(
+      loadBuiltInPluginTemplates().map((t) => t.installId),
+    )
+  }
+  return builtInIdCache.has(installId)
+}
+
 /**
  * plugin が scopeKey (`accountScopeKey`) のアカウントに効くか。
  * scopeKey=null は「アカウント文脈なし」= 全体スコープのみ有効。


### PR DESCRIPTION
## v1.12.0

### Changes

- feat(plugin): プラグイン管理をスコープ別プールに再設計 (#771)
- feat(deck): 管理カラムのセクションを統一 (オリジナル/フォーク + アコーディオン)
- feat(deck): インストール済みタブを出自 3 分類 (ビルドイン/自作/ストア配布) に変更
- refactor(deck): セクションラベル「フォーク」を「ストア配布」に変更
- refactor(deck): セクションラベル「オリジナル」を「ビルドイン」に変更
- refactor(deck): セクション「自作」を「サイドロード」に改名
- chore: bump version to 1.12.0
- chore: regenerate openapi.json for 1.12.0

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)