### PR TITLE
Release v1.20.0 (re-release): Windows ビルド修正

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -434,9 +434,11 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
                     }
                     if let Some(ctx) = os_notify::decode_protocol_url(url.as_str()) {
                         let state = app.state::<os_notify::PendingNotificationClick>();
+                        // 末尾式だと scrutinee の一時値 (Result<MutexGuard>) が
+                        // state より長生きして E0597 になるため文にする
                         if let Ok(mut pending) = state.0.lock() {
                             pending.replace(ctx);
-                        }
+                        };
                     }
                 }
             }

--- a/src-tauri/src/os_notify.rs
+++ b/src-tauri/src/os_notify.rs
@@ -202,7 +202,7 @@ pub use desktop::{init, show};
 /// accountId なし (バースト要約通知) は None = フォーカスのみでよい。
 #[cfg(target_os = "windows")]
 pub fn decode_protocol_url(url: &str) -> Option<NotificationClicked> {
-    let resp = match user_notify::decode_deeplink(url) {
+    let resp = match user_notify::windows::decode_deeplink(url) {
         Ok(resp) => resp,
         Err(e) => {
             tracing::warn!("[notification] protocol url decode failed: {e:?}");


### PR DESCRIPTION
## What

v1.20.0 リリースビルドの Windows (nsis) ジョブが Rust コンパイルエラーで失敗したため、修正して同バージョンを再リリースする。

- `decode_deeplink` を `user_notify::windows::decode_deeplink` に修正 (E0425)
- 通知 cold start 復元の if-let 末尾式で一時値が `state` より長生きする E0597 を rustc 提案どおり文化して修正

## Why

#754 の Windows セッション跨ぎ通知クリック遷移は `cfg(windows)` のため Linux の CI (check/clippy/test) では一切コンパイルされず、tag push 後のリリースビルドで初めて検出された。

バージョンは据え置き (v1.20.0)。マージ後に既存タグを打ち直して release workflow を再実行する。

## Test

- [x] `cargo check` / `cargo clippy --all-targets` / `cargo test` (Linux) パス
- [ ] CI パス
- [ ] タグ再 push 後の Windows ビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)