### PR TITLE
Release v1.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.25.0",
+  "version": "1.26.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.25.0"
+version = "1.26.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.25.0"
+version = "1.26.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.25.0"
+    "version": "1.26.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/ai_chat_service.rs
+++ b/src-tauri/src/ai_chat_service.rs
@@ -903,11 +903,22 @@ fn redact_secrets(s: &str) -> String {
 
 fn format_http_error(status: u16, body: &str) -> String {
     let snippet: String = redact_secrets(body).chars().take(300).collect();
+    let detail = if snippet.trim().is_empty() {
+        String::new()
+    } else {
+        format!(": {snippet}")
+    };
     match status {
-        401 | 403 => format!("APIキーが無効です (HTTP {status})"),
+        // 401 はキーそのものが通っていない。403 はキーは通っていて権限・課金
+        // 状態が理由 (クレジット不足・キーの ACL・地域制限など) なので、対処が
+        // まったく別物になる。プロバイダーが返した理由もそのまま見せる。
+        401 => format!("APIキーが無効です (HTTP {status}){detail}"),
+        403 => format!(
+            "APIキーの権限または課金状態に問題があります (HTTP {status}){detail} — プロバイダーのコンソールで残高と API キーの権限を確認してください"
+        ),
         429 => "レート制限に達しました。少し待ってから再試行してください".into(),
-        500..=599 => format!("サーバーエラー (HTTP {status}): {snippet}"),
-        _ => format!("HTTP {status}: {snippet}"),
+        500..=599 => format!("サーバーエラー (HTTP {status}){detail}"),
+        _ => format!("HTTP {status}{detail}"),
     }
 }
 
@@ -1072,6 +1083,40 @@ mod tests {
         // floor (base/2) があるので 0 秒近傍の hot-retry バーストにならない。
         assert_eq!(backoff_bounds_ms(1), (250, 500));
         assert_eq!(backoff_bounds_ms(2), (500, 1000));
+    }
+
+    #[test]
+    fn format_http_error_separates_401_from_403() {
+        // 401 は「キーが違う」、403 は「キーは通っているが権限・課金が問題」。
+        // 対処が別物なので同じ文言に丸めない。
+        let unauthorized = format_http_error(401, r#"{"error":"Incorrect API key"}"#);
+        let forbidden = format_http_error(403, r#"{"error":"Your team has no credits"}"#);
+        assert!(unauthorized.contains("APIキーが無効"));
+        assert!(!forbidden.contains("APIキーが無効"));
+    }
+
+    #[test]
+    fn format_http_error_shows_provider_reason_for_auth_errors() {
+        // プロバイダーが返した理由を捨てない (クレジット不足を「キーが無効」と
+        // 誤読させない)。
+        let msg = format_http_error(403, r#"{"error":"Your team has no credits"}"#);
+        assert!(msg.contains("Your team has no credits"));
+    }
+
+    #[test]
+    fn format_http_error_redacts_secrets_echoed_in_body() {
+        let msg = format_http_error(
+            401,
+            r#"{"error":"bad key sk-ant-abcdefghijklmnopqrstuvwxyz0123"}"#,
+        );
+        assert!(msg.contains("[REDACTED]"));
+        assert!(!msg.contains("sk-ant-"));
+    }
+
+    #[test]
+    fn format_http_error_omits_empty_body() {
+        // ボディが空のときに ": " だけがぶら下がらない。
+        assert_eq!(format_http_error(401, ""), "APIキーが無効です (HTTP 401)");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/CommandPalette.vue
+++ b/src/components/common/CommandPalette.vue
@@ -584,6 +584,8 @@ function primaryShortcut(cmd: Command): string | null {
 </template>
 
 <style module lang="scss">
+@use '@/styles/spotlight' as *;
+
 /* ========================================
    Background overlay
    ======================================== */
@@ -724,46 +726,13 @@ function primaryShortcut(cmd: Command): string | null {
   }
 
   // AI / チュートリアルが指し示した項目を一時的に光らせる。視覚仕様は
-  // navbar / bottombar の spotlight と統一 (#576: 朱色縦グラデ 2.4s)。
+  // navbar / bottombar と共通 (@/styles/_spotlight.scss)。
   &.spotlighted {
-    position: relative;
-    isolation: isolate;
+    @include spotlight-fill;
 
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
-        color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
-        color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
-      );
-      box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
-      pointer-events: none;
-      z-index: 0;
-      animation: spotlightFill 2.4s ease-out 1 forwards;
-    }
-
-    > * {
-      position: relative;
-      z-index: 1;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      &::before {
-        animation: none;
-        opacity: 1;
-      }
-    }
+    // 選択中の緑ラインと同じ位置を spotlight 色で置き換える
+    border-left-color: color-mix(in srgb, var(--nd-spotlight) 85%, transparent);
   }
-}
-
-@keyframes spotlightFill {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
 }
 
 .itemIcon {

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -998,6 +998,8 @@ function handlePickerReaction(reaction: string) {
 </template>
 
 <style lang="scss" module>
+@use '@/styles/spotlight' as *;
+
 .noteRoot {
   position: relative;
   font-size: 1.05em;
@@ -1673,34 +1675,10 @@ function handlePickerReaction(reaction: string) {
   border-top: 0.5px solid var(--nd-divider);
 }
 
-/* AI Spotlight: note 本体を朱色 glow で囲む (内容を阻害しないよう枠 only) */
+/* AI Spotlight: note 本体を glow で囲む (内容を阻害しないよう枠 only)。
+   視覚仕様は @/styles/_spotlight.scss に集約。 */
 .spotlighted {
-  &::after {
-    content: '';
-    position: absolute;
-    inset: -2px;
-    border-radius: inherit;
-    pointer-events: none;
-    box-shadow:
-      0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
-      0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
-    animation: spotlightNoteAppear 2.4s ease-out 1 forwards;
-    z-index: 2;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::after {
-      animation: none;
-      opacity: 1;
-    }
-  }
-}
-
-@keyframes spotlightNoteAppear {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
+  @include spotlight-ring;
 }
 
 /* Container query responsive breakpoints */

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -29,6 +29,7 @@ import {
 import { useConfirm } from '@/stores/confirm'
 import { useEmojisStore } from '@/stores/emojis'
 import { usePostFormStore } from '@/stores/postForm'
+import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
@@ -86,6 +87,7 @@ const settingsStore = useSettingsStore()
 const postFormStore = usePostFormStore()
 const windowsStore = useWindowsStore()
 const emojisStore = useEmojisStore()
+const serversStore = useServersStore()
 const textareaRef = ref<HTMLTextAreaElement | null>(null)
 const showPreview = computed<boolean>({
   get: () => settingsStore.get('postForm.preview') ?? false,
@@ -348,6 +350,16 @@ function toggleMfmMenu() {
   popups.closeOthers(showMfmMenu)
 }
 
+/** アカウントアバターに重ねるサーバー favicon URL を解決する。 */
+function resolveAccountServerIcon(host: string): string {
+  return (
+    serversStore.servers.get(host)?.iconUrl || `https://${host}/favicon.ico`
+  )
+}
+
+/** 2 アカウント以上ログイン中のときだけサーバーバッジを出す。 */
+const showServerBadge = computed(() => accounts.value.length >= 2)
+
 // --- Autocomplete ---
 const serverHost = computed(() => account.value?.host ?? '')
 const {
@@ -512,10 +524,18 @@ function onPaste(e: ClipboardEvent) {
               :title="getAccountLabel(account)"
               @click="showAccountMenu = !showAccountMenu"
             >
-              <img
-                :src="getAccountAvatarUrl(account)"
-                :class="$style.accountAvatar"
-              />
+              <span :class="$style.accountAvatarWrap">
+                <img
+                  :src="getAccountAvatarUrl(account)"
+                  :class="$style.accountAvatar"
+                />
+                <img
+                  v-if="showServerBadge"
+                  :src="resolveAccountServerIcon(account.host)"
+                  :class="$style.accountServerBadge"
+                  @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
+                />
+              </span>
             </button>
             <div v-if="showAccountMenu && accounts.length > 1" :class="$style.accountMenu">
               <button
@@ -526,12 +546,20 @@ function onPaste(e: ClipboardEvent) {
                 :disabled="isGuestAccount(acc)"
                 @click="acc.hasToken ? switchAccount(acc.id) : showLoginPrompt()"
               >
-                <img
-                  :src="getAccountAvatarUrl(acc)"
-                  :class="$style.accountOptionAvatar"
-                  width="24"
-                  height="24"
-                />
+                <span :class="$style.accountOptionAvatarWrap">
+                  <img
+                    :src="getAccountAvatarUrl(acc)"
+                    :class="$style.accountOptionAvatar"
+                    width="24"
+                    height="24"
+                  />
+                  <img
+                    v-if="showServerBadge"
+                    :src="resolveAccountServerIcon(acc.host)"
+                    :class="$style.accountOptionServerBadge"
+                    @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
+                  />
+                </span>
                 <div :class="$style.accountOptionInfo">
                   <span :class="$style.accountOptionName">{{ isGuestAccount(acc) ? (acc.displayName || 'ゲスト') : acc.username }}</span>
                   <span :class="$style.accountOptionHost">@{{ acc.host }}</span>
@@ -1333,11 +1361,30 @@ function onPaste(e: ClipboardEvent) {
   }
 }
 
+.accountAvatarWrap {
+  position: relative;
+  display: flex;
+}
+
 .accountAvatar {
   width: 28px;
   height: 28px;
   border-radius: 100%;
   object-fit: cover;
+}
+
+.accountServerBadge {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--nd-panel);
+  box-shadow: 0 0 0 2px var(--nd-panel);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 /* Account menu */
@@ -1377,12 +1424,31 @@ function onPaste(e: ClipboardEvent) {
   pointer-events: none;
 }
 
-.accountOptionAvatar {
+.accountOptionAvatarWrap {
+  position: relative;
+  display: flex;
   flex: 0 0 24px;
+}
+
+.accountOptionAvatar {
   width: 24px;
   height: 24px;
   border-radius: 100%;
   object-fit: cover;
+}
+
+.accountOptionServerBadge {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--nd-popup);
+  box-shadow: 0 0 0 2px var(--nd-popup);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .accountOptionInfo {

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -442,6 +442,8 @@ function close() {
 </template>
 
 <style lang="scss" module>
+@use '@/styles/spotlight' as *;
+
 .addOverlay {
   &::backdrop {
     background: var(--nd-modalBg);
@@ -599,46 +601,10 @@ function close() {
   }
 
   // AI / チュートリアルが指し示した項目を一時的に光らせる。視覚仕様は
-  // navbar / bottombar / コマンドパレットの spotlight と統一 (#576: 朱色縦グラデ 2.4s)。
+  // navbar / bottombar / コマンドパレットと共通 (@/styles/_spotlight.scss)。
   &.spotlighted {
-    position: relative;
-    isolation: isolate;
-
-    &::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
-        color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
-        color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
-      );
-      box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
-      pointer-events: none;
-      z-index: 0;
-      animation: spotlightFill 2.4s ease-out 1 forwards;
-    }
-
-    > * {
-      position: relative;
-      z-index: 1;
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      &::before {
-        animation: none;
-        opacity: 1;
-      }
-    }
+    @include spotlight-fill;
   }
-}
-
-@keyframes spotlightFill {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
 }
 
 .addCategorySection {

--- a/src/components/deck/DeckBottomBar.vue
+++ b/src/components/deck/DeckBottomBar.vue
@@ -135,6 +135,7 @@ const {
 
 <style lang="scss" module>
 @use '@/styles/buttons' as *;
+@use '@/styles/spotlight' as *;
 .root {
   --bar-item-size: 42px;
   flex: 0 0 auto;
@@ -251,60 +252,15 @@ const {
 .stackBadge { @include nav-stack-badge; }
 .badge { @include nav-badge; }
 
-// AI 操作の可視化 (Spotlight): Windows タスクバーの「新規起動」インジケーター風。
-// 朱色 #E34234 背景 + オレンジグラデーション枠線 + 上向き glow。
-// Misskey accent (#86b300, 黄緑) との warm/cool 対比で「AI 由来の出来事」を
-// 視覚的に分離しつつ、補色ではないので馴染む。
-//
+// AI 操作の可視化 (Spotlight): 視覚仕様は @/styles/_spotlight.scss に集約。
 // 既存 .tabActive が ::after で短い緑バーを描いているので、spotlight 中は
-// それを隠して朱色バー (より長い) だけ見せる。
+// それを隠して朱色のハイライトだけ見せる。
 .spotlighted {
-  position: relative;
-  isolation: isolate;
+  @include spotlight-fill;
 
-  // spotlight 中は既存アクティブバー (緑) と被らないよう隠す
   &.tabActive::after {
     display: none;
   }
-
-  // アイテム全体をクリーム→オレンジ→朱色のグラデで塗りつぶす
-  // 3 ストップで明度差を作ることでグラデが視認できる。alpha 0.85 で軽く透過。
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
-      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
-      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
-    );
-    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
-    pointer-events: none;
-    z-index: 0;
-    animation: spotlightFill 2.4s ease-out 1 forwards;
-  }
-
-  // 子要素 (アイコン/バッジ) を色レイヤーより上に持ち上げる
-  > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-      opacity: 1;
-    }
-  }
-}
-
-@keyframes spotlightFill {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
 }
 
 .actionBtn {

--- a/src/components/deck/DeckMobileNav.vue
+++ b/src/components/deck/DeckMobileNav.vue
@@ -101,6 +101,7 @@ const {
 
 <style lang="scss" module>
 @use '@/styles/buttons' as *;
+@use '@/styles/spotlight' as *;
 
 .root {
   display: flex;
@@ -183,51 +184,14 @@ const {
 .stackBadge { @include nav-stack-badge; }
 .badge { @include nav-badge; }
 
-// AI 操作の可視化 (Spotlight): Windows タスクバー風アンダーバー (朱色 + オレンジ枠)。
-// 既存 .active が ::after で短い緑バーを描くので、spotlight 中は隠して朱色バー優先。
+// AI 操作の可視化 (Spotlight): 視覚仕様は @/styles/_spotlight.scss に集約。
+// 既存 .active が ::after で短い緑バーを描くので、spotlight 中は隠す。
 .spotlighted {
-  position: relative;
-  isolation: isolate;
+  @include spotlight-fill;
 
   &.active::after {
     display: none;
   }
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
-      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
-      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
-    );
-    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
-    pointer-events: none;
-    z-index: 0;
-    animation: spotlightFill 2.4s ease-out 1 forwards;
-  }
-
-  > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-      opacity: 1;
-    }
-  }
-}
-
-@keyframes spotlightFill {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
 }
 
 </style>

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -776,6 +776,7 @@ defineExpose({
 
 <style lang="scss" module>
 @use '@/styles/buttons' as *;
+@use '@/styles/spotlight' as *;
 @use '@/styles/navMenu';
 
 .wrapper {
@@ -921,49 +922,10 @@ defineExpose({
   }
 }
 
-// AI 操作の可視化 (Spotlight): Windows タスクバー風アンダーバー (朱色 + オレンジ枠)。
-// 現状 MVP では emit されないが、Phase 2 のサイドバー toggle 系 capability で
-// 自動的に光るよう infrastructure として常駐。.sidebarActive は背景色のみで
-// ::after/::before を使わないので隠す処理は不要。
+// AI 操作の可視化 (Spotlight): 視覚仕様は @/styles/_spotlight.scss に集約。
+// .sidebarActive は背景色のみで ::after/::before を使わないので隠す処理は不要。
 .spotlighted {
-  position: relative;
-  isolation: isolate;
-
-  &::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--nd-warn) 55%, transparent) 0%,
-      color-mix(in srgb, var(--nd-warn) 30%, transparent) 50%,
-      color-mix(in srgb, var(--nd-warn) 5%, transparent) 100%
-    );
-    box-shadow: 0 -1px 8px color-mix(in srgb, var(--nd-warn) 25%, transparent);
-    pointer-events: none;
-    z-index: 0;
-    animation: spotlightFill 2.4s ease-out 1 forwards;
-  }
-
-  > * {
-    position: relative;
-    z-index: 1;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-      opacity: 1;
-    }
-  }
-}
-
-@keyframes spotlightFill {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
+  @include spotlight-fill;
 }
 
 .onlineActive {
@@ -1032,30 +994,9 @@ defineExpose({
   position: relative;
 }
 
-/* AI Spotlight: account.switch でこの行を朱色 glow で囲む */
-.accountPopupItem.spotlighted::after {
-  content: '';
-  position: absolute;
-  inset: -2px;
-  border-radius: inherit;
-  pointer-events: none;
-  box-shadow:
-    0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
-    0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
-  animation: spotlightAccountAppear 2.4s ease-out 1 forwards;
-  z-index: 2;
-}
-@media (prefers-reduced-motion: reduce) {
-  .accountPopupItem.spotlighted::after {
-    animation: none;
-    opacity: 1;
-  }
-}
-@keyframes spotlightAccountAppear {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
+/* AI Spotlight: account.switch でこの行の外周を光らせる (中身は潰さない) */
+.accountPopupItem.spotlighted {
+  @include spotlight-ring;
 }
 
 .accountPopupBtn {

--- a/src/components/deck/DeckWindow.vue
+++ b/src/components/deck/DeckWindow.vue
@@ -401,6 +401,8 @@ onBeforeUnmount(() => {
 </template>
 
 <style lang="scss" module>
+@use '@/styles/spotlight' as *;
+
 .deckWindow {
   position: fixed;
   left: 0;
@@ -443,19 +445,10 @@ onBeforeUnmount(() => {
 
 // AI 操作の可視化 (Spotlight): dispatcher が windows.open / windows.focus
 // 成功時に光らせる。塗りつぶしだとウィンドウ内容が読めなくなるので、
-// 外周の朱色 glow で「この window が AI 由来で操作された」ことだけ示す。
+// 外周の glow で「この window が AI 由来で操作された」ことだけ示す。
+// 視覚仕様は @/styles/_spotlight.scss に集約。
 .spotlighted {
-  &::after {
-    content: '';
-    position: absolute;
-    inset: -2px;
-    border-radius: inherit;
-    pointer-events: none;
-    box-shadow:
-      0 0 0 2px color-mix(in srgb, var(--nd-warn) 70%, transparent),
-      0 0 24px 8px color-mix(in srgb, var(--nd-warn) 40%, transparent);
-    animation: spotlightWindowAppear 2.4s ease-out 1 forwards;
-  }
+  @include spotlight-ring;
 
   // モバイルはウィンドウが画面端に張り付くため、外側 (inset:-2px) の光が
   // viewport 外にはみ出て上辺しか見えない。内側に、かつ content
@@ -464,23 +457,9 @@ onBeforeUnmount(() => {
     inset: 0;
     z-index: 4;
     box-shadow:
-      inset 0 0 0 2px color-mix(in srgb, var(--nd-warn) 80%, transparent),
-      inset 0 0 24px 8px color-mix(in srgb, var(--nd-warn) 35%, transparent);
+      inset 0 0 0 1.5px color-mix(in srgb, var(--nd-spotlight) 85%, transparent),
+      inset 0 0 24px 4px color-mix(in srgb, var(--nd-spotlight) 30%, transparent);
   }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::after {
-      animation: none;
-      opacity: 1;
-    }
-  }
-}
-
-@keyframes spotlightWindowAppear {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  85%  { opacity: 1; }
-  100% { opacity: 0; }
 }
 
 .resizing {

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -81,14 +81,15 @@ usePortal(portalRef)
 const accountsStore = useAccountsStore()
 const serversStore = useServersStore()
 
-// Declared up-front because `topTabs` (below) reads `isOwnProfile` inside its
-// computed getter, and `useEditorTabs` triggers an immediate getter call via
-// its internal watch when wiring up tabIndex — accessing the const before its
-// declaration would throw a TDZ ReferenceError at mount time.
+// Declared up-front because `topTabs` (below) reads `isOwnProfile` / `user`
+// inside its computed getter, and `useEditorTabs` triggers an immediate getter
+// call via its internal watch when wiring up tabIndex — accessing the const
+// before its declaration would throw a TDZ ReferenceError at mount time.
 const account = computed(() =>
   accountsStore.accounts.find((a) => a.id === props.accountId),
 )
 const isOwnProfile = computed(() => account.value?.userId === props.userId)
+const user = ref<NormalizedUserDetail | null>(null)
 
 // Top-level editor-style tabs (overview / notes / files grid / reactions /
 // achievements / raw JSON). `reactions` is only surfaced when the user has
@@ -132,7 +133,11 @@ const topTabDefs = computed<TopTabDef[]>(() => {
   defs.push({ value: 'pages', icon: 'note', label: 'ページ' })
   defs.push({ value: 'play', icon: 'player-play', label: 'Play' })
   defs.push({ value: 'gallery', icon: 'icons', label: 'ギャラリー' })
-  defs.push({ value: 'lists', icon: 'list', label: 'リスト' })
+  // users/lists/list はリモートユーザーの userId を渡すと
+  // REMOTE_USER_NOT_ALLOWED を返すため、リモートユーザーではタブごと出さない。
+  if (!user.value?.host) {
+    defs.push({ value: 'lists', icon: 'list', label: 'リスト' })
+  }
   defs.push({ value: 'clips', icon: 'paperclip', label: 'クリップ' })
   defs.push({ value: 'achievements', icon: 'medal', label: '実績' })
   defs.push({ value: 'raw', icon: 'code', label: 'Raw' })
@@ -145,8 +150,6 @@ const { tab: topTab, containerRef: profileRef } = useEditorTabs<TopTab>(
   topTabs,
   'overview',
 )
-
-const user = ref<NormalizedUserDetail | null>(null)
 
 // User memo (#458) の編集 UI は UserProfileHero が所有する。ここでは表示可否と
 // 保存成功時の user への反映 (prop 直接変異を避ける) のみ持つ。

--- a/src/components/window/ai-settings/AiConnectionSection.vue
+++ b/src/components/window/ai-settings/AiConnectionSection.vue
@@ -90,10 +90,7 @@ function openConnectionsWindow(): void {
         <i v-else class="ti ti-plug" :class="$style.connOptionIcon" />
         <div :class="$style.connOptionMain">
           <div :class="$style.connOptionName">{{ conn.name }}</div>
-          <div :class="$style.connOptionDesc">
-            {{ conn.protocol === 'anthropic' ? 'Anthropic' : 'OpenAI 互換' }}
-            · {{ conn.baseUrl }}
-          </div>
+          <div :class="$style.connOptionDesc">{{ conn.baseUrl }}</div>
         </div>
       </label>
       <div v-if="aiConnections.length === 0" :class="$style.connEmpty">

--- a/src/styles/_spotlight.scss
+++ b/src/styles/_spotlight.scss
@@ -1,0 +1,89 @@
+// AI Spotlight (#576) — AI / チュートリアルが操作した UI 要素を一時的に光らせる。
+// 見た目を全コンポーネントで揃えるため、視覚仕様の source of truth はここ 1 箇所。
+// 色 (--nd-spotlight / --nd-spotlightAlt = テーマの warning 色に連動) と
+// keyframes (nd-spotlight-*) は src/styles/global.css にある。
+// 持続時間 2.4s は useSpotlight.ts の DEFAULT_DURATION_MS と対応。
+//
+//   spotlight-fill : ナビボタン / タブ / リスト項目など、面ごと光らせてよい要素
+//   spotlight-ring : ウィンドウ / ノートなど、中身を邪魔せず外周だけ光らせる要素
+
+// 面ハイライト。ベタ塗りではなく「薄いティント + 1px の縁 + 白い光の帯が
+// 1 回走る」構成にして、下の文字やアイコンを潰さずに視線だけ引く。
+@mixin spotlight-fill {
+  position: relative;
+  isolation: isolate;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: 0;
+    // レイヤー 1: 白のスペキュラースイープ / レイヤー 2: warning 色のティント
+    background:
+      linear-gradient(
+        100deg,
+        transparent 40%,
+        rgba(255, 255, 255, 0.32) 50%,
+        transparent 60%
+      ),
+      linear-gradient(
+        115deg,
+        color-mix(in srgb, var(--nd-spotlight) 22%, transparent),
+        color-mix(in srgb, var(--nd-spotlightAlt) 14%, transparent)
+      );
+    background-size: 260% 100%, auto;
+    background-position: 155% 0, 0 0;
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--nd-spotlight) 55%, transparent),
+      0 0 14px -2px color-mix(in srgb, var(--nd-spotlight) 50%, transparent);
+    animation:
+      nd-spotlight-in 2.4s var(--nd-ease-decel) 1 forwards,
+      nd-spotlight-sweep 1.1s var(--nd-ease-decel) 0.05s 1 both;
+  }
+
+  // アイコン / ラベル / バッジを色レイヤーより前面に
+  > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::before {
+      animation: none;
+      opacity: 1;
+      // スイープの白帯を要素外へ逃がして静止ティントだけ残す
+      background-position: -60% 0, 0 0;
+    }
+  }
+}
+
+// 外周リング。中身を読ませたまま「この面が AI 由来で動いた」ことだけ示す。
+@mixin spotlight-ring($inset: -2px, $z: 2) {
+  &::after {
+    content: '';
+    position: absolute;
+    inset: $inset;
+    border-radius: inherit;
+    pointer-events: none;
+    z-index: $z;
+    background: linear-gradient(
+      115deg,
+      color-mix(in srgb, var(--nd-spotlight) 8%, transparent),
+      color-mix(in srgb, var(--nd-spotlightAlt) 4%, transparent)
+    );
+    box-shadow:
+      0 0 0 1.5px color-mix(in srgb, var(--nd-spotlight) 75%, transparent),
+      0 0 20px 2px color-mix(in srgb, var(--nd-spotlight) 30%, transparent),
+      inset 0 0 12px color-mix(in srgb, var(--nd-spotlightAlt) 18%, transparent);
+    animation: nd-spotlight-ring-in 2.4s var(--nd-ease-decel) 1 forwards;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      animation: none;
+      opacity: 1;
+    }
+  }
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -86,6 +86,11 @@
   --nd-statusUnknown: #888;
   /* Navbar polling mode (Misskey テーマ標準キーに紫が無いため独自) */
   --nd-modePolling: #9c27b0;
+  /* AI Spotlight — AI 由来の UI 操作を示す色。テーマの warning 色に連動する
+     (カスタムテーマを入れ替えるとハイライトも追従)。Alt は明度を上げた相方で、
+     2 色のデュオトーングラデにして単色べた塗りに見えないようにする。 */
+  --nd-spotlight: var(--nd-warn);
+  --nd-spotlightAlt: color-mix(in srgb, var(--nd-warn) 58%, #fff);
   /* Footer action hover */
   --nd-replyHover: #3b97c4;
   --nd-reactionHover: #e5a400;
@@ -768,6 +773,32 @@ dialog._nativeDialog[open] {
 @keyframes nd-note-highlight {
   from { background-color: var(--nd-accentedBg); }
   to   { background-color: transparent; }
+}
+
+/* AI Spotlight (#576) — 視覚仕様の実体は src/styles/_spotlight.scss。
+   keyframes だけグローバルに置いて全 CSS Module から参照する。 */
+
+/* 面ハイライト: わずかに縮んだ状態から吸着するように現れ、最後に消える */
+@keyframes nd-spotlight-in {
+  0%   { opacity: 0; scale: 0.97; }
+  6%   { opacity: 1; scale: 1; }
+  80%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* スペキュラースイープ: 白い光の帯が 1 回だけ斜めに走り抜ける
+   (第 2 レイヤー = ティントは動かさないので 0 0 に固定) */
+@keyframes nd-spotlight-sweep {
+  from { background-position: 155% 0, 0 0; }
+  to   { background-position: -55% 0, 0 0; }
+}
+
+/* 外周リング: 外側からロックオンするように締まる */
+@keyframes nd-spotlight-ring-in {
+  0%   { opacity: 0; scale: 1.012; }
+  8%   { opacity: 1; scale: 1; }
+  80%  { opacity: 1; }
+  100% { opacity: 0; }
 }
 
 /* Error shake */


### PR DESCRIPTION
## v1.26.0

### Features
- feat(spotlight): AI ハイライトをティント + 光の帯に刷新
- feat(post-form): 投稿フォームのアバターにサーバーバッジを重ねる

### Fixes
- fix(ai): AI チャットの 401/403 を分けてプロバイダーの理由を表示
- fix(user-profile): リモートユーザーではリストタブを出さない

### Refactor
- refactor(ai): 接続リストからプロトコルラベルを消す

### Chore
- chore: bump version to 1.26.0
- chore: regenerate openapi.json for 1.26.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server favicon badges to account avatars when multiple accounts are available.
  * Introduced consistent Spotlight highlighting across navigation, notes, dialogs, and windows.
* **Bug Fixes**
  * Improved AI connection error messages, including provider details and secret redaction.
  * Prevented the Lists tab from appearing on remote user profiles.
  * Fixed profile initialization issues affecting tab setup.
* **Improvements**
  * Simplified AI connection descriptions to show the configured base URL.
  * Updated the application version to 1.26.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->