### PR TITLE
Release v1.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.12.0",
+  "version": "1.12.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.12.0"
+version = "1.12.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.12.0"
+version = "1.12.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.12.0"
+    "version": "1.12.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -657,8 +657,11 @@ async function sendMessage(
         { sessionId },
       )
     }
-  } else if (outcome.status === 'error' && outcome.wasFirstRound) {
-    // ストリーム例外で抜けた初回 round はタイトル生成も走らないため、
+  } else if (
+    (outcome.status === 'error' || outcome.status === 'cancelled') &&
+    outcome.wasFirstRound
+  ) {
+    // ストリーム例外・中断で抜けた初回 round はタイトル生成も走らないため、
     // ユーザー入力から決定論的に fallback タイトルを付ける (#484)。
     // ユーザーが手動 rename している場合 (= timestamp 形式でない) は触らない。
     const cur = sessionsStore.get(sessionId)
@@ -1013,7 +1016,7 @@ function onKeydown(e: KeyboardEvent) {
       />
 
       <div v-else-if="messages.length > 0" ref="aiMessagesRef" :class="$style.aiMessages">
-        <template v-for="msg in messages" :key="msg.id">
+        <template v-for="(msg, msgIndex) in messages" :key="msg.id">
           <!-- AI が呼び出した tool (assistant + tool_use) -->
           <div
             v-if="isToolUseMessage(msg)"
@@ -1092,8 +1095,10 @@ function onKeydown(e: KeyboardEvent) {
                 <span>Heartbeat</span>
               </div>
               <div :class="$style.chatBubble">
+                <!-- typing indicator はストリーム対象 (常に末尾に追加される placeholder)
+                     のみ。履歴中に残った空 assistant を光らせない (#770) -->
                 <div
-                  v-if="msg.role === 'assistant' && !msg.content && isGenerating"
+                  v-if="msg.role === 'assistant' && !msg.content && isGenerating && msgIndex === messages.length - 1"
                   :class="$style.messageTyping"
                 >
                   <span :class="$style.typingDot" />

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -31,6 +31,10 @@ import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
 import PluginCard from './PluginCard.vue'
+import {
+  type CapabilityCheck,
+  checkKnownCapabilities,
+} from './widgets/capabilities'
 
 // 拒否バッジのクリック → 権限ウィンドウの plugin 行 (#712 §8.4)
 function openPermissionSettings(): void {
@@ -212,6 +216,17 @@ const filteredStorePlugins = computed(() => {
       p.author.toLowerCase().includes(q) ||
       p.tags.some((t) => t.toLowerCase().includes(q)),
   )
+})
+
+// 未知 capability を宣言するエントリは install 不可 (要 NoteDeck アップデート)。
+// widget と違いカラム文脈 (accountId) の条件は無く、実行時の認可は
+// permissions.json5 の plugin principal 側で gate される。
+const capabilityChecks = computed<Record<string, CapabilityCheck>>(() => {
+  const result: Record<string, CapabilityCheck> = {}
+  for (const p of misStore.plugins) {
+    result[p.id] = checkKnownCapabilities(p.capabilities ?? [])
+  }
+  return result
 })
 
 const installError = ref<string | null>(null)
@@ -497,6 +512,9 @@ async function deleteFromLibrary(plugin: PluginMeta) {
             :category-label="entry.category ? PLUGIN_CATEGORY_LABELS[entry.category] : undefined"
             :installing="misStore.installing === entry.id"
             :already-installed="isEntryInScope(entry)"
+            :capabilities="entry.capabilities"
+            :capability-ok="capabilityChecks[entry.id]?.ok"
+            :capability-reason="capabilityChecks[entry.id]?.reason"
             :icon-url="entry.iconUrl"
             @install="handleStoreInstall(entry)"
             @open-detail="handleOpenStoreDetail(entry)"

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -14,6 +14,10 @@ const props = defineProps<{
   active?: boolean
   installing?: boolean
   alreadyInstalled?: boolean
+  /** store mode: MisStore 宣言の capabilities (バッジ表示用) */
+  capabilities?: readonly string[]
+  capabilityOk?: boolean
+  capabilityReason?: string | null
   confirmingUninstall?: boolean
   /** installed mode: trash ボタンの title (スコープ文脈で言い換える) */
   uninstallTitle?: string
@@ -38,13 +42,16 @@ const emit = defineEmits<{
 }>()
 
 const disabled = computed(
-  () => props.mode === 'installed' && props.active === false,
+  () =>
+    (props.mode === 'installed' && props.active === false) ||
+    (props.mode === 'store' && props.capabilityOk === false),
 )
 </script>
 
 <template>
   <div
     :class="[$style.card, disabled && $style.cardDisabled]"
+    :title="mode === 'store' && capabilityOk === false ? (capabilityReason ?? '') : ''"
     @click="emit('click')"
   >
     <div :class="$style.accentBar" />
@@ -80,6 +87,14 @@ const disabled = computed(
         <span v-if="author" :class="$style.author">{{ author }}</span>
         <span v-if="category" :class="$style.category">
           {{ categoryLabel || category }}
+        </span>
+        <!-- capability badges (store mode) -->
+        <span
+          v-for="cap in capabilities ?? []"
+          :key="cap"
+          :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
+        >
+          {{ cap }}
         </span>
         <span :class="$style.spacer" />
         <div :class="$style.actions">
@@ -152,7 +167,7 @@ const disabled = computed(
               v-else
               class="_button"
               :class="$style.primaryBtn"
-              :disabled="installing"
+              :disabled="installing || capabilityOk === false"
               @click.stop="emit('install')"
             >
               <i v-if="installing" class="ti ti-loader-2 nd-spin" />
@@ -329,6 +344,21 @@ const disabled = computed(
   opacity: 0.6;
   flex-shrink: 0;
   line-height: 1.3;
+}
+
+.capBadge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
+  color: var(--nd-accent);
+  flex-shrink: 0;
+  line-height: 1.3;
+}
+
+.capBadgeWarn {
+  background: color-mix(in srgb, var(--nd-love) 15%, transparent);
+  color: var(--nd-love);
 }
 
 .spacer {

--- a/src/components/deck/widgets/AiScriptEditor.vue
+++ b/src/components/deck/widgets/AiScriptEditor.vue
@@ -30,7 +30,7 @@ const props = withDefaults(
   }>(),
   {
     placeholder: '',
-    maxHeight: '200px',
+    maxHeight: 'none',
     useLsp: false,
     autoHeight: false,
   },

--- a/src/components/deck/widgets/capabilities.test.ts
+++ b/src/components/deck/widgets/capabilities.test.ts
@@ -13,6 +13,13 @@ describe('checkWidgetCapabilities', () => {
     expect(result).toEqual({ ok: true, reason: null })
   })
 
+  it('secret-vault は accountId なし (cross-account) でも互換', () => {
+    const result = checkWidgetCapabilities(['secret-vault'], {
+      accountId: null,
+    })
+    expect(result).toEqual({ ok: true, reason: null })
+  })
+
   it('misskey-api は accountId 必須', () => {
     expect(
       checkWidgetCapabilities(['misskey-api'], { accountId: null }).ok,

--- a/src/components/deck/widgets/capabilities.test.ts
+++ b/src/components/deck/widgets/capabilities.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from 'vitest'
-import { checkWidgetCapabilities } from './capabilities'
+import { checkKnownCapabilities, checkWidgetCapabilities } from './capabilities'
+
+describe('checkKnownCapabilities', () => {
+  it('既知 capability のみなら互換 (アカウント条件は見ない)', () => {
+    const result = checkKnownCapabilities([
+      'misskey-api',
+      'misskey-account',
+      'notedeck-api',
+      'secret-vault',
+    ])
+    expect(result).toEqual({ ok: true, reason: null })
+  })
+
+  it('未知 capability は「未対応の機能」として非互換', () => {
+    const result = checkKnownCapabilities(['future-thing'])
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('未対応の機能: future-thing')
+  })
+})
 
 describe('checkWidgetCapabilities', () => {
   it('capability なしはどのカラムでも互換', () => {

--- a/src/components/deck/widgets/capabilities.test.ts
+++ b/src/components/deck/widgets/capabilities.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { checkWidgetCapabilities } from './capabilities'
+
+describe('checkWidgetCapabilities', () => {
+  it('capability なしはどのカラムでも互換', () => {
+    expect(checkWidgetCapabilities([], { accountId: null }).ok).toBe(true)
+  })
+
+  it('notedeck-api は accountId なし (cross-account) でも互換', () => {
+    const result = checkWidgetCapabilities(['notedeck-api'], {
+      accountId: null,
+    })
+    expect(result).toEqual({ ok: true, reason: null })
+  })
+
+  it('misskey-api は accountId 必須', () => {
+    expect(
+      checkWidgetCapabilities(['misskey-api'], { accountId: null }).ok,
+    ).toBe(false)
+    expect(
+      checkWidgetCapabilities(['misskey-api'], { accountId: 'a1' }).ok,
+    ).toBe(true)
+  })
+
+  it('misskey-account は accountId 必須', () => {
+    expect(
+      checkWidgetCapabilities(['misskey-account'], { accountId: null }).ok,
+    ).toBe(false)
+    expect(
+      checkWidgetCapabilities(['misskey-account'], { accountId: 'a1' }).ok,
+    ).toBe(true)
+  })
+
+  it('未知 capability は「未対応の機能」として非互換', () => {
+    const result = checkWidgetCapabilities(['future-thing'], {
+      accountId: 'a1',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.reason).toContain('未対応の機能: future-thing')
+  })
+})

--- a/src/components/deck/widgets/capabilities.ts
+++ b/src/components/deck/widgets/capabilities.ts
@@ -26,6 +26,9 @@ const KNOWN_CAPABILITIES = new Set<string>([
   'misskey-account',
   // Nd:* API (notedeck-api.ts)。accountId 非依存なので追加条件なし。
   'notedeck-api',
+  // Secret Vault (vault.fetch)。認可は permissions.json5 の vault.use 側で
+  // gate されるため、install 判定では互換とだけ扱う。
+  'secret-vault',
 ])
 
 export function checkWidgetCapabilities(

--- a/src/components/deck/widgets/capabilities.ts
+++ b/src/components/deck/widgets/capabilities.ts
@@ -1,12 +1,14 @@
 /**
- * MisStore widget の `capabilities` 配列と、NoteDeck カラム文脈 (accountId 等)
- * との互換性を判定する。
+ * MisStore widget / plugin の `capabilities` 配列と、NoteDeck 側の対応状況
+ * (および widget はカラム文脈 accountId) との互換性を判定する。
  *
  * 方針:
  * - 既知 capability は KNOWN_CAPABILITIES に列挙し、各々の要求条件を記述。
  * - 未知 capability は NoteDeck 未対応として非互換扱いにする (将来 MisStore が
  *   新しい capability を導入したとき、NoteDeck 未更新のユーザーが install して
  *   runtime エラーに遭遇するのを防ぐ)。
+ * - plugin はカラム文脈を持たないため checkKnownCapabilities のみ使う
+ *   (実行時の認可は permissions.json5 の plugin principal 側で gate される)。
  */
 
 export interface CapabilityContext {
@@ -31,9 +33,9 @@ const KNOWN_CAPABILITIES = new Set<string>([
   'secret-vault',
 ])
 
-export function checkWidgetCapabilities(
+/** NoteDeck が capability を理解しているかだけを判定する (plugin install 用)。 */
+export function checkKnownCapabilities(
   capabilities: readonly string[],
-  ctx: CapabilityContext,
 ): CapabilityCheck {
   for (const cap of capabilities) {
     if (!KNOWN_CAPABILITIES.has(cap)) {
@@ -42,6 +44,17 @@ export function checkWidgetCapabilities(
         reason: `未対応の機能: ${cap} (NoteDeck のアップデートが必要です)`,
       }
     }
+  }
+  return { ok: true, reason: null }
+}
+
+export function checkWidgetCapabilities(
+  capabilities: readonly string[],
+  ctx: CapabilityContext,
+): CapabilityCheck {
+  const known = checkKnownCapabilities(capabilities)
+  if (!known.ok) return known
+  for (const cap of capabilities) {
     if (cap === 'misskey-api' && ctx.accountId === null) {
       return {
         ok: false,

--- a/src/components/deck/widgets/capabilities.ts
+++ b/src/components/deck/widgets/capabilities.ts
@@ -21,7 +21,12 @@ export interface CapabilityCheck {
 }
 
 /** NoteDeck が理解する capability の一覧。 */
-const KNOWN_CAPABILITIES = new Set<string>(['misskey-api', 'misskey-account'])
+const KNOWN_CAPABILITIES = new Set<string>([
+  'misskey-api',
+  'misskey-account',
+  // Nd:* API (notedeck-api.ts)。accountId 非依存なので追加条件なし。
+  'notedeck-api',
+])
 
 export function checkWidgetCapabilities(
   capabilities: readonly string[],

--- a/src/components/window/PlayEditContent.vue
+++ b/src/components/window/PlayEditContent.vue
@@ -149,7 +149,7 @@ onMounted(load)
       </div>
 
       <div v-show="tab === 'code'" :class="$style.codePanel">
-        <AiScriptEditor v-model="editingScript" auto-height />
+        <AiScriptEditor v-model="editingScript" :class="$style.editor" />
       </div>
 
       <div v-if="saveError" :class="$style.error">{{ saveError }}</div>
@@ -196,10 +196,17 @@ onMounted(load)
 
 .metaPanel,
 .codePanel {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   gap: 16px;
   padding: 16px;
+}
+
+.editor {
+  flex: 1;
+  min-width: 0;
 }
 
 .field {

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -397,7 +397,7 @@ async function importPlugin() {
       <AiScriptEditor
         v-model="editingCode"
         :placeholder="isNewInstall ? '### { name: &quot;my-plugin&quot;, version: &quot;1.0&quot; } ...' : ''"
-        auto-height
+        :class="$style.codeEditor"
       />
       <div v-if="installError" :class="$style.errorMessage">
         <i class="ti ti-alert-circle" />
@@ -725,7 +725,11 @@ async function importPlugin() {
   padding: 10px;
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
+}
+
+.codeEditor {
+  flex: 1;
+  min-width: 0;
 }
 
 .codeHint {

--- a/src/components/window/ThemeEditorContent.vue
+++ b/src/components/window/ThemeEditorContent.vue
@@ -724,7 +724,6 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
           :language="jsonLang"
           :linter="jsonLinter"
           :class="$style.codeEditorWrap"
-          auto-height
         />
         <div v-if="codeError" :class="$style.codeError">{{ codeError }}</div>
         <button
@@ -1193,10 +1192,11 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   padding: 10px;
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
 }
 
 .codeEditorWrap {
+  flex: 1;
+  min-width: 0;
 }
 
 .codeError {

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -335,7 +335,7 @@ function toggleAutoRun() {
 
     <div v-if="widget" :class="$style.tabBody">
       <template v-if="tab === 'code'">
-        <AiScriptEditor v-model="code" placeholder="AiScript App code..." />
+        <AiScriptEditor v-model="code" placeholder="AiScript App code..." :class="$style.codeEditor" />
       </template>
       <template v-else>
         <div v-if="error" :class="$style.appError">{{ error }}</div>
@@ -552,6 +552,11 @@ function toggleAutoRun() {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+}
+
+.codeEditor {
+  flex: 1;
+  min-width: 0;
 }
 
 .appError {

--- a/src/composables/useAiChat.test.ts
+++ b/src/composables/useAiChat.test.ts
@@ -1,5 +1,39 @@
-import { describe, expect, it } from 'vitest'
-import { toolResultWireMessage, toolUseWireMessage } from './useAiChat'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+import {
+  AiChatCancelledError,
+  toolResultWireMessage,
+  toolUseWireMessage,
+  useAiChat,
+} from './useAiChat'
+
+// --- Tauri mock (cancel settle テスト用 #770) ---
+
+const listeners: Array<(p: unknown) => void> = []
+vi.mock('@/utils/tauriEvents', () => ({
+  listenTauri: vi.fn(async (_event: string, cb: (p: unknown) => void) => {
+    listeners.push(cb)
+    return () => {
+      const i = listeners.indexOf(cb)
+      if (i >= 0) listeners.splice(i, 1)
+    }
+  }),
+}))
+
+const aiChatSend = vi.fn(async () => ({ status: 'ok', data: null }))
+const aiChatCancel = vi.fn(async () => ({ status: 'ok', data: null }))
+vi.mock('@/utils/tauriInvoke', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/tauriInvoke')>(
+    '@/utils/tauriInvoke',
+  )
+  return {
+    unwrap: actual.unwrap,
+    commands: {
+      aiChatSend: (...args: unknown[]) => aiChatSend(...(args as [])),
+      aiChatCancel: (...args: unknown[]) => aiChatCancel(...(args as [])),
+    },
+  }
+})
 
 describe('toolUseWireMessage', () => {
   it('builds an assistant wire message with tool_use_* fields', () => {
@@ -38,5 +72,62 @@ describe('toolResultWireMessage', () => {
     expect(msg.content).toBe('2026-05-01T00:00:00Z')
     expect(msg.tool_result_for).toBe('toolu_1')
     expect(msg.tool_use_id).toBeUndefined()
+  })
+})
+
+describe('useAiChat.cancel (#770: 中断を正規の終端イベントにする)', () => {
+  beforeEach(() => {
+    listeners.length = 0
+    aiChatSend.mockClear()
+    aiChatCancel.mockClear()
+  })
+
+  function setup() {
+    const scope = effectScope()
+    const chat = scope.run(() => useAiChat())
+    if (!chat) throw new Error('scope.run failed')
+    return { scope, chat }
+  }
+
+  it('進行中の sendMessage を AiChatCancelledError で settle する', async () => {
+    const { scope, chat } = setup()
+    const promise = chat.sendMessage({
+      connectionId: 'c1',
+      model: 'm1',
+      history: [],
+    })
+    // listener 登録 (= ストリーム確立) を待つ
+    await vi.waitFor(() => expect(listeners.length).toBe(1))
+    expect(chat.isStreaming.value).toBe(true)
+
+    await chat.cancel()
+
+    await expect(promise).rejects.toBeInstanceOf(AiChatCancelledError)
+    expect(chat.isStreaming.value).toBe(false)
+    // Rust 側の task abort も要求している
+    expect(aiChatCancel).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+
+  it('scope dispose (unmount) でも進行中の sendMessage を settle する', async () => {
+    const { scope, chat } = setup()
+    const promise = chat.sendMessage({
+      connectionId: 'c1',
+      model: 'm1',
+      history: [],
+    })
+    await vi.waitFor(() => expect(listeners.length).toBe(1))
+
+    scope.stop()
+
+    await expect(promise).rejects.toBeInstanceOf(AiChatCancelledError)
+    expect(aiChatCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('ストリームが無いときの cancel は no-op (Rust cancel を呼ばない)', async () => {
+    const { scope, chat } = setup()
+    await chat.cancel()
+    expect(aiChatCancel).not.toHaveBeenCalled()
+    scope.stop()
   })
 })

--- a/src/composables/useAiChat.ts
+++ b/src/composables/useAiChat.ts
@@ -69,6 +69,20 @@ export interface AiChatEventPayload {
   tool_use_input?: Record<string, unknown>
 }
 
+/**
+ * ユーザー操作 (停止ボタン / セッション切替 / unmount) によるストリーム中断 (#770)。
+ * done / error と並ぶ sendMessage の正規の終端イベント。Rust 側は task を
+ * abort するだけでイベントを emit しないため、JS 側で promise をこのエラーで
+ * settle しないと useAiSendLoop が永久 pending になり placeholder の掃除が
+ * 走らない。呼び出し側は instanceof でエラーと区別する。
+ */
+export class AiChatCancelledError extends Error {
+  constructor() {
+    super('応答の生成を中断しました')
+    this.name = 'AiChatCancelledError'
+  }
+}
+
 function generateStreamId(): string {
   return `ai-stream-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 }
@@ -145,6 +159,9 @@ export function useAiChat() {
   // component unmounts while a stream is in flight.
   let activeUnlisten: UnlistenFn | null = null
   let activeStreamId: string | null = null
+  // 進行中 sendMessage の reject。cancel / dispose 時に AiChatCancelledError で
+  // settle し、await している送信ループ側の掃除 (placeholder 除去等) を走らせる。
+  let activeReject: ((e: Error) => void) | null = null
 
   function cleanup() {
     if (activeUnlisten) {
@@ -152,30 +169,28 @@ export function useAiChat() {
       activeUnlisten = null
     }
     activeStreamId = null
+    activeReject = null
     isStreaming.value = false
   }
 
-  // Auto-cleanup on component unmount: tears down any in-flight listener
-  // so we don't leak across columns being added/removed. Also fire-and-forget
-  // a server-side cancel so the Rust task doesn't keep streaming bytes
-  // (and burning API tokens) for an unmounted component.
+  // Auto-cleanup on component unmount: settles the in-flight promise and
+  // tears down the listener so we don't leak across columns being
+  // added/removed. cancel() also aborts the Rust task so it doesn't keep
+  // streaming bytes (and burning API tokens) for an unmounted component.
   onScopeDispose(() => {
-    if (activeStreamId) {
-      void commands.aiChatCancel(activeStreamId)
-    }
-    if (activeUnlisten) {
-      activeUnlisten()
-      activeUnlisten = null
-    }
+    void cancel()
   })
 
   /**
-   * Cancel any in-flight stream. Resolves immediately; the Rust side aborts
-   * the background task and stops emitting events for this stream_id.
+   * Cancel any in-flight stream (#770). Settles the pending sendMessage
+   * promise with AiChatCancelledError, then asks the Rust side to abort the
+   * background task so it stops emitting events for this stream_id.
    */
   async function cancel(): Promise<void> {
     const id = activeStreamId
+    const reject = activeReject
     cleanup()
+    reject?.(new AiChatCancelledError())
     if (id) {
       try {
         unwrap(await commands.aiChatCancel(id))
@@ -199,6 +214,7 @@ export function useAiChat() {
     activeStreamId = streamId
 
     return new Promise<string>((resolve, reject) => {
+      activeReject = reject
       // Subscribe BEFORE invoking, so we never miss the first delta.
       listenTauri('nd:ai-chat-event', (p) => {
         if (p.stream_id !== streamId) return

--- a/src/composables/useAiSendLoop.test.ts
+++ b/src/composables/useAiSendLoop.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
-import type { AiChatSendOptions, ChatMessage } from './useAiChat'
+import {
+  AiChatCancelledError,
+  type AiChatSendOptions,
+  type ChatMessage,
+} from './useAiChat'
 import {
   type AiSendLoopDeps,
   MAX_TOOL_ROUNDS,
@@ -340,6 +344,79 @@ describe('runSend: エラー時の partial 温存 (#508)', () => {
 
     const messages = sessions.get('s1')?.messages ?? []
     expect(messages[1]?.content).toBe('⚠️ boom')
+  })
+})
+
+describe('runSend: ユーザー中断 (#770)', () => {
+  it('partial の無い中断は空 placeholder を除去し cancelled を返す', async () => {
+    const { sessions, deps } = makeDeps([
+      () => {
+        throw new AiChatCancelledError()
+      },
+    ])
+    const loop = useAiSendLoop(deps)
+
+    const outcome = await loop.runSend(request())
+
+    expect(outcome).toEqual({ status: 'cancelled', wasFirstRound: true })
+    const messages = sessions.get('s1')?.messages ?? []
+    // user は残り、空 placeholder は残骸として残らない
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toMatchObject({ role: 'user', content: 'こんにちは' })
+  })
+
+  it('partial のある中断は ⚠️ を付けず途中応答のまま確定する', async () => {
+    const { chat, sessions, deps } = makeDeps([])
+    chat.sendMessage = async () => {
+      chat.isStreaming.value = true
+      chat.currentText.value = '途中まで書いた応答'
+      chat.isStreaming.value = false
+      throw new AiChatCancelledError()
+    }
+    const loop = useAiSendLoop(deps)
+
+    const outcome = await loop.runSend(request())
+
+    expect(outcome).toMatchObject({ status: 'cancelled' })
+    const messages = sessions.get('s1')?.messages ?? []
+    expect(messages).toHaveLength(2)
+    expect(messages[1]?.content).toBe('途中まで書いた応答')
+  })
+
+  it('tool 未実行の中断は mode=resend を記録する', async () => {
+    const { deps } = makeDeps([
+      () => {
+        throw new AiChatCancelledError()
+      },
+    ])
+    const loop = useAiSendLoop(deps)
+
+    await loop.runSend(request())
+
+    expect(loop.retryContext.value).toMatchObject({
+      sessionId: 's1',
+      userText: 'こんにちは',
+      mode: 'resend',
+    })
+  })
+
+  it('tool 実行済みターンの中断は mode=continue を記録する (write 二重実行防止 #737)', async () => {
+    const { dispatch, deps } = makeDeps([
+      toolStep('', 'toolu_1', 'notes.create'),
+      () => {
+        throw new AiChatCancelledError()
+      },
+    ])
+    const loop = useAiSendLoop(deps)
+
+    const outcome = await loop.runSend(request())
+
+    expect(dispatch).toHaveBeenCalledTimes(1)
+    expect(outcome.status).toBe('cancelled')
+    expect(loop.retryContext.value).toMatchObject({
+      sessionId: 's1',
+      mode: 'continue',
+    })
   })
 })
 

--- a/src/composables/useAiSendLoop.ts
+++ b/src/composables/useAiSendLoop.ts
@@ -1,9 +1,10 @@
 import { type Ref, ref, watch } from 'vue'
 import type { DispatchResult } from '@/capabilities/dispatcher'
-import type {
-  AiChatSendOptions,
-  ChatMessage,
-  ToolUseEvent,
+import {
+  AiChatCancelledError,
+  type AiChatSendOptions,
+  type ChatMessage,
+  type ToolUseEvent,
 } from '@/composables/useAiChat'
 import { extractErrorMessage } from '@/utils/errors'
 
@@ -76,6 +77,8 @@ export interface AiSendRequest {
 export type AiSendOutcome =
   | { status: 'done'; finalText: string; wasFirstRound: boolean }
   | { status: 'error'; message: string; wasFirstRound: boolean }
+  /** ユーザー中断 (#770)。partial は温存済み、空 placeholder は除去済み */
+  | { status: 'cancelled'; wasFirstRound: boolean }
   /** session 消失等で何も送らなかった */
   | { status: 'aborted' }
 
@@ -317,35 +320,54 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
       }
       return { status: 'done', finalText: finalAssistantText, wasFirstRound }
     } catch (e) {
-      // 診断: AI ストリーム失敗時の raw error を console に dump。
-      // [object Object] 表示の根本原因 (= 想定外の error shape) を追跡しやすくする。
-      console.error('[ai-send-loop] stream error raw:', e)
+      const cancelled = e instanceof AiChatCancelledError
+      if (!cancelled) {
+        // 診断: AI ストリーム失敗時の raw error を console に dump。
+        // [object Object] 表示の根本原因 (= 想定外の error shape) を追跡しやすくする。
+        console.error('[ai-send-loop] stream error raw:', e)
+      }
       const message = extractErrorMessage(e)
       const cur = deps.sessions.get(req.sessionId)
       if (cur) {
         const last = cur.messages[cur.messages.length - 1]
         if (last?.role === 'assistant' && last.id === placeholderId) {
           // mid-stream 切断 (#508) では placeholder に途中までの応答が入っている。
-          // 上書きで捨てず、末尾にエラーを添えて温存する。エラーと同じ flush
-          // ウィンドウに届いた最終 delta は store 反映前のことがあるため、
-          // currentText と store の長い方を採る。
+          // 上書きで捨てず温存する。エラーと同じ flush ウィンドウに届いた最終
+          // delta は store 反映前のことがあるため、currentText と store の
+          // 長い方を採る。
           const partial =
             deps.chat.currentText.value.length > last.content.length
               ? deps.chat.currentText.value
               : last.content
-          deps.sessions.updateMessages(req.sessionId, [
-            ...cur.messages.slice(0, -1),
-            {
-              ...last,
-              content: partial ? `${partial}\n\n⚠️ ${message}` : `⚠️ ${message}`,
-            },
-          ])
+          if (cancelled) {
+            // ユーザー中断 (#770): エラーではないので ⚠️ は付けず partial を
+            // そのまま確定。partial が無ければ空 placeholder を残骸として
+            // 残さず除去する (typing バブルが履歴に固定化するのを防ぐ)。
+            deps.sessions.updateMessages(
+              req.sessionId,
+              partial
+                ? [...cur.messages.slice(0, -1), { ...last, content: partial }]
+                : cur.messages.slice(0, -1),
+            )
+          } else {
+            deps.sessions.updateMessages(req.sessionId, [
+              ...cur.messages.slice(0, -1),
+              {
+                ...last,
+                content: partial
+                  ? `${partial}\n\n⚠️ ${message}`
+                  : `⚠️ ${message}`,
+              },
+            ])
+          }
         }
       }
       // 再試行コンテキスト (#508 / #737)。tool 未実行の新規ターンは resend
       // (ターン全体を再送)、tool 実行済み or 継続中のターンは continue
       // (実行済み tool を保持して続きから生成)。再送による write capability
-      // の二重実行はこの分岐で構造的に防ぐ。
+      // の二重実行はこの分岐で構造的に防ぐ。中断でも記録する: 「続きを生成」
+      // を通常送信で行うと CONTINUATION_NOTICE が付かず、実行済み write
+      // capability を AI が再実行しうるのはエラー時と同じため。
       retryContext.value = {
         sessionId: req.sessionId,
         userMsgId,
@@ -353,6 +375,7 @@ export function useAiSendLoop(deps: AiSendLoopDeps) {
         userText: req.text,
         mode: toolRound === 0 && !req.continuation ? 'resend' : 'continue',
       }
+      if (cancelled) return { status: 'cancelled', wasFirstRound }
       return { status: 'error', message, wasFirstRound }
     } finally {
       activeStreamSessionId.value = null

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -804,7 +804,11 @@ export function useHeartbeatDaemon() {
       tools,
       buildSystem: () => system,
     })
-    if (outcome.status === 'aborted') return null
+    // cancelled (#770) は scope dispose 等によるユーザー起因の中断なので、
+    // aborted と同じく失敗カウント (auto-disable) に乗せず静かに skip する
+    if (outcome.status === 'aborted' || outcome.status === 'cancelled') {
+      return null
+    }
     // throw に変換して呼び出し側の連続失敗カウント (auto-disable) に乗せる
     if (outcome.status === 'error') throw new Error(outcome.message)
     return outcome.finalText

--- a/src/stores/aiSessions.test.ts
+++ b/src/stores/aiSessions.test.ts
@@ -134,3 +134,47 @@ describe('useAiSessionsStore triggeredSkillIds persistence (#725)', () => {
     expect(store.get('weird')?.triggeredSkillIds).toEqual(['ok'])
   })
 })
+
+describe('中断残骸の読込時浄化 (#770)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    files.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('空 content の assistant placeholder を読込時に落とす (tool_use 付きは残す)', async () => {
+    files.set(
+      'residue.json5',
+      JSON.stringify({
+        schemaVersion: 1,
+        id: 'residue',
+        kind: 'chat',
+        title: 't',
+        model: 'm',
+        connectionId: 'c',
+        createdAt: 1,
+        updatedAt: 1,
+        messages: [
+          { id: 'u1', role: 'user', content: '質問', timestamp: 1 },
+          // 中断で残った streaming placeholder — 落とす
+          { id: 'a1', role: 'assistant', content: '', timestamp: 2 },
+          // tool_use のみで本文空の assistant — 正当なので残す
+          {
+            id: 'a2',
+            role: 'assistant',
+            content: '',
+            timestamp: 3,
+            toolUseId: 'toolu_1',
+            toolUseName: 'time.now',
+          },
+          { id: 'a3', role: 'assistant', content: '回答', timestamp: 4 },
+        ],
+      }),
+    )
+    const store = useAiSessionsStore()
+    await store.loadAllMeta()
+    const messages = store.get('residue')?.messages ?? []
+    expect(messages.map((m) => m.id)).toEqual(['u1', 'a2', 'a3'])
+    expect(store.get('residue')?.messageCount).toBe(3)
+  })
+})

--- a/src/stores/aiSessions.ts
+++ b/src/stores/aiSessions.ts
@@ -130,7 +130,12 @@ function deserialize(raw: string): AiSession | null {
   }
   if (!parsed || typeof parsed !== 'object') return null
   const r = parsed as PersistShape
-  const messages = Array.isArray(r.messages) ? r.messages : []
+  // 空 content の assistant はストリーミング placeholder の残骸 (#770 中断や
+  // 異常終了で永続化されたもの)。tool_use 付き (本文空で tool 呼び出しのみ) は
+  // 正当なターンなので残す。
+  const messages = (Array.isArray(r.messages) ? r.messages : []).filter(
+    (m) => !(m?.role === 'assistant' && !m.content && !m.toolUseId),
+  )
   const triggeredSkillIds = Array.isArray(r.triggeredSkillIds)
     ? r.triggeredSkillIds.filter(
         (x): x is string => typeof x === 'string' && x.length > 0,

--- a/src/stores/misstore.ts
+++ b/src/stores/misstore.ts
@@ -62,6 +62,8 @@ export interface StorePluginEntry {
   author: string
   description: string
   category: PluginCategory
+  /** Plugin が要求する能力。widget と同じ語彙 (checkKnownCapabilities 参照)。 */
+  capabilities?: string[]
   tags: string[]
   sourceUrl: string
   apiUrl: string

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -74,11 +74,11 @@ export const WINDOW_SIZES: Record<
   aiSettings: { width: 400, maxHeight: 700 },
   permissions: { width: 420, maxHeight: 700 },
   // Tool windows
-  plugins: { width: 500, maxHeight: 650 },
+  plugins: { width: 500, maxHeight: 720 },
   // Editor windows
   keybinds: { width: 400, maxHeight: 650 },
   cssEditor: { width: 400, maxHeight: 650 },
-  themeEditor: { width: 400, maxHeight: 700 },
+  themeEditor: { width: 400, maxHeight: 720 },
   profileEditor: { width: 400, maxHeight: 700 },
   // Login
   login: { width: 380, maxHeight: 480 },


### PR DESCRIPTION
## v1.12.1

### Fixes
- fix(ai): 中断した応答の空バブルが履歴に残りアニメーションし続ける問題を修正
- fix(widgets): notedeck-api capability を既知リストに追加
- fix(widgets): secret-vault capability を既知リストに追加
- fix(window): コードタブの高さを skill-edit 式の親フィルに統一

### Features
- feat(plugins): ストアの capability 互換チェックとバッジ表示を追加

### Chore
- chore: bump version to 1.12.1
- chore: regenerate openapi.json for 1.12.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)