### PR TITLE
Release v1.19.0 (rebuild)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3230,6 +3230,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-os",
  "tauri-plugin-process",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-specta",
  "tempfile",
@@ -5945,6 +5946,23 @@ checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
 dependencies = [
  "tauri",
  "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3232,6 +3232,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tauri-specta",
  "tempfile",
  "tokio",
@@ -5996,6 +5997,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.13.0",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin-global-shortcut = { version = "2", optional = true }
 # 多重起動防止 (#642)。"deep-link" feature で 2 個目の argv 中の notedeck:// URL が
 # deep-link プラグインの on_open_url に自動転送される
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"], optional = true }
+tauri-plugin-window-state = { version = "2", optional = true }
 tauri-plugin-autostart = { version = "2", optional = true }
 tauri-plugin-updater = { version = "2", optional = true }
 tauri-plugin-process = { version = "2", optional = true }
@@ -77,7 +78,7 @@ windows = { version = "0.61", features = [
 
 [features]
 default = ["desktop"]
-desktop = ["tauri/tray-icon", "dep:tauri-plugin-global-shortcut", "dep:tauri-plugin-autostart", "dep:tauri-plugin-updater", "dep:tauri-plugin-process", "dep:tauri-plugin-single-instance"]
+desktop = ["tauri/tray-icon", "dep:tauri-plugin-global-shortcut", "dep:tauri-plugin-autostart", "dep:tauri-plugin-updater", "dep:tauri-plugin-process", "dep:tauri-plugin-single-instance", "dep:tauri-plugin-window-state"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -9,6 +9,9 @@ tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-global-shortcut = { version = "2", optional = true }
+# 多重起動防止 (#642)。"deep-link" feature で 2 個目の argv 中の notedeck:// URL が
+# deep-link プラグインの on_open_url に自動転送される
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"], optional = true }
 tauri-plugin-autostart = { version = "2", optional = true }
 tauri-plugin-updater = { version = "2", optional = true }
 tauri-plugin-process = { version = "2", optional = true }
@@ -74,7 +77,7 @@ windows = { version = "0.61", features = [
 
 [features]
 default = ["desktop"]
-desktop = ["tauri/tray-icon", "dep:tauri-plugin-global-shortcut", "dep:tauri-plugin-autostart", "dep:tauri-plugin-updater", "dep:tauri-plugin-process"]
+desktop = ["tauri/tray-icon", "dep:tauri-plugin-global-shortcut", "dep:tauri-plugin-autostart", "dep:tauri-plugin-updater", "dep:tauri-plugin-process", "dep:tauri-plugin-single-instance"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -41,7 +41,8 @@ pub fn set_status_bar_style(light_background: bool) {
         // tauri コマンドは JVM main thread 外で走るため FindClass では
         // アプリクラスを解決できない。ndk_context の Activity インスタンスに
         // 直接 call_method する (Kotlin 側が runOnUiThread へ hop する)。
-        let result = (|| -> Result<(), jni::errors::Error> {
+        // (std::result を明示 — super::Result エイリアスと衝突するため)
+        let result = (|| -> std::result::Result<(), jni::errors::Error> {
             let ctx = ndk_context::android_context();
             let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
             let mut env = vm.attach_current_thread()?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -116,7 +116,26 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     #[cfg(not(mobile))]
     {
+        // ウィンドウ位置・サイズの永続化 (#643)。
+        // - 対象は main のみ: PiP/デッキ派生ウィンドウはラベルが動的生成
+        //   (pip-<ts>-<n>) で復元先が二度とマッチせず、state ファイルに
+        //   ゴミが溜まり続けるため除外
+        // - VISIBLE は保存しない: close→トレイ hide→Quit で visible=false が
+        //   保存されると次回起動が不可視になるため
+        // - DECORATIONS も除外 (decorations:false 固定、win_chrome が管理)
+        use tauri_plugin_window_state::StateFlags;
         builder = builder
+            .plugin(
+                tauri_plugin_window_state::Builder::default()
+                    .with_state_flags(
+                        StateFlags::SIZE
+                            | StateFlags::POSITION
+                            | StateFlags::MAXIMIZED
+                            | StateFlags::FULLSCREEN,
+                    )
+                    .with_filter(|label| label == "main")
+                    .build(),
+            )
             .plugin(tauri_plugin_updater::Builder::new().build())
             .plugin(tauri_plugin_process::init())
             .plugin(tauri_plugin_global_shortcut::Builder::new().build())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -88,7 +88,25 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
     ));
     tauri::async_runtime::set(runtime.handle().clone());
 
-    let mut builder = tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // 多重起動防止 (#642)。他プラグインより先に登録する必要がある (公式要求)。
+    // 2 個目の起動は既存ウィンドウのフォーカスに変換。argv 中の notedeck:// URL は
+    // "deep-link" feature が deep-link プラグインの on_open_url へ自動転送するので、
+    // ここではフォーカスのみ扱う。
+    #[cfg(not(mobile))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, argv, _cwd| {
+            tracing::info!("[single-instance] second launch forwarded: {argv:?}");
+            if let Some(w) = app.get_webview_window("main") {
+                let _ = w.show();
+                let _ = w.unminimize();
+                let _ = w.set_focus();
+            }
+        }));
+    }
+
+    builder = builder
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -349,6 +349,9 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(url) = urls.first() {
                     let url_str = url.as_str().to_string();
                     tracing::info!("[deep-link] received: {url_str}");
+                    // show/set_focus はモバイルの WebviewWindow に存在しない
+                    // (Android は intent で既に前面化されている)
+                    #[cfg(desktop)]
                     if let Some(w) = deep_link_handle.get_webview_window("main") {
                         let _ = w.show();
                         let _ = w.set_focus();


### PR DESCRIPTION
v1.19.0 のリリースビルドが Android ターゲットのコンパイルエラーで落ちたため、修正と合わせて小粒プラグイン 2 件を同梱して再リリースする。バージョンは 1.19.0 のまま（タグを付け直す）。

## 変更内容

- fix: Android ターゲットのコンパイルエラーを修正 (a8be34ea)
  - `set_status_bar_style` の Result エイリアス衝突 (#755 の残)
  - deep-link ハンドラの show/set_focus を `#[cfg(desktop)]` ガード (#754 の残)
- feat(desktop): single-instance プラグイン導入（deep-link 多重起動対策） (556fcc1c)
- feat(desktop): window-state プラグイン導入（ウィンドウ位置・サイズの永続化） (b79eb2be)

Closes #642
Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)