### PR TITLE
Release v1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.12.1",
+  "version": "1.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.12.1"
+version = "1.12.2"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.12.1"
+    "version": "1.12.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/capabilities/builtins/vault.ts
+++ b/src/capabilities/builtins/vault.ts
@@ -206,7 +206,8 @@ export const vaultFetchCapability: Command = {
     const conn = await resolveVisibleConnection(ref, principal)
     if (!conn) {
       throw new Error(
-        `connection "${ref}" は利用できません (存在しないか、この呼び出し元へのアクセスが許可されていません)`,
+        `connection "${ref}" は利用できません (存在しないか、この呼び出し元に開示されていません)。` +
+          '設定 → Secret Vault で接続を作成し、呼び出し元への開示を有効にしてください',
       )
     }
 

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { abortPlugin, launchPlugin } from '@/aiscript/plugin-api'
+import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useTabSlide } from '@/composables/useTabSlide'
@@ -49,7 +50,9 @@ const pluginsStore = usePluginsStore()
 const windowsStore = useWindowsStore()
 const misStore = useMisStoreStore()
 const accountsStore = useAccountsStore()
-const { serverIconUrl } = useServerImages(() => props.column)
+const { serverIconUrl, serverInfoImageUrl } = useServerImages(
+  () => props.column,
+)
 const { columnThemeVars } = useColumnTheme(() => props.column)
 
 pluginsStore.ensureLoaded()
@@ -430,18 +433,18 @@ async function deleteFromLibrary(plugin: PluginMeta) {
             />
           </ColumnSection>
 
-          <div v-if="visiblePluginCount === 0" :class="$style.empty">
-            <template v-if="textQuery || activeFilter !== 'all'">
+          <template v-if="visiblePluginCount === 0">
+            <div v-if="textQuery || activeFilter !== 'all'" :class="$style.empty">
               一致するプラグインがありません
-            </template>
-            <template v-else>
-              <i class="ti ti-puzzle" :class="$style.emptyIcon" />
-              <span>このカラムに追加されたプラグインはありません</span>
-              <button class="_button" :class="$style.emptyLink" @click="viewTab = 'store'">
-                ストアからインストール...
-              </button>
-            </template>
-          </div>
+            </div>
+            <ColumnEmptyState
+              v-else
+              message="このカラムに追加されたプラグインはありません"
+              :image-url="serverInfoImageUrl"
+              cta-label="ストアからインストール..."
+              @cta="viewTab = 'store'"
+            />
+          </template>
 
           <!-- Library picker: スコープ未参加のライブラリ本体を追加/削除 -->
           <div :class="$style.addPluginArea">

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -441,8 +441,6 @@ async function deleteFromLibrary(plugin: PluginMeta) {
               v-else
               message="このカラムに追加されたプラグインはありません"
               :image-url="serverInfoImageUrl"
-              cta-label="ストアからインストール..."
-              @cta="viewTab = 'store'"
             />
           </template>
 
@@ -634,6 +632,8 @@ async function deleteFromLibrary(plugin: PluginMeta) {
 
 // --- List ---
 .list {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   min-height: 0;
   overflow-y: auto;

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -514,6 +514,7 @@ async function deleteFromLibrary(plugin: PluginMeta) {
             :already-installed="isEntryInScope(entry)"
             :capabilities="entry.capabilities"
             :capability-ok="capabilityChecks[entry.id]?.ok"
+            :capability-badge="capabilityChecks[entry.id]?.badge"
             :capability-reason="capabilityChecks[entry.id]?.reason"
             :icon-url="entry.iconUrl"
             @install="handleStoreInstall(entry)"

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -389,6 +389,7 @@ function handleOpenStoreDetail(entry: StoreWidgetEntry) {
             :version="entry.version"
             :capabilities="entry.capabilities ?? []"
             :capability-ok="capabilityChecks[entry.id]?.ok"
+            :capability-badge="capabilityChecks[entry.id]?.badge"
             :capability-reason="capabilityChecks[entry.id]?.reason"
             :installing="installingId === entry.id"
             :already-installed="installedStoreIds.has(entry.id)"

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -41,17 +41,28 @@ const emit = defineEmits<{
   (e: 'delete'): void
 }>()
 
+const incompatible = computed(
+  () => props.mode === 'store' && props.capabilityOk === false,
+)
 const disabled = computed(
   () =>
     (props.mode === 'installed' && props.active === false) ||
-    (props.mode === 'store' && props.capabilityOk === false),
+    incompatible.value,
 )
+// 非互換時のみ tooltip で理由 + 必要 capability を開示する
+const incompatTitle = computed(() => {
+  if (!incompatible.value) return ''
+  const caps = props.capabilities?.length
+    ? `Requires: ${props.capabilities.join(', ')}`
+    : ''
+  return [props.capabilityReason ?? '', caps].filter(Boolean).join('\n')
+})
 </script>
 
 <template>
   <div
     :class="[$style.card, disabled && $style.cardDisabled]"
-    :title="mode === 'store' && capabilityOk === false ? (capabilityReason ?? '') : ''"
+    :title="incompatTitle"
     @click="emit('click')"
   >
     <div :class="$style.accentBar" />
@@ -67,7 +78,8 @@ const disabled = computed(
     <div :class="$style.body">
       <div :class="$style.row1">
         <span :class="$style.name">{{ name }}</span>
-        <span v-if="disabled" :class="$style.disabledBadge">無効</span>
+        <span v-if="incompatible" :class="$style.updateBadge">要アップデート</span>
+        <span v-else-if="disabled" :class="$style.disabledBadge">無効</span>
         <button
           v-if="deniedBadge"
           class="_button"
@@ -82,17 +94,6 @@ const disabled = computed(
       </div>
       <div :class="$style.row2">
         {{ description || 'No description' }}
-      </div>
-      <!-- capability badges (store mode): 個数可変なので専用行で折り返し、
-           アクション行 (row3) のレイアウトに影響させない -->
-      <div v-if="capabilities?.length" :class="$style.rowCaps">
-        <span
-          v-for="cap in capabilities"
-          :key="cap"
-          :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
-        >
-          {{ cap }}
-        </span>
       </div>
       <div :class="$style.row3">
         <span v-if="author" :class="$style.author">{{ author }}</span>
@@ -318,14 +319,6 @@ const disabled = computed(
   margin-top: 1px;
 }
 
-.rowCaps {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 4px;
-  min-width: 0;
-}
-
 .row3 {
   display: flex;
   align-items: center;
@@ -357,19 +350,17 @@ const disabled = computed(
   line-height: 1.3;
 }
 
-.capBadge {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
-  color: var(--nd-accent);
+.updateBadge {
   flex-shrink: 0;
-  line-height: 1.3;
-}
-
-.capBadgeWarn {
+  padding: 0 5px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  height: 14px;
+  border-radius: 2px;
   background: color-mix(in srgb, var(--nd-love) 15%, transparent);
   color: var(--nd-love);
+  letter-spacing: 0.02em;
 }
 
 .spacer {

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -83,18 +83,21 @@ const disabled = computed(
       <div :class="$style.row2">
         {{ description || 'No description' }}
       </div>
-      <div :class="$style.row3">
-        <span v-if="author" :class="$style.author">{{ author }}</span>
-        <span v-if="category" :class="$style.category">
-          {{ categoryLabel || category }}
-        </span>
-        <!-- capability badges (store mode) -->
+      <!-- capability badges (store mode): 個数可変なので専用行で折り返し、
+           アクション行 (row3) のレイアウトに影響させない -->
+      <div v-if="capabilities?.length" :class="$style.rowCaps">
         <span
-          v-for="cap in capabilities ?? []"
+          v-for="cap in capabilities"
           :key="cap"
           :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
         >
           {{ cap }}
+        </span>
+      </div>
+      <div :class="$style.row3">
+        <span v-if="author" :class="$style.author">{{ author }}</span>
+        <span v-if="category" :class="$style.category">
+          {{ categoryLabel || category }}
         </span>
         <span :class="$style.spacer" />
         <div :class="$style.actions">
@@ -172,7 +175,7 @@ const disabled = computed(
             >
               <i v-if="installing" class="ti ti-loader-2 nd-spin" />
               <i v-else class="ti ti-download" />
-              {{ installing ? '...' : 'インストール' }}
+              インストール
             </button>
           </template>
         </div>
@@ -313,6 +316,14 @@ const disabled = computed(
   -webkit-box-orient: vertical;
   line-height: 1.4;
   margin-top: 1px;
+}
+
+.rowCaps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+  min-width: 0;
 }
 
 .row3 {

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -17,6 +17,8 @@ const props = defineProps<{
   /** store mode: MisStore 宣言の capabilities (バッジ表示用) */
   capabilities?: readonly string[]
   capabilityOk?: boolean
+  /** 非互換理由の短いラベル (要アップデート 等) */
+  capabilityBadge?: string | null
   capabilityReason?: string | null
   confirmingUninstall?: boolean
   /** installed mode: trash ボタンの title (スコープ文脈で言い換える) */
@@ -78,7 +80,7 @@ const incompatTitle = computed(() => {
     <div :class="$style.body">
       <div :class="$style.row1">
         <span :class="$style.name">{{ name }}</span>
-        <span v-if="incompatible" :class="$style.updateBadge">要アップデート</span>
+        <span v-if="incompatible" :class="$style.incompatBadge">{{ capabilityBadge ?? '非対応' }}</span>
         <span v-else-if="disabled" :class="$style.disabledBadge">無効</span>
         <button
           v-if="deniedBadge"
@@ -350,7 +352,7 @@ const incompatTitle = computed(() => {
   line-height: 1.3;
 }
 
-.updateBadge {
+.incompatBadge {
   flex-shrink: 0;
   padding: 0 5px;
   font-size: 9px;

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -41,6 +41,14 @@ const isLibrary = computed(() => props.mode === 'library')
 const cardDisabled = computed(
   () => isStore.value && props.capabilityOk === false,
 )
+// 非互換時のみ tooltip で理由 + 必要 capability を開示する
+const incompatTitle = computed(() => {
+  if (!cardDisabled.value) return ''
+  const caps = props.capabilities?.length
+    ? `Requires: ${props.capabilities.join(', ')}`
+    : ''
+  return [props.capabilityReason ?? '', caps].filter(Boolean).join('\n')
+})
 
 function handlePrimaryClick() {
   if (cardDisabled.value) return
@@ -56,7 +64,7 @@ function handlePrimaryClick() {
 <template>
   <div
     :class="[$style.card, cardDisabled && $style.cardDisabled]"
-    :title="cardDisabled ? (capabilityReason ?? '') : ''"
+    :title="incompatTitle"
     @click="handlePrimaryClick"
   >
     <div :class="$style.accentBar" />
@@ -72,22 +80,12 @@ function handlePrimaryClick() {
     <div :class="$style.body">
       <div :class="$style.row1">
         <span :class="$style.name">{{ name }}</span>
+        <span v-if="cardDisabled" :class="$style.updateBadge">要アップデート</span>
         <span :class="$style.spacer" />
         <span v-if="version" :class="$style.version">v{{ version }}</span>
       </div>
       <div v-if="description" :class="$style.row2">
         {{ description }}
-      </div>
-      <!-- capability badges (store mode): 個数可変なので専用行で折り返し、
-           アクション行 (row3) のレイアウトに影響させない -->
-      <div v-if="capabilities?.length" :class="$style.rowCaps">
-        <span
-          v-for="cap in capabilities"
-          :key="cap"
-          :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
-        >
-          {{ cap }}
-        </span>
       </div>
       <div :class="$style.row3">
         <span v-if="author" :class="$style.author">{{ author }}</span>
@@ -271,14 +269,6 @@ function handlePrimaryClick() {
   margin-top: 1px;
 }
 
-.rowCaps {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px;
-  margin-top: 4px;
-  min-width: 0;
-}
-
 .row3 {
   display: flex;
   align-items: center;
@@ -315,19 +305,17 @@ function handlePrimaryClick() {
   opacity: 0.85;
 }
 
-.capBadge {
-  font-size: 10px;
-  padding: 1px 6px;
-  border-radius: 8px;
-  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
-  color: var(--nd-accent);
+.updateBadge {
   flex-shrink: 0;
-  line-height: 1.3;
-}
-
-.capBadgeWarn {
+  padding: 0 5px;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 14px;
+  height: 14px;
+  border-radius: 2px;
   background: color-mix(in srgb, var(--nd-love) 15%, transparent);
   color: var(--nd-love);
+  letter-spacing: 0.02em;
 }
 
 .spacer {

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -78,6 +78,17 @@ function handlePrimaryClick() {
       <div v-if="description" :class="$style.row2">
         {{ description }}
       </div>
+      <!-- capability badges (store mode): 個数可変なので専用行で折り返し、
+           アクション行 (row3) のレイアウトに影響させない -->
+      <div v-if="capabilities?.length" :class="$style.rowCaps">
+        <span
+          v-for="cap in capabilities"
+          :key="cap"
+          :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
+        >
+          {{ cap }}
+        </span>
+      </div>
       <div :class="$style.row3">
         <span v-if="author" :class="$style.author">{{ author }}</span>
         <!-- library mode: ストア/ローカル バッジ -->
@@ -85,14 +96,6 @@ function handlePrimaryClick() {
           <span v-if="storeId" :class="$style.originBadge">ストア</span>
           <span v-else :class="[$style.originBadge, $style.originBadgeLocal]">ローカル</span>
         </template>
-        <!-- capability badges (store mode) -->
-        <span
-          v-for="cap in capabilities ?? []"
-          :key="cap"
-          :class="[$style.capBadge, capabilityOk === false && $style.capBadgeWarn]"
-        >
-          {{ cap }}
-        </span>
         <span :class="$style.spacer" />
         <div :class="$style.actions">
           <!-- store mode -->
@@ -122,7 +125,7 @@ function handlePrimaryClick() {
             >
               <i v-if="installing" class="ti ti-loader-2 nd-spin" />
               <i v-else class="ti ti-download" />
-              {{ installing ? '...' : 'インストール' }}
+              インストール
             </button>
           </template>
           <!-- library mode -->
@@ -268,6 +271,14 @@ function handlePrimaryClick() {
   margin-top: 1px;
 }
 
+.rowCaps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+  min-width: 0;
+}
+
 .row3 {
   display: flex;
   align-items: center;
@@ -275,7 +286,6 @@ function handlePrimaryClick() {
   margin-top: 4px;
   min-width: 0;
   min-height: 20px;
-  flex-wrap: wrap;
 }
 
 .author {
@@ -330,8 +340,6 @@ function handlePrimaryClick() {
   align-items: center;
   gap: 2px;
   flex-shrink: 0;
-  /* row3 の折り返しで独立行になっても右端に寄せる (#729) */
-  margin-left: auto;
   opacity: 0;
   transition: opacity 0.15s;
 

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -12,6 +12,8 @@ const props = withDefaults(
     version?: string
     capabilities?: readonly string[]
     capabilityOk?: boolean
+    /** 非互換理由の短いラベル (要アップデート / 要アカウント 等) */
+    capabilityBadge?: string | null
     capabilityReason?: string | null
     /** store mode: インストール処理中 */
     installing?: boolean
@@ -80,7 +82,7 @@ function handlePrimaryClick() {
     <div :class="$style.body">
       <div :class="$style.row1">
         <span :class="$style.name">{{ name }}</span>
-        <span v-if="cardDisabled" :class="$style.updateBadge">要アップデート</span>
+        <span v-if="cardDisabled" :class="$style.incompatBadge">{{ capabilityBadge ?? '非対応' }}</span>
         <span :class="$style.spacer" />
         <span v-if="version" :class="$style.version">v{{ version }}</span>
       </div>
@@ -305,7 +307,7 @@ function handlePrimaryClick() {
   opacity: 0.85;
 }
 
-.updateBadge {
+.incompatBadge {
   flex-shrink: 0;
   padding: 0 5px;
   font-size: 9px;

--- a/src/components/deck/widgets/capabilities.test.ts
+++ b/src/components/deck/widgets/capabilities.test.ts
@@ -9,12 +9,13 @@ describe('checkKnownCapabilities', () => {
       'notedeck-api',
       'secret-vault',
     ])
-    expect(result).toEqual({ ok: true, reason: null })
+    expect(result).toEqual({ ok: true, badge: null, reason: null })
   })
 
   it('未知 capability は「未対応の機能」として非互換', () => {
     const result = checkKnownCapabilities(['future-thing'])
     expect(result.ok).toBe(false)
+    expect(result.badge).toBe('要アップデート')
     expect(result.reason).toContain('未対応の機能: future-thing')
   })
 })
@@ -28,29 +29,33 @@ describe('checkWidgetCapabilities', () => {
     const result = checkWidgetCapabilities(['notedeck-api'], {
       accountId: null,
     })
-    expect(result).toEqual({ ok: true, reason: null })
+    expect(result).toEqual({ ok: true, badge: null, reason: null })
   })
 
   it('secret-vault は accountId なし (cross-account) でも互換', () => {
     const result = checkWidgetCapabilities(['secret-vault'], {
       accountId: null,
     })
-    expect(result).toEqual({ ok: true, reason: null })
+    expect(result).toEqual({ ok: true, badge: null, reason: null })
   })
 
-  it('misskey-api は accountId 必須', () => {
-    expect(
-      checkWidgetCapabilities(['misskey-api'], { accountId: null }).ok,
-    ).toBe(false)
+  it('misskey-api は accountId 必須 (非互換は「要アカウント」)', () => {
+    const missing = checkWidgetCapabilities(['misskey-api'], {
+      accountId: null,
+    })
+    expect(missing.ok).toBe(false)
+    expect(missing.badge).toBe('要アカウント')
     expect(
       checkWidgetCapabilities(['misskey-api'], { accountId: 'a1' }).ok,
     ).toBe(true)
   })
 
-  it('misskey-account は accountId 必須', () => {
-    expect(
-      checkWidgetCapabilities(['misskey-account'], { accountId: null }).ok,
-    ).toBe(false)
+  it('misskey-account は accountId 必須 (非互換は「要ログイン」)', () => {
+    const missing = checkWidgetCapabilities(['misskey-account'], {
+      accountId: null,
+    })
+    expect(missing.ok).toBe(false)
+    expect(missing.badge).toBe('要ログイン')
     expect(
       checkWidgetCapabilities(['misskey-account'], { accountId: 'a1' }).ok,
     ).toBe(true)
@@ -61,6 +66,7 @@ describe('checkWidgetCapabilities', () => {
       accountId: 'a1',
     })
     expect(result.ok).toBe(false)
+    expect(result.badge).toBe('要アップデート')
     expect(result.reason).toContain('未対応の機能: future-thing')
   })
 })

--- a/src/components/deck/widgets/capabilities.ts
+++ b/src/components/deck/widgets/capabilities.ts
@@ -18,6 +18,8 @@ export interface CapabilityContext {
 
 export interface CapabilityCheck {
   ok: boolean
+  /** 非互換時の短いラベル (カードのバッジ表示用)。ok のとき null。 */
+  badge: string | null
   /** 非互換時の user-facing メッセージ (tooltip 表示用)。ok のとき null。 */
   reason: string | null
 }
@@ -41,11 +43,12 @@ export function checkKnownCapabilities(
     if (!KNOWN_CAPABILITIES.has(cap)) {
       return {
         ok: false,
+        badge: '要アップデート',
         reason: `未対応の機能: ${cap} (NoteDeck のアップデートが必要です)`,
       }
     }
   }
-  return { ok: true, reason: null }
+  return { ok: true, badge: null, reason: null }
 }
 
 export function checkWidgetCapabilities(
@@ -58,15 +61,17 @@ export function checkWidgetCapabilities(
     if (cap === 'misskey-api' && ctx.accountId === null) {
       return {
         ok: false,
+        badge: '要アカウント',
         reason: 'アカウントが必要です (カラムにアカウントを設定してください)',
       }
     }
     if (cap === 'misskey-account' && ctx.accountId === null) {
       return {
         ok: false,
+        badge: '要ログイン',
         reason: 'ログイン済みアカウントが必要です',
       }
     }
   }
-  return { ok: true, reason: null }
+  return { ok: true, badge: null, reason: null }
 }


### PR DESCRIPTION
## v1.12.2

### Fixes
- fix(deck): プラグインカラム空状態の縦位置をウィジェットカラムに揃え CTA を削除
- fix(deck): プラグインカラムの空状態を ColumnEmptyState に統一 (#774)
- fix(vault): vault.fetch の接続未解決エラーを action 誘導型の文言にする
- fix(store): 非互換バッジを固定文言でなく実際の理由ラベルにする
- fix(store): capability バッジをアクション行から分離しレイアウトシフトを解消

### Refactor
- refactor(store): capability バッジは非互換時のみ表示に変更

### Chore
- chore: bump version to 1.12.2
- chore: regenerate openapi.json for 1.12.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)