### PR TITLE
Release v1.25.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,6 +403,9 @@ jobs:
   winget:
     needs: publish
     runs-on: windows-latest
+    # 投稿先は winget-pkgs (WINGET_TOKEN) なので GITHUB_TOKEN は読み取りのみ
+    permissions:
+      contents: read
     steps:
       - name: Get version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,6 +412,8 @@ jobs:
       - name: Submit to winget
         uses: vedantmgoyal9/winget-releaser@v2
         with:
+          # org 名義に寄せる。winget-pkgs では ID 変更 = 新規パッケージ申請
+          # 扱いなので、旧 Hitalin.NoteDeck のユーザーは自動では移行しない
           identifier: NotedeckDev.NoteDeck
           installers-regex: '-windows-x64-setup\.exe$'
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   winget:
     runs-on: windows-latest
+    # winget-pkgs への投稿は WINGET_TOKEN で行うので GITHUB_TOKEN は
+    # Release アセットの参照しか要らない
+    permissions:
+      contents: read
     steps:
       - name: Submit to winget
         uses: vedantmgoyal9/winget-releaser@v2

--- a/.github/workflows/winget-submit.yml
+++ b/.github/workflows/winget-submit.yml
@@ -1,0 +1,27 @@
+# 公開済みの GitHub Release を winget へ手動投稿する。
+# release.yml の winget ジョブが失敗した場合のリカバリ用
+# (v1.21.0〜v1.24.0 は winget へ届かず欠番のまま)。
+name: winget-submit
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '投稿するバージョン (例: 1.24.0、v プレフィックスなし)'
+        required: true
+        type: string
+
+jobs:
+  winget:
+    runs-on: windows-latest
+    steps:
+      - name: Submit to winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          # release.yml の winget ジョブと同じ値にすること
+          identifier: NotedeckDev.NoteDeck
+          installers-regex: '-windows-x64-setup\.exe$'
+          version: ${{ inputs.version }}
+          release-tag: v${{ inputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}
+          fork-user: notedeck-dev

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.24.0",
+  "version": "1.25.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.24.0"
+version = "1.25.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.24.0"
+version = "1.25.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.24.0"
+    "version": "1.25.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/account_service.rs
+++ b/src-tauri/src/account_service.rs
@@ -13,6 +13,13 @@ use crate::commands::invalidate_credentials;
 
 type Result<T> = std::result::Result<T, NoteDeckError>;
 
+/// ゲスト (未認証) アカウントを表す user_id マーカー。
+pub const GUEST_USER_ID: &str = "__guest__";
+
+pub fn is_guest(account: &Account) -> bool {
+    account.user_id == GUEST_USER_ID
+}
+
 /// keychain / DB フォールバックを見て has_token を判定し AccountPublic 化する。
 pub fn to_public(account: &Account) -> AccountPublic {
     let has_token =
@@ -43,7 +50,7 @@ pub fn logout(db: &Database, id: &str) -> Result<()> {
 
 /// 既存アカウント一覧からゲストの連番表示名 (「ゲスト N」) を決める。
 pub fn next_guest_display_name(accounts: &[Account]) -> String {
-    let guest_count = accounts.iter().filter(|a| a.user_id == "__guest__").count();
+    let guest_count = accounts.iter().filter(|a| is_guest(a)).count();
     format!("ゲスト{}", guest_count + 1)
 }
 
@@ -58,7 +65,7 @@ pub fn create_guest(db: &Database, host: String, software: String) -> Result<Acc
         id,
         host,
         token: String::new(),
-        user_id: "__guest__".to_string(),
+        user_id: GUEST_USER_ID.to_string(),
         username,
         display_name,
         avatar_url: None,
@@ -77,7 +84,7 @@ mod tests {
             id: format!("g{n}"),
             host: "misskey.io".into(),
             token: String::new(),
-            user_id: "__guest__".into(),
+            user_id: GUEST_USER_ID.into(),
             username: format!("guest_{n}"),
             display_name: None,
             avatar_url: None,

--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -50,7 +50,8 @@ pub async fn build_health_report(
         .join("notecli.db");
 
     // doctor のチェックを丸ごと再利用 (account_spec = None で全アカウント対象)。
-    let doctor = notecli::commands::doctor::diagnose(db.as_ref(), &db_path, None).await?;
+    let mut doctor = notecli::commands::doctor::diagnose(db.as_ref(), &db_path, None).await?;
+    strip_guest_credential_checks(&mut doctor, &db.load_accounts().unwrap_or_default());
     let (note_cache_count, db_size_bytes) = db.cache_stats()?;
     let log_dir = app
         .path()
@@ -66,4 +67,95 @@ pub async fn build_health_report(
         heartbeat_interval_minutes: scheduler.current_interval(),
         log_dir,
     })
+}
+
+/// ゲストはトークンを持たないまま使うものなので、doctor の credentials
+/// 失敗 (「no token found」) を診断結果から取り除く。ゲストは notedeck 側の
+/// 概念なので notecli の doctor は区別できず、ここで落とす。
+/// 対象の突き合わせは doctor が付けるアカウントラベル (`@user@host`) で行う。
+fn strip_guest_credential_checks(
+    report: &mut notecli::commands::doctor::Report,
+    accounts: &[notecli::models::Account],
+) {
+    let guest_labels: Vec<String> = accounts
+        .iter()
+        .filter(|a| crate::account_service::is_guest(a))
+        .map(|a| format!("@{}@{}", a.username, a.host))
+        .collect();
+    if guest_labels.is_empty() {
+        return;
+    }
+    report.checks.retain(|c| {
+        c.name != "credentials"
+            || !c
+                .account
+                .as_ref()
+                .is_some_and(|label| guest_labels.contains(label))
+    });
+    report.ok = report
+        .checks
+        .iter()
+        .all(|c| c.status != notecli::commands::doctor::Status::Fail);
+}
+
+#[cfg(test)]
+mod tests {
+    use notecli::commands::doctor::{Check, Report, Status};
+    use notecli::models::Account;
+
+    use super::strip_guest_credential_checks;
+
+    fn account(user_id: &str, username: &str) -> Account {
+        Account {
+            id: username.into(),
+            host: "misskey.io".into(),
+            token: String::new(),
+            user_id: user_id.into(),
+            username: username.into(),
+            display_name: None,
+            avatar_url: None,
+            software: "misskey-dev/misskey".into(),
+        }
+    }
+
+    fn credentials_fail(label: &str) -> Check {
+        Check {
+            name: "credentials".into(),
+            status: Status::Fail,
+            message: "no token found in keychain or DB".into(),
+            account: Some(label.into()),
+            fix: None,
+        }
+    }
+
+    #[test]
+    fn guest_credential_failure_is_dropped_and_report_recovers() {
+        let mut report = Report {
+            ok: false,
+            checks: vec![credentials_fail("@guest_1@misskey.io")],
+        };
+        strip_guest_credential_checks(
+            &mut report,
+            &[account(crate::account_service::GUEST_USER_ID, "guest_1")],
+        );
+        assert!(report.checks.is_empty());
+        assert!(report.ok);
+    }
+
+    #[test]
+    fn logged_out_account_keeps_its_credential_failure() {
+        let mut report = Report {
+            ok: false,
+            checks: vec![credentials_fail("@alice@misskey.io")],
+        };
+        strip_guest_credential_checks(
+            &mut report,
+            &[
+                account(crate::account_service::GUEST_USER_ID, "guest_1"),
+                account("u1", "alice"),
+            ],
+        );
+        assert_eq!(report.checks.len(), 1);
+        assert!(!report.ok);
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/commands/quickPickProviders.test.ts
+++ b/src/commands/quickPickProviders.test.ts
@@ -98,31 +98,11 @@ describe('getSettingsItems', () => {
     }
   })
 
-  it('reflects OS theme sync state in the description', () => {
-    themeMock.manualMode = null
-    expect(
-      getSettingsItems().find((i) => i.id === 'toggle-os-theme-sync')
-        ?.description,
-    ).toBe('オン')
-    themeMock.manualMode = 'dark'
-    expect(
-      getSettingsItems().find((i) => i.id === 'toggle-os-theme-sync')
-        ?.description,
-    ).toBe('オフ')
-  })
-
-  it('toggle-dark-mode action toggles the theme', () => {
-    getSettingsItems()
-      .find((i) => i.id === 'toggle-dark-mode')
-      ?.action?.()
-    expect(themeMock.toggleTheme).toHaveBeenCalledOnce()
-  })
-
-  it('remove-wallpaper action clears the deck wallpaper', () => {
-    getSettingsItems()
-      .find((i) => i.id === 'remove-wallpaper')
-      ?.action?.()
-    expect(deckMock.clearWallpaper).toHaveBeenCalledOnce()
+  it('アピアランスは個別操作ではなくウィンドウを開く', () => {
+    const items = getSettingsItems()
+    expect(items.filter((i) => i.group === 'アピアランス')).toHaveLength(1)
+    items.find((i) => i.id === 'appearance')?.action?.()
+    expect(windowsMock.open).toHaveBeenCalledWith('appearanceEditor')
   })
 
   it('window-opening settings route to the windows store', () => {

--- a/src/commands/quickPickProviders.test.ts
+++ b/src/commands/quickPickProviders.test.ts
@@ -98,9 +98,9 @@ describe('getSettingsItems', () => {
     }
   })
 
-  it('アピアランスは個別操作ではなくウィンドウを開く', () => {
+  it('全項目がウィンドウを開くだけのフラットな一覧', () => {
     const items = getSettingsItems()
-    expect(items.filter((i) => i.group === 'アピアランス')).toHaveLength(1)
+    expect(items.every((i) => i.group === undefined)).toBe(true)
     items.find((i) => i.id === 'appearance')?.action?.()
     expect(windowsMock.open).toHaveBeenCalledWith('appearanceEditor')
   })

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -1,4 +1,3 @@
-import { relaunch } from '@tauri-apps/plugin-process'
 import { reactive } from 'vue'
 import {
   ACCOUNT_INDEPENDENT_TYPES,
@@ -148,46 +147,11 @@ export function getSettingsItems(): QuickPickItem[] {
       action: () => useWindowsStore().open('cacheEditor'),
     },
     {
-      id: 'export-db',
-      label: 'DBエクスポート',
-      icon: 'database-export',
+      id: 'backup',
+      label: 'バックアップ',
+      icon: 'database',
       group: 'バックアップ',
-      action: async () => {
-        unwrap(await commands.exportDb())
-      },
-    },
-    {
-      id: 'import-db',
-      label: 'DBインポート',
-      icon: 'database-import',
-      group: 'バックアップ',
-      action: () =>
-        backupWithConfirm(
-          'importDb',
-          'DBインポート',
-          '現在のDBが上書きされます。',
-        ),
-    },
-    {
-      id: 'export-settings',
-      label: '設定エクスポート',
-      icon: 'file-export',
-      group: 'バックアップ',
-      action: async () => {
-        unwrap(await commands.exportSettingsJson())
-      },
-    },
-    {
-      id: 'import-settings',
-      label: '設定インポート',
-      icon: 'file-import',
-      group: 'バックアップ',
-      action: () =>
-        backupWithConfirm(
-          'importSettingsJson',
-          '設定インポート',
-          '現在の設定が上書きされます。',
-        ),
+      action: () => useWindowsStore().open('backup'),
     },
   ]
 }
@@ -204,23 +168,6 @@ function pickWallpaperFile() {
     reader.readAsDataURL(file)
   }
   input.click()
-}
-
-async function backupWithConfirm(
-  command: 'importDb' | 'importSettingsJson',
-  title: string,
-  message: string,
-) {
-  const { confirm } = useConfirm()
-  const ok = await confirm({
-    title,
-    message,
-    okLabel: 'インポート',
-    type: 'danger',
-  })
-  if (!ok) return
-  const result = unwrap(await commands[command]())
-  if (result) await relaunch()
 }
 
 // ============================================================

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -27,7 +27,6 @@ import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { useDeckProfileStore } from '@/stores/deckProfile'
 import { usePrompt } from '@/stores/prompt'
-import { useThemeStore } from '@/stores/theme'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { proxyThumbUrl } from '@/utils/imageProxy'
@@ -41,45 +40,14 @@ import { useCommandStore } from './registry'
 
 export function getSettingsItems(): QuickPickItem[] {
   return [
-    // Appearance
+    // ダークモード切替や壁紙は個別項目を並べず、モバイルの設定メニューと
+    // 同じくアピアランスウィンドウに集約する
     {
-      id: 'toggle-dark-mode',
-      label: 'ダーク / ライトモード切替',
-      icon: 'moon',
+      id: 'appearance',
+      label: 'アピアランス',
+      icon: 'brush',
       group: 'アピアランス',
-      action: () => useThemeStore().toggleTheme(),
-    },
-    {
-      id: 'toggle-os-theme-sync',
-      label: 'デバイスのダークモードに同期',
-      icon: 'device-desktop',
-      group: 'アピアランス',
-      description: useThemeStore().manualMode == null ? 'オン' : 'オフ',
-      action: () => {
-        const themeStore = useThemeStore()
-        if (themeStore.manualMode == null) {
-          themeStore.pinCurrentMode()
-        } else {
-          themeStore.resetToOsTheme()
-        }
-      },
-    },
-    // テーマ選択 / 編集 / 削除はテーマカラム (themeManager) に集約済みのため
-    // アピアランス quickPick からは撤去。テーマカラムを開くには
-    // 「テーマを管理」コマンドを使う。
-    {
-      id: 'set-wallpaper',
-      label: '壁紙を設定',
-      icon: 'photo',
-      group: 'アピアランス',
-      action: () => pickWallpaperFile(),
-    },
-    {
-      id: 'remove-wallpaper',
-      label: '壁紙を削除',
-      icon: 'photo-off',
-      group: 'アピアランス',
-      action: () => useDeckStore().clearWallpaper(),
+      action: () => useWindowsStore().open('appearanceEditor'),
     },
     // Environment settings
     {
@@ -154,20 +122,6 @@ export function getSettingsItems(): QuickPickItem[] {
       action: () => useWindowsStore().open('backup'),
     },
   ]
-}
-
-function pickWallpaperFile() {
-  const input = document.createElement('input')
-  input.type = 'file'
-  input.accept = 'image/*'
-  input.onchange = () => {
-    const file = input.files?.[0]
-    if (!file) return
-    const reader = new FileReader()
-    reader.onload = () => useDeckStore().setWallpaper(reader.result as string)
-    reader.readAsDataURL(file)
-  }
-  input.click()
 }
 
 // ============================================================

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -40,85 +40,71 @@ import { useCommandStore } from './registry'
 
 export function getSettingsItems(): QuickPickItem[] {
   return [
-    // ダークモード切替や壁紙は個別項目を並べず、モバイルの設定メニューと
-    // 同じくアピアランスウィンドウに集約する
+    // 個別操作は並べず、モバイルの設定メニューと同じくウィンドウに集約する
     {
       id: 'appearance',
       label: 'アピアランス',
       icon: 'brush',
-      group: 'アピアランス',
       action: () => useWindowsStore().open('appearanceEditor'),
     },
-    // Environment settings
     {
       id: 'ai-settings',
       label: 'エージェント',
       icon: 'robot',
-      group: '環境設定',
       action: () => useWindowsStore().open('aiSettings'),
     },
     {
       id: 'permissions',
       label: '権限',
       icon: 'shield-lock',
-      group: '環境設定',
       action: () => useWindowsStore().open('permissions'),
     },
     {
       id: 'connections',
       label: '接続',
       icon: 'plug-connected',
-      group: '環境設定',
       action: () => useWindowsStore().open('connections'),
     },
     {
       id: 'keybinds',
       label: 'キーバインド',
       icon: 'keyboard',
-      group: '環境設定',
       action: () => useWindowsStore().open('keybinds'),
     },
     {
       id: 'performance',
       label: 'パフォーマンス',
       icon: 'gauge',
-      group: '環境設定',
       action: () => useWindowsStore().open('performanceEditor'),
     },
     {
       id: 'css-editor',
       label: 'カスタムCSS',
       icon: 'code',
-      group: '環境設定',
       action: () => useWindowsStore().open('cssEditor'),
     },
     {
       id: 'tasks-editor',
       label: 'タスク',
       icon: 'player-play',
-      group: '環境設定',
       action: () => useWindowsStore().open('tasksEditor'),
     },
     {
       id: 'snippets-editor',
       label: 'スニペット',
       icon: 'code-plus',
-      group: '環境設定',
       action: () => useWindowsStore().open('snippetsEditor'),
     },
-    // Cache
     {
       id: 'cache-editor',
-      label: 'キャッシュ管理',
+      label: 'キャッシュ',
       icon: 'eraser',
-      group: 'キャッシュ',
       action: () => useWindowsStore().open('cacheEditor'),
     },
     {
       id: 'backup',
       label: 'バックアップ',
       icon: 'database',
-      group: 'バックアップ',
       action: () => useWindowsStore().open('backup'),
     },
   ]

--- a/src/components/common/NoteMoreMenu.vue
+++ b/src/components/common/NoteMoreMenu.vue
@@ -18,6 +18,7 @@ import { useConfirm } from '@/stores/confirm'
 import { useDeckStore } from '@/stores/deck'
 import { usePrompt } from '@/stores/prompt'
 import { useToast } from '@/stores/toast'
+import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
 import { proxyThumbUrl } from '@/utils/imageProxy'
@@ -48,22 +49,34 @@ const { confirm } = useConfirm()
 const { prompt } = usePrompt()
 const { getOrCreate } = useMultiAccountAdapters()
 const commandStore = useCommandStore()
+const isCompact = useIsCompactLayout()
 const { canInteract, isGuest } = useAccountMode(() => props.note._accountId)
 
 const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
 const showDeleteConfirm = ref(false)
 const showDeleteAndEditConfirm = ref(false)
 const showReportForm = ref(false)
+// compact ではコマンドパレットが無いので、シート内で 2 段選択する (#627)
+const showActAs = ref(false)
+const actAsAccountId = ref<string | null>(null)
 const reportComment = ref('')
 const localIsFavorited = ref(props.isFavorited)
 const localIsPinned = ref(props.isPinned)
 
-type MenuView = 'main' | 'deleteConfirm' | 'deleteAndEditConfirm' | 'reportForm'
+type MenuView =
+  | 'main'
+  | 'deleteConfirm'
+  | 'deleteAndEditConfirm'
+  | 'reportForm'
+  | 'actAsAccounts'
+  | 'actAsOperations'
 
 const currentView = computed<MenuView>(() => {
   if (showDeleteConfirm.value) return 'deleteConfirm'
   if (showDeleteAndEditConfirm.value) return 'deleteAndEditConfirm'
   if (showReportForm.value) return 'reportForm'
+  if (showActAs.value)
+    return actAsAccountId.value ? 'actAsOperations' : 'actAsAccounts'
   return 'main'
 })
 
@@ -99,6 +112,8 @@ function resetSubViews() {
   showDeleteConfirm.value = false
   showDeleteAndEditConfirm.value = false
   showReportForm.value = false
+  showActAs.value = false
+  actAsAccountId.value = null
   reportComment.value = ''
 }
 
@@ -212,6 +227,11 @@ const actAsCandidates = computed(() =>
   ),
 )
 
+const actAsAccountLabel = computed(() => {
+  const acc = actAsCandidates.value.find((a) => a.id === actAsAccountId.value)
+  return acc ? getAccountLabel(acc) : ''
+})
+
 function actAsOperations(accountId: string) {
   return [
     {
@@ -244,7 +264,13 @@ function actAsOperations(accountId: string) {
   ]
 }
 
-function openActAsQuickPick() {
+function openActAs() {
+  // compact はコマンドパレットが無い (TitleBar ごと非表示) ので
+  // ボトムシートの中で同じ 2 段選択を再現する
+  if (isCompact.value) {
+    showActAs.value = true
+    return
+  }
   close()
   commandStore.pushQuickPick({
     title: '別のアカウントで…',
@@ -342,6 +368,45 @@ defineExpose({ open })
 
 
 
+    <!-- 別のアカウントで… (compact のみ): アカウント選択 -->
+    <template v-else-if="currentView === 'actAsAccounts'">
+      <div class="_popupConfirmText">別のアカウントで…</div>
+      <button
+        v-for="acc in actAsCandidates"
+        :key="acc.id"
+        class="_popupItem"
+        @click="actAsAccountId = acc.id"
+      >
+        <img :src="proxyThumbUrl(getAccountAvatarUrl(acc), 18)" :class="$style.actAsAvatar" alt="" />
+        {{ getAccountLabel(acc) }}
+      </button>
+      <button class="_popupItem" @click="backToMain">
+        <i class="ti ti-arrow-left" />
+        戻る
+      </button>
+    </template>
+
+    <!-- 別のアカウントで… (compact のみ): 操作選択 -->
+    <template v-else-if="currentView === 'actAsOperations'">
+      <div class="_popupConfirmText">{{ actAsAccountLabel }}</div>
+      <button class="_popupItem" @click="emit('reactAs', actAsAccountId!); close()">
+        <i class="ti ti-mood-plus" />
+        リアクション
+      </button>
+      <button class="_popupItem" @click="emit('renoteAs', actAsAccountId!); close()">
+        <i class="ti ti-repeat" />
+        リノート
+      </button>
+      <button class="_popupItem" @click="emit('quoteAs', actAsAccountId!); close()">
+        <i class="ti ti-quote" />
+        引用
+      </button>
+      <button class="_popupItem" @click="actAsAccountId = null">
+        <i class="ti ti-arrow-left" />
+        戻る
+      </button>
+    </template>
+
     <!-- Report form -->
     <template v-else-if="currentView === 'reportForm'">
       <div class="_popupConfirmText">@{{ note.user.username }} を通報</div>
@@ -381,7 +446,7 @@ defineExpose({ open })
         <i class="ti ti-paperclip" />
         クリップに追加
       </button>
-      <button v-if="actAsCandidates.length > 0" class="_popupItem" @click="openActAsQuickPick">
+      <button v-if="actAsCandidates.length > 0" class="_popupItem" @click="openActAs">
         <i class="ti ti-users" />
         別のアカウントで…
       </button>
@@ -446,3 +511,14 @@ defineExpose({ open })
     </template>
   </PopupMenu>
 </template>
+
+<style lang="scss" module>
+// 「別のアカウントで…」のアカウント行アバター (._popupItem .ti と同じ幅に揃える)
+.actAsAvatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+</style>

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -151,11 +151,22 @@ const {
   updateAvailable,
   updateVersion,
   isInstalling,
+  updateReady,
   downloadProgress,
   updateError,
   checkForUpdate,
   installUpdate,
+  restartToUpdate,
 } = useUpdater()
+
+const showUpdateSection = computed(
+  () => updateAvailable.value || isInstalling.value || updateReady.value,
+)
+const updateIcon = computed(() => {
+  if (updateReady.value) return 'ti ti-refresh'
+  if (isInstalling.value) return 'ti ti-download'
+  return 'ti ti-arrow-up-circle'
+})
 
 const buildDate = __BUILD_DATE__
 const gitCommit = __GIT_COMMIT__
@@ -247,44 +258,27 @@ function reportBug() {
       >
         NoteDeck
       </button>
-      <!-- バージョン表記自体がアップデート確認のタッチポイント (モバイルは表示のみ) -->
-      <template v-if="!uiStore.isMobilePlatform">
-        <button
-          type="button"
-          class="_button"
-          :class="[$style.aboutVersion, isUpToDate && $style.versionOk]"
-          title="アップデートを確認"
-          :disabled="isChecking"
-          @click="checkForUpdate(true)"
-        >
-          v{{ appVersion }}
-          <i
-            :class="[
-              isChecking ? 'ti ti-loader-2 nd-spin' : isUpToDate ? 'ti ti-check' : 'ti ti-refresh',
-              $style.versionIcon,
-            ]"
-          />
-          <span v-if="isUpToDate">最新</span>
-        </button>
-        <button
-          v-if="updateAvailable"
-          type="button"
-          class="_button"
-          :class="$style.updatePill"
-          :disabled="isInstalling"
-          @click="installUpdate"
-        >
-          <i :class="isInstalling ? 'ti ti-loader-2 nd-spin' : 'ti ti-download'" />
-          <template v-if="isInstalling && downloadProgress !== null">
-            ダウンロード中… {{ downloadProgress }}%
-          </template>
-          <template v-else-if="isInstalling">インストール中...</template>
-          <template v-else>v{{ updateVersion }} にアップデート</template>
-        </button>
-        <div v-if="updateError" :class="$style.updateError">
-          {{ updateError }}
-        </div>
-      </template>
+      <!-- バージョン表記自体がアップデート確認のタッチポイント。更新が待機中は
+           アクションを更新セクションに一本化するので、ここは表示だけに戻す
+           (モバイルも表示のみ) -->
+      <button
+        v-if="!uiStore.isMobilePlatform && !showUpdateSection"
+        type="button"
+        class="_button"
+        :class="[$style.aboutVersion, isUpToDate && $style.versionOk]"
+        title="アップデートを確認"
+        :disabled="isChecking"
+        @click="checkForUpdate(true)"
+      >
+        v{{ appVersion }}
+        <i
+          :class="[
+            isChecking ? 'ti ti-loader-2 nd-spin' : isUpToDate ? 'ti ti-check' : 'ti ti-refresh',
+            $style.versionIcon,
+          ]"
+        />
+        <span v-if="isUpToDate">最新</span>
+      </button>
       <div v-else :class="$style.aboutVersion">v{{ appVersion }}</div>
     </div>
 
@@ -293,6 +287,42 @@ function reportBug() {
         <i class="ti ti-presentation-analytics" />
         チュートリアルを見る
       </button>
+    </div>
+
+    <!-- アップデートは hero から切り離した独立セクション (VSCode の
+         「バッジで気づく → 明示的な行で実行」モデル)。hero にアクションを
+         置かないことでチュートリアルとの誤タップも防ぐ -->
+    <div v-if="showUpdateSection" :class="$style.formSection">
+      <div :class="$style.formSectionLabel">アップデート</div>
+      <div :class="$style.sectionBody">
+        <div :class="$style.updateRow">
+          <i :class="[updateIcon, $style.updateIcon]" />
+          <span :class="$style.updateText">
+            <template v-if="updateReady">更新の準備ができました</template>
+            <template v-else-if="isInstalling">v{{ updateVersion }} をダウンロード中</template>
+            <template v-else>{{ appVersion }} → {{ updateVersion }}</template>
+          </span>
+          <span v-if="isInstalling && downloadProgress !== null" :class="$style.updatePercent">
+            {{ downloadProgress }}%
+          </span>
+          <button
+            v-else-if="!isInstalling"
+            type="button"
+            class="_button"
+            :class="$style.updateAction"
+            @click="updateReady ? restartToUpdate() : installUpdate()"
+          >
+            {{ updateReady ? '再起動' : '更新' }}
+          </button>
+        </div>
+        <div v-if="isInstalling" :class="$style.progressTrack">
+          <div
+            :class="[$style.progressBar, downloadProgress === null && $style.progressIndeterminate]"
+            :style="downloadProgress !== null ? { width: `${downloadProgress}%` } : undefined"
+          />
+        </div>
+        <div v-if="updateError" :class="$style.updateError">{{ updateError }}</div>
+      </div>
     </div>
 
     <!-- 本家 about-misskey の projectMembers 踏襲 (行の型は formLink に統一)。
@@ -341,7 +371,7 @@ function reportBug() {
         <button type="button" class="_button" :class="$style.formLink" @click="reportBug">
           <i class="ti ti-bug" :class="$style.formLinkIcon" />
           <span>バグを報告</span>
-          <span :class="$style.formLinkSuffix">GitHub Issues<i class="ti ti-external-link" /></span>
+          <span :class="$style.formLinkSuffix">GitHub Issues <i class="ti ti-external-link" /></span>
         </button>
       </div>
     </div>
@@ -455,26 +485,70 @@ function reportBug() {
   font-size: 0.9em;
 }
 
-// 更新があるときだけバージョンの直下に出すアクセント色ピル (pillBtn と同型)
-.updatePill {
-  display: inline-flex;
+// 更新セクション: formLink と同じ「1 行」の型に揃え、hero には出さない
+.updateRow {
+  display: flex;
   align-items: center;
-  gap: 5px;
-  margin-top: 8px;
-  padding: 7px 14px;
-  border-radius: var(--nd-radius-full);
+  gap: 8px;
+  font-size: 0.9em;
+}
+
+.updateIcon {
+  color: var(--nd-accent);
+}
+
+.updateText {
+  flex: 1;
+  min-width: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.updatePercent {
+  font-size: 0.85em;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+.updateAction {
+  padding: 4px 12px;
+  border-radius: var(--nd-radius-sm);
   background: var(--nd-accent);
   color: var(--nd-fgOnAccent);
   font-weight: bold;
   font-size: 0.85em;
   transition: background var(--nd-duration-base);
 
-  &:hover:not(:disabled) {
+  &:hover {
     background: hsl(from var(--nd-accent) h s calc(l + 5));
   }
+}
 
-  &:disabled {
-    opacity: 0.7;
+.progressTrack {
+  margin-top: 8px;
+  height: 2px;
+  border-radius: 1px;
+  overflow: hidden;
+  background: var(--nd-divider);
+}
+
+.progressBar {
+  height: 100%;
+  background: var(--nd-accent);
+  transition: width var(--nd-duration-base);
+}
+
+// contentLength 不明でパーセントが出せない間は流れるバーで生存を示す
+.progressIndeterminate {
+  width: 40%;
+  animation: about-progress-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes about-progress-slide {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(250%);
   }
 }
 

--- a/src/components/window/CacheEditorContent.vue
+++ b/src/components/window/CacheEditorContent.vue
@@ -217,33 +217,32 @@ onMounted(refreshStats)
         <i class="ti ti-photo" :class="$style.sectionIcon" />
         <span :class="$style.sectionTitle">画像キャッシュ</span>
       </div>
-      <p :class="$style.hint">
-        アバターや絵文字などの画像をディスクに保持します。上限を超えた分と期限切れは古いものから自動で削除されます。
-      </p>
-      <label :class="$style.field">
-        <span :class="$style.fieldLabel">上限</span>
-        <input
-          v-model.number="imageCacheMaxMB"
-          type="number"
-          min="64"
-          max="4096"
-          step="64"
-          :class="$style.numberInput"
-        />
-        <span :class="$style.fieldUnit">MB</span>
-      </label>
-      <label :class="$style.field">
-        <span :class="$style.fieldLabel">保持期間</span>
-        <input
-          v-model.number="imageCacheTTLDays"
-          type="number"
-          min="1"
-          max="30"
-          step="1"
-          :class="$style.numberInput"
-        />
-        <span :class="$style.fieldUnit">日</span>
-      </label>
+      <div :class="$style.fieldRow">
+        <label :class="$style.field">
+          <span :class="$style.fieldLabel">上限</span>
+          <input
+            v-model.number="imageCacheMaxMB"
+            type="number"
+            min="64"
+            max="4096"
+            step="64"
+            :class="$style.numberInput"
+          />
+          <span :class="$style.fieldUnit">MB</span>
+        </label>
+        <label :class="$style.field">
+          <span :class="$style.fieldLabel">保持期間</span>
+          <input
+            v-model.number="imageCacheTTLDays"
+            type="number"
+            min="1"
+            max="30"
+            step="1"
+            :class="$style.numberInput"
+          />
+          <span :class="$style.fieldUnit">日</span>
+        </label>
+      </div>
       <div :class="$style.btnRow">
         <button
           class="_button"
@@ -349,6 +348,9 @@ onMounted(refreshStats)
 .content {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
   padding: 16px;
   gap: 0;
 }
@@ -385,7 +387,7 @@ onMounted(refreshStats)
 
 .statsRow {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 8px;
 }
 
@@ -464,21 +466,25 @@ onMounted(refreshStats)
   @include btn-action;
 }
 
+.fieldRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+
 .field {
   display: flex;
   align-items: center;
   gap: 8px;
-  margin-bottom: 8px;
 }
 
 .fieldLabel {
-  min-width: 72px;
   font-size: 13px;
   color: var(--fgTransparentWeak, #888);
 }
 
 .numberInput {
-  width: 96px;
+  width: 80px;
   padding: 4px 8px;
   border: 1px solid var(--divider, #ddd);
   border-radius: 6px;

--- a/src/components/window/ConnectionsContent.vue
+++ b/src/components/window/ConnectionsContent.vue
@@ -162,7 +162,7 @@ function classBadge(
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
 }
 

--- a/src/components/window/PerformanceEditorContent.vue
+++ b/src/components/window/PerformanceEditorContent.vue
@@ -9,7 +9,9 @@ import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
 import {
   CATEGORY_LABELS,
+  FADER_CATEGORIES,
   FIELD_META,
+  interpolateCategory,
   type PerformanceKey,
   usePerformanceStore,
 } from '@/stores/performance'
@@ -46,7 +48,7 @@ const categories = computed(() => {
   return cats
 })
 
-const expandedSections = ref<string[]>(['emoji'])
+const expandedSections = ref<string[]>([])
 
 function toggleSection(catKey: string) {
   const idx = expandedSections.value.indexOf(catKey)
@@ -70,20 +72,74 @@ function handleNumberInput(key: PerformanceKey, event: Event) {
   }
 }
 
-// --- Master slider ---
+// --- Mixer (master + category faders) ---
 
-const sliderPosition = computed(() => perfStore.sliderPosition)
-const isCustom = computed(() => sliderPosition.value === null)
-const sliderValue = computed(() =>
-  sliderPosition.value !== null ? Math.round(sliderPosition.value * 100) : 50,
-)
+// フェーダー位置は UI 側で保持する。config から毎回逆算すると、step 丸めで
+// 同じ値になる t のうち最も低い位置に吸われて、動かすたびに下へずれてしまう。
+const positions = ref<Record<string, number>>({})
+const masterValue = ref(0)
 
-function handleMasterSlider(event: Event) {
-  const t = Number((event.target as HTMLInputElement).value) / 100
-  perfStore.applySlider(t)
+/** そのカテゴリが「今の位置から作った値」のままかどうか。 */
+function matchesPosition(cat: string): boolean {
+  const patch = interpolateCategory(cat, positions.value[cat] ?? 0)
+  return Object.entries(patch).every(
+    ([key, value]) => perfStore.get(key as PerformanceKey) === value,
+  )
 }
 
-// スライダーの塗りつぶし率 (OS のボリュームバー式に左側をアクセント色で塗る)
+function syncPositions() {
+  const next: Record<string, number> = {}
+  for (const cat of FADER_CATEGORIES) {
+    next[cat] = perfStore.categoryPosition(cat).t
+  }
+  positions.value = next
+  masterValue.value = Math.round(average(Object.values(next)) * 100)
+}
+
+function average(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0) / (values.length || 1)
+}
+
+syncPositions()
+
+// リセット・インポート・コードタブ・個別項目など、ミキサー以外で値が
+// 変わったときだけ位置を取り直す (フェーダー操作中は動かさない)
+watch(
+  () => perfStore.config,
+  () => {
+    if (!FADER_CATEGORIES.every(matchesPosition)) syncPositions()
+  },
+)
+
+const channels = computed(() =>
+  FADER_CATEGORIES.map((cat) => ({
+    cat,
+    meta: CATEGORY_LABELS[cat] ?? { label: cat, short: cat, icon: 'ti-dots' },
+    t: positions.value[cat] ?? 0,
+    exact: matchesPosition(cat),
+  })),
+)
+
+/** マスターは VCA 式: 各チャンネルの相対差を保ったまま全体を上下させる。 */
+function handleMasterFader(event: Event) {
+  const next = Number((event.target as HTMLInputElement).value)
+  const delta = (next - masterValue.value) / 100
+  masterValue.value = next
+  for (const cat of FADER_CATEGORIES) {
+    const t = Math.min(1, Math.max(0, (positions.value[cat] ?? 0) + delta))
+    positions.value[cat] = t
+    perfStore.applyCategorySlider(cat, t)
+  }
+}
+
+function handleCategoryFader(cat: string, event: Event) {
+  const t = Number((event.target as HTMLInputElement).value) / 100
+  positions.value[cat] = t
+  perfStore.applyCategorySlider(cat, t)
+  masterValue.value = Math.round(average(Object.values(positions.value)) * 100)
+}
+
+// フェーダーの塗りつぶし率 (つまみより下をアクセント色で塗る)
 function sliderFill(value: number, min: number, max: number): string {
   return `${((value - min) / (max - min)) * 100}%`
 }
@@ -179,24 +235,50 @@ function handleReset() {
 
     <!-- Visual Tab -->
     <div v-show="tab === 'visual'" :class="$style.panel">
+      <!-- マスターは横 1 本。各チャンネルの相対差を保ったまま全体を上下させる -->
       <div :class="$style.section">
         <div :class="$style.sliderRow">
           <span :class="$style.sliderEndLabel">省メモリ</span>
           <input
             type="range"
             :class="$style.masterSlider"
-            :value="sliderValue"
+            :value="masterValue"
             min="0"
             max="100"
             step="1"
-            :style="{ '--fill': sliderFill(sliderValue, 0, 100) }"
-            @input="handleMasterSlider"
+            title="全体のバランスを保ったまま上下させる"
+            :style="{ '--fill': sliderFill(masterValue, 0, 100) }"
+            @input="handleMasterFader"
           />
           <span :class="$style.sliderEndLabel">高性能</span>
         </div>
-        <div v-if="isCustom" :class="$style.customNotice">
-          <i class="ti ti-settings" />
-          カスタム — スライダーを動かすと線形補間に戻ります
+      </div>
+
+      <!-- 分野ごとの味付けは DAW のミキサー式に縦フェーダーで -->
+      <div :class="[$style.section, $style.mixer]">
+        <div :class="$style.scale">
+          <span>高性能</span>
+          <span>省メモリ</span>
+        </div>
+        <div :class="$style.channels">
+          <div v-for="ch in channels" :key="ch.cat" :class="$style.channel">
+            <span :class="$style.channelValue">
+              {{ Math.round(ch.t * 100) }}<span v-if="!ch.exact" :class="$style.customDot">*</span>
+            </span>
+            <input
+              type="range"
+              :class="$style.fader"
+              :value="Math.round(ch.t * 100)"
+              min="0"
+              max="100"
+              step="1"
+              :title="ch.meta.label"
+              :style="{ '--fill': sliderFill(ch.t * 100, 0, 100) }"
+              @input="handleCategoryFader(ch.cat, $event)"
+            />
+            <i :class="['ti', ch.meta.icon, $style.channelIcon]" />
+            <span :class="$style.channelLabel">{{ ch.meta.short }}</span>
+          </div>
         </div>
       </div>
 
@@ -377,8 +459,6 @@ function handleReset() {
   transform: rotate(0deg);
 }
 
-// --- Slider ---
-
 .sliderRow {
   display: flex;
   align-items: center;
@@ -430,12 +510,107 @@ function handleReset() {
   }
 }
 
-.customNotice {
+// --- Mixer (DAW 風の縦フェーダー) ---
+
+$fader-height: 132px;
+
+.mixer {
+  flex-direction: row;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.scale {
   display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  // 上の値表示・下のアイコンとラベルのぶんだけ詰めてフェーダーの両端に合わせる
+  padding: 18px 0 32px;
+  font-size: 0.65em;
+  opacity: 0.5;
+  white-space: nowrap;
+}
+
+.channels {
+  display: flex;
+  flex: 1;
+  justify-content: space-between;
+  gap: 2px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.channel {
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 4px;
+  min-width: 34px;
+}
+
+.channelValue {
   font-size: 0.7em;
-  opacity: 0.4;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.7;
+}
+
+// 補間から外れた (個別に触った) チャンネルの目印
+.customDot {
+  color: var(--nd-accent);
+}
+
+.channelIcon {
+  font-size: 0.85em;
+  opacity: 0.5;
+}
+
+.channelLabel {
+  font-size: 0.65em;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+// 縦向き range。writing-mode が現行仕様で、古い WebKit 用に
+// slider-vertical も残す (効かない環境では横向きにフォールバックする)
+.fader {
+  appearance: none;
+  -webkit-appearance: slider-vertical;
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: 4px;
+  height: $fader-height;
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+  /* thumb より下を塗りつぶす (--fill は template 側で算出) */
+  background: linear-gradient(
+    to top,
+    var(--nd-accent) var(--fill, 0%),
+    var(--nd-divider) var(--fill, 0%)
+  );
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--nd-fg);
+    cursor: pointer;
+    transition: transform 0.1s;
+
+    &:hover {
+      transform: scale(1.15);
+    }
+  }
+
+  &::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    border: none;
+    border-radius: 50%;
+    background: var(--nd-fg);
+    cursor: pointer;
+  }
 }
 
 // --- Fields ---
@@ -555,8 +730,6 @@ function handleReset() {
   opacity: 0.4;
   line-height: 1.3;
 }
-
-// --- Code Tab ---
 
 .codePanel {
   display: flex;

--- a/src/components/window/ai-settings/AiConnectionSection.vue
+++ b/src/components/window/ai-settings/AiConnectionSection.vue
@@ -118,7 +118,7 @@ function openConnectionsWindow(): void {
       v-model="currentModel"
       :class="$style.input"
       type="text"
-      placeholder="claude-sonnet-5, gpt-5.4-mini, deepseek/deepseek-v4-pro など"
+      placeholder="claude-sonnet-5, gpt-5.4-mini, moonshotai/kimi-k3 など"
     />
   </AiSettingsSection>
 </template>

--- a/src/composables/useUpdater.ts
+++ b/src/composables/useUpdater.ts
@@ -6,6 +6,8 @@ const isUpToDate = ref(false)
 const updateAvailable = ref(false)
 const updateVersion = ref('')
 const isInstalling = ref(false)
+/** 差し替えが済み、再起動を待っている状態 (Windows は到達しない — 下記参照) */
+const updateReady = ref(false)
 /** ダウンロード進捗 (0-100)。contentLength 不明時は null のまま */
 const downloadProgress = ref<number | null>(null)
 const updateError = ref<string | null>(null)
@@ -62,8 +64,10 @@ async function installUpdate() {
         downloadProgress.value = 100
       }
     })
-    const { relaunch } = await import('@tauri-apps/plugin-process')
-    await relaunch()
+    // 差し替えが済んだら再起動はユーザーに委ねる (VSCode の "Restart to Update")。
+    // Windows は installer 起動時にアプリが終了するのでここには到達しない。
+    isInstalling.value = false
+    updateReady.value = true
   } catch (e) {
     console.error('[updater] install failed:', e)
     updateError.value =
@@ -73,6 +77,11 @@ async function installUpdate() {
   }
 }
 
+async function restartToUpdate() {
+  const { relaunch } = await import('@tauri-apps/plugin-process')
+  await relaunch()
+}
+
 export function useUpdater() {
   return {
     isChecking,
@@ -80,9 +89,11 @@ export function useUpdater() {
     updateAvailable,
     updateVersion,
     isInstalling,
+    updateReady,
     downloadProgress,
     updateError,
     checkForUpdate,
     installUpdate,
+    restartToUpdate,
   }
 }

--- a/src/data/connectionTemplates.ts
+++ b/src/data/connectionTemplates.ts
@@ -6,7 +6,7 @@
  * テンプレ id は `builtin:<id>@<version>` 形式 — v2 で MisStore 配布の
  * `@<author>/<id>@<version>` 形式と名前空間を分離するための予約。
  *
- * v1 では AI プロバイダー 3 種のみ。GitHub / Linear / Slack 等の汎用 API
+ * v1 では AI プロバイダー 4 種のみ。GitHub / Linear / Slack 等の汎用 API
  * テンプレは需要を見て v1.x で追加する (手動追加 / URL ペーストは現状でも可)。
  */
 
@@ -71,6 +71,19 @@ export const BUILTIN_TEMPLATES: ConnectionTemplate[] = [
     secretHelpUrl: 'https://console.anthropic.com/settings/keys',
     protocol: 'anthropic',
     defaultModel: 'claude-sonnet-5',
+  },
+  {
+    id: 'builtin:grok@1',
+    name: 'Grok',
+    icon: 'brand-x',
+    baseUrl: 'https://api.x.ai/v1',
+    authType: { kind: 'bearer' },
+    allowedHosts: ['api.x.ai'],
+    testPath: '/models',
+    secretLabel: 'API Key',
+    secretHelpUrl: 'https://console.x.ai/',
+    protocol: 'openai-compat',
+    defaultModel: 'grok-4.5',
   },
   {
     id: 'builtin:openrouter@1',

--- a/src/data/connectionTemplates.ts
+++ b/src/data/connectionTemplates.ts
@@ -96,7 +96,7 @@ export const BUILTIN_TEMPLATES: ConnectionTemplate[] = [
     secretLabel: 'API Key',
     secretHelpUrl: 'https://openrouter.ai/keys',
     protocol: 'openai-compat',
-    defaultModel: 'deepseek/deepseek-v4-pro',
+    defaultModel: 'moonshotai/kimi-k3',
   },
 ]
 

--- a/src/stores/performance.ts
+++ b/src/stores/performance.ts
@@ -80,12 +80,17 @@ export interface PerformanceConfig {
 export type PerformanceKey = keyof PerformanceConfig
 
 export {
+  CATEGORY_KEYS,
   CATEGORY_LABELS,
   CSS_BASE_DURATIONS,
+  categoryKeys,
   DEFAULTS,
+  detectPosition,
   detectSliderPosition,
+  FADER_CATEGORIES,
   FIELD_META,
   type FieldMeta,
+  interpolateCategory,
   interpolateConfig,
   SLIDER_HIGH,
   SLIDER_LOW,
@@ -93,9 +98,12 @@ export {
 
 import {
   CSS_BASE_DURATIONS,
+  categoryKeys,
   DEFAULTS,
+  detectPosition,
   detectSliderPosition,
   FIELD_META,
+  interpolateCategory,
   interpolateConfig,
 } from '@/stores/performanceData'
 
@@ -345,6 +353,30 @@ export const usePerformanceStore = defineStore('performance', () => {
     applySideEffects()
   }
 
+  /** Apply a per-category fader position — そのカテゴリの key だけを補間する。 */
+  function applyCategorySlider(category: string, t: number) {
+    const target = interpolateCategory(category, t)
+    const updated: Partial<PerformanceConfig> = { ...overrides.value }
+    for (const [key, value] of Object.entries(target) as [
+      PerformanceKey,
+      number,
+    ][]) {
+      if (value === DEFAULTS[key]) {
+        delete updated[key]
+      } else {
+        ;(updated as Record<string, number>)[key] = value
+      }
+    }
+    overrides.value = updated
+    schedulePersist()
+    applySideEffects()
+  }
+
+  /** Current fader position of a category (常に位置を返し、ズレは exact=false で示す)。 */
+  function categoryPosition(category: string): { t: number; exact: boolean } {
+    return detectPosition(config.value, categoryKeys(category))
+  }
+
   /** Current slider position (0–1), or null if config doesn't match any interpolation point. */
   const sliderPosition = computed<number | null>(() => {
     return detectSliderPosition(config.value)
@@ -365,6 +397,8 @@ export const usePerformanceStore = defineStore('performance', () => {
     resetKey,
     resetAll,
     applySlider,
+    applyCategorySlider,
+    categoryPosition,
     isCustomized,
   }
 })

--- a/src/stores/performanceData.test.ts
+++ b/src/stores/performanceData.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  categoryKeys,
+  detectPosition,
+  FADER_CATEGORIES,
+  interpolateCategory,
+  interpolateConfig,
+  interpolateKey,
+  SLIDER_HIGH,
+  SLIDER_LOW,
+} from '@/stores/performanceData'
+
+describe('interpolateKey', () => {
+  it('両端は SLIDER_LOW / SLIDER_HIGH そのもの', () => {
+    expect(interpolateKey('noteStoreMax', 0)).toBe(SLIDER_LOW.noteStoreMax)
+    expect(interpolateKey('noteStoreMax', 1)).toBe(SLIDER_HIGH.noteStoreMax)
+    expect(interpolateKey('streamPollingInterval', 0)).toBe(
+      SLIDER_LOW.streamPollingInterval,
+    )
+    expect(interpolateKey('streamPollingInterval', 1)).toBe(
+      SLIDER_HIGH.streamPollingInterval,
+    )
+  })
+
+  it('中点は対数補間なので線形の中点より低い (増加キー)', () => {
+    // 800 → 3000: 線形なら 1900、対数なら √(800×3000) ≒ 1549
+    const mid = interpolateKey('noteStoreMax', 0.5)
+    expect(mid).toBeLessThan(1900)
+    expect(mid).toBeGreaterThan(SLIDER_LOW.noteStoreMax)
+  })
+
+  it('値が下がるキーも対数で単調に減る', () => {
+    // 30s → 5s
+    const values = [0, 0.25, 0.5, 0.75, 1].map((t) =>
+      interpolateKey('streamPollingInterval', t),
+    )
+    for (let i = 1; i < values.length; i++) {
+      expect(Number(values[i])).toBeLessThanOrEqual(Number(values[i - 1]))
+    }
+    expect(interpolateKey('streamPollingInterval', 0.5)).toBeLessThan(17.5) // 線形中点
+  })
+
+  it('端点に 0 を含むキーは線形にフォールバックする', () => {
+    // cssBlurLevel: 0 → 2 は対数補間が定義できない
+    expect(interpolateKey('cssBlurLevel', 0)).toBe(0)
+    expect(interpolateKey('cssBlurLevel', 0.5)).toBe(1)
+    expect(interpolateKey('cssBlurLevel', 1)).toBe(2)
+  })
+})
+
+describe('interpolateCategory', () => {
+  it('そのカテゴリの key だけを返す', () => {
+    const patch = interpolateCategory('polling', 1)
+    expect(Object.keys(patch).sort()).toEqual(
+      categoryKeys('polling').slice().sort(),
+    )
+    expect(patch.streamPollingInterval).toBe(SLIDER_HIGH.streamPollingInterval)
+  })
+
+  it('可変キーを持たないカテゴリはフェーダー対象から外れる', () => {
+    // interaction は LOW と HIGH が全て同値
+    expect(FADER_CATEGORIES).not.toContain('interaction')
+    expect(FADER_CATEGORIES).toContain('polling')
+  })
+})
+
+describe('detectPosition', () => {
+  it('フェーダーで作った値なら exact に一致する', () => {
+    const cfg = { ...interpolateConfig(0.4) }
+    const found = detectPosition(cfg, categoryKeys('polling'))
+    expect(found.exact).toBe(true)
+    // step 丸めで同じ値になる t が複数あるので、位置そのものではなく
+    // 「その位置から作り直すと同じ値になる」ことを見る
+    expect(interpolateCategory('polling', found.t)).toEqual({
+      streamPollingInterval: cfg.streamPollingInterval,
+      notificationPollInterval: cfg.notificationPollInterval,
+      chatPollInterval: cfg.chatPollInterval,
+    })
+  })
+
+  it('手で外した値は exact=false でも最も近い位置を返す', () => {
+    const cfg = { ...interpolateConfig(0.4), streamPollingInterval: 7 }
+    const found = detectPosition(cfg, categoryKeys('polling'))
+    expect(found.exact).toBe(false)
+    expect(found.t).toBeGreaterThan(0)
+    expect(found.t).toBeLessThanOrEqual(1)
+  })
+})

--- a/src/stores/performanceData.ts
+++ b/src/stores/performanceData.ts
@@ -475,18 +475,25 @@ export const FIELD_META: Record<PerformanceKey, FieldMeta> = {
   },
 }
 
-export const CATEGORY_LABELS: Record<string, { label: string; icon: string }> =
-  {
-    emoji: { label: '絵文字キャッシュ', icon: 'ti-mood-smile' },
-    note: { label: 'ノート', icon: 'ti-note' },
-    cache: { label: 'パースキャッシュ', icon: 'ti-database' },
-    realtime: { label: 'リアルタイム', icon: 'ti-bolt' },
-    backend: { label: 'バックエンド', icon: 'ti-server' },
-    css: { label: 'CSS描画', icon: 'ti-palette' },
-    polling: { label: 'ポーリング', icon: 'ti-refresh' },
-    telemetry: { label: 'テレメトリ', icon: 'ti-chart-line' },
-    interaction: { label: 'インタラクション', icon: 'ti-hand-finger' },
-  }
+/** `short` はミキサーのチャンネル名 (幅が狭いので 4 文字程度まで)。 */
+export const CATEGORY_LABELS: Record<
+  string,
+  { label: string; short: string; icon: string }
+> = {
+  emoji: { label: '絵文字キャッシュ', short: '絵文字', icon: 'ti-mood-smile' },
+  note: { label: 'ノート', short: 'ノート', icon: 'ti-note' },
+  cache: { label: 'パースキャッシュ', short: 'パース', icon: 'ti-database' },
+  realtime: { label: 'リアルタイム', short: 'リアル', icon: 'ti-bolt' },
+  backend: { label: 'バックエンド', short: 'バック', icon: 'ti-server' },
+  css: { label: 'CSS描画', short: 'CSS', icon: 'ti-palette' },
+  polling: { label: 'ポーリング', short: '取得', icon: 'ti-refresh' },
+  telemetry: { label: 'テレメトリ', short: '計測', icon: 'ti-chart-line' },
+  interaction: {
+    label: 'インタラクション',
+    short: '操作',
+    icon: 'ti-hand-finger',
+  },
+}
 
 /** Preset definitions. */
 /** Slider endpoint: t=0 (省メモリ) */
@@ -597,35 +604,109 @@ export const SLIDER_HIGH: PerformanceConfig = {
 
 export const DEFAULTS: PerformanceConfig = defaultsJson as PerformanceConfig
 
-/** Interpolate all config values linearly between SLIDER_LOW (t=0) and SLIDER_HIGH (t=1). */
+export const ALL_KEYS = Object.keys(DEFAULTS) as PerformanceKey[]
+
+/** カテゴリごとの key 一覧 (FIELD_META 由来)。 */
+export const CATEGORY_KEYS: Record<string, PerformanceKey[]> = (() => {
+  const map: Record<string, PerformanceKey[]> = {}
+  for (const key of ALL_KEYS) {
+    const cat = FIELD_META[key].category
+    const list = map[cat]
+    if (list) list.push(key)
+    else map[cat] = [key]
+  }
+  return map
+})()
+
+export function categoryKeys(category: string): PerformanceKey[] {
+  return CATEGORY_KEYS[category] ?? []
+}
+
+/**
+ * フェーダーで動かせるカテゴリ。LOW と HIGH が全て同値のカテゴリ
+ * (interaction 系の閾値など) は動かしても何も変わらないので除く。
+ */
+export const FADER_CATEGORIES = Object.keys(CATEGORY_KEYS).filter((cat) =>
+  categoryKeys(cat).some((key) => SLIDER_LOW[key] !== SLIDER_HIGH[key]),
+)
+
+/**
+ * SLIDER_LOW (t=0) と SLIDER_HIGH (t=1) の間を補間する。
+ *
+ * 件数・MB・ms は桁で効くパラメータなので対数 (幾何) 補間を使う —
+ * 線形だと 500〜10000 のようなレンジでスライダー前半の変化が体感できない。
+ * 値が下がる向きのキー (ポーリング間隔など) も同じ式でそのまま扱える。
+ * 端点に 0 を含むキーだけは対数が定義できないので線形にフォールバックする。
+ */
+export function interpolateKey(key: PerformanceKey, t: number): number {
+  const low = SLIDER_LOW[key]
+  const high = SLIDER_HIGH[key]
+  const meta = FIELD_META[key]
+  const clamp = (v: number) => Math.max(meta.min, Math.min(meta.max, v))
+  // 両端は step 丸めを通さない (プリセット値そのものに着地させる)
+  if (t <= 0) return clamp(low)
+  if (t >= 1) return clamp(high)
+  const raw =
+    low > 0 && high > 0 ? low * (high / low) ** t : low + (high - low) * t
+  return clamp(Math.round(raw / meta.step) * meta.step)
+}
+
+/** Interpolate all config values between SLIDER_LOW (t=0) and SLIDER_HIGH (t=1). */
 export function interpolateConfig(t: number): PerformanceConfig {
   const result = {} as Record<string, number>
-  for (const key of Object.keys(DEFAULTS) as PerformanceKey[]) {
-    const low = SLIDER_LOW[key]
-    const high = SLIDER_HIGH[key]
-    const meta = FIELD_META[key]
-    const raw = low + (high - low) * t
-    const snapped = Math.round(raw / meta.step) * meta.step
-    result[key] = Math.max(meta.min, Math.min(meta.max, snapped))
+  for (const key of ALL_KEYS) {
+    result[key] = interpolateKey(key, t)
   }
   return result as unknown as PerformanceConfig
 }
 
-/** Find slider position t ∈ [0,1] that matches config, or null if custom. */
-export function detectSliderPosition(cfg: PerformanceConfig): number | null {
+/** 1 カテゴリ分だけを補間した patch を返す。 */
+export function interpolateCategory(
+  category: string,
+  t: number,
+): Partial<PerformanceConfig> {
+  const patch: Record<string, number> = {}
+  for (const key of categoryKeys(category)) {
+    patch[key] = interpolateKey(key, t)
+  }
+  return patch as Partial<PerformanceConfig>
+}
+
+/**
+ * 与えられた key 群にとって現在値が最も近いフェーダー位置を返す。
+ * `exact` は補間結果と完全一致 (= フェーダーで作った値) かどうか。
+ * 一致しなくても位置を返すのは、マスターフェーダーが相対移動 (VCA) で
+ * 常に動かせるようにするため。
+ */
+export function detectPosition(
+  cfg: PerformanceConfig,
+  keys: PerformanceKey[],
+): { t: number; exact: boolean } {
+  let bestT = 0
+  let bestError = Number.POSITIVE_INFINITY
   for (let i = 0; i <= 100; i++) {
     const t = i / 100
-    const interp = interpolateConfig(t)
-    let match = true
-    for (const key of Object.keys(DEFAULTS) as PerformanceKey[]) {
-      if (cfg[key] !== interp[key]) {
-        match = false
-        break
-      }
+    let error = 0
+    let exact = true
+    for (const key of keys) {
+      const value = interpolateKey(key, t)
+      if (cfg[key] !== value) exact = false
+      const span = Math.abs(SLIDER_HIGH[key] - SLIDER_LOW[key]) || 1
+      error += Math.abs(cfg[key] - value) / span
     }
-    if (match) return t
+    if (exact) return { t, exact: true }
+    if (error < bestError) {
+      bestError = error
+      bestT = t
+    }
   }
-  return null
+  return { t: bestT, exact: false }
+}
+
+/** Find slider position t ∈ [0,1] that matches config, or null if custom. */
+export function detectSliderPosition(cfg: PerformanceConfig): number | null {
+  const { t, exact } = detectPosition(cfg, ALL_KEYS)
+  return exact ? t : null
 }
 
 /** Base durations (seconds) matching global.css :root values. */


### PR DESCRIPTION
## 変更点 (v1.24.0 → v1.25.0)

### 新機能
- `feat(performance)` パフォーマンス設定を DAW のミキサー式に作り替え。横 1 本のマスター (VCA 式) + 分野ごとの縦フェーダー 8ch。補間は対数 (幾何) 補間に変更し、桁の違う値でもスライダー全域で同じ割合ずつ変わるように
- `feat(about)` アップデート導線を hero から独立セクションへ (VSCode 式)。ダウンロード進捗バーと「再起動して更新」を追加し、インストール後の自動再起動をやめてタイミングをユーザーに委ねる
- `feat(connections)` Grok (xAI) の接続テンプレートを追加、テンプレートのグリッドを 4 列に

### 修正
- `fix(health)` ゲストアカウントの未ログインを自己診断の失敗として数えないように
- `fix(note)` モバイルサイズで「別のアカウントで…」がコマンドパレット不在のため何も起きなかったのを、ボトムシート内の 2 段選択で完結するように
- `fix(cache)` キャッシュ管理ウィンドウの内容が見切れていたのを修正 + 使用状況/画像キャッシュ設定の横並び化
- `fix(settings)` デスクトップの設定パレットで、バックアップとアピアランスがウィンドウではなく個別操作として並んでいたのをウィンドウ起動に統一
- `refactor(settings)` 設定パレットのカテゴリ分けを廃止してフラットな一覧に

### その他
- `chore(connections)` OpenRouter の既定モデルを kimi-k3 に
- `ci` winget の手動投稿ワークフロー (`workflow_dispatch`) を追加

## 既知の問題

winget ジョブは今回も失敗する見込み。`winget-releaser` は新規パッケージを作成できず、`NotedeckDev.NoteDeck` は winget-pkgs に未登録のため。初回のみ `wingetcreate new` で手動 PR を出す必要がある (v1.21.0〜v1.24.0 も同じ理由で未配信)。

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DAW-style performance mixer with a master control and per-category faders.
  * Added a compact “act as” two-step flow for account switching and actions.
  * Added a manual winget publishing workflow as a recovery path.
* **Improvements**
  * Updated updater UI to show an “アップデート” section and allow restart when ready.
  * Simplified settings access into dedicated editor screens.
  * Refined cache, connections, and About update layout for better spacing/structure.
* **Bug Fixes**
  * Guest accounts no longer trigger incorrect credential health warnings.
* **Release**
  * Updated application version to **1.25.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->