### PR TITLE
Release v1.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=cb0a7f388c621965e1465e72f67f6cba60e76ca2#cb0a7f388c621965e1465e72f67f6cba60e76ca2"
+source = "git+https://github.com/hitalin/notecli?rev=d25d8fdcef837f5026dd57092002956a2b9fd658#d25d8fdcef837f5026dd57092002956a2b9fd658"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=d25d8fdcef837f5026dd57092002956a2b9fd658#d25d8fdcef837f5026dd57092002956a2b9fd658"
+source = "git+https://github.com/hitalin/notecli?rev=615a5993256e5fe8dd466809f7a1f79d681a596d#615a5993256e5fe8dd466809f7a1f79d681a596d"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +439,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,6 +600,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +667,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1004,6 +1043,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1899,6 +1939,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2285,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -2779,7 +2847,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=21ac0b05ef79f5af1bd664efbff680ec5142f1ba#21ac0b05ef79f5af1bd664efbff680ec5142f1ba"
+source = "git+https://github.com/hitalin/notecli?rev=b242213391dc35ea8ad39ba865f925dd7b151e98#b242213391dc35ea8ad39ba865f925dd7b151e98"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -2809,6 +2877,7 @@ dependencies = [
  "utoipa-axum",
  "uuid",
  "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
  "zeroize",
 ]
 
@@ -2889,10 +2958,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4324,6 +4456,25 @@ checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
 ]
 
 [[package]]
@@ -7157,6 +7308,17 @@ dependencies = [
  "zbus_macros",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eaa71bfd72ff7ee11e747174d666ff0b9fcaa4b1df94ca119e7e64703d77f1"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2779,7 +2779,7 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 [[package]]
 name = "notecli"
 version = "0.4.0"
-source = "git+https://github.com/hitalin/notecli?rev=615a5993256e5fe8dd466809f7a1f79d681a596d#615a5993256e5fe8dd466809f7a1f79d681a596d"
+source = "git+https://github.com/hitalin/notecli?rev=21ac0b05ef79f5af1bd664efbff680ec5142f1ba#21ac0b05ef79f5af1bd664efbff680ec5142f1ba"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.13.0"
+version = "1.14.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.13.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "cb0a7f388c621965e1465e72f67f6cba60e76ca2", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "d25d8fdcef837f5026dd57092002956a2b9fd658", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.13.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "d25d8fdcef837f5026dd57092002956a2b9fd658", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "615a5993256e5fe8dd466809f7a1f79d681a596d", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.13.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "615a5993256e5fe8dd466809f7a1f79d681a596d", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "21ac0b05ef79f5af1bd664efbff680ec5142f1ba", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.13.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/hitalin/notecli", rev = "21ac0b05ef79f5af1bd664efbff680ec5142f1ba", features = ["specta"] }
+notecli = { git = "https://github.com/hitalin/notecli", rev = "b242213391dc35ea8ad39ba865f925dd7b151e98", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.13.0"
+    "version": "1.14.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -116,9 +116,12 @@ pub async fn auth_complete_and_save(
         .get_account_by_host_user(&session.host, &auth_result.user.id)?
         .ok_or_else(|| NoteDeckError::Auth("Failed to save account".to_string()))?;
 
-    // キーチェーンに保存し、読み戻せたら DB のトークンをクリア
+    // キーチェーンに保存し、読み戻せたら DB のトークンをクリア。
+    // 再起動非永続な store (Linux keyutils) では keychain はキャッシュ扱いとし、
+    // DB フォールバックを残す (#785)
     if keychain::store_token(&saved.id, &token).is_ok()
         && keychain::get_token(&saved.id).ok().flatten().is_some()
+        && keychain::is_persistent()
     {
         let _ = db.clear_token(&saved.id);
     }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -279,10 +279,10 @@ pub fn get_credentials(db: &Database, account_id: &str) -> Result<(String, Strin
     let host = account.host.clone();
 
     // Try keychain first (ignore errors — keychain may be unavailable)
-    // Try keychain first (ignore errors — keychain may be unavailable)
     if let Some(token) = keychain::get_token(account_id).ok().flatten() {
-        // Keychain has the token; clear DB copy if still present
-        if !account.token.is_empty() {
+        // Keychain has the token; clear DB copy if still present.
+        // 再起動非永続な store (Linux keyutils) では DB フォールバックを消さない (#785)
+        if !account.token.is_empty() && keychain::is_persistent() {
             let _ = db.clear_token(account_id);
         }
         CREDENTIAL_CACHE.insert(account_id, &host, &token);
@@ -293,7 +293,8 @@ pub fn get_credentials(db: &Database, account_id: &str) -> Result<(String, Strin
     let mut db_token = account.token.clone();
     if !db_token.is_empty() {
         // Try lazy migration to keychain; verify before clearing DB
-        if keychain::store_token(account_id, &db_token).is_ok()
+        if keychain::is_persistent()
+            && keychain::store_token(account_id, &db_token).is_ok()
             && keychain::get_token(account_id).ok().flatten().is_some()
         {
             let _ = db.clear_token(account_id);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tests/bindings_snapshot.rs
+++ b/src-tauri/tests/bindings_snapshot.rs
@@ -26,10 +26,7 @@ fn bindings_do_not_expose_raw_token_fields() {
         let name = if i == 0 {
             "(commands section)"
         } else {
-            chunk
-                .split(|c: char| c == ' ' || c == '=' || c == '<')
-                .next()
-                .unwrap_or("?")
+            chunk.split([' ', '=', '<']).next().unwrap_or("?")
         };
         if ALLOWED_TYPES.contains(&name) {
             continue;

--- a/src-tauri/tests/bindings_snapshot.rs
+++ b/src-tauri/tests/bindings_snapshot.rs
@@ -6,6 +6,49 @@
 //! If this test fails, run `cargo run --example gen_bindings` and commit the
 //! result.
 
+/// 生成された TS に raw トークンフィールドが露出しないことを保証する (#780)。
+///
+/// アカウントトークンはフロントに渡さない設計（`AccountPublic.hasToken` の
+/// ブール化）だが、将来誰かが `Account` 等をうっかり specta export しても
+/// スナップショット更新だけでは CI が通ってしまう。ここで不変条件として検証する。
+#[test]
+fn bindings_do_not_expose_raw_token_fields() {
+    // ローカル HTTP API 用トークンの発行時 1 回だけ raw を返す設計上、意図的な露出
+    const ALLOWED_TYPES: &[&str] = &["CreatedApiToken"];
+
+    let tmp = tempfile::NamedTempFile::new().expect("create tempfile for bindings export");
+    notedeck_lib::export_typescript_bindings(tmp.path()).expect("export typescript bindings");
+    let generated = std::fs::read_to_string(tmp.path()).expect("read generated bindings");
+
+    let mut offenders: Vec<&str> = Vec::new();
+    for (i, chunk) in generated.split("export type ").enumerate() {
+        // 先頭チャンクはコマンド定義部（引数・戻り値のインライン型を含む）
+        let name = if i == 0 {
+            "(commands section)"
+        } else {
+            chunk
+                .split(|c: char| c == ' ' || c == '=' || c == '<')
+                .next()
+                .unwrap_or("?")
+        };
+        if ALLOWED_TYPES.contains(&name) {
+            continue;
+        }
+        // `token: string` / `xxxToken: string` / `xxx_token: string` を検出。
+        // `hasToken: boolean` のようなブール化は許容される
+        if chunk.to_lowercase().contains("token: string") {
+            offenders.push(name);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "raw token field exposed in bindings.ts: {offenders:?} — \
+         トークンは hasToken のようにブール化するか、意図的な露出なら \
+         ALLOWED_TYPES に理由を添えて追加すること",
+    );
+}
+
 #[test]
 fn bindings_snapshot_is_current() {
     let tmp = tempfile::NamedTempFile::new().expect("create tempfile for bindings export");


### PR DESCRIPTION
## v1.14.0

トークン取り扱いの堅牢化リリース。Linux の「再起動ごとにログアウトされる」実害バグの修正と、secret-service 対応による暗号化永続ストレージ、検索の編集ノート取りこぼし修正を含む。

### ハイライト

- **fix: Linux で再起動のたびにログアウトされる問題を修正** (#785) — keyutils keychain は再起動非永続なのに DB フォールバックをクリアしていた。store の永続性を問い合わせてクリア判断をゲートする方式に変更
- **feat: デスクトップ Linux で secret-service (gnome-keyring / KWallet) を優先** (#786) — at-rest 暗号化 + 再起動永続。roundtrip probe で実用性を判定し、使えない環境 (WSL2 等) は自動で従来挙動に劣化
- **security: トークン取り扱いの機械的担保** (#780) — Debug 出力の token redaction、bindings への raw トークン露出を検知する CI ガード、DB ファイルの owner-only (0600) 化
- **fix: 編集されたノートが検索で取りこぼされる問題を修正** (notecli#33) — FTS 索引が編集前テキストのまま残っていた

### Changelog

- chore: regenerate openapi.json for 1.14.0
- chore: bump version to 1.14.0
- chore: notecli rev を b242213 に bump (Linux secret-service 優先ストア #786)
- chore: notecli rev を main (21ac0b0) に再 pin
- fix(auth): 再起動非永続な keychain では DB トークンフォールバックを消さない (#785)
- chore: notecli rev を d25d8fd に bump (token Debug redaction + FTS 編集追随修正)
- test(security): bindings への raw トークンフィールド露出を CI で検知する (#780)

notecli 側: hitalin/notecli#32, hitalin/notecli#33, hitalin/notecli#34, hitalin/notecli#35

### 備考

- Linux で既にトークンを失っている環境 (WSL2 等) は、このバージョンでの初回起動時に 1 回だけ再ログインが必要。以降はログイン状態が維持される
- デスクトップ Linux の secret-service 成功パスは実機 end-to-end 未検証 (fail-safe 設計のため出荷可能と判断、詳細は hitalin/notecli#35)

Closes #780
Closes #785
Closes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)