### PR TITLE
Release v1.22.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.22.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.22.0"
+version = "1.22.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.22.0"
+version = "1.22.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.22.0"
+    "version": "1.22.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/aiscript/plugin-api.test.ts
+++ b/src/aiscript/plugin-api.test.ts
@@ -5,6 +5,7 @@ import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
 import { type Account, useAccountsStore } from '@/stores/accounts'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { type PluginMeta, usePluginsStore } from '@/stores/plugins'
+import { useToast } from '@/stores/toast'
 import { commands } from '@/utils/tauriInvoke'
 import { openSafeUrl } from '@/utils/url'
 import {
@@ -506,5 +507,30 @@ describe('abort / launchAll', () => {
     abortAllPlugins()
     expect(getPluginHandlers('note_action')).toHaveLength(0)
     expect(getPluginHandlers('user_action')).toHaveLength(0)
+  })
+})
+
+describe('Mk:toast (プラグイン env の配線)', () => {
+  // onToast 未配線だと Mk:toast が無言の no-op になり、プラグインからの
+  // 成否フィードバックがユーザーに一切届かない (実機で「押しても無反応」)
+  it('プラグインの Mk:toast がトーストとして表示される', async () => {
+    const { toasts } = useToast()
+    toasts.value.splice(0)
+    await installAndLaunch('Mk:toast("saved", "success")')
+    expect(toasts.value.map((t) => [t.text, t.type])).toEqual([
+      ['saved', 'success'],
+    ])
+  })
+
+  it('note action ハンドラからの Mk:toast も表示される', async () => {
+    const { toasts } = useToast()
+    toasts.value.splice(0)
+    await installAndLaunch(
+      'Plugin:register_note_action("T", @(note) { Mk:toast("done", "info") })',
+    )
+    // handler は execFn の Promise を返さない (発火のみ) ため flush して待つ
+    await getPluginHandlers('note_action')[0]?.handler({ id: 'n1' })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(toasts.value.map((t) => t.text)).toEqual(['done'])
   })
 })

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -19,6 +19,7 @@ import {
   type PluginMeta,
   usePluginsStore,
 } from '@/stores/plugins'
+import { useToast } from '@/stores/toast'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { openSafeUrl } from '@/utils/url'
 import { createAiScriptEnv } from './api'
@@ -506,6 +507,9 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
         name: plugin.name,
       },
       storagePrefix: `plugin:${plugin.installId}`,
+      // onToast 未指定だと Mk:toast が無言の no-op になり、プラグインからの
+      // 成否フィードバックが一切ユーザーに届かない (widget / Play は配線済み)
+      onToast: (text, type) => useToast().show(text, type),
     },
     { LOCALE: navigator.language },
   )

--- a/src/capabilities/builtins/files.ts
+++ b/src/capabilities/builtins/files.ts
@@ -62,7 +62,11 @@ async function resolveItems(
   for (const noteId of noteIds) {
     try {
       const note = unwrap(await commands.apiGetNote(accountId, noteId))
-      for (const f of note.files ?? []) {
+      // 純粋なリノートは添付を内側のノートが持つ (MkNote の effectiveNote と同じ規則)
+      const inner = note.renote as { files?: typeof note.files } | null
+      const files =
+        note.text === null && inner?.files ? inner.files : note.files
+      for (const f of files ?? []) {
         if (f.url) {
           collected.set(f.id, {
             url: f.url,


### PR DESCRIPTION
## Release v1.22.1

v1.22.0 で開放した保存機能をプラグインから使ったところ「押しても何も起きない」状態になったため、その原因を修正するパッチリリース。

### 変更一覧

- fix(plugin): プラグインの Mk:toast が無言で捨てられるのを修正
- chore: bump version to 1.22.1 / regenerate openapi.json

### 内容

- **プラグインのトーストが一切表示されなかった問題を修正**: プラグイン環境の構築時だけ `onToast` が渡されておらず (ウィジェット / Play / スクラッチパッドは配線済み)、`Mk:toast` が no-op になっていた。このためプラグインが成功・失敗のどちらを報告しても画面上は完全な沈黙になっていた。既存の公開プラグイン (post-guard / deepl-translate / pakuru など Mk:toast を使う全プラグイン) が本修正で初めてフィードバックを表示するようになる
- **`files.export` が純粋なリノートの添付を取りこぼしていたのを修正**: 添付は内側のノートが持つため、そちらを見るようにした (MkNote の effectiveNote と同じ規則)

回帰テストとして、トップレベルと note action ハンドラの両方から `Mk:toast` が実際に表示されることを検証するテストを追加した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plugin actions using `Mk:toast` now display notifications in the app with the specified message and type.

- **Bug Fixes**
  - Corrected attachment handling for pure reposts, ensuring files from the original post are displayed when appropriate.

- **Release**
  - Updated the application version to **1.22.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->