### PR TITLE
Release v1.27.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -416,6 +416,20 @@ Profile B ──→ Main Window（プロファイル切り替え時）
 | `ignoreSuspension` | 凍結のみ | 自分が保存した面（お気に入り・自クリップ・詳細の祖先スレッド） |
 | `ignoreSubject` | 対象由来を全て | 明示的に開いた面（プロフィール） |
 
+面別マトリクス（本家の read-time フィルタ挙動に準拠）:
+
+| 面 | opts |
+|----|------|
+| TL 全種 / リスト / アンテナ / チャンネル / ロール / メンション / explore / 検索 / 通知 | なし（全適用） |
+| お気に入り / クリップカラム（自分 + お気に入りしたクリップ） | `ignoreSuspension` |
+| クリップ詳細ウィンドウ | 自分のクリップなら `ignoreSuspension`、他人なら なし |
+| ノート詳細・Lookup の本体ノート | 述語を通さない |
+| ノート詳細・Lookup の祖先スレッド | `ignoreSuspension` |
+| ノート詳細・Lookup の返信ツリー | なし |
+| プロフィール（ノート / ファイル / ユーザーカラム） | `ignoreSubject` |
+
+カラム系は `NoteColumnConfig.visibility` で指定し `useNoteList` へ透過する。独自 ref の面は `filterVisible(notes, opts)` を表示用 computed で使う（書込基底は unfiltered のまま）。「見えているもの」の下流供給（`reportVisibleItems`）には述語適用後を渡す。
+
 **凍結ストア（`stores/suspensions.ts`）:**
 
 サーバーで凍結（または削除）されたユーザーの per-account 集合。mutes は「自分の意思」、こちらは「サーバー側の事実」なので相乗りさせない。SQLite キャッシュは触らないので、凍結解除で自動的に表示が戻る。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -405,6 +405,25 @@ Profile B ──→ Main Window（プロファイル切り替え時）
 
 バッファ末尾を位置決めに使うと、ページが丸ごとフィルタで落ちたとき位置が前進せず、`loadMore` が同じページを取り続ける無限ループになる。
 
+**表示述語 `useNoteVisibility().isHidden(note, opts?)`:**
+
+判定材料は 2 種類に分かれる。**対象由来**（ユーザーミュート [#574](https://github.com/notedeck-dev/notedeck/issues/574) / インスタンスミュート [#613](https://github.com/notedeck-dev/notedeck/issues/613) / リノートミュート [#614](https://github.com/notedeck-dev/notedeck/issues/614) / 凍結 [#828](https://github.com/notedeck-dev/notedeck/issues/828)）は「誰か」に紐づき、**内容由来**（ワードミュート [#610](https://github.com/notedeck-dev/notedeck/issues/610) / 削除 tombstone [#602](https://github.com/notedeck-dev/notedeck/issues/602)）は「何が書かれているか・存在するか」に紐づく。
+
+`VisibilityOpts` は面ごとの opt-out（既定は全適用 = 安全側）:
+
+| opt | 無視する材料 | 適用面 |
+|-----|------------|--------|
+| `ignoreSuspension` | 凍結のみ | 自分が保存した面（お気に入り・自クリップ・詳細の祖先スレッド） |
+| `ignoreSubject` | 対象由来を全て | 明示的に開いた面（プロフィール） |
+
+**凍結ストア（`stores/suspensions.ts`）:**
+
+サーバーで凍結（または削除）されたユーザーの per-account 集合。mutes は「自分の意思」、こちらは「サーバー側の事実」なので相乗りさせない。SQLite キャッシュは触らないので、凍結解除で自動的に表示が戻る。
+
+検知は `users/show({ userIds })` の 3 値判定 — 応答から欠落 = 凍結（非モデレーターにはサーバーが `isSuspended:false` で絞る）/ `isSuspended === true` = 凍結（モデレーター経路）/ 返却され false = 解除。取得失敗は無更新（fail-open）。
+
+probe の供給は**挿入 1 点フック**にまとめてある（`useNoteList` の `rawNotes` setter / `DeckNotificationColumn` の `notifications` watch / `useCrossAccountNotes` の `rawNotes` watch）。経路を列挙しないので、ストリーミングやページングの取りこぼしが構造的に起きない。解除の検知はストア自身の周期タイマー（15 分・aging 付き）が担当し、カラム構成にも probe 発火にも依存しない。
+
 ### Vue Vapor モード（[#52](https://github.com/notedeck-dev/notedeck/issues/52)）— 移行準備完了
 
 Vue 3.6 の Vapor モード（仮想DOMレス・コンパイル時DOM操作）への移行準備が**完了**。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -379,6 +379,32 @@ Profile B ──→ Main Window（プロファイル切り替え時）
 
 `useColumnTabs.ts` の `COLUMN_ICONS` / `COLUMN_LABELS` がカラムタイプのアイコンとラベルの SSoT。ナビバー、ボトムバー、エディタすべてがこれを参照する。
 
+### Note List: 表示述語とフェッチカーソル（[#831](https://github.com/notedeck-dev/notedeck/issues/831)）
+
+大原則は **データは保持し、表示時に決める**。取り込み時フィルタ・物理削除は採らないため、ミュート/凍結の解除で表示が即時に復活する。
+
+**2 つの基底（`useNoteList`）:**
+
+| ref | 内容 | 用途 |
+|-----|------|------|
+| `rawNotes` | unfiltered な書込基底（writable） | 全ての read-modify-write（マージ・挿入・削除・truncate）と**同期位置の決定** |
+| `notes` | `isHidden` 述語でフィルタした表示列（readonly） | 描画・**ユーザー可視状態の判定** |
+
+読取の判別規則: `sinceId` / `untilId` / `hadNotes` / 空ガード / `refreshFetch` 引数 / キャッシュアンカーは `rawNotes`。skeleton 表示・エラー UI は `notes`。filtered を書込基底にすると、隠れているノートが書き戻しのたびに列から落ちて焼き込まれ、解除で復活しなくなる。
+
+**規約**: `rawNotes` の setter を迂回してノートを挿入する経路を増やさない（[#828](https://github.com/notedeck-dev/notedeck/issues/828) の凍結 probe が「新規挿入 1 点フック」で全経路を捕捉する前提）。
+
+**フェッチカーソル（`useNoteColumn`）:**
+
+`fetchCursor = { id, createdAt } | null` に、取り込んだ**生ページ**（`filterNotes` 適用前）の最古ノートを保持する。ページングの位置決めはバッファ末尾ではなくこれを使う。
+
+- API `loadMore` の `untilId` = `fetchCursor.id ?? rawNotes 末尾`
+- キャッシュ `loadMore` のアンカー = `fetchCursor.createdAt ?? rawNotes 末尾の createdAt`
+- 単調前進: 生ページの最古が現カーソルより古いときだけ更新（最新側ページで新しい方向へ戻さない）
+- リセット: バッファを全置換する操作（reconnect / gap catch-up / タブ切替 / 非 streaming の refresh）で null にし、置換ページから貼り直す。旧世代カーソルが残ると新バッファとの間がサイレントにスキップされる
+
+バッファ末尾を位置決めに使うと、ページが丸ごとフィルタで落ちたとき位置が前進せず、`loadMore` が同じページを取り続ける無限ループになる。
+
 ### Vue Vapor モード（[#52](https://github.com/notedeck-dev/notedeck/issues/52)）— 移行準備完了
 
 Vue 3.6 の Vapor モード（仮想DOMレス・コンパイル時DOM操作）への移行準備が**完了**。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.26.0",
+  "version": "1.27.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.26.0"
+version = "1.27.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.26.0"
+    "version": "1.27.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckClipColumn.vue
+++ b/src/components/deck/DeckClipColumn.vue
@@ -17,6 +17,10 @@ const noteColumnConfig: NoteColumnConfig = {
   cache: {
     getKey: () => (props.column.clipId ? `clip:${props.column.clipId}` : null),
   },
+  // カラム化できるのは自分のクリップとお気に入りしたクリップ（picker 経由）
+  // = 自分が保存した面なので凍結は貫通させる。他人のクリップは
+  // ClipDetail ウィンドウで開かれ、そちらは全適用（#606）
+  visibility: { ignoreSuspension: true },
 }
 
 const { rename, deleteEntity, config } = useEntityCrud(

--- a/src/components/deck/DeckFavoritesColumn.vue
+++ b/src/components/deck/DeckFavoritesColumn.vue
@@ -13,6 +13,9 @@ const noteColumnConfig: NoteColumnConfig = {
   cache: {
     getKey: () => 'favorites',
   },
+  // 自分が保存した面。凍結は貫通させる（本家 i/favorites も貫通）。
+  // ミュートは自分の意思なので適用したまま（#606）
+  visibility: { ignoreSuspension: true },
 }
 </script>
 

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -5,6 +5,7 @@ import {
   onMounted,
   ref,
   useTemplateRef,
+  watch,
 } from 'vue'
 import type { NormalizedNote, UserRelation } from '@/adapters/types'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
@@ -18,6 +19,7 @@ import MkNoteTree from '@/components/common/MkNoteTree.vue'
 import MkUserListItem from '@/components/common/MkUserListItem.vue'
 import { useColumnSetup } from '@/composables/useColumnSetup'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePortal } from '@/composables/usePortal'
 import {
   type MergedThread,
@@ -27,6 +29,7 @@ import {
 import { resolveNoteUriFor } from '@/services/entityResolution'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { mapWithConcurrency } from '@/utils/concurrency'
 import { isImeComposing } from '@/utils/ime'
 import { getNoteUri, parseUserQuery } from '@/utils/noteUrl'
@@ -111,9 +114,21 @@ function buildTree(
   return roots
 }
 
+const { filterVisible } = useNoteVisibility()
+// 凍結 probe の供給点（#828）
+watch([ancestors, children], ([a, c]) =>
+  useSuspensionsStore().probeNotes([...a, ...c]),
+)
+
+// 明示的に開いた本体ノート（result.note）は述語を通さない。祖先は文脈欠損を
+// 避けるため凍結のみ貫通、返信ツリーは一覧面なので全適用（#606）
+const visibleAncestors = computed(() =>
+  filterVisible(ancestors.value, { ignoreSuspension: true }),
+)
+
 const childrenTree = computed<NoteTreeNode[]>(() => {
   if (result.value?.type !== 'Note') return []
-  return buildTree(children.value, result.value.note.id)
+  return buildTree(filterVisible(children.value), result.value.note.id)
 })
 
 const treeHandlers = computed<NoteTreeHandlers>(() => ({
@@ -630,9 +645,9 @@ async function handlePosted(editedNoteId?: string) {
       <ColumnEmptyState v-else-if="!result" message="URLまたは@ユーザー名を入力して照会" :image-url="serverInfoImageUrl" />
 
       <div v-else-if="result.type === 'Note'" ref="lookupResultRef" :class="$style.lookupResult">
-        <div v-if="ancestors.length > 0" :class="$style.ancestors">
+        <div v-if="visibleAncestors.length > 0" :class="$style.ancestors">
           <MkNote
-            v-for="ancestor in ancestors"
+            v-for="ancestor in visibleAncestors"
             :key="ancestor.id"
             :note="ancestor"
             @react="handlers.reaction"

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -257,16 +257,8 @@ const { viewMarkerId } = useReadMarker(
   () => notifications.value[0]?.id ?? null,
 )
 
-// Report visible notifications to deckStore (汎用 visibleItems API)
 const suspensionsStore = useSuspensionsStore()
-watch(
-  notifications,
-  (items) => {
-    deckStore.reportVisibleItems(props.column.id, items)
-    probeSuspensions(items)
-  },
-  { immediate: true },
-)
+watch(notifications, (items) => probeSuspensions(items), { immediate: true })
 
 /**
  * 凍結 probe の供給点（#828）。通知リストへの全挿入（キャッシュ復元・fetch・
@@ -371,6 +363,16 @@ const visibleNotifications = computed(() =>
       }
       return n
     }),
+)
+
+// 「見えているもの」の下流供給は述語適用後を渡す（AI / インスペクタ /
+// 監査ログが隠したはずの通知を読めてしまわないように）
+watch(
+  visibleNotifications,
+  (items) => {
+    deckStore.reportVisibleItems(props.column.id, items)
+  },
+  { immediate: true },
 )
 
 const filteredNotifications = computed(() => {

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -46,6 +46,7 @@ import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
 import { usePerformanceStore } from '@/stores/performance'
 import { useServersStore } from '@/stores/servers'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
@@ -257,13 +258,37 @@ const { viewMarkerId } = useReadMarker(
 )
 
 // Report visible notifications to deckStore (汎用 visibleItems API)
+const suspensionsStore = useSuspensionsStore()
 watch(
   notifications,
   (items) => {
     deckStore.reportVisibleItems(props.column.id, items)
+    probeSuspensions(items)
   },
   { immediate: true },
 )
+
+/**
+ * 凍結 probe の供給点（#828）。通知リストへの全挿入（キャッシュ復元・fetch・
+ * merge・ストリーミング到着）はこの ref を通るので、ここ 1 点で notifier /
+ * grouped のユーザーを拾える（TTL・dedupe はストア側）。
+ */
+function probeSuspensions(items: NormalizedNotification[]) {
+  const byAccount = new Map<string, Set<string>>()
+  for (const n of items) {
+    let set = byAccount.get(n._accountId)
+    if (!set) {
+      set = new Set()
+      byAccount.set(n._accountId, set)
+    }
+    if (n.user?.id) set.add(n.user.id)
+    for (const r of n.reactions ?? []) if (r.user?.id) set.add(r.user.id)
+    for (const u of n.users ?? []) if (u?.id) set.add(u.id)
+  }
+  for (const [accountId, ids] of byAccount) {
+    suspensionsStore.probe(accountId, ids)
+  }
+}
 const followRequestStates = ref<Record<string, 'accepted' | 'rejected'>>({})
 
 // --- Notification cache helpers ---

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -28,10 +28,12 @@ const MkPostForm = defineAsyncComponent(
 import { useColumnSetup } from '@/composables/useColumnSetup'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
 import { useNoteFocus } from '@/composables/useNoteFocus'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useSearchFilters } from '@/composables/useSearchFilters'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { AppError } from '@/utils/errors'
 import { isImeComposing } from '@/utils/ime'
 import {
@@ -75,7 +77,13 @@ const {
 } = useColumnSetup(() => props.column)
 
 const { navigateToNote } = useNavigation()
-const notes = shallowRef<NormalizedNote[]>([])
+// 取得した生データ。表示用 notes は述語で隠す（#606）。検索は一覧面なので
+// opt-out なし（全材料を適用）
+const rawNotes = shallowRef<NormalizedNote[]>([])
+const { filterVisible } = useNoteVisibility()
+const notes = computed(() => filterVisible(rawNotes.value))
+// 凍結 probe の供給点（#828）。独自 ref の面は fetch 完了時に自前で probe する
+watch(rawNotes, (items) => useSuspensionsStore().probeNotes(items))
 const noteScrollerRef = ref<{
   getElement: () => HTMLElement | null
   scrollToIndex: (
@@ -91,7 +99,7 @@ watch(
   { flush: 'post' },
 )
 setOnNotesMutated(() => {
-  notes.value = [...notes.value]
+  rawNotes.value = [...rawNotes.value]
 })
 const { focusedNoteId } = useNoteFocus(
   props.column.id,
@@ -245,7 +253,7 @@ async function searchLocalPerAccount(q: string, hint: string) {
       if (regexMode.value) {
         local = await filterNotesByRegexAsync(local, q)
       }
-      notes.value = local
+      rawNotes.value = local
       isPreview.value = true
       hasLocalResults.value = local.length > 0
     }
@@ -276,7 +284,7 @@ async function searchLocalCrossAccount(q: string, hint: string) {
       if (regexMode.value) {
         merged = await filterNotesByRegexAsync(merged, q)
       }
-      notes.value = mergeNotes([], merged)
+      rawNotes.value = mergeNotes([], merged)
       isPreview.value = true
       hasLocalResults.value = merged.length > 0
     }
@@ -290,7 +298,7 @@ watch(searchQuery, (val) => {
   if (debounceTimer) clearTimeout(debounceTimer)
   regexError.value = null
   if (!q) {
-    notes.value = []
+    rawNotes.value = []
     isPreview.value = false
     hasLocalResults.value = false
     return
@@ -312,7 +320,7 @@ watch(
     searchQuery.value = q
     // 手入力フローと違いプレビュー検索を経ないため、前クエリの結果に
     // server 結果が merge されないようリセットしてから検索する
-    notes.value = []
+    rawNotes.value = []
     hasLocalResults.value = false
     performSearch()
   },
@@ -375,7 +383,7 @@ async function performSearchPerAccount(q: string, hint: string) {
         local = await filterNotesByRegexAsync(local, q)
       }
       if (local.length > 0) {
-        notes.value = local
+        rawNotes.value = local
         hasLocalResults.value = true
       }
     } catch {
@@ -397,8 +405,8 @@ async function performSearchPerAccount(q: string, hint: string) {
         if (regexMode.value) {
           results = await filterNotesByRegexAsync(results, q)
         }
-        notes.value = mergeNotes(
-          hasLocalResults.value ? notes.value : [],
+        rawNotes.value = mergeNotes(
+          hasLocalResults.value ? rawNotes.value : [],
           results,
         )
       }
@@ -435,7 +443,7 @@ async function performSearchCrossAccount(q: string, hint: string) {
         merged = await filterNotesByRegexAsync(merged, q)
       }
       if (merged.length > 0) {
-        notes.value = mergeNotes([], merged)
+        rawNotes.value = mergeNotes([], merged)
         hasLocalResults.value = true
       }
     } catch {
@@ -460,7 +468,10 @@ async function performSearchCrossAccount(q: string, hint: string) {
       if (regexMode.value) {
         merged = await filterNotesByRegexAsync(merged, q)
       }
-      notes.value = mergeNotes(hasLocalResults.value ? notes.value : [], merged)
+      rawNotes.value = mergeNotes(
+        hasLocalResults.value ? rawNotes.value : [],
+        merged,
+      )
     } catch (e) {
       if (!hasLocalResults.value) {
         error.value = AppError.from(e)
@@ -479,8 +490,8 @@ async function loadMore() {
 
 async function loadMorePerAccount() {
   const adapter = getAdapter()
-  if (!adapter || isLoading.value || notes.value.length === 0) return
-  const lastNote = notes.value.at(-1)
+  if (!adapter || isLoading.value || rawNotes.value.length === 0) return
+  const lastNote = rawNotes.value.at(-1)
   if (!lastNote) return
 
   const q = confirmedQuery.value || searchQuery.value.trim()
@@ -499,7 +510,7 @@ async function loadMorePerAccount() {
     if (regexMode.value) {
       older = await filterNotesByRegexAsync(older, q)
     }
-    notes.value = mergeNotes(notes.value, older)
+    rawNotes.value = mergeNotes(rawNotes.value, older)
   } catch (e) {
     error.value = AppError.from(e)
   } finally {
@@ -508,7 +519,7 @@ async function loadMorePerAccount() {
 }
 
 async function loadMoreCrossAccount() {
-  if (isLoading.value || notes.value.length === 0) return
+  if (isLoading.value || rawNotes.value.length === 0) return
 
   const q = confirmedQuery.value || searchQuery.value.trim()
   const hint = getSearchHint(q)
@@ -523,7 +534,7 @@ async function loadMoreCrossAccount() {
         const adapter = await multiAdapters.getOrCreate(acc.id)
         if (!adapter) return []
         // Find this account's oldest note for pagination
-        const lastForAccount = [...notes.value]
+        const lastForAccount = [...rawNotes.value]
           .reverse()
           .find((n) => n._accountId === acc.id)
         return adapter.api.searchNotes(hint, {
@@ -538,7 +549,7 @@ async function loadMoreCrossAccount() {
     if (regexMode.value) {
       older = await filterNotesByRegexAsync(older, q)
     }
-    notes.value = mergeNotes(notes.value, older)
+    rawNotes.value = mergeNotes(rawNotes.value, older)
   } catch (e) {
     error.value = AppError.from(e)
   } finally {
@@ -548,23 +559,25 @@ async function loadMoreCrossAccount() {
 
 async function removeNote(note: NormalizedNote) {
   const id = note.id
-  const prevNotes = notes.value
-  notes.value = notes.value.filter((n) => n.id !== id && n.renoteId !== id)
+  const prevNotes = rawNotes.value
+  rawNotes.value = rawNotes.value.filter(
+    (n) => n.id !== id && n.renoteId !== id,
+  )
 
   if (isCrossAccount.value) {
     const adapter = await multiAdapters.getOrCreate(note._accountId)
     if (!adapter) {
-      notes.value = prevNotes
+      rawNotes.value = prevNotes
       return
     }
     try {
       await adapter.api.deleteNote(note.id)
     } catch {
-      notes.value = prevNotes
+      rawNotes.value = prevNotes
     }
   } else {
     if (!(await handlers.delete(note))) {
-      notes.value = prevNotes
+      rawNotes.value = prevNotes
     }
   }
 }
@@ -574,7 +587,7 @@ async function handlePosted(editedNoteId?: string) {
   if (editedNoteId) {
     let adapter: Awaited<ReturnType<typeof multiAdapters.getOrCreate>> = null
     if (isCrossAccount.value) {
-      const note = notes.value.find((n) => n.id === editedNoteId)
+      const note = rawNotes.value.find((n) => n.id === editedNoteId)
       if (note) adapter = await multiAdapters.getOrCreate(note._accountId)
     } else {
       adapter = getAdapter()
@@ -582,7 +595,7 @@ async function handlePosted(editedNoteId?: string) {
     if (!adapter) return
     try {
       const updated = await adapter.api.getNote(editedNoteId)
-      notes.value = notes.value.map((n) =>
+      rawNotes.value = rawNotes.value.map((n) =>
         n.id === editedNoteId
           ? updated
           : n.renoteId === editedNoteId

--- a/src/components/deck/DeckUserColumn.vue
+++ b/src/components/deck/DeckUserColumn.vue
@@ -32,6 +32,9 @@ const noteColumnConfig: NoteColumnConfig = {
     const fetched = await adapter.api.getUserNotes(userId)
     return { notes: fetched, mode: 'replace' as const }
   },
+  // 明示的に開いた対象なので、対象由来の材料（ミュート・凍結）は貫通させる。
+  // ワードミュートと削除 tombstone は内容由来なので適用したまま（#606）
+  visibility: { ignoreSubject: true },
 }
 </script>
 

--- a/src/components/window/ClipDetailContent.vue
+++ b/src/components/window/ClipDetailContent.vue
@@ -6,6 +6,7 @@ import type { Clip } from '@/bindings'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkNote from '@/components/common/MkNote.vue'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePaginatedList } from '@/composables/usePaginatedList'
 import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
@@ -53,6 +54,13 @@ const {
 
 const isOwnClip = computed(
   () => !!clip.value && clip.value.userId === account.value?.userId,
+)
+
+// 自分のクリップは「自分が保存した面」なので凍結を貫通させる。他人のクリップは
+// 一覧面と同じ全適用（本家 clips/notes も凍結を弾く）（#606）
+const { filterVisible } = useNoteVisibility()
+const visibleNotes = computed(() =>
+  filterVisible(notes.value, { ignoreSuspension: isOwnClip.value }),
 )
 
 const clipWebUrl = computed(() => {
@@ -175,7 +183,7 @@ onMounted(async () => {
 
       <div :class="$style.notes">
         <MkNote
-          v-for="note in notes"
+          v-for="note in visibleNotes"
           :key="note.id"
           :note="note"
           :account-id="accountId"
@@ -189,7 +197,7 @@ onMounted(async () => {
           is-error
         />
         <ColumnEmptyState
-          v-else-if="notes.length === 0"
+          v-else-if="visibleNotes.length === 0"
           message="クリップにノートがありません"
         />
       </div>

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -32,10 +32,12 @@ const MkPostForm = defineAsyncComponent(
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
 import { useNoteCapture } from '@/composables/useNoteCapture'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePortal } from '@/composables/usePortal'
 import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { useIsCompactLayout } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { proxyUrl } from '@/utils/imageProxy'
@@ -373,9 +375,21 @@ function buildTree(
   return roots
 }
 
+const { filterVisible } = useNoteVisibility()
+// 凍結 probe の供給点（#828）
+watch([ancestors, children], ([a, c]) =>
+  useSuspensionsStore().probeNotes([...a, ...c]),
+)
+
+// 明示的に開いた本体ノートは述語を通さない。祖先は文脈欠損を避けるため凍結の
+// み貫通（本家 notes/conversation も貫通）、返信ツリーは一覧面なので全適用（#606）
+const visibleAncestors = computed(() =>
+  filterVisible(ancestors.value, { ignoreSuspension: true }),
+)
+
 const childrenTree = computed<NoteTreeNode[]>(() => {
   if (!note.value) return []
-  return buildTree(children.value, note.value.id)
+  return buildTree(filterVisible(children.value), note.value.id)
 })
 
 const treeHandlers = computed<NoteTreeHandlers>(() => ({
@@ -427,9 +441,9 @@ async function handlePosted(editedNoteId?: string) {
     </div>
 
     <div v-else-if="note" :class="$style.noteDetail">
-      <div v-if="ancestors.length > 0" :class="$style.ancestors">
+      <div v-if="visibleAncestors.length > 0" :class="$style.ancestors">
         <MkNote
-          v-for="ancestor in ancestors"
+          v-for="ancestor in visibleAncestors"
           :key="ancestor.id"
           :note="ancestor"
           @react="handleReaction"

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -56,6 +56,7 @@ const UserActivityPvChart = defineAsyncComponent(
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePaginatedList } from '@/composables/usePaginatedList'
 import { usePortal } from '@/composables/usePortal'
 import { useSensitiveMask } from '@/composables/useSensitiveMask'
@@ -209,10 +210,15 @@ const {
   maxItems: MAX_PROFILE_NOTES,
   onError: raiseWindowError,
 })
+// 明示的に開いた対象なので、対象由来の材料（ミュート・凍結）は貫通させる（#606）
+const { filterVisible } = useNoteVisibility()
+const visibleFilesNotes = computed(() =>
+  filterVisible(filesNotes.value, { ignoreSubject: true }),
+)
 // ゲスト時は withFiles フィルタが無視されて全ノートが返るため、
 // filesNotes.length === 0 ではなく実際のファイル有無で判定する
 const hasFilesContent = computed(() =>
-  filesNotes.value.some((n) => n.files.length > 0),
+  visibleFilesNotes.value.some((n) => n.files.length > 0),
 )
 
 // Reactions top-tab. Each entry pairs a reaction type with the note it was
@@ -706,7 +712,7 @@ async function handlePosted(editedNoteId?: string) {
         </div>
 
         <div v-show="topTab === 'files'" :class="$style.filesPane">
-          <UserProfileFileGrid :account-id="accountId" :notes="filesNotes" />
+          <UserProfileFileGrid :account-id="accountId" :notes="visibleFilesNotes" />
           <div v-if="isLoadingFiles" :class="$style.stateMessage">
             <LoadingSpinner />
           </div>

--- a/src/components/window/user-profile/UserProfileNotesList.vue
+++ b/src/components/window/user-profile/UserProfileNotesList.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import MkNote from '@/components/common/MkNote.vue'
+import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePaginatedList } from '@/composables/usePaginatedList'
 
 // プロフィールの notes 面 (#707): 内タブ (ハイライト/ノート/全て/ファイル付き)
@@ -100,6 +101,13 @@ onMounted(() => {
   void loadTabNotes()
 })
 
+// 明示的に開いた対象なので、対象由来の材料（ミュート・凍結）は貫通させる。
+// ワードミュートと削除 tombstone は内容由来なので適用したまま（#606）
+const { filterVisible } = useNoteVisibility()
+const visibleNotes = computed(() =>
+  filterVisible(notes.value, { ignoreSubject: true }),
+)
+
 /** 親の削除 handler から呼ぶ (リノート元の削除も波及させる) */
 function removeNote(id: string) {
   notes.value = notes.value.filter((n) => n.id !== id && n.renoteId !== id)
@@ -131,7 +139,7 @@ defineExpose({ loadMore, removeNote, replaceNote })
     </div>
 
     <MkNote
-      v-for="note in notes"
+      v-for="note in visibleNotes"
       :key="note.id"
       :note="note"
       :pinned-note-ids="pinnedNoteIds"
@@ -150,7 +158,7 @@ defineExpose({ loadMore, removeNote, replaceNote })
       <LoadingSpinner />
     </div>
 
-    <div v-if="!isLoadingNotes && notes.length === 0" :class="$style.stateMessage">
+    <div v-if="!isLoadingNotes && visibleNotes.length === 0" :class="$style.stateMessage">
       ノートはありません
     </div>
   </div>

--- a/src/composables/useCrossAccountNotes.ts
+++ b/src/composables/useCrossAccountNotes.ts
@@ -1,4 +1,4 @@
-import { computed, onMounted, type Ref, shallowRef } from 'vue'
+import { computed, onMounted, type Ref, shallowRef, watch } from 'vue'
 import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
 import { useMultiAccountAdapters } from '@/composables/useMultiAccountAdapters'
 import {
@@ -9,6 +9,7 @@ import { useNoteScrollerRef } from '@/composables/useNoteScrollerRef'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useAccountsStore } from '@/stores/accounts'
 import { useNoteStore } from '@/stores/notes'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { mapWithConcurrency } from '@/utils/concurrency'
 import { AppError } from '@/utils/errors'
 import { createWorkerClient } from '@/utils/workerClient'
@@ -107,6 +108,10 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
   // 取得した生データ。表示用 notes はミュート/削除を表示時に除外（#606 / #574）
   const rawNotes = shallowRef<NormalizedNote[]>([])
   const notes = computed(() => rawNotes.value.filter((n) => !isHidden(n)))
+
+  // 凍結 probe の供給点（#828）。per-account fetch 完了ごとに rawNotes が
+  // 差し替わるので、ここ 1 点で全経路を拾える（TTL・dedupe はストア側）
+  watch(rawNotes, (items) => useSuspensionsStore().probeNotes(items))
   const { noteScrollerRef } = useNoteScrollerRef(scroller)
 
   function scrollToTop() {

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -8,15 +8,22 @@ import { useUiStore } from '@/stores/ui'
 import { matchesFilter } from '@/utils/timelineFilter'
 import { type NoteColumnConfig, useNoteColumn } from './useNoteColumn'
 
-// tauri-specta bindings: 全コマンドを空成功で応答（SQLite キャッシュは空扱い）
+// tauri-specta bindings: 全コマンドを空成功で応答（SQLite キャッシュは空扱い）。
+// 呼び出しは記録し、キャッシュ系アサーションで参照する
+const bindings = vi.hoisted(() => ({
+  calls: [] as { name: string; args: unknown[] }[],
+}))
+
 vi.mock('@/bindings', () => ({
   commands: new Proxy(
     {},
     {
       get:
-        () =>
-        (..._args: unknown[]) =>
-          Promise.resolve({ status: 'ok', data: [] }),
+        (_t, name: string) =>
+        (...args: unknown[]) => {
+          bindings.calls.push({ name, args })
+          return Promise.resolve({ status: 'ok', data: [] })
+        },
     },
   ),
 }))
@@ -69,6 +76,7 @@ let apps: App[] = []
 let pinia: ReturnType<typeof createPinia>
 
 beforeEach(() => {
+  bindings.calls.length = 0
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
   pinia = createPinia()
@@ -341,5 +349,82 @@ describe('useNoteColumn: スリープ復帰 catch-up とタブ切替の gap 検�
 
     // no-op ではなく最新ページを取得し、gap なら置換される
     expect(ids(api)).toEqual(['h11', 'h10'])
+  })
+})
+
+describe('useNoteColumn: フェッチカーソル (#831 Step 0)', () => {
+  it('生ページが全件フィルタ落ちでも loadMore が前進する (API 経路)', async () => {
+    addAccount('acc-cursor-api')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h05'), note('h04')]) // 初回ページ (全件却下)
+      .mockResolvedValueOnce([])
+    const { api } = mountColumn({
+      accountId: 'acc-cursor-api',
+      fetch: (_a, opts) => fetchImpl(opts),
+      filterNotes: () => [],
+    })
+    await flush()
+    expect(ids(api)).toEqual([])
+
+    await api.loadMore()
+    await flush()
+
+    // バッファ末尾基準だと空ガードで止まり、同じページを取り続ける。
+    // カーソルは落ちたノートを含めて前進するので続きを取りに行ける
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+    expect(fetchImpl.mock.calls[1]?.[0]).toEqual({ untilId: 'h04' })
+  })
+
+  it('オフライン fallback のキャッシュ経路もカーソルの createdAt でアンカーする', async () => {
+    addAccount('acc-cursor-cache')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h05'), note('h04')]) // 初回ページ (全件却下)
+      .mockRejectedValueOnce(new Error('offline'))
+    const { api } = mountColumn({
+      accountId: 'acc-cursor-cache',
+      fetch: () => fetchImpl(),
+      filterNotes: () => [],
+    })
+    await flush()
+
+    await api.loadMore()
+    await flush()
+
+    const before = bindings.calls.find(
+      (c) => c.name === 'apiGetCachedTimelineBefore',
+    )
+    expect(before?.args[2]).toBe(note('h04').createdAt)
+  })
+
+  it('reconnect でカーソルがリセットされ、旧世代の位置から取り直さない', async () => {
+    addAccount('acc-cursor-reset')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([note('h05'), note('h04')]) // mount 時 connect
+      .mockResolvedValueOnce([note('h03')]) // loadMore
+      .mockResolvedValueOnce([note('h09')]) // reconnect (gap → 置換)
+      .mockResolvedValueOnce([])
+    const { api } = mountColumn({
+      accountId: 'acc-cursor-reset',
+      fetch: (_a, opts) => fetchImpl(opts),
+    })
+    await flush()
+
+    await api.loadMore()
+    await flush()
+    expect(fetchImpl.mock.calls[1]?.[0]).toEqual({ untilId: 'h04' })
+
+    vi.advanceTimersByTime(6000) // dedup TTL 失効
+    await api.reconnect()
+    await flush()
+    expect(ids(api)).toEqual(['h09'])
+
+    await api.loadMore()
+    await flush()
+
+    // 旧カーソル (h03) が残っていると h09 と h03 の間がスキップされる
+    expect(fetchImpl.mock.calls[3]?.[0]).toEqual({ untilId: 'h09' })
   })
 })

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -112,6 +112,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
   const {
     notes,
+    rawNotes,
     orderedIds,
     noteIds,
     setNotes,
@@ -136,7 +137,9 @@ export function useNoteColumn(config: NoteColumnConfig) {
   const toast = useToast()
   const streamingBatch = isStreaming
     ? useStreamingBatch({
-        notes,
+        // 書込基底は unfiltered 側。filtered を基底にすると隠れたノートが
+        // flush のたびに列から落ちて焼き込まれる（#831 §1.4）
+        notes: rawNotes,
         noteIds,
         scroller,
         onNewNotes: (batch) => {
@@ -244,6 +247,46 @@ export function useNoteColumn(config: NoteColumnConfig) {
   }
 
   /**
+   * フェッチカーソル（#831 §1.4）。取り込んだ「生ページ」（applyFilter 前）の
+   * 最古ノートを保持し、ページングの位置決めに使う。
+   *
+   * バッファ末尾を位置決めに使うと、ページが丸ごとフィルタで落ちたとき位置が
+   * 前進せず、loadMore が同じページを取り続ける無限ループになる。カーソルは
+   * 落ちたノートも含めて前進するため、この同型のループが構造的に消える。
+   */
+  const fetchCursor = shallowRef<{ id: string; createdAt: string } | null>(null)
+
+  function oldestOf(page: NormalizedNote[]): NormalizedNote | null {
+    let oldest: NormalizedNote | null = null
+    for (const n of page) {
+      if (!oldest || n.createdAt < oldest.createdAt) oldest = n
+    }
+    return oldest
+  }
+
+  /**
+   * 単調前進: 取り込んだページの最古が現カーソルより古いときだけ更新する。
+   * pullRefresh / resume の最新側ページでカーソルが新しい方向へ戻ることを禁止。
+   */
+  function advanceFetchCursor(page: NormalizedNote[]): void {
+    const oldest = oldestOf(page)
+    if (!oldest) return
+    const cur = fetchCursor.value
+    if (cur && oldest.createdAt >= cur.createdAt) return
+    fetchCursor.value = { id: oldest.id, createdAt: oldest.createdAt }
+  }
+
+  /**
+   * バッファを全置換する操作（reconnect / gap catch-up / タブ切替 / 非
+   * streaming の refresh）で呼ぶ。旧世代カーソルが残ると、新バッファと旧
+   * カーソルの間がページングでサイレントにスキップされる。
+   */
+  function resetFetchCursor(page: NormalizedNote[] = []): void {
+    fetchCursor.value = null
+    advanceFetchCursor(page)
+  }
+
+  /**
    * 非同期フェッチ中にタブ (cache key) が切り替わったら結果を破棄するための
    * ガード。フェッチ開始時に呼んで capture し、await 後に返り値で検査する (#651)。
    */
@@ -259,6 +302,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (!column.accountId || !cacheKey) return []
     try {
       const cached = await loadCachedTimeline(column.accountId, cacheKey)
+      advanceFetchCursor(cached)
       return applyFilter(cached)
     } catch (e) {
       logWarn(label, e)
@@ -280,6 +324,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (incoming.length === 0) return
     if (opts?.replace) {
       setNotes(incoming)
+      // 全置換なので旧世代カーソルは捨てる。置換ページ自体を新カーソルに
+      // 据える（フィルタ後の最古なので生ページより新しい側に寄りうるが、
+      // 取りこぼしは生まない）
+      resetFetchCursor(incoming)
       return
     }
     if (streamingBatch) {
@@ -322,6 +370,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     const fetched = await dedup(getDedupKey(), () =>
       config.fetch(adapter, opts),
     )
+    advanceFetchCursor(fetched)
     // REST 取得もキャッシュ・ストリーミングと同じ防御フィルタを通す (#651)
     return applyFilter(fetched)
   }
@@ -394,6 +443,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
       : null
     if (snapshot) {
       setNotes(snapshot.notes)
+      resetFetchCursor(snapshot.notes)
       const { scrollTop: savedScrollTop, anchor } = snapshot
       nextTick(() => {
         // アンカー (note id) 基準で復元し、仮想スクローラの再測定による
@@ -498,8 +548,11 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
       // Fetch fresh data from API (runs after cache is already displayed)
       const hasCached = cachedIds.length > 0
+      // 同期位置の決定は unfiltered 基底で読む（隠れた先頭ノートを飛ばさない）
       const sinceId =
-        !hasCached && notes.value.length > 0 ? notes.value[0]?.id : undefined
+        !hasCached && rawNotes.value.length > 0
+          ? rawNotes.value[0]?.id
+          : undefined
       const fetched = await fetchAndDedup(adapter, sinceId ? { sinceId } : {})
       // フェッチ中にタブが切り替わっていたら旧タブの結果を破棄 (#651)
       if (!stillCurrent()) return
@@ -527,20 +580,25 @@ export function useNoteColumn(config: NoteColumnConfig) {
     const column = config.getColumn()
     const cacheKey = config.cache?.getKey()
     if (!column.accountId || !cacheKey) return
-    const lastNote = notes.value.at(-1)
-    if (!lastNote) return
+    // createdAt ベースのページングなのでアンカーもカーソルの createdAt を使う。
+    // 全件フィルタ落ちのページでもアンカーが前進し、API 経路と同型のループが
+    // キャッシュ経路に残らない
+    const anchor =
+      fetchCursor.value?.createdAt ?? rawNotes.value.at(-1)?.createdAt
+    if (!anchor) return
     const stillCurrent = tabGuard()
     isLoading.value = true
     try {
       const older = await loadCachedTimelineBefore(
         column.accountId,
         cacheKey,
-        lastNote.createdAt,
+        anchor,
       )
       if (!stillCurrent()) return
+      advanceFetchCursor(older)
       const filtered = applyFilter(older)
       if (filtered.length > 0) {
-        setNotes(insertIntoSorted(notes.value, filtered))
+        setNotes(insertIntoSorted(rawNotes.value, filtered))
       }
     } catch (e) {
       logWarn('load-more-cache', e)
@@ -550,7 +608,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
   }
 
   async function loadMore() {
-    if (isLoading.value || notes.value.length === 0) return
+    // 空ガードは「まだ 1 ページも取っていない」の意。初回ページが全件フィルタ
+    // 落ちでもカーソルが立っていれば続きを取りに行ける
+    if (isLoading.value) return
+    if (fetchCursor.value == null && rawNotes.value.length === 0) return
     if (config.validate && !config.validate()) return
 
     // Offline: load from cache instead
@@ -561,14 +622,15 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
     const adapter = getAdapter()
     if (!adapter) return
-    const lastNote = notes.value.at(-1)
-    if (!lastNote) return
+    const untilId = fetchCursor.value?.id ?? rawNotes.value.at(-1)?.id
+    if (!untilId) return
     const stillCurrent = tabGuard()
     isLoading.value = true
     try {
-      const older = await config.fetch(adapter, { untilId: lastNote.id })
+      const older = await config.fetch(adapter, { untilId })
       if (!stillCurrent()) return
-      setNotes(insertIntoSorted(notes.value, applyFilter(older)))
+      advanceFetchCursor(older)
+      setNotes(insertIntoSorted(rawNotes.value, applyFilter(older)))
     } catch (e) {
       logWarn('load-more', e)
       isOffline.value = true
@@ -612,17 +674,19 @@ export function useNoteColumn(config: NoteColumnConfig) {
     error.value = null
     try {
       if (config.refreshFetch) {
-        const result = await config.refreshFetch(adapter, notes.value)
+        const result = await config.refreshFetch(adapter, rawNotes.value)
         if (result.mode === 'replace') {
           setNotes(result.notes)
+          resetFetchCursor(result.notes)
           scrollToTop()
         } else if (result.notes.length > 0) {
-          setNotes(insertIntoSorted(notes.value, result.notes))
+          setNotes(insertIntoSorted(rawNotes.value, result.notes))
           scrollToTop()
         }
       } else {
         const fetched = await config.fetch(adapter, {})
         setNotes(fetched)
+        resetFetchCursor(fetched)
         scrollToTop()
       }
       isOffline.value = false
@@ -641,7 +705,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     const adapter = getAdapter()
     if (!adapter) return
     if (config.validate && !config.validate()) return
-    const sinceId = notes.value[0]?.id
+    const sinceId = rawNotes.value[0]?.id
     const stillCurrent = tabGuard()
     try {
       const fetched = await fetchAndDedup(adapter, sinceId ? { sinceId } : {})
@@ -674,7 +738,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (now - lastResumeAt < 3000) return
     lastResumeAt = now
 
-    const hadNotes = notes.value.length > 0
+    const hadNotes = rawNotes.value.length > 0
     const stillCurrent = tabGuard()
 
     // Run cache fetch and API fetch in parallel. Fetch the LATEST page (not
@@ -748,6 +812,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (useOfflineModeStore().isOfflineMode) {
       // Offline mode: load cache only, skip API fetch and streaming
       setNotes([])
+      resetFetchCursor()
       isLoading.value = true
       if (useCache && config.cache) {
         const filtered = await loadFilteredCache('reconnect-cache')
@@ -760,6 +825,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
       streamingBatch.setPaused(true)
       resubscribe(adapter)
       setNotes([])
+      resetFetchCursor()
       error.value = null
       isLoading.value = true
       try {
@@ -786,6 +852,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
       disconnect()
       streamingBatch?.resetBatch()
       setNotes([])
+      resetFetchCursor()
       await connect(useCache)
     }
   }
@@ -809,6 +876,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     // Swap subscription (stream/WebSocket stays connected)
     resubscribe(adapter)
     setNotes(snapshotNotes)
+    resetFetchCursor(snapshotNotes)
     error.value = null
     await nextTick()
     const restored = anchor

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -27,6 +27,7 @@ import { useNoteFocus } from '@/composables/useNoteFocus'
 import { useNoteList } from '@/composables/useNoteList'
 import { useNoteScrollerRef } from '@/composables/useNoteScrollerRef'
 import { useNoteSound } from '@/composables/useNoteSound'
+import type { VisibilityOpts } from '@/composables/useNoteVisibility'
 import { usePullToRefresh } from '@/composables/usePullToRefresh'
 import { useReadMarker } from '@/composables/useReadMarker'
 import * as snapshotStore from '@/composables/useSnapshotStore'
@@ -80,6 +81,12 @@ export interface NoteColumnConfig {
    * Used by timeline columns to wait for policy detection before connecting.
    */
   connectReady?: Ref<boolean>
+  /**
+   * 表示述語の面別 opt-out（#606）。既定（未指定）は全適用。
+   * お気に入り・自分のクリップは `ignoreSuspension`、プロフィールは
+   * `ignoreSubject`（面別マトリクスは DEVELOPMENT.md 参照）。
+   */
+  visibility?: VisibilityOpts
 }
 
 export function useNoteColumn(config: NoteColumnConfig) {
@@ -127,6 +134,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     getAdapter,
     deleteHandler: handlers.delete,
     closePostForm: postForm.close,
+    visibility: config.visibility,
   })
 
   // Streaming (Group A) or NoteCapture (Group B)

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -9,7 +9,7 @@ import { usePerformanceStore } from '@/stores/performance'
 import { useSuspensionsStore } from '@/stores/suspensions'
 import { insertIntoSorted } from '@/utils/sortNotes'
 import { commands } from '@/utils/tauriInvoke'
-import { useNoteVisibility } from './useNoteVisibility'
+import { useNoteVisibility, type VisibilityOpts } from './useNoteVisibility'
 
 /** @deprecated Use usePerformanceStore().get('noteListMax') instead. Kept for test compatibility. */
 export const NOTE_LIST_MAX = 200
@@ -21,6 +21,8 @@ export interface UseNoteListOptions {
   closePostForm: () => void
   onNotesChanged?: (notes: NormalizedNote[]) => void
   maxNotes?: number
+  /** 面ごとの述語 opt-out（お気に入り・プロフィール等）。既定は全適用 */
+  visibility?: VisibilityOpts
 }
 
 export function useNoteList(options: UseNoteListOptions) {
@@ -85,7 +87,7 @@ export function useNoteList(options: UseNoteListOptions) {
    * muted/archived の合成もこの述語に集約。書込は rawNotes 側で行う。
    */
   const notes = computed(() =>
-    rawNotes.value.filter((n) => !visibility.isHidden(n)),
+    visibility.filterVisible(rawNotes.value, options.visibility),
   )
 
   function setOnNotesChanged(fn: (notes: NormalizedNote[]) => void) {

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -44,13 +44,14 @@ export function useNoteList(options: UseNoteListOptions) {
   const unregisterRoot = noteStore.registerRoot(() => noteIds)
   onScopeDispose(unregisterRoot)
 
-  const notes = computed({
-    // 削除済みノートはキャッシュ再読込で noteMap/orderedIds に復活しうるため、
-    // 表示時の可視性述語で除外する（#602）。muted/archived の合成もこの述語に集約。
-    get: () =>
-      noteStore
-        .resolve(orderedIds.value)
-        .filter((n) => !visibility.isHidden(n)),
+  /**
+   * 書込基底となる unfiltered なノート列（#831 層 1 / Step 0）。
+   * 全ての read-modify-write（マージ・挿入・削除・truncate）はこちらを基底に
+   * する。filtered な `notes` を基底にすると、隠れているノートが書き戻しの
+   * たびに列から落ちて焼き込まれ、ミュート解除で復活しなくなる。
+   */
+  const rawNotes = computed({
+    get: () => noteStore.resolve(orderedIds.value),
     set: (newNotes: NormalizedNote[]) => {
       const trimmed =
         newNotes.length > maxNotes ? newNotes.slice(0, maxNotes) : newNotes
@@ -69,13 +70,22 @@ export function useNoteList(options: UseNoteListOptions) {
     },
   })
 
+  /**
+   * 表示専用の filtered な列（readonly）。削除済みノートはキャッシュ再読込で
+   * noteMap/orderedIds に復活しうるため、表示時の可視性述語で除外する（#602）。
+   * muted/archived の合成もこの述語に集約。書込は rawNotes 側で行う。
+   */
+  const notes = computed(() =>
+    rawNotes.value.filter((n) => !visibility.isHidden(n)),
+  )
+
   function setOnNotesChanged(fn: (notes: NormalizedNote[]) => void) {
     onNotesChangedFn = fn
   }
 
   function setNotes(newNotes: NormalizedNote[]) {
-    notes.value = newNotes
-    // Pass the trimmed result (setter may have truncated)
+    rawNotes.value = newNotes
+    // 可視ノートのみを通知する（noteCapture の購読対象は表示中ノート）
     onNotesChangedFn?.(notes.value)
   }
 
@@ -88,7 +98,8 @@ export function useNoteList(options: UseNoteListOptions) {
     const existing = newNotes.filter((n) => noteIds.has(n.id))
     const brandNew = newNotes.filter((n) => !noteIds.has(n.id))
     if (existing.length > 0) noteStore.put(existing)
-    if (brandNew.length > 0) setNotes(insertIntoSorted(notes.value, brandNew))
+    if (brandNew.length > 0)
+      setNotes(insertIntoSorted(rawNotes.value, brandNew))
   }
 
   function onNoteUpdate(event: NoteUpdateEvent) {
@@ -135,7 +146,9 @@ export function useNoteList(options: UseNoteListOptions) {
       removingIds.value = next
     }
     const prevIds = orderedIds.value
-    notes.value = notes.value.filter((n) => n.id !== id && n.renoteId !== id)
+    rawNotes.value = rawNotes.value.filter(
+      (n) => n.id !== id && n.renoteId !== id,
+    )
 
     if (await options.deleteHandler(note)) {
       noteStore.remove(id)
@@ -152,6 +165,9 @@ export function useNoteList(options: UseNoteListOptions) {
 
   return {
     notes,
+    // unfiltered な書込基底。同期位置の決定（sinceId / untilId / 空ガード等）は
+    // 隠れたノートを含むこちらを読む（#831 §1.4 の読取判別規則）
+    rawNotes,
     // 表示述語でフィルタされない「列のメンバーシップ」。snapshot 保存はこれを使う
     // ことで、ミュート等の可視性状態を焼き込まず、解除で復活できる（#574）。
     orderedIds,

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -6,6 +6,7 @@ import type {
 } from '@/adapters/types'
 import { useNoteStore } from '@/stores/notes'
 import { usePerformanceStore } from '@/stores/performance'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { insertIntoSorted } from '@/utils/sortNotes'
 import { commands } from '@/utils/tauriInvoke'
 import { useNoteVisibility } from './useNoteVisibility'
@@ -26,6 +27,7 @@ export function useNoteList(options: UseNoteListOptions) {
   const noteStore = useNoteStore()
   const visibility = useNoteVisibility()
   const perfStore = usePerformanceStore()
+  const suspensionsStore = useSuspensionsStore()
   const maxNotes = options.maxNotes ?? perfStore.get('noteListMax')
   const orderedIds = shallowRef<string[]>([])
   const noteIds = new Set<string>()
@@ -59,14 +61,21 @@ export function useNoteList(options: UseNoteListOptions) {
       // A global triggerRef would redundantly invalidate ALL columns' notes computeds.
       noteStore.put(trimmed, true)
       const ids: string[] = new Array(trimmed.length)
-      noteIds.clear()
+      // 凍結 probe の供給点（#828）。全書込経路（connect / streaming /
+      // loadMore / キャッシュ復元 / snapshot / resume / refresh）はこの setter
+      // を通るため、ここで新規ノートを拾えば経路列挙が不要になる。
+      // setter を迂回する書込を増やさないことを規約とする。
+      const inserted: NormalizedNote[] = []
       for (let i = 0; i < trimmed.length; i++) {
         // biome-ignore lint/style/noNonNullAssertion: bounded loop
-        const id = trimmed[i]!.id
-        ids[i] = id
-        noteIds.add(id)
+        const note = trimmed[i]!
+        ids[i] = note.id
+        if (!noteIds.has(note.id)) inserted.push(note)
       }
+      noteIds.clear()
+      for (const id of ids) noteIds.add(id)
       orderedIds.value = ids
+      if (inserted.length > 0) suspensionsStore.probeNotes(inserted)
     },
   })
 

--- a/src/composables/useNoteVisibility.ts
+++ b/src/composables/useNoteVisibility.ts
@@ -7,6 +7,23 @@ import type {
 import { useAccountsStore } from '@/stores/accounts'
 import { useMutesStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useSuspensionsStore } from '@/stores/suspensions'
+
+/**
+ * 述語の opt-out オプション（#828 / #831 §1.1）。
+ *
+ * 判定材料は 2 種類に分かれる:
+ * - **対象由来**（userMute / instanceMute / renoteMute / suspension）= 「誰か」に紐づく
+ * - **内容由来**（wordMute / tombstone）= 「何が書かれているか・存在するか」
+ *
+ * 明示的に開いた面（プロフィール等）は前者を貫通させ、後者は常に適用する。
+ */
+export interface VisibilityOpts {
+  /** 凍結のみ無視する。保存面（お気に入り・自クリップ・祖先スレッド）用 */
+  ignoreSuspension?: boolean
+  /** 対象の同一性に由来する材料を全て無視する。明示的に開いた面（プロフィール）用 */
+  ignoreSubject?: boolean
+}
 
 /**
  * ノートの表示可視性述語。
@@ -24,6 +41,7 @@ export function useNoteVisibility() {
   const noteStore = useNoteStore()
   const mutesStore = useMutesStore()
   const accountsStore = useAccountsStore()
+  const suspensionsStore = useSuspensionsStore()
 
   /** ワードミュートのマッチ対象テキスト（本家準拠で cw + text）。 */
   function noteMatchText(note: NormalizedNote): string {
@@ -41,20 +59,47 @@ export function useNoteVisibility() {
    * 表示から隠すべきノートか。判定材料:
    * - 削除 tombstone（#602, 非 reactive・再読込復活を抑止）
    * - ミュート（#574, per-account reactive・投稿者/reply先/renote元のいずれか）
-   * ミュートは reactive なので、この述語を読む computed は解除で即復活する。
+   * - 凍結（#828, サーバー側の事実・投稿者/reply先/renote元のいずれか）
+   * ミュート・凍結は reactive なので、この述語を読む computed は解除で即復活する。
+   *
+   * `opts` は明示的に開いた面・保存した面のための opt-out（既定は全適用 = 安全側）。
    */
-  function isHidden(note: NormalizedNote): boolean {
+  function isHidden(note: NormalizedNote, opts?: VisibilityOpts): boolean {
     if (noteStore.isDeleted(note.id)) return true
     const acc = note._accountId
+    const subject = !opts?.ignoreSubject
     return (
-      mutesStore.isUserMuted(acc, note.user.id) ||
-      mutesStore.isUserMuted(acc, note.reply?.user?.id) ||
-      mutesStore.isUserMuted(acc, note.renote?.user?.id) ||
+      (subject &&
+        (mutesStore.isUserMuted(acc, note.user.id) ||
+          mutesStore.isUserMuted(acc, note.reply?.user?.id) ||
+          mutesStore.isUserMuted(acc, note.renote?.user?.id))) ||
       isHardWordMuted(note) ||
-      isRenoteMuted(note) ||
-      isInstanceMuted(note)
+      (subject && isRenoteMuted(note)) ||
+      (subject && isInstanceMuted(note)) ||
+      (subject && !opts?.ignoreSuspension && isSuspendedNote(note))
     )
     // 将来の OR 合成点: || archiveStore.isArchived(...)  // 魚拓
+  }
+
+  /** 表示用に述語を適用した列を返す。独自 ref の面（検索・詳細等）が使う。 */
+  function filterVisible(
+    notes: NormalizedNote[],
+    opts?: VisibilityOpts,
+  ): NormalizedNote[] {
+    return notes.filter((n) => !isHidden(n, opts))
+  }
+
+  /**
+   * 凍結（#828）。本家 `generateSuspendedUserQueryForNote` に合わせて
+   * note / reply先 / renote元 の 3 者で判定する。
+   */
+  function isSuspendedNote(note: NormalizedNote): boolean {
+    const acc = note._accountId
+    return (
+      suspensionsStore.isSuspended(acc, note.user.id) ||
+      suspensionsStore.isSuspended(acc, note.reply?.user?.id) ||
+      suspensionsStore.isSuspended(acc, note.renote?.user?.id)
+    )
   }
 
   /**
@@ -111,27 +156,36 @@ export function useNoteVisibility() {
     )
   }
 
-  /** grouped reaction 通知から、ミュート済みリアクターを除いた一覧（#575） */
-  function visibleReactions(notif: NormalizedNotification): ReactionInfo[] {
-    if (!notif.reactions) return []
-    return notif.reactions.filter(
-      (r) => !mutesStore.isUserMuted(notif._accountId, r.user.id),
+  /** ミュート済み or 凍結済みのユーザーか（grouped 通知の除外判定） */
+  function isHiddenUser(
+    accountId: string,
+    userId: string | null | undefined,
+  ): boolean {
+    return (
+      mutesStore.isUserMuted(accountId, userId) ||
+      suspensionsStore.isSuspended(accountId, userId)
     )
   }
 
-  /** grouped renote 通知から、ミュート済みリノーターを除いた一覧（#575） */
+  /** grouped reaction 通知から、ミュート/凍結済みリアクターを除いた一覧（#575 / #828） */
+  function visibleReactions(notif: NormalizedNotification): ReactionInfo[] {
+    if (!notif.reactions) return []
+    return notif.reactions.filter(
+      (r) => !isHiddenUser(notif._accountId, r.user.id),
+    )
+  }
+
+  /** grouped renote 通知から、ミュート/凍結済みリノーターを除いた一覧（#575 / #828） */
   function visibleGroupedUsers(
     notif: NormalizedNotification,
   ): NormalizedUser[] {
     if (!notif.users) return []
-    return notif.users.filter(
-      (u) => !mutesStore.isUserMuted(notif._accountId, u.id),
-    )
+    return notif.users.filter((u) => !isHiddenUser(notif._accountId, u.id))
   }
 
   /**
    * 表示から隠すべき通知か（#606 / #575）。
-   * - notifier（reaction/follow/mention 等の発生元ユーザー）がミュート済み
+   * - notifier（reaction/follow/mention 等の発生元ユーザー）がミュート済み or 凍結
    *   = 本家 read-time フィルタ（NotificationEntityService#filterValidNotifier）相当
    * - 関連ノートが削除 / ミュート投稿者（isHidden 経由）
    * - grouped 通知でリアクター/リノーターが全員ミュート済み（#575）。
@@ -140,7 +194,7 @@ export function useNoteVisibility() {
    *   visibleReactions / visibleGroupedUsers により当該ユーザーを除外する。
    */
   function isNotificationHidden(notif: NormalizedNotification): boolean {
-    if (mutesStore.isUserMuted(notif._accountId, notif.user?.id)) return true
+    if (isHiddenUser(notif._accountId, notif.user?.id)) return true
     if (notif.note && isHidden(notif.note)) return true
     if (notif.type === 'reaction:grouped' && notif.reactions?.length) {
       return visibleReactions(notif).length === 0
@@ -153,6 +207,7 @@ export function useNoteVisibility() {
 
   return {
     isHidden,
+    filterVisible,
     isSoftWordMuted,
     isNotificationHidden,
     visibleReactions,

--- a/src/stores/accounts.test.ts
+++ b/src/stores/accounts.test.ts
@@ -35,7 +35,7 @@ vi.mock('@/utils/storage', async () => {
   const actual =
     await vi.importActual<typeof import('@/utils/storage')>('@/utils/storage')
   return {
-    STORAGE_KEYS: actual.STORAGE_KEYS,
+    ...actual,
     removeStorage: vi.fn(),
   }
 })

--- a/src/stores/accounts.ts
+++ b/src/stores/accounts.ts
@@ -4,6 +4,7 @@ import { destroyAdapter } from '@/adapters/factory'
 import type { ServerSoftware } from '@/adapters/types'
 import { deleteAllMemos } from '@/composables/useMemos'
 import { invalidateResolutionCache } from '@/services/entityResolution'
+import { useSuspensionsStore } from '@/stores/suspensions'
 import { removeStorage, STORAGE_KEYS } from '@/utils/storage'
 import { listenTauri } from '@/utils/tauriEvents'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -164,6 +165,7 @@ export const useAccountsStore = defineStore('accounts', () => {
     // Clean up localStorage caches associated with this account
     removeStorage(STORAGE_KEYS.notificationCache(id))
     removeStorage(STORAGE_KEYS.policies(id))
+    useSuspensionsStore().purgeAccount(id)
     deleteAllMemos(id)
   }
 

--- a/src/stores/suspensions.test.ts
+++ b/src/stores/suspensions.test.ts
@@ -1,0 +1,192 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed } from 'vue'
+import type { NormalizedNote } from '@/adapters/types'
+import { useNoteList } from '@/composables/useNoteList'
+import { useSuspensionsStore } from '@/stores/suspensions'
+
+const api = vi.hoisted(() => ({ getUserRaw: vi.fn() }))
+
+vi.mock('@/bindings', () => ({
+  commands: new Proxy(
+    {},
+    {
+      get: (_t, name: string) => {
+        if (name === 'apiGetUserRaw') {
+          return (accountId: string, params: unknown) =>
+            api.getUserRaw(accountId, params)
+        }
+        return () => Promise.resolve({ status: 'ok', data: [] })
+      },
+    },
+  ),
+}))
+
+const HOUR = 60 * 60_000
+
+/** デバウンス + 逐次 chunk の完了まで進める */
+async function settle() {
+  await vi.advanceTimersByTimeAsync(1000)
+}
+
+function ok(users: { id: string; isSuspended?: boolean }[]) {
+  return { status: 'ok', data: users }
+}
+
+function makeNote(id: string, userId: string): NormalizedNote {
+  return {
+    id,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    text: id,
+    user: { id: userId, username: userId, host: null, avatarUrl: null },
+    visibility: 'public',
+    reactions: {},
+    reactionEmojis: {},
+    files: [],
+    _accountId: 'acc1',
+  } as unknown as NormalizedNote
+}
+
+let store: ReturnType<typeof useSuspensionsStore>
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  setActivePinia(createPinia())
+  api.getUserRaw.mockReset()
+  store = useSuspensionsStore()
+  // 周期タイマーは止め、再検証は reverifyTick を直接呼んで検証する
+  store.stopReverifyCycle()
+})
+
+afterEach(() => {
+  store.stopReverifyCycle()
+  vi.useRealTimers()
+})
+
+describe('useSuspensionsStore: probe の 3 値判定 (#828)', () => {
+  it('欠落 = 凍結 / isSuspended:true = 凍結 / 返却され false = 解除', async () => {
+    api.getUserRaw.mockResolvedValue(
+      ok([{ id: 'u2' }, { id: 'u3', isSuspended: true }]),
+    )
+
+    store.probe('acc1', ['u1', 'u2', 'u3'])
+    await settle()
+
+    expect(store.isSuspended('acc1', 'u1')).toBe(true) // 応答から欠落
+    expect(store.isSuspended('acc1', 'u2')).toBe(false)
+    expect(store.isSuspended('acc1', 'u3')).toBe(true) // モデレーター経路
+  })
+
+  it('chunk の取得に失敗したら無更新にする (fail-open)', async () => {
+    store.applyProbeResult('acc1', { suspended: ['u1'] })
+    api.getUserRaw.mockRejectedValue(new Error('network'))
+
+    store.probe('acc1', ['u1'])
+    await settle()
+
+    // 失敗を「返ってこなかった = 凍結」とも「解除」とも解釈しない
+    expect(store.isSuspended('acc1', 'u1')).toBe(true)
+  })
+
+  it('50 件ずつに分割して問い合わせる', async () => {
+    api.getUserRaw.mockResolvedValue(ok([]))
+    const ids = Array.from({ length: 120 }, (_, i) => `u${i}`)
+
+    store.probe('acc1', ids)
+    await settle()
+
+    expect(api.getUserRaw).toHaveBeenCalledTimes(3)
+    const first = api.getUserRaw.mock.calls[0]?.[1] as { userIds: string[] }
+    expect(first.userIds).toHaveLength(50)
+  })
+
+  it('同一 id は 15 分間、再問い合わせしない', async () => {
+    api.getUserRaw.mockResolvedValue(ok([{ id: 'u1' }]))
+
+    store.probe('acc1', ['u1'])
+    await settle()
+    expect(api.getUserRaw).toHaveBeenCalledTimes(1)
+
+    store.probe('acc1', ['u1'])
+    await settle()
+    expect(api.getUserRaw).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(Date.now() + 16 * 60_000)
+    store.probe('acc1', ['u1'])
+    await settle()
+    expect(api.getUserRaw).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useSuspensionsStore: 差分 trigger と再検証サイクル (#828)', () => {
+  it('集合に差分がなければ購読側を再評価させない', () => {
+    store.applyProbeResult('acc1', { suspended: ['u1'] })
+    let evals = 0
+    const hidden = computed(() => {
+      evals++
+      return store.isSuspended('acc1', 'u1')
+    })
+    expect(hidden.value).toBe(true)
+    const before = evals
+
+    // 既に凍結済みの u1 を再検知 + 未登録の u9 を解除 = 集合は不変
+    store.applyProbeResult('acc1', { suspended: ['u1'], cleared: ['u9'] })
+
+    expect(hidden.value).toBe(true)
+    expect(evals).toBe(before)
+  })
+
+  it('再検証は TTL 抑制を貫通し、解除を検知する', async () => {
+    api.getUserRaw.mockResolvedValue(ok([]))
+    store.probe('acc1', ['u1'])
+    await settle()
+    expect(store.isSuspended('acc1', 'u1')).toBe(true)
+
+    // TTL 内でも再検証サイクルは問い合わせる
+    api.getUserRaw.mockResolvedValue(ok([{ id: 'u1' }]))
+    store.reverifyTick()
+    await settle()
+
+    expect(store.isSuspended('acc1', 'u1')).toBe(false)
+  })
+
+  it('検知から 24h を過ぎた entry は再検証済みなら due にしない (aging)', async () => {
+    api.getUserRaw.mockResolvedValue(ok([]))
+    store.probe('acc1', ['u1'])
+    await settle()
+
+    // 25h 後: fresh 期間を抜けている → due
+    vi.setSystemTime(Date.now() + 25 * HOUR)
+    api.getUserRaw.mockClear()
+    store.reverifyTick()
+    await settle()
+    expect(api.getUserRaw).toHaveBeenCalledTimes(1)
+
+    // 直後は lastVerified が新しいので due にならない
+    vi.setSystemTime(Date.now() + HOUR)
+    api.getUserRaw.mockClear()
+    store.reverifyTick()
+    await settle()
+    expect(api.getUserRaw).not.toHaveBeenCalled()
+  })
+})
+
+describe('useSuspensionsStore: probe 供給の 1 点フック (#828)', () => {
+  it('useNoteList への新規挿入で当事者が probe される', async () => {
+    api.getUserRaw.mockResolvedValue(ok([]))
+    const { setNotes } = useNoteList({
+      getMyUserId: () => 'me',
+      getAdapter: () => null,
+      deleteHandler: async () => true,
+      closePostForm: () => {
+        /* noop */
+      },
+    })
+
+    setNotes([makeNote('n1', 'author-1'), makeNote('n2', 'author-2')])
+    await settle()
+
+    const params = api.getUserRaw.mock.calls[0]?.[1] as { userIds: string[] }
+    expect(params.userIds.sort()).toEqual(['author-1', 'author-2'])
+  })
+})

--- a/src/stores/suspensions.ts
+++ b/src/stores/suspensions.ts
@@ -1,0 +1,348 @@
+import { defineStore } from 'pinia'
+import { shallowRef, triggerRef } from 'vue'
+import type { NormalizedNote } from '@/adapters/types'
+import { logWarn } from '@/utils/logger'
+import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
+import { commands, unwrap } from '@/utils/tauriInvoke'
+
+/** 1 リクエストで問い合わせる userId 数。users/show の userIds に上限は無いが
+ *  応答が UserDetailed pack（pinnedNotes の packMany・ロールポリシー解決込み）
+ *  でサーバー側コストが重いため、リクエスト数ではなく pack コストで律速する。 */
+const PROBE_CHUNK = 50
+/** 同一 id を再度問い合わせるまでの抑制時間 */
+const PROBE_TTL_MS = 15 * 60_000
+/** 供給元（ノート挿入・通知挿入）のバーストをまとめる */
+const PROBE_DEBOUNCE_MS = 300
+/** 再検証サイクルの周期 */
+const REVERIFY_INTERVAL_MS = 15 * 60_000
+/** 検知直後のこの期間は毎周期 due にする（解除の即応性） */
+const REVERIFY_FRESH_MS = 24 * 60 * 60_000
+/** 上記を過ぎた entry の再検証間隔 */
+const REVERIFY_AGED_MS = 24 * 60 * 60_000
+/** 集合がこれを超えたら 1 サイクルあたりのローテーションに切り替える */
+const REVERIFY_ROTATION_THRESHOLD = 100
+/** ローテーション時の 1 サイクル最大 chunk 数 */
+const REVERIFY_MAX_CHUNKS = 2
+
+const STORAGE_VERSION = 1
+
+export interface SuspensionEntry {
+  userId: string
+  /** 検知した時刻 (epoch ms) */
+  since: number
+  /** 最後に再検証した時刻 (epoch ms) */
+  lastVerified: number
+}
+
+interface StorageEnvelope {
+  _v: number
+  accounts: Record<string, SuspensionEntry[]>
+}
+
+function isEntry(v: unknown): v is SuspensionEntry {
+  if (typeof v !== 'object' || v === null) return false
+  const e = v as Record<string, unknown>
+  return (
+    typeof e.userId === 'string' &&
+    typeof e.since === 'number' &&
+    typeof e.lastVerified === 'number'
+  )
+}
+
+function loadPersisted(): Map<string, Map<string, SuspensionEntry>> {
+  const out = new Map<string, Map<string, SuspensionEntry>>()
+  const raw = getStorageJson<unknown>(STORAGE_KEYS.suspensions, null)
+  const envelope = raw as Partial<StorageEnvelope> | null
+  if (
+    !envelope ||
+    envelope._v !== STORAGE_VERSION ||
+    typeof envelope.accounts !== 'object' ||
+    envelope.accounts === null
+  ) {
+    return out
+  }
+  for (const [accountId, entries] of Object.entries(envelope.accounts)) {
+    if (!Array.isArray(entries)) continue
+    const map = new Map<string, SuspensionEntry>()
+    for (const e of entries) if (isEntry(e)) map.set(e.userId, e)
+    if (map.size > 0) out.set(accountId, map)
+  }
+  return out
+}
+
+/**
+ * サーバーで凍結（または削除）されたユーザーの per-account ストア（#828）。
+ *
+ * mutes と違い「自分の意思」ではなく**サーバー側の事実**なので相乗りさせない。
+ * 表示述語 `useNoteVisibility().isHidden` の判定材料になり、集合が変われば
+ * リロード無しで既存ノートが隠れる／復活する。SQLite キャッシュは触らない。
+ *
+ * 検知は `users/show({ userIds })` の 3 値判定:
+ *   1. 応答から欠落 → 凍結（非モデレーターにはサーバーが isSuspended:false で絞る）
+ *   2. `isSuspended === true` → 凍結（モデレーター経路）
+ *   3. 返却され isSuspended ≠ true → 解除
+ * 欠落は凍結・削除・不可視を区別しない。一覧面から隠すのは同原理で正しいため
+ * 誤検知ではなく、開示 UI でも中立表現を使う。
+ */
+export const useSuspensionsStore = defineStore('suspensions', () => {
+  const byAccount = shallowRef(loadPersisted())
+
+  /** `${accountId}:${userId}` → 最後に問い合わせた時刻。TTL 抑制用 */
+  const probedAt = new Map<string, number>()
+  /** デバウンス待ちの問い合わせ対象 */
+  const pending = new Map<string, Set<string>>()
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let reverifyTimer: ReturnType<typeof setInterval> | null = null
+  let flushing = false
+
+  function isSuspended(
+    accountId: string | null | undefined,
+    userId: string | null | undefined,
+  ): boolean {
+    if (!accountId || !userId) return false
+    return byAccount.value.get(accountId)?.has(userId) ?? false
+  }
+
+  /** 凍結一覧 UI 用（#828 Step 1b）。検知が新しい順 */
+  function entries(accountId: string): SuspensionEntry[] {
+    const map = byAccount.value.get(accountId)
+    if (!map) return []
+    return [...map.values()].sort((a, b) => b.since - a.since)
+  }
+
+  function persist(): void {
+    const accounts: Record<string, SuspensionEntry[]> = {}
+    for (const [accountId, map] of byAccount.value) {
+      if (map.size > 0) accounts[accountId] = [...map.values()]
+    }
+    try {
+      setStorageJson(STORAGE_KEYS.suspensions, {
+        _v: STORAGE_VERSION,
+        accounts,
+      } satisfies StorageEnvelope)
+    } catch {
+      // QuotaExceeded 等。永続化は諦めるがセッション内の判定は維持する
+    }
+  }
+
+  /**
+   * probe 結果の一括反映。差分がある場合のみ trigger する（無差分の再検証で
+   * 全カラムの notes computed を無駄に再評価させない）。
+   */
+  function applyProbeResult(
+    accountId: string,
+    result: { suspended?: string[]; cleared?: string[] },
+  ): void {
+    const now = Date.now()
+    let map = byAccount.value.get(accountId)
+    let changed = false
+
+    for (const userId of result.suspended ?? []) {
+      if (!map) {
+        map = new Map()
+        byAccount.value.set(accountId, map)
+      }
+      const prev = map.get(userId)
+      map.set(userId, {
+        userId,
+        since: prev?.since ?? now,
+        lastVerified: now,
+      })
+      if (!prev) changed = true
+    }
+
+    for (const userId of result.cleared ?? []) {
+      if (map?.delete(userId)) changed = true
+    }
+
+    if (!changed) {
+      // 集合は同じでも lastVerified は進める（aging のため）。表示には
+      // 影響しないので trigger も persist もしない
+      return
+    }
+    triggerRef(byAccount)
+    persist()
+  }
+
+  /** アカウント削除時に該当アカウントの検知結果を捨てる */
+  function purgeAccount(accountId: string): void {
+    if (!byAccount.value.delete(accountId)) return
+    triggerRef(byAccount)
+    persist()
+  }
+
+  // --- probe キュー ---
+
+  function enqueue(
+    accountId: string,
+    userIds: Iterable<string>,
+    force = false,
+  ) {
+    const now = Date.now()
+    let set = pending.get(accountId)
+    for (const userId of userIds) {
+      const key = `${accountId}:${userId}`
+      if (!force) {
+        const last = probedAt.get(key)
+        if (last != null && now - last < PROBE_TTL_MS) continue
+      }
+      if (!set) {
+        set = new Set()
+        pending.set(accountId, set)
+      }
+      set.add(userId)
+    }
+    if (pending.size === 0) return
+    ensureReverifyTimer()
+    if (debounceTimer) return
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      void flush()
+    }, PROBE_DEBOUNCE_MS)
+  }
+
+  /**
+   * 表示に乗ったユーザーの凍結状態を問い合わせる。デバウンス + dedupe +
+   * TTL 抑制 + chunk 分割 + 逐次実行で総量を制御する。
+   */
+  function probe(
+    accountId: string | null | undefined,
+    userIds: Iterable<string>,
+  ): void {
+    if (!accountId) return
+    enqueue(accountId, userIds)
+  }
+
+  /** ノート列から distinct な当事者（投稿者 / reply 先 / renote 元）を probe する */
+  function probeNotes(notes: Iterable<NormalizedNote>): void {
+    const byAcc = new Map<string, Set<string>>()
+    for (const note of notes) {
+      const acc = note._accountId
+      if (!acc) continue
+      let set = byAcc.get(acc)
+      if (!set) {
+        set = new Set()
+        byAcc.set(acc, set)
+      }
+      set.add(note.user.id)
+      if (note.reply?.user?.id) set.add(note.reply.user.id)
+      if (note.renote?.user?.id) set.add(note.renote.user.id)
+    }
+    for (const [accountId, ids] of byAcc) enqueue(accountId, ids)
+  }
+
+  async function probeChunk(accountId: string, chunk: string[]): Promise<void> {
+    const now = Date.now()
+    for (const userId of chunk) probedAt.set(`${accountId}:${userId}`, now)
+
+    let raw: unknown
+    try {
+      raw = unwrap(
+        await commands.apiGetUserRaw(accountId, { userIds: chunk }),
+      ) as unknown
+    } catch (e) {
+      // I-4: 材料取得失敗は無更新（fail-open）
+      logWarn('suspension-probe', e)
+      return
+    }
+    if (!Array.isArray(raw)) return
+
+    const returned = new Map<string, Record<string, unknown>>()
+    for (const u of raw) {
+      if (
+        u &&
+        typeof u === 'object' &&
+        typeof (u as { id?: unknown }).id === 'string'
+      ) {
+        returned.set((u as { id: string }).id, u as Record<string, unknown>)
+      }
+    }
+
+    const suspended: string[] = []
+    const cleared: string[] = []
+    for (const userId of chunk) {
+      const user = returned.get(userId)
+      if (!user || user.isSuspended === true) {
+        suspended.push(userId)
+      } else {
+        cleared.push(userId)
+      }
+    }
+    applyProbeResult(accountId, { suspended, cleared })
+  }
+
+  async function flush(): Promise<void> {
+    if (flushing) return
+    flushing = true
+    try {
+      while (pending.size > 0) {
+        const [accountId, set] = [...pending.entries()][0] as [
+          string,
+          Set<string>,
+        ]
+        pending.delete(accountId)
+        const ids = [...set]
+        for (let i = 0; i < ids.length; i += PROBE_CHUNK) {
+          await probeChunk(accountId, ids.slice(i, i + PROBE_CHUNK))
+        }
+      }
+    } finally {
+      flushing = false
+    }
+  }
+
+  // --- 再検証サイクル ---
+
+  function isDue(entry: SuspensionEntry, now: number): boolean {
+    if (now - entry.since < REVERIFY_FRESH_MS) return true
+    return now - entry.lastVerified >= REVERIFY_AGED_MS
+  }
+
+  /**
+   * 凍結集合の解除検知は、カラム構成にも probe 発火にも依存させない。
+   * 単一の周期タイマーが due な entry を選んで再検証する。
+   */
+  function reverifyTick(): void {
+    const now = Date.now()
+    for (const [accountId, map] of byAccount.value) {
+      let due = [...map.values()].filter((e) => isDue(e, now))
+      if (due.length === 0) continue
+      if (map.size > REVERIFY_ROTATION_THRESHOLD) {
+        due = due
+          .sort((a, b) => a.lastVerified - b.lastVerified)
+          .slice(0, PROBE_CHUNK * REVERIFY_MAX_CHUNKS)
+      }
+      // TTL 抑制を貫通させる（通常 probe には同梱しない）
+      enqueue(
+        accountId,
+        due.map((e) => e.userId),
+        true,
+      )
+    }
+  }
+
+  function ensureReverifyTimer(): void {
+    if (reverifyTimer) return
+    reverifyTimer = setInterval(reverifyTick, REVERIFY_INTERVAL_MS)
+  }
+
+  /** テスト用。周期タイマーを止める */
+  function stopReverifyCycle(): void {
+    if (!reverifyTimer) return
+    clearInterval(reverifyTimer)
+    reverifyTimer = null
+  }
+
+  if (byAccount.value.size > 0) ensureReverifyTimer()
+
+  return {
+    isSuspended,
+    entries,
+    applyProbeResult,
+    probe,
+    probeNotes,
+    purgeAccount,
+    reverifyTick,
+    stopReverifyCycle,
+  }
+})

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -121,6 +121,9 @@ export const STORAGE_KEYS = {
   // { dateEpochDays, count }
   heartbeatDailyCounter: 'nd-heartbeat-daily-counter',
 
+  // サーバーで凍結/削除されたユーザー (#828)。account ごとの entry を 1 キーに集約
+  suspensions: 'nd-suspensions',
+
   // Custom timelines (per-host / per-account)
   customTimeline: (host: string) => `nd:custom_tl:${host}`,
   policies: (accountId: string) => `nd:policies:${accountId}`,

--- a/tests/composables/useNoteList.test.ts
+++ b/tests/composables/useNoteList.test.ts
@@ -66,12 +66,23 @@ describe('useNoteList', () => {
     )
   })
 
-  it('trims on direct notes.value assignment', () => {
-    const { notes, noteIds } = createNoteList(5)
+  it('trims on direct rawNotes.value assignment', () => {
+    const { notes, rawNotes, noteIds } = createNoteList(5)
     const items = Array.from({ length: 10 }, (_, i) => makeNote(String(i)))
-    notes.value = items
+    rawNotes.value = items
     expect(notes.value).toHaveLength(5)
     expect(noteIds.size).toBe(5)
+  })
+
+  it('rawNotes は可視性述語でフィルタされず、notes だけが隠される (#831)', () => {
+    const { notes, rawNotes, setNotes } = createNoteList()
+    const muteStore = useMutesStore()
+    setNotes([makeNote('1'), makeNote('2'), makeNote('3')])
+
+    muteStore.muteUser('acc1', 'u1')
+    expect(notes.value).toHaveLength(0)
+    // 書込基底は隠れたノートを保持し続ける（同期位置の決定に使う）
+    expect(rawNotes.value.map((n) => n.id)).toEqual(['1', '2', '3'])
   })
 
   it('does not trim when under limit', () => {
@@ -111,9 +122,8 @@ describe('useNoteList', () => {
   })
 
   it('retains muted notes in orderedIds so a snapshot restores them on unmute (#574)', () => {
-    const { notes, setNotes, orderedIds } = createNoteList()
+    const { notes, rawNotes, setNotes, orderedIds } = createNoteList()
     const muteStore = useMutesStore()
-    const noteStore = useNoteStore()
     setNotes([makeNote('1'), makeNote('2'), makeNote('3')]) // all authored by 'u1'
 
     muteStore.muteUser('acc1', 'u1')
@@ -124,10 +134,26 @@ describe('useNoteList', () => {
     // bring them back.
     expect(orderedIds.value).toEqual(['1', '2', '3'])
 
-    // Simulate snapshot save (unfiltered ids) → restore.
-    setNotes(noteStore.resolve(orderedIds.value))
+    // Simulate snapshot save (unfiltered) → restore.
+    setNotes(rawNotes.value)
     muteStore.unmuteUser('acc1', 'u1')
     expect(notes.value.map((n) => n.id)).toEqual(['1', '2', '3'])
+  })
+
+  it('隠れている間にマージしても焼き込まれず、解除で復活する (#831)', () => {
+    const { notes, mergeUpdate, setNotes } = createNoteList()
+    const muteStore = useMutesStore()
+    setNotes([makeNote('2'), makeNote('1')]) // 新しい順
+
+    muteStore.muteUser('acc1', 'u1')
+    expect(notes.value).toHaveLength(0)
+
+    // 隠れている状態での read-modify-write。filtered を基底にすると
+    // ここで '1' '2' が列から落ちる
+    mergeUpdate([makeNote('3')])
+
+    muteStore.unmuteUser('acc1', 'u1')
+    expect(notes.value.map((n) => n.id)).toEqual(['3', '2', '1'])
   })
 
   it('passes trimmed notes to onNotesChanged callback', () => {

--- a/tests/composables/useNoteVisibility.test.ts
+++ b/tests/composables/useNoteVisibility.test.ts
@@ -4,6 +4,7 @@ import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
 import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { useMutesStore } from '@/stores/mutes'
 import { useNoteStore } from '@/stores/notes'
+import { useSuspensionsStore } from '@/stores/suspensions'
 
 function makeNote(
   id: string,
@@ -332,5 +333,103 @@ describe('useNoteVisibility instance mute (#613)', () => {
     })
     instanceMuteStore.setMutedInstances('acc1', ['bad.example'])
     expect(isHidden(note)).toBe(true)
+  })
+})
+
+describe('useNoteVisibility 凍結と面別 opt-out (#828 / #606)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('凍結ユーザーのノートを隠す (投稿者 / reply 先 / renote 元)', () => {
+    const { isHidden } = useNoteVisibility()
+    useSuspensionsStore().applyProbeResult('acc1', { suspended: ['banned'] })
+
+    expect(isHidden(makeNote('1', 'banned'))).toBe(true)
+    expect(
+      isHidden(makeNote('2', 'ok', { reply: makeNote('3', 'banned') })),
+    ).toBe(true)
+    expect(
+      isHidden(makeNote('4', 'ok', { renote: makeNote('5', 'banned') })),
+    ).toBe(true)
+    expect(isHidden(makeNote('6', 'ok'))).toBe(false)
+  })
+
+  it('凍結解除でリロード無しに復活する', () => {
+    const { isHidden } = useNoteVisibility()
+    const suspensions = useSuspensionsStore()
+    const note = makeNote('1', 'banned')
+
+    suspensions.applyProbeResult('acc1', { suspended: ['banned'] })
+    expect(isHidden(note)).toBe(true)
+
+    suspensions.applyProbeResult('acc1', { cleared: ['banned'] })
+    expect(isHidden(note)).toBe(false)
+  })
+
+  it('ignoreSuspension は凍結だけを貫通し、ミュートは適用したままにする', () => {
+    const { isHidden } = useNoteVisibility()
+    useSuspensionsStore().applyProbeResult('acc1', { suspended: ['banned'] })
+    useMutesStore().muteUser('acc1', 'muted')
+
+    const opts = { ignoreSuspension: true }
+    expect(isHidden(makeNote('1', 'banned'), opts)).toBe(false)
+    // 自分の意思であるミュートは保存面でも効かせる
+    expect(isHidden(makeNote('2', 'muted'), opts)).toBe(true)
+  })
+
+  it('ignoreSubject は対象由来を全て貫通し、内容由来は適用したままにする', () => {
+    const { isHidden } = useNoteVisibility()
+    const mutes = useMutesStore()
+    const noteStore = useNoteStore()
+    useSuspensionsStore().applyProbeResult('acc1', { suspended: ['banned'] })
+    mutes.muteUser('acc1', 'muted')
+    mutes.setMutedInstances('acc1', ['bad.example'])
+    mutes.setMutedWords('acc1', [], [['ngword']])
+
+    const opts = { ignoreSubject: true }
+    // 対象由来: ユーザーミュート / インスタンスミュート / 凍結
+    expect(isHidden(makeNote('1', 'banned'), opts)).toBe(false)
+    expect(isHidden(makeNote('2', 'muted'), opts)).toBe(false)
+    expect(
+      isHidden(
+        makeNote('3', 'remote', {
+          user: {
+            id: 'remote',
+            username: 'remote',
+            host: 'bad.example',
+            avatarUrl: null,
+          },
+        }),
+        opts,
+      ),
+    ).toBe(false)
+
+    // 内容由来: ワードミュートと削除 tombstone は貫通させない
+    expect(isHidden(makeNote('4', 'ok', { text: 'a ngword b' }), opts)).toBe(
+      true,
+    )
+    const deleted = makeNote('5', 'ok')
+    noteStore.put([deleted])
+    noteStore.remove(deleted.id)
+    expect(isHidden(deleted, opts)).toBe(true)
+  })
+
+  it('凍結された notifier の通知を隠し、grouped からも除外する', () => {
+    const { isNotificationHidden, visibleReactions } = useNoteVisibility()
+    useSuspensionsStore().applyProbeResult('acc1', { suspended: ['banned'] })
+
+    expect(
+      isNotificationHidden(makeNotif('reaction', { user: makeUser('banned') })),
+    ).toBe(true)
+
+    const grouped = makeNotif('reaction:grouped', {
+      reactions: [
+        { reaction: '👍', user: makeUser('banned') },
+        { reaction: '👍', user: makeUser('ok') },
+      ],
+    } as Partial<NormalizedNotification>)
+    expect(visibleReactions(grouped).map((r) => r.user.id)).toEqual(['ok'])
+    expect(isNotificationHidden(grouped)).toBe(false)
   })
 })


### PR DESCRIPTION
表示制御アーキテクチャ（#831）の基盤 3 ステップ。凍結アカウントのノートが消えないバグ (#828) の修正と、表示可視性述語の適用面の完全化 (#606) を含む。

## 変更

- refactor(note-list): rawNotes 基底化 + フェッチカーソルを導入 (#831 Step 0)
- feat(visibility): 凍結アカウントを表示述語に合成する (#828 Step 1a)
- feat(visibility): 表示述語を全表示面に適用し、面別 opt-out を導入 (#606 Step 2)
- chore: bump version to 1.27.0 / regenerate openapi.json for 1.27.0

## 中身

**焼き込み修正とページング（Step 0）**

ノート列に unfiltered な書込基底を追加し、表示用の列は述語適用後の読み取り専用に降格した。これまではミュート等で隠れているノートが、マージ・挿入・truncate のたびに列から落ちて焼き込まれ、解除しても復活しないことがあった。あわせてページングの位置決めをバッファ末尾からフェッチカーソル（フィルタ前の生ページの最古）に変更し、ページが丸ごとフィルタで落ちたときに「もっと読む」が同じページを取り続ける構造を潰した。

**凍結アカウント（Step 1a, #828）**

サーバーで凍結されたユーザーのノートを表示時に隠す。ローカルのキャッシュは消さないので、凍結が解除されれば元どおり表示に戻る。検知は表示に乗ったユーザーをまとめて問い合わせる方式で、取得に失敗したときは隠さない側に倒す。解除の検知は定期的な再検証で、カラム構成にも表示の発火にも依存しない。通知（notifier と grouped のリアクター/リノーター）にも適用。

開示 UI（凍結ユーザーのプロフィールからローカルの過去ノートを辿る導線）は見送った。理由は #828 のコメント参照。

**適用面の完全化（Step 2, #606）**

述語が効いていたのはカラム系と通知カラムだけで、検索・ノート詳細・Lookup・プロフィール・クリップ詳細は素通しだった。本家の read-time フィルタ挙動に合わせて全面に適用しつつ、明示的に開いた面・自分が保存した面は貫通させる。

| 面 | 扱い |
|---|---|
| TL 全種 / リスト / アンテナ / チャンネル / ロール / メンション / explore / 検索 / 通知 | 全適用 |
| お気に入り / クリップカラム | 凍結を貫通 |
| クリップ詳細ウィンドウ | 自分のクリップなら凍結を貫通 |
| ノート詳細・Lookup の本体ノート | 述語を通さない |
| ノート詳細・Lookup の祖先スレッド | 凍結を貫通 |
| ノート詳細・Lookup の返信ツリー | 全適用 |
| プロフィール | ミュート・凍結を貫通（ワードミュートと削除は適用） |

## 既知の残り

ノートに付いたリアクションの数は、凍結・ミュート済みのリアクターを含んだままになる。ノート単体からはリアクターが分からず別途取得が要るため、#575 の残作業（#831 Step 5）として扱う。

Closes #828
Closes #606

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added suspension-aware visibility filtering across timelines, searches, notifications, profiles, clips, and note details.
  * Suspended users’ notes and grouped reactions are hidden while preserving applicable mute and deletion rules.
  * Added exceptions for views that should continue displaying suspended content.
  * Suspension status is refreshed automatically and restored visibility appears without reloading.

* **Bug Fixes**
  * Improved pagination and reconnect behavior so hidden notes do not interrupt or duplicate loading.
  * Preserved hidden notes during updates so they reappear when visibility changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->