### PR TITLE
Release v1.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.12.2",
+  "version": "1.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2814,7 +2814,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.12.2"
+version = "1.13.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.12.2"
+version = "1.13.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.12.2"
+    "version": "1.13.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -500,6 +500,7 @@ function handlePickerReaction(reaction: string) {
       },
     ]"
     :style="channelInfo && showChannelInfo ? { '--nd-channel-color': channelInfo.color } : undefined"
+    :data-visibility="effectiveNote.visibility"
     tabindex="0"
     @mousedown="clearSpotlight"
     @contextmenu.prevent.stop="moreMenuRef?.open($event)"

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -501,6 +501,7 @@ function handlePickerReaction(reaction: string) {
     ]"
     :style="channelInfo && showChannelInfo ? { '--nd-channel-color': channelInfo.color } : undefined"
     :data-visibility="effectiveNote.visibility"
+    :data-own="isOwnNote"
     tabindex="0"
     @mousedown="clearSpotlight"
     @contextmenu.prevent.stop="moreMenuRef?.open($event)"
@@ -776,7 +777,7 @@ function handlePickerReaction(reaction: string) {
               <img v-if="reactionUrls[r.reaction]" :src="proxyUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" />
               <img v-else-if="r.reaction.startsWith(':')" src="/emoji-unknown.svg" :alt="r.reaction" :title="r.reaction" :class="$style.customEmoji" />
               <MkEmoji v-else :emoji="r.reaction" :class="$style.reactionEmoji" />
-              <span :class="$style.count">{{ r.count }}</span>
+              <span class="note-reaction-count" :class="$style.count">{{ r.count }}</span>
             </button>
           </div>
         </div>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -806,7 +806,7 @@ function handlePickerReaction(reaction: string) {
           </button>
           <button v-if="canRenote" :class="[$style.footerButton, $style.renoteButton, { [$style.renoted]: isRenoted, [$style.footerDisabled]: isGuest }]" :disabled="isGuest" @click.stop="canInteract ? openRenoteMenu($event) : showLoginPrompt()">
             <i class="ti ti-repeat" />
-            <span v-if="effectiveNote.renoteCount > 0" :class="$style.buttonCount">
+            <span v-if="effectiveNote.renoteCount > 0" class="note-renote-count" :class="$style.buttonCount">
               {{ effectiveNote.renoteCount }}
             </span>
           </button>

--- a/src/components/common/MkUserPopup.vue
+++ b/src/components/common/MkUserPopup.vue
@@ -39,6 +39,8 @@ const account = computed(() =>
 const user = ref<NormalizedUserDetail | null>(null)
 const isLoading = ref(true)
 
+const isOwnUser = computed(() => account.value?.userId === user.value?.id)
+
 onMounted(async () => {
   const cacheKey = `${props.accountId}:${props.userId}`
   try {
@@ -153,10 +155,10 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown))
           <MkMfm :text="user.description" :server-host="account?.host" />
         </div>
 
-        <div :class="$style.popupStats">
-          <span><b>{{ formatCount(user.notesCount) }}</b> ノート</span>
-          <span><b>{{ formatCount(user.followingCount) }}</b> フォロー</span>
-          <span><b>{{ formatCount(user.followersCount) }}</b> フォロワー</span>
+        <div class="user-stats" :class="$style.popupStats" :data-own="isOwnUser">
+          <span><b class="user-stat-count">{{ formatCount(user.notesCount) }}</b> ノート</span>
+          <span><b class="user-stat-count">{{ formatCount(user.followingCount) }}</b> フォロー</span>
+          <span><b class="user-stat-count">{{ formatCount(user.followersCount) }}</b> フォロワー</span>
         </div>
 
         <div v-if="user.isFollowed" :class="$style.popupBadge">フォローされています</div>

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -343,8 +343,8 @@ usePortal(postPortalRef)
                   plain
                 />
               </div>
-              <div :class="$style.exploreUserMeta">
-                <i class="ti ti-users" /> {{ user.followersCount }}
+              <div class="user-stats" :class="$style.exploreUserMeta" :data-own="account?.userId === user.id">
+                <i class="ti ti-users" /> <span class="user-stat-count">{{ user.followersCount }}</span>
               </div>
             </template>
           </MkUserListItem>

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -949,6 +949,12 @@ watch(tab, (t) => {
   opacity: 0.8;
 }
 
+// sectionValue がある行では auto マージンを値側だけに持たせ、
+// 値をシェブロン直前に右揃えする (両方 auto だと余白が均等分配され中間に浮く)
+.sectionValue + .chevron {
+  margin-left: 0;
+}
+
 .dropdown {
   position: relative;
   width: 100%;

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -67,6 +67,8 @@ const presets = ref({
   fontSize: 0,
   customCursor: '',
   visibilityBg: '',
+  hideReactionCount: '',
+  hideUserStats: '',
 })
 
 // Parse existing CSS to restore preset states
@@ -79,6 +81,12 @@ function parsePresetsFromCss(cssStr: string) {
   presets.value.customCursor = cursorMatch?.[1] ?? ''
   const visibilityBgMatch = cssStr.match(/\/\* nd-visibility-bg: (.+?) \*\//)
   presets.value.visibilityBg = visibilityBgMatch?.[1] ?? ''
+  const reactionCountMatch = cssStr.match(
+    /\/\* nd-hide-reaction-count: (.+?) \*\//,
+  )
+  presets.value.hideReactionCount = reactionCountMatch?.[1] ?? ''
+  const userStatsMatch = cssStr.match(/\/\* nd-hide-user-stats: (.+?) \*\//)
+  presets.value.hideUserStats = userStatsMatch?.[1] ?? ''
 }
 parsePresetsFromCss(cssCode.value)
 
@@ -174,6 +182,27 @@ const VISIBILITY_BG_OPTIONS: VisibilityBgOption[] = [
   { key: 'tint', label: '背景色で色分け' },
 ]
 
+// 数字の非表示 (#593/#594)。yamisskey の hideReactionCount / hide*Count と
+// 同じ self/others/all の 3 段階。導線 (クリックで一覧を開く等) は残し数字だけ消す
+interface HideCountOption {
+  key: string
+  label: string
+}
+
+const HIDE_COUNT_OPTIONS: HideCountOption[] = [
+  { key: '', label: 'デフォルト' },
+  { key: 'self', label: '自分のみ隠す' },
+  { key: 'others', label: '他人のみ隠す' },
+  { key: 'all', label: 'すべて隠す' },
+]
+
+function hideCountTargets(key: string): string[] {
+  if (key === 'self') return ['true']
+  if (key === 'others') return ['false']
+  if (key === 'all') return ['true', 'false']
+  return []
+}
+
 const fontSizeLabel = computed(() => {
   if (presets.value.fontSize === 0) return 'デフォルト (15px)'
   return `${FONT_SIZE_BASE + presets.value.fontSize}px`
@@ -240,6 +269,31 @@ function buildPresetCss(): string {
     }
   }
 
+  const reactionTargets = hideCountTargets(presets.value.hideReactionCount)
+  if (reactionTargets.length > 0) {
+    parts.push(
+      `/* nd-hide-reaction-count: ${presets.value.hideReactionCount} */`,
+    )
+    for (const own of reactionTargets) {
+      parts.push(
+        `.note-root[data-own="${own}"] .note-reaction-count { display: none; }`,
+      )
+    }
+  }
+
+  const statsTargets = hideCountTargets(presets.value.hideUserStats)
+  if (statsTargets.length > 0) {
+    parts.push(`/* nd-hide-user-stats: ${presets.value.hideUserStats} */`)
+    for (const own of statsTargets) {
+      parts.push(
+        `.user-stats[data-own="${own}"] .user-stat-count { font-size: 0; }`,
+      )
+      parts.push(
+        `.user-stats[data-own="${own}"] .user-stat-count::before { content: '-'; font-size: 1rem; }`,
+      )
+    }
+  }
+
   return parts.join('\n')
 }
 
@@ -253,8 +307,12 @@ function extractUserCss(fullCss: string): string {
       if (t.startsWith('/* nd-fontsize:')) return false
       if (t.startsWith('/* nd-cursor:')) return false
       if (t.startsWith('/* nd-visibility-bg:')) return false
+      if (t.startsWith('/* nd-hide-reaction-count:')) return false
+      if (t.startsWith('/* nd-hide-user-stats:')) return false
       // 生成行 (1 行完結) のみ除去。ユーザーが複数行で書いた同セレクタは残す
       if (t.match(/^\.note-root\[data-visibility=.+\{.*\}$/)) return false
+      if (t.match(/^\.note-root\[data-own=.+\{.*\}$/)) return false
+      if (t.match(/^\.user-stats\[data-own=.+\{.*\}$/)) return false
       if (t.startsWith('@import url(')) return false
       if (t.startsWith('@font-face')) return false
       if (t.match(/^html\s*\{\s*font-family:/)) return false
@@ -299,6 +357,8 @@ watch(
     presets.value.fontSize,
     presets.value.customCursor,
     presets.value.visibilityBg,
+    presets.value.hideReactionCount,
+    presets.value.hideUserStats,
   ],
   () => {
     const cssStr = fullCss.value
@@ -379,6 +439,8 @@ function handleClear() {
       fontSize: 0,
       customCursor: '',
       visibilityBg: '',
+      hideReactionCount: '',
+      hideUserStats: '',
     }
     userFreeformCss.value = ''
     cssCode.value = ''
@@ -447,6 +509,34 @@ function selectVisibilityBg(key: string) {
 
 useClickOutside(visibilityBgDropdownRef, () => {
   showVisibilityBgDropdown.value = false
+})
+
+// Hide-count dropdowns (#593/#594)
+const showReactionCountDropdown = ref(false)
+const reactionCountDropdownRef = ref<HTMLElement | null>(null)
+const showUserStatsDropdown = ref(false)
+const userStatsDropdownRef = ref<HTMLElement | null>(null)
+
+function hideCountLabel(key: string): string {
+  return HIDE_COUNT_OPTIONS.find((o) => o.key === key)?.label ?? 'デフォルト'
+}
+
+function selectReactionCount(key: string) {
+  presets.value.hideReactionCount = key
+  showReactionCountDropdown.value = false
+}
+
+function selectUserStats(key: string) {
+  presets.value.hideUserStats = key
+  showUserStatsDropdown.value = false
+}
+
+useClickOutside(reactionCountDropdownRef, () => {
+  showReactionCountDropdown.value = false
+})
+
+useClickOutside(userStatsDropdownRef, () => {
+  showUserStatsDropdown.value = false
 })
 
 watch(tab, (t) => {
@@ -628,6 +718,77 @@ watch(tab, (t) => {
             >
               {{ label }}
             </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Hide reaction count (#594) -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('reactionCount')">
+          <i class="ti ti-mood-smile" />
+          リアクション数を隠す
+          <span :class="$style.sectionValue">{{ hideCountLabel(presets.hideReactionCount) }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.reactionCount }]" />
+        </button>
+        <template v-if="expandedSections.reactionCount">
+          <div ref="reactionCountDropdownRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showReactionCountDropdown = !showReactionCountDropdown"
+            >
+              <span>{{ hideCountLabel(presets.hideReactionCount) }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showReactionCountDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in HIDE_COUNT_OPTIONS"
+                :key="opt.key"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: presets.hideReactionCount === opt.key }]"
+                @click="selectReactionCount(opt.key)"
+              >
+                <span>{{ opt.label }}</span>
+                <i v-if="presets.hideReactionCount === opt.key" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+        </template>
+      </div>
+
+      <!-- Hide user stats (#593) -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('userStats')">
+          <i class="ti ti-chart-bar" />
+          プロフィールの数字を隠す
+          <span :class="$style.sectionValue">{{ hideCountLabel(presets.hideUserStats) }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.userStats }]" />
+        </button>
+        <template v-if="expandedSections.userStats">
+          <div ref="userStatsDropdownRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showUserStatsDropdown = !showUserStatsDropdown"
+            >
+              <span>{{ hideCountLabel(presets.hideUserStats) }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showUserStatsDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in HIDE_COUNT_OPTIONS"
+                :key="opt.key"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: presets.hideUserStats === opt.key }]"
+                @click="selectUserStats(opt.key)"
+              >
+                <span>{{ opt.label }}</span>
+                <i v-if="presets.hideUserStats === opt.key" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+          <div :class="$style.hideCountNote">
+            ノート数・フォロー数・フォロワー数が「-」になります (クリック導線は残ります)
           </div>
         </template>
       </div>
@@ -870,6 +1031,11 @@ watch(tab, (t) => {
 
 .visibilityBgRow {
   padding: 8px 10px;
+}
+
+.hideCountNote {
+  font-size: 0.75em;
+  opacity: 0.6;
 }
 
 .sliderRow { display: flex; align-items: center; gap: 8px; }

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -66,6 +66,7 @@ const presets = ref({
   customFont: '',
   fontSize: 0,
   customCursor: '',
+  visibilityBg: '',
 })
 
 // Parse existing CSS to restore preset states
@@ -76,6 +77,8 @@ function parsePresetsFromCss(cssStr: string) {
   presets.value.fontSize = sizeMatch ? Number(sizeMatch[1]) : 0
   const cursorMatch = cssStr.match(/\/\* nd-cursor: (.+?) \*\//)
   presets.value.customCursor = cursorMatch?.[1] ?? ''
+  const visibilityBgMatch = cssStr.match(/\/\* nd-visibility-bg: (.+?) \*\//)
+  presets.value.visibilityBg = visibilityBgMatch?.[1] ?? ''
 }
 parsePresetsFromCss(cssCode.value)
 
@@ -154,6 +157,23 @@ const CURSOR_OPTIONS: CursorOption[] = [
   },
 ]
 
+// 公開範囲ごとのノート背景色 (public はデフォルトのまま)
+const VISIBILITY_BG_COLORS: Record<string, { label: string; color: string }> = {
+  home: { label: 'ホーム', color: 'rgba(51, 127, 255, 0.08)' },
+  followers: { label: 'フォロワー', color: 'rgba(0, 170, 100, 0.08)' },
+  specified: { label: 'ダイレクト', color: 'rgba(255, 90, 120, 0.1)' },
+}
+
+interface VisibilityBgOption {
+  key: string
+  label: string
+}
+
+const VISIBILITY_BG_OPTIONS: VisibilityBgOption[] = [
+  { key: '', label: 'デフォルト' },
+  { key: 'tint', label: '背景色で色分け' },
+]
+
 const fontSizeLabel = computed(() => {
   if (presets.value.fontSize === 0) return 'デフォルト (15px)'
   return `${FONT_SIZE_BASE + presets.value.fontSize}px`
@@ -209,6 +229,17 @@ function buildPresetCss(): string {
     }
   }
 
+  if (presets.value.visibilityBg === 'tint') {
+    parts.push('/* nd-visibility-bg: tint */')
+    for (const [visibility, { color }] of Object.entries(
+      VISIBILITY_BG_COLORS,
+    )) {
+      parts.push(
+        `.note-root[data-visibility="${visibility}"] { background-color: ${color}; }`,
+      )
+    }
+  }
+
   return parts.join('\n')
 }
 
@@ -221,6 +252,9 @@ function extractUserCss(fullCss: string): string {
       if (t.startsWith('/* nd-font:')) return false
       if (t.startsWith('/* nd-fontsize:')) return false
       if (t.startsWith('/* nd-cursor:')) return false
+      if (t.startsWith('/* nd-visibility-bg:')) return false
+      // 生成行 (1 行完結) のみ除去。ユーザーが複数行で書いた同セレクタは残す
+      if (t.match(/^\.note-root\[data-visibility=.+\{.*\}$/)) return false
       if (t.startsWith('@import url(')) return false
       if (t.startsWith('@font-face')) return false
       if (t.match(/^html\s*\{\s*font-family:/)) return false
@@ -264,6 +298,7 @@ watch(
     presets.value.customFont,
     presets.value.fontSize,
     presets.value.customCursor,
+    presets.value.visibilityBg,
   ],
   () => {
     const cssStr = fullCss.value
@@ -339,7 +374,12 @@ const { confirming: confirmingClear, trigger: triggerClear } =
 
 function handleClear() {
   triggerClear(() => {
-    presets.value = { customFont: '', fontSize: 0, customCursor: '' }
+    presets.value = {
+      customFont: '',
+      fontSize: 0,
+      customCursor: '',
+      visibilityBg: '',
+    }
     userFreeformCss.value = ''
     cssCode.value = ''
     cssError.value = null
@@ -387,6 +427,26 @@ function selectCursor(key: string) {
 
 useClickOutside(cursorDropdownRef, () => {
   showCursorDropdown.value = false
+})
+
+// Visibility background dropdown
+const showVisibilityBgDropdown = ref(false)
+const visibilityBgDropdownRef = ref<HTMLElement | null>(null)
+
+const selectedVisibilityBgLabel = computed(() => {
+  const opt = VISIBILITY_BG_OPTIONS.find(
+    (o) => o.key === presets.value.visibilityBg,
+  )
+  return opt?.label ?? 'デフォルト'
+})
+
+function selectVisibilityBg(key: string) {
+  presets.value.visibilityBg = key
+  showVisibilityBgDropdown.value = false
+}
+
+useClickOutside(visibilityBgDropdownRef, () => {
+  showVisibilityBgDropdown.value = false
 })
 
 watch(tab, (t) => {
@@ -524,6 +584,50 @@ watch(tab, (t) => {
           </div>
           <div :class="$style.preview" :style="cursorPreviewStyle">
             ここにマウスを重ねてプレビュー
+          </div>
+        </template>
+      </div>
+
+      <!-- Visibility background -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('visibilityBg')">
+          <i class="ti ti-eye" />
+          公開範囲の色分け
+          <span :class="$style.sectionValue">{{ selectedVisibilityBgLabel }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.visibilityBg }]" />
+        </button>
+        <template v-if="expandedSections.visibilityBg">
+          <div ref="visibilityBgDropdownRef" :class="$style.dropdown">
+            <button
+              class="_button"
+              :class="$style.dropdownTrigger"
+              @click="showVisibilityBgDropdown = !showVisibilityBgDropdown"
+            >
+              <span>{{ selectedVisibilityBgLabel }}</span>
+              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
+            </button>
+            <div v-if="showVisibilityBgDropdown" :class="$style.dropdownPanel">
+              <button
+                v-for="opt in VISIBILITY_BG_OPTIONS"
+                :key="opt.key"
+                class="_button"
+                :class="[$style.dropdownItem, { [$style.selected]: presets.visibilityBg === opt.key }]"
+                @click="selectVisibilityBg(opt.key)"
+              >
+                <span>{{ opt.label }}</span>
+                <i v-if="presets.visibilityBg === opt.key" class="ti ti-check" :class="$style.checkIcon" />
+              </button>
+            </div>
+          </div>
+          <div v-if="presets.visibilityBg === 'tint'" :class="$style.visibilityBgPreview">
+            <div
+              v-for="({ label, color }, visibility) in VISIBILITY_BG_COLORS"
+              :key="visibility"
+              :class="$style.visibilityBgRow"
+              :style="{ backgroundColor: color }"
+            >
+              {{ label }}
+            </div>
           </div>
         </template>
       </div>
@@ -753,6 +857,19 @@ watch(tab, (t) => {
   background: var(--nd-bg);
   font-size: 0.9em;
   text-align: center;
+}
+
+.visibilityBgPreview {
+  display: flex;
+  flex-direction: column;
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-bg);
+  font-size: 0.9em;
+  overflow: hidden;
+}
+
+.visibilityBgRow {
+  padding: 8px 10px;
 }
 
 .sliderRow { display: flex; align-items: center; gap: 8px; }

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -67,7 +67,7 @@ const presets = ref({
   fontSize: 0,
   customCursor: '',
   visibilityBg: '',
-  hideReactionCount: '',
+  hideNoteCounts: '',
   hideUserStats: '',
 })
 
@@ -81,10 +81,8 @@ function parsePresetsFromCss(cssStr: string) {
   presets.value.customCursor = cursorMatch?.[1] ?? ''
   const visibilityBgMatch = cssStr.match(/\/\* nd-visibility-bg: (.+?) \*\//)
   presets.value.visibilityBg = visibilityBgMatch?.[1] ?? ''
-  const reactionCountMatch = cssStr.match(
-    /\/\* nd-hide-reaction-count: (.+?) \*\//,
-  )
-  presets.value.hideReactionCount = reactionCountMatch?.[1] ?? ''
+  const noteCountsMatch = cssStr.match(/\/\* nd-hide-note-counts: (.+?) \*\//)
+  presets.value.hideNoteCounts = noteCountsMatch?.[1] ?? ''
   const userStatsMatch = cssStr.match(/\/\* nd-hide-user-stats: (.+?) \*\//)
   presets.value.hideUserStats = userStatsMatch?.[1] ?? ''
 }
@@ -183,7 +181,8 @@ const VISIBILITY_BG_OPTIONS: VisibilityBgOption[] = [
 ]
 
 // 数字の非表示 (#593/#594)。yamisskey の hideReactionCount / hide*Count と
-// 同じ self/others/all の 3 段階。導線 (クリックで一覧を開く等) は残し数字だけ消す
+// 同じ self/others/all の 3 段階。導線 (クリックで一覧を開く等) は残し数字だけ消す。
+// ノート側はリアクション数 + リノート数 (評価シグナル)。返信数は会話の量なので対象外
 interface HideCountOption {
   key: string
   label: string
@@ -269,14 +268,12 @@ function buildPresetCss(): string {
     }
   }
 
-  const reactionTargets = hideCountTargets(presets.value.hideReactionCount)
-  if (reactionTargets.length > 0) {
-    parts.push(
-      `/* nd-hide-reaction-count: ${presets.value.hideReactionCount} */`,
-    )
-    for (const own of reactionTargets) {
+  const noteCountTargets = hideCountTargets(presets.value.hideNoteCounts)
+  if (noteCountTargets.length > 0) {
+    parts.push(`/* nd-hide-note-counts: ${presets.value.hideNoteCounts} */`)
+    for (const own of noteCountTargets) {
       parts.push(
-        `.note-root[data-own="${own}"] .note-reaction-count { display: none; }`,
+        `.note-root[data-own="${own}"] :is(.note-reaction-count, .note-renote-count) { display: none; }`,
       )
     }
   }
@@ -307,7 +304,7 @@ function extractUserCss(fullCss: string): string {
       if (t.startsWith('/* nd-fontsize:')) return false
       if (t.startsWith('/* nd-cursor:')) return false
       if (t.startsWith('/* nd-visibility-bg:')) return false
-      if (t.startsWith('/* nd-hide-reaction-count:')) return false
+      if (t.startsWith('/* nd-hide-note-counts:')) return false
       if (t.startsWith('/* nd-hide-user-stats:')) return false
       // 生成行 (1 行完結) のみ除去。ユーザーが複数行で書いた同セレクタは残す
       if (t.match(/^\.note-root\[data-visibility=.+\{.*\}$/)) return false
@@ -357,7 +354,7 @@ watch(
     presets.value.fontSize,
     presets.value.customCursor,
     presets.value.visibilityBg,
-    presets.value.hideReactionCount,
+    presets.value.hideNoteCounts,
     presets.value.hideUserStats,
   ],
   () => {
@@ -439,7 +436,7 @@ function handleClear() {
       fontSize: 0,
       customCursor: '',
       visibilityBg: '',
-      hideReactionCount: '',
+      hideNoteCounts: '',
       hideUserStats: '',
     }
     userFreeformCss.value = ''
@@ -512,8 +509,8 @@ useClickOutside(visibilityBgDropdownRef, () => {
 })
 
 // Hide-count dropdowns (#593/#594)
-const showReactionCountDropdown = ref(false)
-const reactionCountDropdownRef = ref<HTMLElement | null>(null)
+const showNoteCountsDropdown = ref(false)
+const noteCountsDropdownRef = ref<HTMLElement | null>(null)
 const showUserStatsDropdown = ref(false)
 const userStatsDropdownRef = ref<HTMLElement | null>(null)
 
@@ -521,9 +518,9 @@ function hideCountLabel(key: string): string {
   return HIDE_COUNT_OPTIONS.find((o) => o.key === key)?.label ?? 'デフォルト'
 }
 
-function selectReactionCount(key: string) {
-  presets.value.hideReactionCount = key
-  showReactionCountDropdown.value = false
+function selectNoteCounts(key: string) {
+  presets.value.hideNoteCounts = key
+  showNoteCountsDropdown.value = false
 }
 
 function selectUserStats(key: string) {
@@ -531,8 +528,8 @@ function selectUserStats(key: string) {
   showUserStatsDropdown.value = false
 }
 
-useClickOutside(reactionCountDropdownRef, () => {
-  showReactionCountDropdown.value = false
+useClickOutside(noteCountsDropdownRef, () => {
+  showNoteCountsDropdown.value = false
 })
 
 useClickOutside(userStatsDropdownRef, () => {
@@ -722,36 +719,39 @@ watch(tab, (t) => {
         </template>
       </div>
 
-      <!-- Hide reaction count (#594) -->
+      <!-- Hide note counts (#594) -->
       <div :class="$style.section">
-        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('reactionCount')">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('noteCounts')">
           <i class="ti ti-mood-smile" />
-          リアクション数を隠す
-          <span :class="$style.sectionValue">{{ hideCountLabel(presets.hideReactionCount) }}</span>
-          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.reactionCount }]" />
+          ノートの数字を隠す
+          <span :class="$style.sectionValue">{{ hideCountLabel(presets.hideNoteCounts) }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.noteCounts }]" />
         </button>
-        <template v-if="expandedSections.reactionCount">
-          <div ref="reactionCountDropdownRef" :class="$style.dropdown">
+        <template v-if="expandedSections.noteCounts">
+          <div ref="noteCountsDropdownRef" :class="$style.dropdown">
             <button
               class="_button"
               :class="$style.dropdownTrigger"
-              @click="showReactionCountDropdown = !showReactionCountDropdown"
+              @click="showNoteCountsDropdown = !showNoteCountsDropdown"
             >
-              <span>{{ hideCountLabel(presets.hideReactionCount) }}</span>
+              <span>{{ hideCountLabel(presets.hideNoteCounts) }}</span>
               <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
             </button>
-            <div v-if="showReactionCountDropdown" :class="$style.dropdownPanel">
+            <div v-if="showNoteCountsDropdown" :class="$style.dropdownPanel">
               <button
                 v-for="opt in HIDE_COUNT_OPTIONS"
                 :key="opt.key"
                 class="_button"
-                :class="[$style.dropdownItem, { [$style.selected]: presets.hideReactionCount === opt.key }]"
-                @click="selectReactionCount(opt.key)"
+                :class="[$style.dropdownItem, { [$style.selected]: presets.hideNoteCounts === opt.key }]"
+                @click="selectNoteCounts(opt.key)"
               >
                 <span>{{ opt.label }}</span>
-                <i v-if="presets.hideReactionCount === opt.key" class="ti ti-check" :class="$style.checkIcon" />
+                <i v-if="presets.hideNoteCounts === opt.key" class="ti ti-check" :class="$style.checkIcon" />
               </button>
             </div>
+          </div>
+          <div :class="$style.hideCountNote">
+            リアクション数とリノート数が消えます (返信数は会話の量なので残ります)
           </div>
         </template>
       </div>

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -65,7 +65,6 @@ const cssCode = ref(themeStore.customCss)
 const presets = ref({
   customFont: '',
   fontSize: 0,
-  customCursor: '',
   visibilityBg: '',
   hideNoteCounts: '',
   hideUserStats: '',
@@ -77,8 +76,6 @@ function parsePresetsFromCss(cssStr: string) {
   presets.value.customFont = fontMatch?.[1] ?? ''
   const sizeMatch = cssStr.match(/\/\* nd-fontsize: (.+?) \*\//)
   presets.value.fontSize = sizeMatch ? Number(sizeMatch[1]) : 0
-  const cursorMatch = cssStr.match(/\/\* nd-cursor: (.+?) \*\//)
-  presets.value.customCursor = cursorMatch?.[1] ?? ''
   const visibilityBgMatch = cssStr.match(/\/\* nd-visibility-bg: (.+?) \*\//)
   presets.value.visibilityBg = visibilityBgMatch?.[1] ?? ''
   const noteCountsMatch = cssStr.match(/\/\* nd-hide-note-counts: (.+?) \*\//)
@@ -144,24 +141,6 @@ const FONT_OPTIONS: FontOption[] = [
 const FONT_SIZE_BASE = 15
 const FONT_SIZE_MIN = -3
 const FONT_SIZE_MAX = 5
-
-interface CursorOption {
-  key: string
-  label: string
-  css: string
-}
-
-const ROCKET_CURSOR_SVG =
-  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='20' height='20'><text y='16' font-size='16'>%F0%9F%9A%80</text></svg>"
-
-const CURSOR_OPTIONS: CursorOption[] = [
-  { key: '', label: 'デフォルト', css: '' },
-  {
-    key: 'rocket',
-    label: 'ロケット',
-    css: `url("${ROCKET_CURSOR_SVG}") 2 18, auto`,
-  },
-]
 
 // 公開範囲ごとのノート背景色 (public はデフォルトのまま)
 const VISIBILITY_BG_COLORS: Record<string, { label: string; color: string }> = {
@@ -249,14 +228,6 @@ function buildPresetCss(): string {
     parts.push(`html { font-size: ${px}px; }`)
   }
 
-  if (presets.value.customCursor) {
-    const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
-    if (opt?.css) {
-      parts.push(`/* nd-cursor: ${opt.key} */`)
-      parts.push(`*, *::before, *::after { cursor: ${opt.css}; }`)
-    }
-  }
-
   if (presets.value.visibilityBg === 'tint') {
     parts.push('/* nd-visibility-bg: tint */')
     for (const [visibility, { color }] of Object.entries(
@@ -302,7 +273,6 @@ function extractUserCss(fullCss: string): string {
       if (!t) return false
       if (t.startsWith('/* nd-font:')) return false
       if (t.startsWith('/* nd-fontsize:')) return false
-      if (t.startsWith('/* nd-cursor:')) return false
       if (t.startsWith('/* nd-visibility-bg:')) return false
       if (t.startsWith('/* nd-hide-note-counts:')) return false
       if (t.startsWith('/* nd-hide-user-stats:')) return false
@@ -314,7 +284,6 @@ function extractUserCss(fullCss: string): string {
       if (t.startsWith('@font-face')) return false
       if (t.match(/^html\s*\{\s*font-family:/)) return false
       if (t.match(/^html\s*\{\s*font-size:/)) return false
-      if (t.match(/^\*,\s*\*::before,\s*\*::after\s*\{\s*cursor:/)) return false
       return true
     })
     .join('\n')
@@ -352,7 +321,6 @@ watch(
   () => [
     presets.value.customFont,
     presets.value.fontSize,
-    presets.value.customCursor,
     presets.value.visibilityBg,
     presets.value.hideNoteCounts,
     presets.value.hideUserStats,
@@ -434,7 +402,6 @@ function handleClear() {
     presets.value = {
       customFont: '',
       fontSize: 0,
-      customCursor: '',
       visibilityBg: '',
       hideNoteCounts: '',
       hideUserStats: '',
@@ -463,29 +430,6 @@ function selectFont(value: string) {
 
 useClickOutside(dropdownRef, () => {
   showFontDropdown.value = false
-})
-
-// Cursor dropdown
-const showCursorDropdown = ref(false)
-const cursorDropdownRef = ref<HTMLElement | null>(null)
-
-const selectedCursorLabel = computed(() => {
-  const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
-  return opt?.label ?? 'デフォルト'
-})
-
-const cursorPreviewStyle = computed(() => {
-  const opt = CURSOR_OPTIONS.find((o) => o.key === presets.value.customCursor)
-  return opt?.css ? { cursor: opt.css } : {}
-})
-
-function selectCursor(key: string) {
-  presets.value.customCursor = key
-  showCursorDropdown.value = false
-}
-
-useClickOutside(cursorDropdownRef, () => {
-  showCursorDropdown.value = false
 })
 
 // Visibility background dropdown
@@ -634,44 +578,6 @@ watch(tab, (t) => {
           >
             リセット
           </button>
-        </template>
-      </div>
-
-      <!-- Cursor -->
-      <div :class="$style.section">
-        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('cursor')">
-          <i class="ti ti-pointer" />
-          カーソル
-          <span :class="$style.sectionValue">{{ selectedCursorLabel }}</span>
-          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.cursor }]" />
-        </button>
-        <template v-if="expandedSections.cursor">
-          <div ref="cursorDropdownRef" :class="$style.dropdown">
-            <button
-              class="_button"
-              :class="$style.dropdownTrigger"
-              @click="showCursorDropdown = !showCursorDropdown"
-            >
-              <span>{{ selectedCursorLabel }}</span>
-              <i class="ti ti-chevron-down" :class="$style.dropdownChevron" />
-            </button>
-            <div v-if="showCursorDropdown" :class="$style.dropdownPanel">
-              <button
-                v-for="opt in CURSOR_OPTIONS"
-                :key="opt.key"
-                class="_button"
-                :class="[$style.dropdownItem, { [$style.selected]: presets.customCursor === opt.key }]"
-                :style="opt.css ? { cursor: opt.css } : {}"
-                @click="selectCursor(opt.key)"
-              >
-                <span>{{ opt.label }}</span>
-                <i v-if="presets.customCursor === opt.key" class="ti ti-check" :class="$style.checkIcon" />
-              </button>
-            </div>
-          </div>
-          <div :class="$style.preview" :style="cursorPreviewStyle">
-            ここにマウスを重ねてプレビュー
-          </div>
         </template>
       </div>
 

--- a/src/components/window/user-profile/UserProfileHero.vue
+++ b/src/components/window/user-profile/UserProfileHero.vue
@@ -317,17 +317,17 @@ onMounted(() => {
     </div>
 
     <!-- Stats -->
-    <div :class="$style.stats">
+    <div class="user-stats" :class="$style.stats" :data-own="isOwnProfile">
       <div :class="$style.stat">
-        <b>{{ formatCount(user.notesCount) }}</b>
+        <b class="user-stat-count">{{ formatCount(user.notesCount) }}</b>
         <span>ノート</span>
       </div>
       <button v-if="canSeeFollowing" :class="[$style.stat, $style.statLink]" class="_button" @click="openFollowList('following')">
-        <b>{{ formatCount(user.followingCount) }}</b>
+        <b class="user-stat-count">{{ formatCount(user.followingCount) }}</b>
         <span>フォロー</span>
       </button>
       <button v-if="canSeeFollowers" :class="[$style.stat, $style.statLink]" class="_button" @click="openFollowList('followers')">
-        <b>{{ formatCount(user.followersCount) }}</b>
+        <b class="user-stat-count">{{ formatCount(user.followersCount) }}</b>
         <span>フォロワー</span>
       </button>
     </div>


### PR DESCRIPTION
## Changes

- feat(theme): 公開範囲ごとのノート背景色プリセットを追加
- feat(theme): リアクション数・プロフィール数字の非表示プリセットを追加
- feat(theme): 数字非表示プリセットにリノート数を追加し返信数と線引き
- fix(theme): プリセット選択値ラベルをシェブロン直前に右揃え
- refactor(theme): カーソルプリセットを削除 (MisStore 配布へ移行)
- chore: bump version to 1.13.0
- chore: regenerate openapi.json for 1.13.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)