### PR TITLE
Release v1.28.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,23 @@
       // Linear-style instant display: restore cached UI shell, or show splash.
       (function () {
         var root = document.documentElement
+        // 0. Safe mode (#794). CLI 引数 (--safe-mode → Rust の initialization script)
+        //    と URL クエリを localStorage の 1 キーへ畳み込む。以降アプリ全体は
+        //    このキーだけを見る (src/utils/safeMode.ts と同じリテラル)。
+        var safeMode = false
+        try {
+          safeMode =
+            localStorage.getItem('nd-safe-mode') === 'true' ||
+            window.__ND_SAFE_MODE_ARG__ === true ||
+            new URLSearchParams(location.search).get('safemode') === 'true'
+          if (safeMode) localStorage.setItem('nd-safe-mode', 'true')
+        } catch (e) {
+          // localStorage 不可 — 通常起動として続行
+        }
         try {
           // 1. Restore theme CSS variables (same data themeStore.init reads later)
-          var compiled = localStorage.getItem('nd-theme-compiled')
+          //    セーフモードではユーザーテーマを一切当てない (既定テーマで描画する)
+          var compiled = safeMode ? null : localStorage.getItem('nd-theme-compiled')
           if (compiled) {
             var vars = JSON.parse(compiled)
             for (var k in vars) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.27.0",
+  "version": "1.28.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.27.0"
+version = "1.28.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.27.0"
+version = "1.28.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.27.0"
+    "version": "1.28.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,6 +161,19 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     builder = builder.invoke_handler(specta_builder.invoke_handler());
 
+    // セーフモード (#794) — `notedeck --safe-mode` で起動したとき、ページ評価前に
+    // フラグを注入する。index.html の boot script がこれを localStorage へ畳み込み、
+    // 以降フロントは localStorage だけを見る (解除手順を 1 つに保つため)。
+    // 通常起動では何も注入しない。
+    if std::env::args().any(|a| a == "--safe-mode") {
+        tracing::warn!("[safe-mode] launched with --safe-mode");
+        builder = builder.plugin(
+            tauri::plugin::Builder::<tauri::Wry, ()>::new("nd-safe-mode")
+                .js_init_script("window.__ND_SAFE_MODE_ARG__ = true;")
+                .build(),
+        );
+    }
+
     #[cfg(not(mobile))]
     let has_tray = Arc::new(AtomicBool::new(false));
     #[cfg(not(mobile))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ import { useTheme } from '@/composables/useTheme'
 import { useWordMuteSync } from '@/composables/useWordMuteSync'
 import { useLogsStore } from '@/stores/logs'
 import { useIsCompactLayout, useUiStore } from '@/stores/ui'
+import { exitSafeMode, readSafeMode } from '@/utils/safeMode'
 import {
   getStorageString,
   removeStorage,
@@ -32,6 +33,9 @@ const { isTauri, isDesktop } = uiStore
 const isCompact = useIsCompactLayout()
 const route = useRoute()
 const isPipWindow = computed(() => route.meta.pip === true)
+
+// セーフモード (#794) は起動時に確定し、実行中に変わらない (解除はリロード)
+const isSafeMode = readSafeMode()
 
 const DevWelcome = isTauri
   ? null
@@ -217,6 +221,11 @@ onUnmounted(() => {
   <div :class="$style.root">
     <template v-if="isTauri">
       <TitleBar v-if="(isDesktop || !isCompact) && !isPipWindow" />
+      <div v-if="isSafeMode && !isPipWindow" :class="$style.safeModeBar">
+        <i class="ti ti-shield-half" />
+        <span :class="$style.safeModeText">セーフモードで起動中 — プラグイン・ウィジェット・カスタム CSS・テーマ・HEARTBEAT は無効です</span>
+        <button type="button" :class="$style.safeModeExit" @click="exitSafeMode">オフにする</button>
+      </div>
       <div :class="$style.content">
         <router-view />
       </div>
@@ -243,6 +252,41 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+}
+
+/* セーフモード (#794)。テーマ変数は当たっていない前提なので配色は固定値で持つ */
+.safeModeBar {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  background: #8a5a00;
+  color: #fff;
+}
+
+.safeModeText {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.safeModeExit {
+  flex: none;
+  padding: 2px 10px;
+  border: 1px solid rgb(255 255 255 / 0.5);
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+
+  &:hover {
+    background: rgb(255 255 255 / 0.15);
+  }
 }
 
 </style>

--- a/src/aiscript/notedeck-api.test.ts
+++ b/src/aiscript/notedeck-api.test.ts
@@ -32,11 +32,18 @@ function makeFakeStores(): {
   register: ReturnType<typeof vi.fn>
   unregister: ReturnType<typeof vi.fn>
 } {
-  const register = vi.fn()
-  const unregister = vi.fn()
+  // 衝突検出 (先勝ち) を検証するため、登録済み Map を持つ実体に寄せる
+  const registered = new Map<string, unknown>()
+  const register = vi.fn((cmd: { id: string }) => {
+    registered.set(cmd.id, cmd)
+  })
+  const unregister = vi.fn((id: string) => {
+    registered.delete(id)
+  })
   const commandStore = {
     register,
     unregister,
+    commands: registered,
   } as unknown as ReturnType<typeof useCommandStore>
   // dispatcher は useAiConfig() singleton から権限を解決する。既定は full で
   // permission gate を通し、拒否系テストだけ setPresetForTest で絞る。
@@ -45,8 +52,8 @@ function makeFakeStores(): {
     ctx: {
       commandStore,
       principal: { kind: 'plugin', pluginId: 'test-plugin' } as const,
-      registeredCommandIds: [],
-      subscriptions: [],
+      provider: 'acme.clock',
+      disposers: [],
     },
     register,
     unregister,
@@ -149,7 +156,7 @@ describe('Nd:register_command (4-arg legacy form)', () => {
     ])
     expect(register).toHaveBeenCalledTimes(1)
     const cmd = nthCommand(register, 0)
-    expect(cmd.id).toBe('nd-plugin:greet')
+    expect(cmd.id).toBe('acme.clock:greet')
     expect(cmd.label).toBe('Greet')
     expect(cmd.icon).toBe('ti-hand')
     expect(cmd.category).toBe('general')
@@ -419,7 +426,7 @@ describe('Nd:on', () => {
     await callNative(env, 'Nd:on', [values.STR('column:added'), dummyHandler])
     expect(subscribeMock).toHaveBeenCalledTimes(1)
     expect(subscribeMock.mock.calls[0]?.[0]).toBe('column:added')
-    expect(stores.ctx.subscriptions).toContain(unsub)
+    expect(stores.ctx.disposers).toHaveLength(1)
   })
 
   it('returns an AiScript fn that, when called, unsubscribes', async () => {
@@ -438,7 +445,7 @@ describe('Nd:on', () => {
     // biome-ignore lint/suspicious/noExplicitAny: AiScript の native opts は run-time に大量のコールバックを持つ
     await result.native([], nativeOpts as any)
     expect(unsub).toHaveBeenCalledTimes(1)
-    expect(stores.ctx.subscriptions).not.toContain(unsub)
+    expect(stores.ctx.disposers).toHaveLength(0)
   })
 })
 
@@ -458,15 +465,12 @@ describe('cleanupNoteDeckEnv', () => {
       values.STR('ti-b'),
       dummyHandler,
     ])
-    expect(stores.ctx.registeredCommandIds).toEqual([
-      'nd-plugin:a',
-      'nd-plugin:b',
-    ])
+    expect(stores.ctx.disposers).toHaveLength(2)
     cleanupNoteDeckEnv(stores.ctx)
     expect(stores.unregister).toHaveBeenCalledTimes(2)
-    expect(stores.unregister).toHaveBeenNthCalledWith(1, 'nd-plugin:a')
-    expect(stores.unregister).toHaveBeenNthCalledWith(2, 'nd-plugin:b')
-    expect(stores.ctx.registeredCommandIds).toEqual([])
+    expect(stores.unregister).toHaveBeenNthCalledWith(1, 'acme.clock:a')
+    expect(stores.unregister).toHaveBeenNthCalledWith(2, 'acme.clock:b')
+    expect(stores.ctx.disposers).toEqual([])
   })
 
   it('unsubscribes every active Nd:on subscription', async () => {
@@ -482,10 +486,98 @@ describe('cleanupNoteDeckEnv', () => {
       values.STR('streaming:status'),
       dummyHandler,
     ])
-    expect(stores.ctx.subscriptions).toHaveLength(2)
+    expect(stores.ctx.disposers).toHaveLength(2)
     cleanupNoteDeckEnv(stores.ctx)
     expect(unsubA).toHaveBeenCalledTimes(1)
     expect(unsubB).toHaveBeenCalledTimes(1)
-    expect(stores.ctx.subscriptions).toEqual([])
+    expect(stores.ctx.disposers).toEqual([])
+  })
+})
+
+describe('登録解除の規約 — disposers 一本化 (#794 原則 5)', () => {
+  it('登録種別に関係なく cleanupNoteDeckEnv が一括解除する', () => {
+    const stores = makeFakeStores()
+    const order: string[] = []
+    stores.ctx.disposers.push(() => order.push('a'))
+    stores.ctx.disposers.push(() => order.push('b'))
+
+    cleanupNoteDeckEnv(stores.ctx)
+
+    expect(order).toEqual(['a', 'b'])
+    expect(stores.ctx.disposers).toEqual([])
+  })
+
+  it('1 つの disposer が throw しても残りは解除される', () => {
+    const stores = makeFakeStores()
+    const after = vi.fn()
+    stores.ctx.disposers.push(() => {
+      throw new Error('boom')
+    })
+    stores.ctx.disposers.push(after)
+
+    expect(() => cleanupNoteDeckEnv(stores.ctx)).not.toThrow()
+    expect(after).toHaveBeenCalledTimes(1)
+    expect(stores.ctx.disposers).toEqual([])
+  })
+
+  it('二重 cleanup は安全 (プラグイン停止が二度走っても壊れない)', () => {
+    const stores = makeFakeStores()
+    const dispose = vi.fn()
+    stores.ctx.disposers.push(dispose)
+
+    cleanupNoteDeckEnv(stores.ctx)
+    cleanupNoteDeckEnv(stores.ctx)
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('登録 ID は provider 名前空間 (#794 未決事項 2)', () => {
+  it('コマンド ID が <provider>:<localName> になる', async () => {
+    const stores = makeFakeStores()
+    const env = createNoteDeckEnv(stores.ctx)
+    await callRegisterCommand(env, [
+      values.STR('greet'),
+      values.STR('G'),
+      values.STR('ti-g'),
+      dummyHandler,
+    ])
+    expect(stores.register.mock.calls[0]?.[0]?.id).toBe('acme.clock:greet')
+  })
+
+  it('同一 ID の二重登録は先勝ちで拒否する', async () => {
+    const stores = makeFakeStores()
+    const env = createNoteDeckEnv(stores.ctx)
+    const args = [
+      values.STR('greet'),
+      values.STR('G'),
+      values.STR('ti-g'),
+      dummyHandler,
+    ]
+    await callRegisterCommand(env, args)
+    await expect(callRegisterCommand(env, args)).rejects.toThrow(
+      /already registered/,
+    )
+    expect(stores.register).toHaveBeenCalledTimes(1)
+  })
+
+  it('provider が違えば同じ名前でも衝突しない', async () => {
+    const a = makeFakeStores()
+    const b = makeFakeStores()
+    b.ctx.provider = 'other.plugin'
+    await callRegisterCommand(createNoteDeckEnv(a.ctx), [
+      values.STR('greet'),
+      values.STR('G'),
+      values.STR('ti-g'),
+      dummyHandler,
+    ])
+    await callRegisterCommand(createNoteDeckEnv(b.ctx), [
+      values.STR('greet'),
+      values.STR('G'),
+      values.STR('ti-g'),
+      dummyHandler,
+    ])
+    expect(a.register.mock.calls[0]?.[0]?.id).toBe('acme.clock:greet')
+    expect(b.register.mock.calls[0]?.[0]?.id).toBe('other.plugin:greet')
   })
 })

--- a/src/aiscript/notedeck-api.ts
+++ b/src/aiscript/notedeck-api.ts
@@ -6,13 +6,13 @@ import { listCapabilities } from '@/capabilities/registry'
 import type { CapabilitySignature, PermissionKey } from '@/capabilities/types'
 import type { Command, useCommandStore } from '@/commands/registry'
 import type { Principal } from '@/permissions/principal'
+import { makeRegistrationId } from '@/plugins/registrationId'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { version as appVersion } from '../../package.json'
 import {
   type NoteDeckEventName,
   SUPPORTED_EVENT_NAMES,
   subscribeNoteDeckEvent,
-  type Unsubscribe,
 } from './events'
 
 export interface NoteDeckEnvContext {
@@ -25,12 +25,24 @@ export interface NoteDeckEnvContext {
    * populate できない実行文脈は plugin principal を名乗れない (型で強制)。
    */
   principal: Principal
+  /**
+   * 登録アイテムの名前空間になるプラグイン安定キー (#794 未決事項 2)。
+   * `pluginProviderKey` の戻り値 — MisStore 配布物は storeId、ローカル自作は
+   * `local:<installId>`。全登録 ID がこの下に切られるので、プラグイン同士が
+   * 名前で衝突しない。
+   */
+  provider: string
   /** Set after interpreter is created, enables Nd:register_command handlers */
   interpreter?: Interpreter
-  /** Track registered command IDs for cleanup */
-  registeredCommandIds: string[]
-  /** Active Nd:on subscriptions; auto-disposed by cleanupNoteDeckEnv */
-  subscriptions: Unsubscribe[]
+  /**
+   * この env が行った全登録の解除関数 (#794 原則 5)。
+   *
+   * 「プラグインからの登録は必ずコンテキスト経由で行い、停止時に一括解除される」
+   * を単一の配列で表現する。登録面ごとに配列を増やす方式だと、開放面が 1 つ
+   * 増えるたび cleanup 側にも 1 行足す必要があり、#794 が解こうとしている
+   * まだら化を解除側で再発させる。
+   */
+  disposers: Array<() => void>
   /**
    * 呼び出し文脈のアカウントを返すアクセサ (#821)。プラグインは
    * withPluginAccountContext が設定するミュータブル文脈を読むため関数。
@@ -177,13 +189,13 @@ export function createNoteDeckEnv(
         console.warn('[Nd:on]', eventName, e)
       }
     })
-    ctx.subscriptions.push(unsubscribe)
+    ctx.disposers.push(unsubscribe)
 
     // AiScript 側に返す unsubscribe 関数
     return values.FN_NATIVE(() => {
       unsubscribe()
-      const idx = ctx.subscriptions.indexOf(unsubscribe)
-      if (idx >= 0) ctx.subscriptions.splice(idx, 1)
+      const idx = ctx.disposers.indexOf(unsubscribe)
+      if (idx >= 0) ctx.disposers.splice(idx, 1)
     })
   })
 
@@ -203,7 +215,14 @@ export function createNoteDeckEnv(
       utils.assertFunction(handlerVal)
 
       const parsed = parseRegisterCommandOptions(optionsVal)
-      const commandId = `nd-plugin:${idVal.value}`
+      // 旧実装は全プラグイン共通の `nd-plugin:` 名前空間だったため、別々の
+      // プラグインが同じ id を使うと無言で後勝ち上書きされていた
+      const commandId = makeRegistrationId(ctx.provider, idVal.value)
+      if (commandStore.commands.has(commandId)) {
+        throw new Error(
+          `Nd:register_command: "${commandId}" already registered`,
+        )
+      }
       const handler = handlerVal as VFn
       const command: Command = {
         id: commandId,
@@ -240,7 +259,7 @@ export function createNoteDeckEnv(
       if (parsed.signature) command.signature = parsed.signature
 
       commandStore.register(command)
-      ctx.registeredCommandIds.push(commandId)
+      ctx.disposers.push(() => commandStore.unregister(commandId))
     },
   )
 
@@ -252,18 +271,17 @@ export function createNoteDeckEnv(
  * プラグイン abort / カラム破棄 / interpreter 再起動時に呼ばれる。
  */
 export function cleanupNoteDeckEnv(ctx: NoteDeckEnvContext): void {
-  for (const id of ctx.registeredCommandIds) {
-    ctx.commandStore.unregister(id)
-  }
-  ctx.registeredCommandIds.length = 0
-  for (const unsub of ctx.subscriptions) {
+  // 配列を先に空にしてから回す。解除中に例外が出ても未解除分が残らないよう、
+  // また二重 cleanup で同じ disposer が二度走らないようにするため。
+  const disposers = ctx.disposers.splice(0, ctx.disposers.length)
+  for (const dispose of disposers) {
     try {
-      unsub()
+      dispose()
     } catch (e) {
-      console.warn('[cleanupNoteDeckEnv] unsubscribe failed:', e)
+      // 1 つの失敗で残りの解除を止めない (解除漏れの方が被害が大きい)
+      console.warn('[cleanupNoteDeckEnv] dispose failed:', e)
     }
   }
-  ctx.subscriptions.length = 0
 }
 
 function isSupportedEvent(name: string): name is NoteDeckEventName {

--- a/src/aiscript/plugin-api.test.ts
+++ b/src/aiscript/plugin-api.test.ts
@@ -568,6 +568,23 @@ describe('abort / launchAll', () => {
   })
 })
 
+describe('セーフモード (#794)', () => {
+  afterEach(() => {
+    localStorage.removeItem('nd-safe-mode')
+  })
+
+  it('セーフモード中は active なプラグインでも起動しない', async () => {
+    localStorage.setItem('nd-safe-mode', 'true')
+    await installAndLaunch('Plugin:register_note_action("A", @(note) { note })')
+    expect(getPluginHandlers('note_action')).toHaveLength(0)
+  })
+
+  it('セーフモード解除後は通常どおり起動する', async () => {
+    await installAndLaunch('Plugin:register_note_action("A", @(note) { note })')
+    expect(getPluginHandlers('note_action')).toHaveLength(1)
+  })
+})
+
 describe('Mk:toast (プラグイン env の配線)', () => {
   // onToast 未配線だと Mk:toast が無言の no-op になり、プラグインからの
   // 成否フィードバックがユーザーに一切届かない (実機で「押しても無反応」)

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -8,6 +8,7 @@ import {
 import type { Value, VFn } from '@syuilo/aiscript/interpreter/value.js'
 import type { JsonValue } from '@/bindings'
 import { assertMisskeyApiAllowed } from '@/permissions/misskeyApiGate'
+import { pluginProviderKey } from '@/plugins/registrationId'
 import { accountScopeKey, useAccountsStore } from '@/stores/accounts'
 import {
   type AiScriptRunLogger,
@@ -532,8 +533,8 @@ export async function launchPlugin(plugin: PluginMeta): Promise<void> {
       pluginId: plugin.installId,
       name: plugin.name,
     },
-    registeredCommandIds: [],
-    subscriptions: [],
+    provider: pluginProviderKey(plugin),
+    disposers: [],
     // Nd:call が Mk:api と同じアカウント文脈 (withPluginAccountContext) を
     // 参照する (#821)
     getAccountId: () => ctx.accountId,

--- a/src/aiscript/plugin-api.ts
+++ b/src/aiscript/plugin-api.ts
@@ -20,6 +20,7 @@ import {
   usePluginsStore,
 } from '@/stores/plugins'
 import { useToast } from '@/stores/toast'
+import { readSafeMode } from '@/utils/safeMode'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { openSafeUrl } from '@/utils/url'
 import { createAiScriptEnv } from './api'
@@ -486,6 +487,9 @@ export function applyNotePostInterruptors<T>(
 const pluginRunLoggers = new Map<string, AiScriptRunLogger>()
 
 export async function launchPlugin(plugin: PluginMeta): Promise<void> {
+  // セーフモード (#794) — 起動経路を 1 箇所で塞ぐ。プラグイン管理からの手動
+  // 再起動もここを通るので、追加の gate は要らない
+  if (readSafeMode()) return
   if (!plugin.src || !plugin.active) return
 
   // Abort existing instance if re-launching

--- a/src/capabilities/builtins/column.test.ts
+++ b/src/capabilities/builtins/column.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ALL_COLUMN_TYPES,
+  COLUMN_REGISTRY,
+  registerColumnType,
+  unregisterColumnType,
+} from '@/columns/registry'
 import {
   COLUMN_BUILTIN_CAPABILITIES,
   columnAddCapability,
@@ -118,5 +124,51 @@ describe('COLUMN_BUILTIN_CAPABILITIES', () => {
     expect(COLUMN_BUILTIN_CAPABILITIES).toContain(columnListCapability)
     expect(COLUMN_BUILTIN_CAPABILITIES).toContain(columnAddCapability)
     expect(COLUMN_BUILTIN_CAPABILITIES).toContain(columnRemoveCapability)
+  })
+})
+
+describe('addable な種別はレジストリ由来 (#794 W2)', () => {
+  const enumTypes = () =>
+    (columnAddCapability.signature?.params?.type?.enum ??
+      []) as readonly string[]
+
+  afterEach(() => {
+    unregisterColumnType('x:demo')
+  })
+
+  it('固有の生成フローを持つ種別だけを除外する', () => {
+    for (const t of ['widget', 'aiscript', 'play', 'page']) {
+      expect(enumTypes()).not.toContain(t)
+    }
+    // 手書きリスト時代に取りこぼしていた role も lookup ID 付きで追加できる
+    expect(enumTypes()).toContain('role')
+  })
+
+  it('レジストリの全種別 (除外分を除く) が enum に載る', () => {
+    const expected = ALL_COLUMN_TYPES.filter(
+      (t) => !COLUMN_REGISTRY[t]?.customAddFlow,
+    )
+    expect([...enumTypes()].sort()).toEqual([...expected].sort())
+  })
+
+  it('実行時登録した種別が enum に載る', () => {
+    expect(enumTypes()).not.toContain('x:demo')
+    registerColumnType('x:demo', {
+      label: 'デモ',
+      icon: 'flask',
+      group: 'tool',
+      component: async () => ({ default: {} }),
+    })
+    expect(enumTypes()).toContain('x:demo')
+  })
+
+  it('lookup ID 必須の対応表もレジストリの selectable.idKey 由来', () => {
+    // role は registry で roleId を宣言しているので、ID 無しでは弾かれる
+    expect(() =>
+      columnAddCapability.execute?.(
+        { type: 'role' },
+        { principal: { kind: 'user' } },
+      ),
+    ).toThrow(/roleId/)
   })
 })

--- a/src/capabilities/builtins/column.ts
+++ b/src/capabilities/builtins/column.ts
@@ -1,60 +1,27 @@
+import { ALL_COLUMN_TYPES, COLUMN_REGISTRY } from '@/columns/registry'
 import type { Command } from '@/commands/registry'
 import { useAccountsStore } from '@/stores/accounts'
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 
 /**
- * `column.add` で受け付けるカラム種別。lookup ID 必須カラム (list / antenna /
- * channel / clip / user) は対応する `*Id` を `params` で渡せばここから追加できる。
- * `widget` / `aiscript` / `play` / `page` 等は固有の生成フローが必要なため
- * 引き続き専用 UI 経由で追加する。
+ * `column.add` で受け付けるカラム種別 (#794 W2)。
+ *
+ * 手書きの許可リストではなくカラムレジストリから導出する。手書きだと種別を
+ * 足すたびに更新漏れが起き (実際に role が抜けていた)、実行時登録された
+ * プラグイン定義カラムは原理的に載せられない。
+ *
+ * 除外するのは「先に中身を作る」固有フローを持つ種別 (customAddFlow) だけ。
  */
-const ADDABLE_COLUMN_TYPES: readonly ColumnType[] = [
-  // 引数なしで開けるシンプル系
-  'timeline',
-  'notifications',
-  'mentions',
-  'specified',
-  'search',
-  'favorites',
-  'drive',
-  'gallery',
-  'explore',
-  'memos',
-  'charts',
-  'federation',
-  'aboutMisskey',
-  'announcements',
-  'achievements',
-  'followRequests',
-  'apiConsole',
-  'apiDocs',
-  'lookup',
-  'serverInfo',
-  'streamInspector',
-  'pluginManager',
-  'themeManager',
-  'taskRunner',
-  'skill',
-  'ai',
-  'chat',
-  'emoji',
-  'ads',
-  // lookup ID 必須カラム
-  'list',
-  'antenna',
-  'channel',
-  'clip',
-  'user',
-] as const
+function addableColumnTypes(): readonly ColumnType[] {
+  return ALL_COLUMN_TYPES.filter((t) => !COLUMN_REGISTRY[t]?.customAddFlow)
+}
 
-/** type と必須 lookup ID の対応表 */
-const LOOKUP_ID_REQUIRED: Partial<Record<ColumnType, keyof DeckColumn>> = {
-  list: 'listId',
-  antenna: 'antennaId',
-  channel: 'channelId',
-  clip: 'clipId',
-  user: 'userId',
+/**
+ * type と必須 lookup ID の対応表。レジストリの `selectable.idKey` が正本。
+ */
+function lookupIdKey(type: ColumnType): keyof DeckColumn | undefined {
+  return COLUMN_REGISTRY[type]?.selectable?.idKey
 }
 
 /**
@@ -180,7 +147,11 @@ export const columnAddCapability: Command = {
       type: {
         type: 'string',
         description: '追加するカラムの種別',
-        enum: ADDABLE_COLUMN_TYPES,
+        // getter: tool schema は呼び出しのたびに組まれるので、実行時登録
+        // された種別もそのまま AI に見える
+        get enum() {
+          return addableColumnTypes()
+        },
       },
       name: {
         type: 'string',
@@ -242,13 +213,14 @@ export const columnAddCapability: Command = {
   visible: false,
   execute: (params) => {
     const type = typeof params?.type === 'string' ? params.type : ''
-    if (!ADDABLE_COLUMN_TYPES.includes(type as ColumnType)) {
+    const addable = addableColumnTypes()
+    if (!addable.includes(type as ColumnType)) {
       throw new Error(
         `Unsupported column type "${type}". ` +
-          `Supported: ${ADDABLE_COLUMN_TYPES.join(', ')}`,
+          `Supported: ${addable.join(', ')}`,
       )
     }
-    const requiredIdKey = LOOKUP_ID_REQUIRED[type as ColumnType]
+    const requiredIdKey = lookupIdKey(type as ColumnType)
     if (requiredIdKey && typeof params?.[requiredIdKey] !== 'string') {
       throw new Error(`${requiredIdKey} is required for column type "${type}"`)
     }
@@ -538,7 +510,11 @@ export const sidebarToggleCapability: Command = {
         type: 'string',
         description:
           'カラム種別 (notifications / chat / search / ai / memos など)',
-        enum: ADDABLE_COLUMN_TYPES,
+        // getter: tool schema は呼び出しのたびに組まれるので、実行時登録
+        // された種別もそのまま AI に見える
+        get enum() {
+          return addableColumnTypes()
+        },
       },
       accountId: {
         type: 'string',
@@ -554,10 +530,11 @@ export const sidebarToggleCapability: Command = {
   visible: false,
   execute: (params) => {
     const type = typeof params?.type === 'string' ? params.type : ''
-    if (!ADDABLE_COLUMN_TYPES.includes(type as ColumnType)) {
+    const addable = addableColumnTypes()
+    if (!addable.includes(type as ColumnType)) {
       throw new Error(
         `Unsupported column type "${type}". ` +
-          `Supported: ${ADDABLE_COLUMN_TYPES.join(', ')}`,
+          `Supported: ${addable.join(', ')}`,
       )
     }
     const accountId =

--- a/src/capabilities/builtins/navbar.ts
+++ b/src/capabilities/builtins/navbar.ts
@@ -1,7 +1,9 @@
+import { isColumnType } from '@/columns/registry'
 import type { Command } from '@/commands/registry'
 import {
   type ColumnType,
   DEFAULT_NAV_ITEMS,
+  isNavDivider,
   type NavItem,
   useDeckStore,
 } from '@/stores/deck'
@@ -19,48 +21,6 @@ import {
  *   基本構造のみ AI 操作対象。複雑な columnProps が必要なら手で UI から触る
  *   (= AI 用 API はシンプルに保つ)
  */
-
-const VALID_COLUMN_TYPES: readonly ColumnType[] = [
-  'timeline',
-  'notifications',
-  'search',
-  'list',
-  'antenna',
-  'favorites',
-  'clip',
-  'user',
-  'mentions',
-  'channel',
-  'role',
-  'specified',
-  'chat',
-  'widget',
-  'aiscript',
-  'play',
-  'page',
-  'ai',
-  'announcements',
-  'drive',
-  'gallery',
-  'explore',
-  'followRequests',
-  'achievements',
-  'apiConsole',
-  'apiDocs',
-  'lookup',
-  'serverInfo',
-  'ads',
-  'aboutMisskey',
-  'emoji',
-  'streamInspector',
-  'pluginManager',
-  'themeManager',
-  'taskRunner',
-  'memos',
-  'charts',
-  'federation',
-  'skill',
-] as const
 
 /** AI 入力 (JSON) を NavItem[] に変換しつつ最小限の sanity check。 */
 function parseNavItems(input: unknown): NavItem[] {
@@ -81,7 +41,9 @@ function parseNavItems(input: unknown): NavItem[] {
     if (typeof obj.type !== 'string') {
       throw new Error(`navbar.set: item #${i} missing string "type"`)
     }
-    if (!VALID_COLUMN_TYPES.includes(obj.type as ColumnType)) {
+    // 手書きの許可リストではなくレジストリ照会 (#794 W2)。実行時登録された
+    // プラグイン定義カラムもナビバーに置ける
+    if (!isColumnType(obj.type)) {
       throw new Error(`navbar.set: item #${i} has unknown type "${obj.type}"`)
     }
     const item: NavItem = {
@@ -121,7 +83,7 @@ export const navbarListCapability: Command = {
   execute: () => {
     const store = useDeckStore()
     return store.navItems.map((item) => {
-      if (item.type === 'divider') return { type: 'divider' as const }
+      if (isNavDivider(item)) return { type: 'divider' as const }
       return {
         type: item.type,
         accountId: item.accountId,
@@ -196,7 +158,7 @@ export const navbarResetCapability: Command = {
     message: `現在のカスタム構成を破棄し、デフォルトの ${DEFAULT_NAV_ITEMS.length} 項目に戻します。`,
     code: JSON.stringify(
       DEFAULT_NAV_ITEMS.map((i) =>
-        i.type === 'divider'
+        isNavDivider(i)
           ? { type: 'divider' }
           : { type: i.type, accountId: i.accountId },
       ),

--- a/src/capabilities/builtins/windows.test.ts
+++ b/src/capabilities/builtins/windows.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { WINDOW_SIZES } from '@/stores/windows'
 import {
   WINDOWS_BUILTIN_CAPABILITIES,
   windowsCloseAllCapability,
@@ -83,6 +84,27 @@ describe('WINDOWS_BUILTIN_CAPABILITIES', () => {
   it('all capabilities are exposed to AI (aiTool: true)', () => {
     for (const cap of WINDOWS_BUILTIN_CAPABILITIES) {
       expect(cap.aiTool, `${cap.id} should be aiTool`).toBe(true)
+    }
+  })
+})
+
+describe('valid な WindowType はレジストリ相当 (WINDOW_SIZES) 由来 (#794 W2)', () => {
+  const enumTypes = () =>
+    (windowsOpenCapability.signature?.params?.type?.enum ??
+      []) as readonly string[]
+
+  it('全 WindowType が enum に載る', () => {
+    expect([...enumTypes()].sort()).toEqual(Object.keys(WINDOW_SIZES).sort())
+  })
+
+  it('手書き時代に漏れていた 4 種も開ける', () => {
+    for (const t of [
+      'drive-file-detail',
+      'connections',
+      'connectionEdit',
+      'tutorial',
+    ]) {
+      expect(enumTypes()).toContain(t)
     }
   })
 })

--- a/src/capabilities/builtins/windows.ts
+++ b/src/capabilities/builtins/windows.ts
@@ -1,5 +1,9 @@
 import type { Command } from '@/commands/registry'
-import { useWindowsStore, type WindowType } from '@/stores/windows'
+import {
+  useWindowsStore,
+  WINDOW_SIZES,
+  type WindowType,
+} from '@/stores/windows'
 
 /**
  * Windows 系 capability — DeckWindow (= 一時 UI、設定エディタ / プロファイル
@@ -13,42 +17,23 @@ import { useWindowsStore, type WindowType } from '@/stores/windows'
  * - windows.close も確認 UI 無し (= 不要なウィンドウを片付けるための片手間)
  * - windows.closeAll は念のため warning 確認 (= 大量同時破棄が起きるので意図確認)
  * - WindowType の enum を embed して AI に valid な type を伝える
+ *   (enum はレジストリ相当の WINDOW_SIZES から導出する)
  */
 
-const VALID_WINDOW_TYPES: readonly WindowType[] = [
-  'note-detail',
-  'note-inspector',
-  'notification-inspector',
-  'user-profile',
-  'federation-instance',
-  'follow-list',
-  'login',
-  'plugins',
-  'keybinds',
-  'cssEditor',
-  'themeEditor',
-  'profileEditor',
-  'aiSettings',
-  'permissions',
-  'about',
-  'navEditor',
-  'performanceEditor',
-  'appearanceEditor',
-  'backup',
-  'cacheEditor',
-  'tasksEditor',
-  'snippetsEditor',
-  'memoEditor',
-  'page-detail',
-  'play-detail',
-  'gallery-detail',
-  'list-detail',
-  'clip-detail',
-  'page-edit',
-  'play-edit',
-  'widget-edit',
-  'skill-edit',
-] as const
+/**
+ * AI から開ける DeckWindow 種別 (#794 W2)。
+ *
+ * 手書きの列挙をやめ WINDOW_SIZES から導出する。WINDOW_SIZES は
+ * `Record<WindowType, _>` なので、ウィンドウ種別を足せば必ずここにも載る
+ * (手書き時代は drive-file-detail / connections / connectionEdit / tutorial の
+ * 4 種が漏れていた)。
+ *
+ * 全種別を開けてよい理由は windows.open が ungated なのと同じ — 開くこと自体は
+ * 可逆で、中の操作は対応する capability で guard される。
+ */
+const VALID_WINDOW_TYPES: readonly WindowType[] = Object.keys(
+  WINDOW_SIZES,
+) as WindowType[]
 
 function isValidWindowType(t: string): t is WindowType {
   return VALID_WINDOW_TYPES.includes(t as WindowType)

--- a/src/columns/registry.dom.test.ts
+++ b/src/columns/registry.dom.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { computed, defineComponent, h } from 'vue'
+import {
+  ACCOUNT_INDEPENDENT_TYPES,
+  ALL_COLUMN_TYPES,
+  buildColumnDefaults,
+  COLUMN_ICONS,
+  COLUMN_LABELS,
+  COLUMN_REGISTRY,
+  COLUMN_TYPE_GROUPS,
+  CROSS_ACCOUNT_TYPES,
+  GUEST_ALLOWED_TYPES,
+  isColumnType,
+  PIP_ENABLED_TYPES,
+  registerColumnType,
+  unregisterColumnType,
+  WIDE_COLUMN_TYPES,
+} from './registry'
+
+const Stub = defineComponent({ render: () => h('div') })
+
+function spec(overrides: Record<string, unknown> = {}) {
+  return {
+    label: 'テスト',
+    icon: 'flask',
+    group: 'tool' as const,
+    component: async () => ({ default: Stub }),
+    ...overrides,
+  }
+}
+
+describe('カラムレジストリの実行時登録 (#794 W2)', () => {
+  afterEach(() => {
+    unregisterColumnType('x:demo')
+    unregisterColumnType('x:other')
+  })
+
+  it('登録した種別が registry と派生に反映される', () => {
+    registerColumnType('x:demo', spec())
+
+    expect(COLUMN_REGISTRY['x:demo']).toBeDefined()
+    expect(ALL_COLUMN_TYPES).toContain('x:demo')
+    expect(COLUMN_LABELS['x:demo']).toBe('テスト')
+    expect(COLUMN_ICONS['x:demo']).toBe('flask')
+    expect(isColumnType('x:demo')).toBe(true)
+  })
+
+  it('解除すると registry と派生の両方から消える', () => {
+    registerColumnType('x:demo', spec())
+    unregisterColumnType('x:demo')
+
+    expect(COLUMN_REGISTRY['x:demo']).toBeUndefined()
+    expect(ALL_COLUMN_TYPES).not.toContain('x:demo')
+    expect(COLUMN_LABELS['x:demo']).toBeUndefined()
+    expect(isColumnType('x:demo')).toBe(false)
+  })
+
+  it('フラグが各派生 Set に反映される', () => {
+    registerColumnType(
+      'x:demo',
+      spec({ guestAllowed: true, crossAccount: true, wide: true }),
+    )
+
+    expect(GUEST_ALLOWED_TYPES.has('x:demo')).toBe(true)
+    expect(CROSS_ACCOUNT_TYPES.has('x:demo')).toBe(true)
+    expect(WIDE_COLUMN_TYPES.has('x:demo')).toBe(true)
+    expect(ACCOUNT_INDEPENDENT_TYPES.has('x:demo')).toBe(false)
+  })
+
+  it('登録種別は既定で PiP 非対応 (#794 未決事項 5)', () => {
+    registerColumnType('x:demo', spec())
+    expect(PIP_ENABLED_TYPES.has('x:demo')).toBe(false)
+
+    // 組込は従来どおり PiP 可
+    expect(PIP_ENABLED_TYPES.has('timeline')).toBe(true)
+  })
+
+  it('group に応じて COLUMN_TYPE_GROUPS へ入る', () => {
+    registerColumnType('x:demo', spec({ group: 'tool' }))
+    const tool = COLUMN_TYPE_GROUPS.find((g) => g.group === 'tool')
+    expect(tool?.types).toContain('x:demo')
+  })
+
+  it('組込の ID 空間は予約されており上書きできない', () => {
+    expect(() => registerColumnType('timeline', spec())).toThrow()
+    expect(COLUMN_LABELS.timeline).toBe('タイムライン')
+  })
+
+  it('同じ ID の二重登録は先勝ちで拒否する (#794 未決事項 2)', () => {
+    registerColumnType('x:demo', spec({ label: '先' }))
+    expect(() => registerColumnType('x:demo', spec({ label: '後' }))).toThrow()
+    expect(COLUMN_LABELS['x:demo']).toBe('先')
+  })
+
+  it('組込の解除は拒否する', () => {
+    expect(() => unregisterColumnType('timeline')).toThrow()
+    expect(COLUMN_REGISTRY.timeline).toBeDefined()
+  })
+
+  it('未登録種別の解除は何もしない (停止時の一括解除が二重に走っても安全)', () => {
+    expect(() => unregisterColumnType('x:never-registered')).not.toThrow()
+  })
+
+  it('buildColumnDefaults が登録種別にも効く', () => {
+    registerColumnType('x:demo', spec({ defaultWidth: 480 }))
+    const defaults = buildColumnDefaults('x:demo', null)
+    expect(defaults.name).toBe('テスト')
+    expect(defaults.width).toBe(480)
+  })
+
+  it('登録が Vue の computed に伝播する (プラグイン起動はデッキ復元より後)', () => {
+    const labels = computed(() => ALL_COLUMN_TYPES.map((t) => COLUMN_LABELS[t]))
+    expect(labels.value).not.toContain('テスト')
+
+    registerColumnType('x:demo', spec())
+    expect(labels.value).toContain('テスト')
+
+    unregisterColumnType('x:demo')
+    expect(labels.value).not.toContain('テスト')
+  })
+})

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -1,6 +1,6 @@
 import type { Component } from 'vue'
-import { defineAsyncComponent } from 'vue'
-import type { ColumnType, DeckColumn } from '@/stores/deck'
+import { defineAsyncComponent, reactive, shallowReactive } from 'vue'
+import type { BuiltinColumnType, ColumnType, DeckColumn } from '@/stores/deck'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 export type ColumnGroup = 'account' | 'server' | 'tool'
@@ -54,6 +54,12 @@ export interface ColumnSpec {
   component: () => Promise<{ default: Component }>
   /** list/antenna/channel/clip/user のような選択式タイプ */
   selectable?: SelectableSpec
+  /**
+   * 固有の生成フローを持つため汎用の追加経路 (`column.add` capability) からは
+   * 作れない。ウィジェット / AiScript / Play / ページのように「先に中身を
+   * 作る」種別が該当する。
+   */
+  customAddFlow?: boolean
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: bindings の Result<T, E> と SelectableItem の橋渡し
@@ -164,10 +170,13 @@ async function fetchListsWithFavorites(
 }
 
 /**
- * カラム種別の Single Source of Truth。
+ * 組込カラム種別の定義。`Record<BuiltinColumnType, _>` なので、種別を足して
+ * ここに書き忘れるとコンパイルエラーになる (開いた registry では検査できない
+ * 網羅性を、この 1 定数で維持する)。
+ *
  * UI 表示順はこのオブジェクトの宣言順を用いる (group ごとに抽出)。
  */
-export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
+const BUILTIN_COLUMN_REGISTRY: Record<BuiltinColumnType, ColumnSpec> = {
   // ============================================================
   // アカウント系
   // ============================================================
@@ -394,6 +403,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
     icon: 'player-play',
     group: 'server',
     guestAllowed: true,
+    customAddFlow: true,
     component: () => import('@/components/deck/DeckPlayColumn.vue'),
   },
   page: {
@@ -401,6 +411,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
     icon: 'note',
     group: 'server',
     guestAllowed: true,
+    customAddFlow: true,
     component: () => import('@/components/deck/DeckPageColumn.vue'),
   },
   user: {
@@ -468,6 +479,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
     // column.accountId を `Mk:api` に渡して使うため、null = 認証必須機能の
     // capability チェックで弾かれる仕様。
     crossAccount: true,
+    customAddFlow: true,
     defaultProps: { widgets: [] },
     component: () => import('@/components/deck/DeckWidgetColumn.vue'),
   },
@@ -486,6 +498,7 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
     group: 'tool',
     guestAllowed: true,
     accountOptional: true,
+    customAddFlow: true,
     defaultProps: { aiscriptCode: '<: "Hello, AiScript!"' },
     component: () => import('@/components/deck/DeckAiScriptColumn.vue'),
   },
@@ -545,47 +558,49 @@ export const COLUMN_REGISTRY: Record<ColumnType, ColumnSpec> = {
 }
 
 // ============================================================
-// 派生ヘルパー
+// レジストリ本体と派生 (#794 W2)
 // ============================================================
 
+/**
+ * カラム種別の Single Source of Truth。組込 + 実行時登録分。
+ *
+ * shallowReactive: プラグインの登録/解除が Vue の computed に伝播する必要が
+ * ある (プラグイン起動はデッキ復元より後なので、登録時点で UI は既に描画済み)。
+ * ColumnSpec 自体は不変なので深い追跡は不要。
+ */
+export const COLUMN_REGISTRY = shallowReactive<Record<string, ColumnSpec>>({
+  ...BUILTIN_COLUMN_REGISTRY,
+})
+
+const BUILTIN_TYPES: ReadonlySet<string> = new Set(
+  Object.keys(BUILTIN_COLUMN_REGISTRY),
+)
+
+// 派生は「登録のたびに全再構築」する。派生ごとに差分更新すると、派生が 1 つ
+// 増えるたびに更新漏れの面が増える (= #794 が解こうとしている、まだら化そのもの)。
+// 全再構築なら rebuildDerived が唯一の同期点になる。
+// いずれも reactive で、参照側の `.has()` / `[type]` / `.filter()` はそのまま
+// 追跡される — 呼び出し側の書き換えが不要。
+
 /** Registry 宣言順の全カラムタイプ */
-export const ALL_COLUMN_TYPES = Object.keys(
-  COLUMN_REGISTRY,
-) as readonly ColumnType[]
+export const ALL_COLUMN_TYPES: ColumnType[] = reactive([])
 
-export function isColumnType(value: unknown): value is ColumnType {
-  return typeof value === 'string' && value in COLUMN_REGISTRY
-}
+export const COLUMN_LABELS: Record<string, string> = reactive({})
 
-export const COLUMN_LABELS: Record<string, string> = Object.fromEntries(
-  ALL_COLUMN_TYPES.map((t) => [t, COLUMN_REGISTRY[t].label]),
-)
+export const COLUMN_ICONS: Record<string, string> = reactive({})
 
-export const COLUMN_ICONS: Record<string, string> = Object.fromEntries(
-  ALL_COLUMN_TYPES.map((t) => [t, COLUMN_REGISTRY[t].icon]),
-)
+export const GUEST_ALLOWED_TYPES: Set<ColumnType> = reactive(new Set())
+export const CROSS_ACCOUNT_TYPES: Set<ColumnType> = reactive(new Set())
+export const ACCOUNT_OPTIONAL_TYPES: Set<ColumnType> = reactive(new Set())
+export const ACCOUNT_INDEPENDENT_TYPES: Set<ColumnType> = reactive(new Set())
+export const WIDE_COLUMN_TYPES: Set<ColumnType> = reactive(new Set())
 
-function typesWithFlag(
-  flag:
-    | 'guestAllowed'
-    | 'crossAccount'
-    | 'accountOptional'
-    | 'accountIndependent'
-    | 'wide',
-): Set<ColumnType> {
-  return new Set(ALL_COLUMN_TYPES.filter((t) => COLUMN_REGISTRY[t][flag]))
-}
-
-export const GUEST_ALLOWED_TYPES = typesWithFlag('guestAllowed')
-export const CROSS_ACCOUNT_TYPES = typesWithFlag('crossAccount')
-export const ACCOUNT_OPTIONAL_TYPES = typesWithFlag('accountOptional')
-export const ACCOUNT_INDEPENDENT_TYPES = typesWithFlag('accountIndependent')
-export const WIDE_COLUMN_TYPES = typesWithFlag('wide')
-
-/** pipEnabled は既定 true。false を明示したカラムのみ除外する。 */
-export const PIP_ENABLED_TYPES: ReadonlySet<ColumnType> = new Set(
-  ALL_COLUMN_TYPES.filter((t) => COLUMN_REGISTRY[t].pipEnabled !== false),
-)
+/**
+ * pipEnabled は組込では既定 true (false を明示して opt-out)。
+ * 実行時登録されたカラムは既定 false — PiP は別 WebView で、プラグインの
+ * インタプリタをどちら側で動かすかが未定のため (#794 未決事項 5)。
+ */
+export const PIP_ENABLED_TYPES: Set<ColumnType> = reactive(new Set())
 
 export interface ColumnGroupInfo {
   group: ColumnGroup
@@ -595,31 +610,91 @@ export interface ColumnGroupInfo {
 }
 
 /** AddColumnDialog / コマンドパレット双方が使う UI グループ定義 */
-export const COLUMN_TYPE_GROUPS: ColumnGroupInfo[] = (() => {
-  const mk = (
-    group: ColumnGroup,
-    label: string,
-    icon: string,
-  ): ColumnGroupInfo => ({
-    group,
-    label,
-    icon,
-    types: ALL_COLUMN_TYPES.filter((t) => COLUMN_REGISTRY[t].group === group),
-  })
-  return [
-    mk('account', 'アカウント', 'user'),
-    mk('server', 'サーバー', 'server'),
-    mk('tool', 'ツール', 'tool'),
-  ]
-})()
+export const COLUMN_TYPE_GROUPS: ColumnGroupInfo[] = reactive([
+  { group: 'account', label: 'アカウント', icon: 'user', types: [] },
+  { group: 'server', label: 'サーバー', icon: 'server', types: [] },
+  { group: 'tool', label: 'ツール', icon: 'tool', types: [] },
+])
 
 /** Vue コンポーネントマップ (PipPage / DeckColumnsArea から参照) */
-export const COLUMN_COMPONENTS: Record<string, Component> = Object.fromEntries(
-  ALL_COLUMN_TYPES.map((t) => [
-    t,
-    defineAsyncComponent(COLUMN_REGISTRY[t].component),
-  ]),
-)
+export const COLUMN_COMPONENTS = shallowReactive<Record<string, Component>>({})
+
+const FLAG_SETS: ReadonlyArray<[keyof ColumnSpec, Set<ColumnType>]> = [
+  ['guestAllowed', GUEST_ALLOWED_TYPES],
+  ['crossAccount', CROSS_ACCOUNT_TYPES],
+  ['accountOptional', ACCOUNT_OPTIONAL_TYPES],
+  ['accountIndependent', ACCOUNT_INDEPENDENT_TYPES],
+  ['wide', WIDE_COLUMN_TYPES],
+]
+
+function rebuildDerived(): void {
+  const types = Object.keys(COLUMN_REGISTRY)
+
+  ALL_COLUMN_TYPES.length = 0
+  ALL_COLUMN_TYPES.push(...types)
+
+  for (const key of Object.keys(COLUMN_LABELS)) delete COLUMN_LABELS[key]
+  for (const key of Object.keys(COLUMN_ICONS)) delete COLUMN_ICONS[key]
+  for (const key of Object.keys(COLUMN_COMPONENTS))
+    delete COLUMN_COMPONENTS[key]
+  for (const [, set] of FLAG_SETS) set.clear()
+  PIP_ENABLED_TYPES.clear()
+  for (const g of COLUMN_TYPE_GROUPS) g.types.length = 0
+
+  for (const type of types) {
+    const spec = COLUMN_REGISTRY[type]
+    if (!spec) continue
+    COLUMN_LABELS[type] = spec.label
+    COLUMN_ICONS[type] = spec.icon
+    COLUMN_COMPONENTS[type] = defineAsyncComponent(spec.component)
+    for (const [flag, set] of FLAG_SETS) {
+      if (spec[flag]) set.add(type)
+    }
+    const pipDefault = BUILTIN_TYPES.has(type)
+    if (spec.pipEnabled ?? pipDefault) PIP_ENABLED_TYPES.add(type)
+    COLUMN_TYPE_GROUPS.find((g) => g.group === spec.group)?.types.push(type)
+  }
+}
+
+rebuildDerived()
+
+export function isColumnType(value: unknown): value is ColumnType {
+  return typeof value === 'string' && value in COLUMN_REGISTRY
+}
+
+/**
+ * カラム種別を実行時登録する (#794 W2)。
+ *
+ * 衝突は先勝ちで拒否する — 後勝ち上書きだと、あるプラグインが別のプラグインや
+ * 組込カラムを黙って乗っ取れてしまう (#794 未決事項 2)。組込 ID 空間は予約。
+ *
+ * @throws 組込 ID または登録済み ID を指定した場合
+ */
+export function registerColumnType(type: string, spec: ColumnSpec): void {
+  if (BUILTIN_TYPES.has(type)) {
+    throw new Error(`column type "${type}" is reserved by NoteDeck`)
+  }
+  if (type in COLUMN_REGISTRY) {
+    throw new Error(`column type "${type}" is already registered`)
+  }
+  COLUMN_REGISTRY[type] = spec
+  rebuildDerived()
+}
+
+/**
+ * 登録を解除する。未登録 ID は no-op — プラグイン停止時の一括解除が二重に
+ * 走っても安全にするため (原則 5)。
+ *
+ * @throws 組込 ID を指定した場合
+ */
+export function unregisterColumnType(type: string): void {
+  if (BUILTIN_TYPES.has(type)) {
+    throw new Error(`column type "${type}" is builtin and cannot be removed`)
+  }
+  if (!(type in COLUMN_REGISTRY)) return
+  delete COLUMN_REGISTRY[type]
+  rebuildDerived()
+}
 
 /**
  * カラム追加時の共通デフォルト。呼び出し側は type/accountId を指定するだけでよい。
@@ -629,12 +704,14 @@ export function buildColumnDefaults(
   type: ColumnType,
   accountId: string | null,
 ): Omit<DeckColumn, 'id' | 'type'> {
+  // 未登録種別でも追加自体は成立させる (種別名を仮のカラム名にして tombstone を
+  // 描画する)。ここで throw すると、プラグイン起動前のデッキ復元が壊れる
   const spec = COLUMN_REGISTRY[type]
   return {
-    name: spec.label,
-    width: spec.defaultWidth ?? 360,
+    name: spec?.label ?? type,
+    width: spec?.defaultWidth ?? 360,
     accountId,
     active: true,
-    ...spec.defaultProps,
+    ...spec?.defaultProps,
   }
 }

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -289,7 +289,7 @@ interface QPSelectable {
 
 function getSelectable(type: ColumnType): QPSelectable | null {
   const spec = COLUMN_REGISTRY[type]
-  return spec.selectable ? { type, spec: spec.selectable } : null
+  return spec?.selectable ? { type, spec: spec.selectable } : null
 }
 
 async function buildDetailStep(

--- a/src/components/common/SafeModeNotice.vue
+++ b/src/components/common/SafeModeNotice.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+/**
+ * セーフモード (#794) の理由表示。プラグイン / ウィジェット / カスタム CSS /
+ * テーマの管理面に置き、「編集はできるが今は効いていない」ことを伝える。
+ *
+ * 管理 UI 自体は塞がない — セーフモードは「暴走している拡張を直すために入る」
+ * モードなので、直す手段まで消してしまうと脱出ハッチとして機能しない。
+ */
+import { readSafeMode } from '@/utils/safeMode'
+
+defineProps<{
+  /** 何が効いていないかの主語 (例: 「プラグイン」) */
+  subject: string
+}>()
+
+const isSafeMode = readSafeMode()
+</script>
+
+<template>
+  <div v-if="isSafeMode" :class="$style.notice">
+    <i class="ti ti-shield-half" />
+    <span>セーフモードで起動中のため{{ subject }}は適用されていません。編集内容は保存され、通常起動で有効になります。</span>
+  </div>
+</template>
+
+<style lang="scss" module>
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin: 8px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  background: color-mix(in srgb, var(--nd-warn) 15%, transparent);
+  color: var(--nd-warn);
+}
+</style>

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -4,6 +4,8 @@ import {
   ACCOUNT_INDEPENDENT_TYPES,
   ACCOUNT_OPTIONAL_TYPES,
   buildColumnDefaults,
+  COLUMN_ICONS,
+  COLUMN_LABELS,
   COLUMN_REGISTRY,
   COLUMN_TYPE_GROUPS,
   CROSS_ACCOUNT_TYPES,
@@ -112,7 +114,7 @@ interface ActiveSelectable {
 
 function getSelectable(type: ColumnType): ActiveSelectable | null {
   const spec = COLUMN_REGISTRY[type]
-  if (!spec.selectable) return null
+  if (!spec?.selectable) return null
   return { type, label: spec.label, spec: spec.selectable }
 }
 
@@ -335,8 +337,8 @@ function close() {
               :class="[$style.addTypeBtn, { [$style.spotlighted]: spotlightStore.spotlights.has(commandItemTargetId(`col-${t}`)) }]"
               @click="selectColumnType(t)"
             >
-              <i class="ti" :class="`ti-${COLUMN_REGISTRY[t].icon}`" />
-              <span>{{ COLUMN_REGISTRY[t].label }}</span>
+              <i class="ti" :class="`ti-${COLUMN_ICONS[t]}`" />
+              <span>{{ COLUMN_LABELS[t] }}</span>
             </button>
           </template>
         </div>
@@ -397,7 +399,7 @@ function close() {
           @click="addSelectableColumn(item)"
         >
           <img v-if="item.avatarUrl" :src="item.avatarUrl" :class="$style.selectItemAvatar" />
-          <i v-else class="ti" :class="`ti-${COLUMN_REGISTRY[selectConfig.type].icon}`" />
+          <i v-else class="ti" :class="`ti-${COLUMN_ICONS[selectConfig.type]}`" />
           <span>{{ item.name }}</span>
         </button>
       </template>

--- a/src/components/deck/ColumnTombstone.vue
+++ b/src/components/deck/ColumnTombstone.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+/**
+ * 未登録カラム種別の墓標 (#794 未決事項 1)。
+ *
+ * プラグイン起動 (useDeckInit の idle コールバック) はデッキ復元より後なので、
+ * プラグイン定義カラムは正常起動でも必ず一度「未登録種別」を通る。したがって
+ * 「未登録なら捨てる」実装は通常起動のたびにデッキ構成を削ってしまう。
+ * 捨てずに墓標を出し、レジストリに登録された時点で実体へ差し替わるようにする。
+ *
+ * 起動途中の未登録と恒久的な欠落は区別しない — 区別すると起動順序に依存した
+ * 特別扱いが生まれる。ユーザーから見れば「まだ出ていない」だけで同じ。
+ */
+import { useDeckStore } from '@/stores/deck'
+
+const props = defineProps<{
+  colId: string
+  type: string
+}>()
+
+const deckStore = useDeckStore()
+
+function remove() {
+  deckStore.removeColumn(props.colId)
+}
+</script>
+
+<template>
+  <div :class="$style.tombstone">
+    <i class="ti ti-puzzle-off" :class="$style.icon" />
+    <div :class="$style.title">拡張カラム「{{ type }}」は読み込まれていません</div>
+    <div :class="$style.body">
+      提供元のプラグインが無効・削除されているか、まだ起動していません。
+      プラグインが起動すると自動的に表示されます。
+    </div>
+    <button type="button" :class="$style.remove" @click="remove">
+      このカラムを削除
+    </button>
+  </div>
+</template>
+
+<style lang="scss" module>
+.tombstone {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px 16px;
+  text-align: center;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--nd-panel) 92%, transparent);
+  border: 1px dashed color-mix(in srgb, var(--nd-divider, currentColor) 45%, transparent);
+}
+
+.icon {
+  font-size: 28px;
+  opacity: 0.5;
+}
+
+.title {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.body {
+  font-size: 0.8rem;
+  line-height: 1.6;
+  opacity: 0.7;
+  max-width: 28em;
+}
+
+.remove {
+  margin-top: 8px;
+  padding: 4px 14px;
+  border: 1px solid color-mix(in srgb, var(--nd-divider, currentColor) 45%, transparent);
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font-size: 0.8rem;
+  cursor: pointer;
+
+  &:hover {
+    background: color-mix(in srgb, currentColor 8%, transparent);
+  }
+}
+</style>

--- a/src/components/deck/DeckAiScriptColumn.vue
+++ b/src/components/deck/DeckAiScriptColumn.vue
@@ -29,6 +29,7 @@ import { usePortal } from '@/composables/usePortal'
 import { useSwipeTab } from '@/composables/useSwipeTab'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { useVerticalResize } from '@/composables/useVerticalResize'
+import { providerFromPrincipal } from '@/plugins/registrationId'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -245,8 +246,11 @@ async function run() {
     // playground: 本人がその場で書いて実行するコードは本人の操作 (#712 §3.2 —
     // ターミナルにシェルスクリプトを貼るのと同じ local trust)
     principal: { kind: 'user' },
-    registeredCommandIds: [] as string[],
-    subscriptions: [],
+    // スクラッチパッドは本人のコードなので固定の local:user 名前空間。
+    // カラムを跨いで同じ名前を登録すると衝突する (先勝ち) が、本人の
+    // コード同士なので黙って上書きするより気付ける方がよい
+    provider: providerFromPrincipal({ kind: 'user' }),
+    disposers: [],
     getAccountId: () => props.column.accountId ?? null,
   }
   const ndEnv = createNoteDeckEnv(ndCtx)

--- a/src/components/deck/DeckLaunchPad.vue
+++ b/src/components/deck/DeckLaunchPad.vue
@@ -4,6 +4,8 @@ import { computed, nextTick, ref, useCssModule, watch } from 'vue'
 import {
   ACCOUNT_INDEPENDENT_TYPES,
   ALL_COLUMN_TYPES,
+  COLUMN_ICONS,
+  COLUMN_LABELS,
   COLUMN_REGISTRY,
   CROSS_ACCOUNT_TYPES,
 } from '@/columns/registry'
@@ -51,7 +53,7 @@ const items = computed<ColumnType[]>(() =>
   ALL_COLUMN_TYPES.filter((t) => {
     if (navTypes.value.has(t)) return false
     const spec = COLUMN_REGISTRY[t]
-    if (spec.selectable) return false
+    if (spec?.selectable) return false
     return CROSS_ACCOUNT_TYPES.has(t) || ACCOUNT_INDEPENDENT_TYPES.has(t)
   }),
 )
@@ -141,8 +143,8 @@ function close() {
           :class="$style.item"
           @click="selectItem(t)"
         >
-          <i class="ti" :class="[$style.icon, `ti-${COLUMN_REGISTRY[t].icon}`]" />
-          <span :class="$style.label">{{ COLUMN_REGISTRY[t].label }}</span>
+          <i class="ti" :class="[$style.icon, `ti-${COLUMN_ICONS[t]}`]" />
+          <span :class="$style.label">{{ COLUMN_LABELS[t] }}</span>
         </button>
       </div>
     </div>

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from 'vue'
 import { abortPlugin, launchPlugin } from '@/aiscript/plugin-api'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
+import SafeModeNotice from '@/components/common/SafeModeNotice.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useTabSlide } from '@/composables/useTabSlide'
@@ -360,6 +361,8 @@ async function deleteFromLibrary(plugin: PluginMeta) {
     </template>
 
     <div ref="columnContentRef" :class="$style.wrapper">
+      <SafeModeNotice subject="プラグイン" />
+
       <ColumnTabs
         :tabs="tabDefs"
         :model-value="viewTab"

--- a/src/components/deck/DeckStackCell.vue
+++ b/src/components/deck/DeckStackCell.vue
@@ -2,6 +2,7 @@
 import { computed, toRef, useCssModule, useTemplateRef } from 'vue'
 import { COLUMN_COMPONENTS } from '@/columns/registry'
 import ColumnErrorBoundary from '@/components/deck/ColumnErrorBoundary.vue'
+import ColumnTombstone from '@/components/deck/ColumnTombstone.vue'
 import { useColumnMount } from '@/composables/useColumnMount'
 import type { DeckColumn } from '@/stores/deck'
 import { useStreamInspectorStore } from '@/stores/streamInspector'
@@ -36,6 +37,13 @@ const { shouldMount } = useColumnMount(props.colId, cellRef, {
 const columnComponent = computed(() =>
   props.column ? COLUMN_COMPONENTS[props.column.type] : null,
 )
+
+// 種別が registry に無い = 提供元プラグインが未起動 / 無効 / 削除 (#794)。
+// mount 判定 (shouldMount) とは独立に判断する — 画面外で mount されていない
+// だけの通常カラムを墓標にしてはいけない
+const isUnknownType = computed(
+  () => !!props.column && !COLUMN_COMPONENTS[props.column.type],
+)
 </script>
 
 <template>
@@ -55,6 +63,11 @@ const columnComponent = computed(() =>
         :column="column"
       />
     </ColumnErrorBoundary>
+    <ColumnTombstone
+      v-else-if="isUnknownType && column"
+      :col-id="colId"
+      :type="column.type"
+    />
     <div v-else :class="$style.columnShell" aria-hidden="true">
       <div :class="$style.columnShellHeader" />
       <div :class="$style.columnShellBody">

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import SafeModeNotice from '@/components/common/SafeModeNotice.vue'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useTabSlide } from '@/composables/useTabSlide'
@@ -393,6 +394,8 @@ function storeEntryToTheme(entry: StoreThemeEntry): MisskeyTheme {
     </template>
 
     <div ref="columnContentRef" :class="$style.wrapper">
+      <SafeModeNotice subject="テーマ" />
+
       <ColumnTabs
         :tabs="tabDefs"
         :model-value="viewTab"

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -26,6 +26,7 @@ import { useCommandStore } from '@/commands/registry'
 import AiScriptDialog from '@/components/common/AiScriptDialog.vue'
 import { usePortal } from '@/composables/usePortal'
 import { useToast } from '@/stores/toast'
+import { readSafeMode } from '@/utils/safeMode'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const MkPostForm = defineAsyncComponent(
@@ -131,6 +132,13 @@ watch(
 
 async function run() {
   if (running.value) return
+  // セーフモード (#794) — ウィジェットも AiScript なのでプラグインと同格に止める。
+  // 自動実行 / 再実行シグナル / 手動実行が全部ここを通る。
+  // 無言の空白にせず理由を出す (silent no-op はユーザーが原因を追えない)
+  if (readSafeMode()) {
+    error.value = 'セーフモードのため実行されません'
+    return
+  }
   running.value = true
   error.value = null
   uiComponents.value = []

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -25,6 +25,7 @@ import type { JsonValue } from '@/bindings'
 import { useCommandStore } from '@/commands/registry'
 import AiScriptDialog from '@/components/common/AiScriptDialog.vue'
 import { usePortal } from '@/composables/usePortal'
+import { providerFromPrincipal } from '@/plugins/registrationId'
 import { useToast } from '@/stores/toast'
 import { readSafeMode } from '@/utils/safeMode'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -226,8 +227,11 @@ async function run() {
       pluginId: `widget:${props.widget.installId}`,
       name: props.widget.name,
     },
-    registeredCommandIds: [] as string[],
-    subscriptions: [],
+    provider: providerFromPrincipal(
+      { kind: 'plugin', pluginId: `widget:${props.widget.installId}` },
+      props.widget.storeId,
+    ),
+    disposers: [],
     getAccountId: () => props.accountId,
   }
   const ndEnv = createNoteDeckEnv(ndCtx)

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -3,6 +3,7 @@ import { css } from '@codemirror/lang-css'
 import { type Diagnostic, linter } from '@codemirror/lint'
 import { computed, reactive, ref, watch } from 'vue'
 import EditorTabs from '@/components/common/EditorTabs.vue'
+import SafeModeNotice from '@/components/common/SafeModeNotice.vue'
 import CodeEditor from '@/components/deck/widgets/CodeEditor.vue'
 import CssPresetDropdown from '@/components/window/CssPresetDropdown.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
@@ -454,6 +455,8 @@ watch(tab, (t) => {
 
 <template>
   <div ref="editorRef" :class="$style.cssContent">
+    <SafeModeNotice subject="カスタム CSS" />
+
     <EditorTabs
       v-model="tab"
       :tabs="[

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -32,6 +32,7 @@ import AiScriptUiRenderer, {
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { usePortal } from '@/composables/usePortal'
 import { useWindowEditAction } from '@/composables/useWindowEditAction'
+import { providerFromPrincipal } from '@/plugins/registrationId'
 import { useAccountsStore } from '@/stores/accounts'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
@@ -208,8 +209,11 @@ async function run() {
       pluginId: `widget:${props.widgetId}`,
       name: widget.value.name,
     },
-    registeredCommandIds: [] as string[],
-    subscriptions: [],
+    provider: providerFromPrincipal(
+      { kind: 'plugin', pluginId: `widget:${props.widgetId}` },
+      widget.value.storeId,
+    ),
+    disposers: [],
     getAccountId: () => activeAccountId.value,
   }
   const ndEnv = createNoteDeckEnv(ndCtx)

--- a/src/composables/useAiScriptRunner.ts
+++ b/src/composables/useAiScriptRunner.ts
@@ -18,6 +18,7 @@ import type { JsonValue } from '@/bindings'
 import { useCommandStore } from '@/commands/registry'
 import type AiScriptDialog from '@/components/common/AiScriptDialog.vue'
 import type { Principal } from '@/permissions/principal'
+import { providerFromPrincipal } from '@/plugins/registrationId'
 import {
   logSourceOfPrincipal,
   useAiScriptLogsStore,
@@ -146,8 +147,8 @@ export function useAiScriptRunner() {
     const ndCtx: NoteDeckEnvContext = {
       commandStore,
       principal: options.principal,
-      registeredCommandIds: [],
-      subscriptions: [],
+      provider: providerFromPrincipal(options.principal),
+      disposers: [],
       getAccountId: () => options.accountId,
     }
     const ndEnv = createNoteDeckEnv(ndCtx)

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -35,6 +35,7 @@ import { type SkillMeta, useSkillsStore } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { timestampTitle } from '@/utils/aiSessionTitle'
 import { sendDesktopNotification } from '@/utils/desktopNotification'
+import { readSafeMode } from '@/utils/safeMode'
 import { isTauri } from '@/utils/settingsFs'
 import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 import { listenTauri } from '@/utils/tauriEvents'
@@ -364,6 +365,11 @@ const HEARTBEAT_TITLE_SYSTEM_PROMPT =
   'あなたは HEARTBEAT 通知の要約タイトル生成アシスタントです。与えられた通知内容を端的に表す短い日本語のタイトルを 1 行で出力してください。20 文字程度 (最大 40 文字) に収めること。引用符、前置き、改行、絵文字、文末句点は付けないでください。タイトルのみを返してください。'
 
 export function useHeartbeatDaemon() {
+  // セーフモード (#794) — 常駐して AI 推論を回す global daemon なので、
+  // 第三者コードと同格に止める。App.vue の mount より手前で抜けるので
+  // Rust scheduler への configure も listen も一切行われない
+  if (readSafeMode()) return
+
   const { config } = useAiConfig()
   const sessionsStore = useAiSessionsStore()
   const accountsStore = useAccountsStore()

--- a/src/plugins/registrationId.test.ts
+++ b/src/plugins/registrationId.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import {
+  makeRegistrationId,
+  parseRegistrationId,
+  pluginProviderKey,
+  providerFromPrincipal,
+  registrationId,
+} from './registrationId'
+
+describe('pluginProviderKey (#794 未決事項 2)', () => {
+  it('MisStore 由来は storeId を安定キーにする', () => {
+    expect(
+      pluginProviderKey({ installId: 'inst-1', storeId: 'acme.clock' }),
+    ).toBe('acme.clock')
+  })
+
+  it('再インストールで installId が変わっても storeId 由来なら同一', () => {
+    const before = pluginProviderKey({ installId: 'a', storeId: 'acme.clock' })
+    const after = pluginProviderKey({ installId: 'b', storeId: 'acme.clock' })
+    expect(before).toBe(after)
+  })
+
+  it('ローカル自作は local: 接頭辞つき installId', () => {
+    expect(pluginProviderKey({ installId: 'inst-1' })).toBe('local:inst-1')
+  })
+
+  it('ローカル自作は再インストールで別物になる (意図した挙動)', () => {
+    expect(pluginProviderKey({ installId: 'a' })).not.toBe(
+      pluginProviderKey({ installId: 'b' }),
+    )
+  })
+})
+
+describe('registrationId', () => {
+  it('provider:localName の 2 段 ID を組む', () => {
+    expect(
+      registrationId({ installId: 'i', storeId: 'acme.clock' }, 'main'),
+    ).toBe('acme.clock:main')
+  })
+
+  // ローカル自作は必ず local: が付くので予約領域に届かない。
+  // 予約を突破しうるのは storeId を自称できる配布物だけ。
+  it('組込の予約接頭辞 nd は storeId でも名乗れない', () => {
+    expect(() =>
+      registrationId({ installId: 'i', storeId: 'nd' }, 'x'),
+    ).toThrow()
+    expect(() =>
+      registrationId({ installId: 'i', storeId: 'nd:core' }, 'x'),
+    ).toThrow()
+  })
+
+  it('localName が空なら拒否する', () => {
+    expect(() => registrationId({ installId: 'i' }, '')).toThrow()
+  })
+
+  it('localName に区切り文字を含められない (ID の解釈が壊れるため)', () => {
+    expect(() => registrationId({ installId: 'i' }, 'a:b')).toThrow()
+  })
+
+  it('往復できる', () => {
+    const id = registrationId({ installId: 'i', storeId: 'acme.clock' }, 'main')
+    expect(parseRegistrationId(id)).toEqual({
+      provider: 'acme.clock',
+      localName: 'main',
+    })
+  })
+
+  it('local: 接頭辞つきでも往復できる (provider に : を含む)', () => {
+    const id = registrationId({ installId: 'inst-1' }, 'main')
+    expect(parseRegistrationId(id)).toEqual({
+      provider: 'local:inst-1',
+      localName: 'main',
+    })
+  })
+
+  it('2 段になっていない ID は null', () => {
+    expect(parseRegistrationId('timeline')).toBeNull()
+  })
+})
+
+describe('makeRegistrationId', () => {
+  it('provider 文字列から直接組める', () => {
+    expect(makeRegistrationId('acme.clock', 'main')).toBe('acme.clock:main')
+  })
+
+  it('provider が違えば localName が同じでも衝突しない', () => {
+    expect(makeRegistrationId('a', 'main')).not.toBe(
+      makeRegistrationId('b', 'main'),
+    )
+  })
+})
+
+describe('providerFromPrincipal', () => {
+  it('storeId があれば最優先', () => {
+    expect(
+      providerFromPrincipal(
+        { kind: 'plugin', pluginId: 'widget:w1' },
+        'acme.clock',
+      ),
+    ).toBe('acme.clock')
+  })
+
+  it('plugin principal は local:<pluginId>', () => {
+    expect(providerFromPrincipal({ kind: 'plugin', pluginId: 'play:p1' })).toBe(
+      'local:play:p1',
+    )
+  })
+
+  it('user principal は local:user', () => {
+    expect(providerFromPrincipal({ kind: 'user' })).toBe('local:user')
+  })
+})

--- a/src/plugins/registrationId.ts
+++ b/src/plugins/registrationId.ts
@@ -1,0 +1,103 @@
+/**
+ * プラグイン登録アイテムの同一性 (#794 未決事項 2)。
+ *
+ * 永続化されたデッキ構成やナビバー構成は「どのプラグインの、どの登録物か」を
+ * 参照する。`installId` は再インストールで変わるので、そのまま参照すると
+ * アカウント内部 UUID 再生成と同型の「再インストールで無言に腐る」罠になる。
+ *
+ * ID は `<provider>:<localName>` の 2 段構成:
+ *   - provider  = プラグインの安定キー
+ *   - localName = プラグインが自分で付ける名前 (プラグイン内で一意)
+ */
+
+const BUILTIN_PREFIX = 'nd'
+const SEPARATOR = ':'
+
+export interface ProviderSource {
+  installId: string
+  /** MisStore 由来の追跡 ID */
+  storeId?: string
+}
+
+/**
+ * プラグインの安定キー。
+ *
+ * 配布物 (MisStore 経由) は再インストールしても `storeId` で同一性が保たれる。
+ * ローカル自作は `local:<installId>` になり、再インストールすると別物になる —
+ * これは意図した挙動で、手元で作り直したものを黙って同一視しない方が安全。
+ */
+export function pluginProviderKey(source: ProviderSource): string {
+  return source.storeId ?? `local${SEPARATOR}${source.installId}`
+}
+
+/**
+ * 登録 ID を組む。
+ *
+ * @throws 予約接頭辞を名乗った場合、localName が空 or 区切り文字を含む場合
+ */
+export function registrationId(
+  source: ProviderSource,
+  localName: string,
+): string {
+  return makeRegistrationId(pluginProviderKey(source), localName)
+}
+
+/**
+ * 安定キーを既に持っている呼び出し側 (AiScript env など) 向け。
+ *
+ * @throws 予約接頭辞を名乗った場合、localName が空 or 区切り文字を含む場合
+ */
+export function makeRegistrationId(
+  provider: string,
+  localName: string,
+): string {
+  if (
+    provider === BUILTIN_PREFIX ||
+    provider.startsWith(`${BUILTIN_PREFIX}${SEPARATOR}`)
+  ) {
+    throw new Error(`provider "${provider}" is reserved by NoteDeck`)
+  }
+  if (!localName) {
+    throw new Error('registration name must not be empty')
+  }
+  if (localName.includes(SEPARATOR)) {
+    throw new Error(
+      `registration name "${localName}" must not contain "${SEPARATOR}"`,
+    )
+  }
+  return `${provider}${SEPARATOR}${localName}`
+}
+
+/**
+ * 登録 ID を分解する。組込種別のような 2 段でない ID は null。
+ *
+ * provider 側は `local:<installId>` のように区切り文字を含みうるので、
+ * 最後の区切りで割る。
+ */
+export function parseRegistrationId(
+  id: string,
+): { provider: string; localName: string } | null {
+  const idx = id.lastIndexOf(SEPARATOR)
+  if (idx <= 0 || idx === id.length - 1) return null
+  return { provider: id.slice(0, idx), localName: id.slice(idx + 1) }
+}
+
+/**
+ * 実行文脈の principal から provider を導く。
+ *
+ * プラグイン / ウィジェット / Play / ページはいずれも `{ kind: 'plugin' }` を
+ * 名乗り、`pluginId` に `widget:<id>` / `play:<id>` 等の出自つき ID を持つ。
+ * MisStore 配布物は storeId が渡るのでそちらを優先する (再インストールを跨いで
+ * 同一性が保たれる)。
+ */
+export function providerFromPrincipal(
+  principal: { kind: string; pluginId?: string },
+  storeId?: string,
+): string {
+  if (storeId) return storeId
+  if (principal.kind === 'plugin' && principal.pluginId) {
+    return `local${SEPARATOR}${principal.pluginId}`
+  }
+  // 本人がその場で書いて実行するコード (スクラッチパッド等)
+  return `local${SEPARATOR}user`
+}

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -15,7 +15,11 @@ import { hapticMedium } from '@/utils/haptics'
 import { isTauri, readNavbar, writeNavbar } from '@/utils/settingsFs'
 import { getStorageJson, removeStorage, STORAGE_KEYS } from '@/utils/storage'
 
-export type ColumnType =
+/**
+ * 組込カラム種別。COLUMN_REGISTRY はこの union で網羅性を検査するので、
+ * ここに足して registry に足し忘れるとコンパイルエラーになる。
+ */
+export type BuiltinColumnType =
   | 'timeline'
   | 'notifications'
   | 'search'
@@ -55,6 +59,16 @@ export type ColumnType =
   | 'charts'
   | 'federation'
   | 'skill'
+
+/**
+ * カラム種別 (#794 W2)。プラグインが実行時に登録できるよう open にしてある。
+ * `string & {}` は組込リテラルの補完を残したまま任意文字列を許すための定型。
+ *
+ * 開いた結果、永続化されたデッキ構成に「今このアプリが知らない種別」が入りうる。
+ * 未登録種別は捨てずに tombstone 描画する (#794 未決事項 1) — プラグイン起動は
+ * デッキ復元より後なので、正常起動でも必ず一度この状態を通るため。
+ */
+export type ColumnType = BuiltinColumnType | (string & {})
 
 /**
  * ノートを連続ストリーミング表示するカラム型 (= 「直近フォーカスしたタイムライン」

--- a/src/stores/theme.dom.test.ts
+++ b/src/stores/theme.dom.test.ts
@@ -1,0 +1,64 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MisskeyTheme } from '@/theme/types'
+import { STORAGE_KEYS } from '@/utils/storage'
+import { useThemeStore } from './theme'
+
+vi.mock('@/utils/settingsFs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/utils/settingsFs')>(
+      '@/utils/settingsFs',
+    )
+  return { ...actual, isTauri: false }
+})
+
+const RED: MisskeyTheme = {
+  id: 'red-theme',
+  name: 'Red',
+  base: 'dark',
+  props: { bg: '#ff0000' },
+}
+
+describe('useThemeStore — セーフモード (#794)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('セーフモード中は選択中のユーザーテーマを無視して組込テーマを当てる', () => {
+    localStorage.setItem(STORAGE_KEYS.safeMode, 'true')
+    const store = useThemeStore()
+    store.installedThemes = [RED]
+    store.selectedDarkThemeId = RED.id
+    store.selectedLightThemeId = RED.id
+
+    store.applyCurrentTheme()
+
+    expect(store.currentSource?.kind).toMatch(/^builtin-/)
+  })
+
+  it('通常起動では選択中のユーザーテーマが当たる', () => {
+    const store = useThemeStore()
+    store.installedThemes = [RED]
+    store.selectedDarkThemeId = RED.id
+    store.selectedLightThemeId = RED.id
+
+    store.applyCurrentTheme()
+
+    expect(store.currentSource?.kind).toMatch(/^custom-/)
+  })
+
+  it('セーフモード中はカスタム CSS を注入しない', () => {
+    localStorage.setItem(STORAGE_KEYS.safeMode, 'true')
+    const store = useThemeStore()
+
+    store.setCustomCss('body { display: none }')
+
+    expect(document.adoptedStyleSheets.length).toBe(0)
+    expect(document.head.querySelector('style[data-nd-custom-css]')).toBeNull()
+  })
+})

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -14,6 +14,7 @@ import { compileMisskeyTheme } from '@/theme/compiler'
 import { CustomCssManager } from '@/theme/cssApplier'
 import type { CompiledProps, MisskeyTheme, ThemeSource } from '@/theme/types'
 import { pushSnapshot } from '@/utils/historyFs'
+import { readSafeMode } from '@/utils/safeMode'
 import * as settingsFs from '@/utils/settingsFs'
 import {
   getStorageJson,
@@ -127,10 +128,11 @@ export const useThemeStore = defineStore('theme', () => {
     // This is NOT a source of truth — just a rendering cache to avoid a
     // white flash. The actual theme preference comes from settingsStore
     // (already loaded via await in main.ts).
-    const storedCompiled = getStorageJson<CompiledProps | null>(
-      STORAGE_KEYS.themeCompiled,
-      null,
-    )
+    // セーフモード (#794) では FOUC 防止のキャッシュ復元もしない
+    // (index.html の boot script も同じ理由で復元をスキップしている)
+    const storedCompiled = readSafeMode()
+      ? null
+      : getStorageJson<CompiledProps | null>(STORAGE_KEYS.themeCompiled, null)
     if (storedCompiled) {
       applyTheme(storedCompiled)
     }
@@ -200,9 +202,12 @@ export const useThemeStore = defineStore('theme', () => {
   function applyCurrentTheme(): void {
     const apply = () => {
       const dark = wantsDark()
-      const selectedId = dark
-        ? selectedDarkThemeId.value
-        : selectedLightThemeId.value
+      // セーフモード (#794) — ユーザーテーマは一切当てず組込テーマに固定する
+      const selectedId = readSafeMode()
+        ? null
+        : dark
+          ? selectedDarkThemeId.value
+          : selectedLightThemeId.value
       let custom = selectedId
         ? installedThemes.value.find((t) => t.id === selectedId)
         : null
@@ -479,6 +484,9 @@ export const useThemeStore = defineStore('theme', () => {
   const cssManager = new CustomCssManager()
 
   function applyCustomCss(css: string): void {
+    // セーフモード (#794) — 起動時復元だけでなく CSS エディタからの保存も
+    // 塞ぐ。「編集はできるが効かない」を一箇所で保証する
+    if (readSafeMode()) return
     cssManager.apply(css)
   }
 
@@ -664,6 +672,9 @@ export const useThemeStore = defineStore('theme', () => {
   }
 
   function getCompiledForAccount(accountId: string): CompiledProps | null {
+    // セーフモード (#794) — per-account のカラムテーマも当てない。
+    // getStyleVarsForAccount もここを通るので gate は 1 箇所でよい
+    if (readSafeMode()) return null
     void accountThemeCache.value // reactive 依存確立 (上記同様)
     const cacheKey = accountCacheKey(accountId)
 

--- a/src/utils/safeMode.dom.test.ts
+++ b/src/utils/safeMode.dom.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readSafeMode, resolveSafeMode } from './safeMode'
+
+describe('resolveSafeMode', () => {
+  it('保存済みフラグがあれば true', () => {
+    expect(
+      resolveSafeMode({ argFlag: false, search: '', stored: 'true' }),
+    ).toBe(true)
+  })
+
+  it('CLI 引数フラグで true', () => {
+    expect(resolveSafeMode({ argFlag: true, search: '', stored: null })).toBe(
+      true,
+    )
+  })
+
+  it('URL クエリ ?safemode=true で true', () => {
+    expect(
+      resolveSafeMode({
+        argFlag: false,
+        search: '?safemode=true',
+        stored: null,
+      }),
+    ).toBe(true)
+  })
+
+  it('?safemode 単独 / 他の値では有効化しない (誤爆防止)', () => {
+    expect(
+      resolveSafeMode({ argFlag: false, search: '?safemode', stored: null }),
+    ).toBe(false)
+    expect(
+      resolveSafeMode({
+        argFlag: false,
+        search: '?safemode=false',
+        stored: null,
+      }),
+    ).toBe(false)
+  })
+
+  it('どの経路もなければ false', () => {
+    expect(
+      resolveSafeMode({ argFlag: false, search: '?foo=1', stored: null }),
+    ).toBe(false)
+  })
+
+  it('保存値が "true" 以外なら無効 (壊れた値で居座らせない)', () => {
+    expect(resolveSafeMode({ argFlag: false, search: '', stored: '1' })).toBe(
+      false,
+    )
+  })
+})
+
+describe('readSafeMode', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('localStorage の値をそのまま反映する', () => {
+    expect(readSafeMode()).toBe(false)
+    localStorage.setItem('nd-safe-mode', 'true')
+    expect(readSafeMode()).toBe(true)
+  })
+})

--- a/src/utils/safeMode.ts
+++ b/src/utils/safeMode.ts
@@ -1,0 +1,61 @@
+/**
+ * セーフモード (#794) — 第三者コード・ユーザー装飾を全部止めて起動する脱出ハッチ。
+ *
+ * 判定の正本は localStorage の 1 キーだけ。CLI 引数 (`--safe-mode`) と URL クエリ
+ * (`?safemode=true`) は「そのキーを立てる起動経路」に徹する。こうすると解除は常に
+ * 「キーを消してリロード」の 1 手で済み、起動経路ごとの解除手順を持たなくてよい。
+ * (本家 Misskey 2026.6.0 の isSafeMode と同じ構造)
+ *
+ * 無効化するもの:
+ *   - AiScript プラグイン / ウィジェット (起動時に自動実行される第三者コード)
+ *   - カスタム CSS
+ *   - ユーザーテーマ (既定テーマに固定)
+ *   - HEARTBEAT daemon (常駐して AI 推論を回す global daemon)
+ *
+ * 本家との差は下 2 つ。本家のウィジェットは AiScript ではないため対象外で、
+ * HEARTBEAT は本家に存在しない。どちらも「起動時に勝手に走る」点でプラグインと
+ * 同格なので NoteDeck では止める。
+ */
+
+import { STORAGE_KEYS } from './storage'
+
+/** Rust 側が `--safe-mode` 付き起動時に initialization script で立てるフラグ */
+declare global {
+  interface Window {
+    __ND_SAFE_MODE_ARG__?: boolean
+  }
+}
+
+export interface SafeModeSources {
+  /** CLI 引数由来 (Tauri) */
+  argFlag: boolean
+  /** `location.search` 相当 (ブラウザ / dev サーバー用) */
+  search: string
+  /** localStorage の保存値 */
+  stored: string | null
+}
+
+export function resolveSafeMode(sources: SafeModeSources): boolean {
+  if (sources.stored === 'true') return true
+  if (sources.argFlag) return true
+  return new URLSearchParams(sources.search).get('safemode') === 'true'
+}
+
+/** 現在のセーフモード状態。boot script が確定させた localStorage を読むだけ。 */
+export function readSafeMode(): boolean {
+  // node 環境の単体テストから gate 済みモジュールを import しても落ちないように
+  if (typeof localStorage === 'undefined') return false
+  return localStorage.getItem(STORAGE_KEYS.safeMode) === 'true'
+}
+
+/**
+ * セーフモードを解除する。localStorage を消してリロードするだけ —
+ * `--safe-mode` 付きで起動していた場合は次の起動でまた立つが、それは
+ * 「引数を外して起動し直す」で解決する話で、解除手順は 1 つに保つ。
+ */
+export function exitSafeMode(): void {
+  localStorage.removeItem(STORAGE_KEYS.safeMode)
+  const url = new URL(window.location.href)
+  url.searchParams.delete('safemode')
+  window.location.replace(url.toString())
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -70,6 +70,11 @@ export function removeStorageByPrefix(prefix: string): void {
 // ---------------------------------------------------------------------------
 
 export const STORAGE_KEYS = {
+  // Safe mode (#794) — 値の解決とキー名は index.html の inline boot script にも
+  // 同じリテラルで書かれている (テーマ復元をスキップするため boot 前に判定が要る)。
+  // 変更するときは両方直すこと。
+  safeMode: 'nd-safe-mode',
+
   // Deck
   // TODO: `deck` は pre-profile 時代 (<= v0.10.2) からの migration 読取専用。
   // 十分時間が経ったら読取ごと削除する。

--- a/src/views/PipPage.vue
+++ b/src/views/PipPage.vue
@@ -13,6 +13,7 @@ import { COLUMN_COMPONENTS, COLUMN_LABELS } from '@/columns/registry'
 import AppToast from '@/components/common/AppToast.vue'
 import AppTooltip from '@/components/common/AppTooltip.vue'
 import AddColumnDialog from '@/components/deck/AddColumnDialog.vue'
+import ColumnTombstone from '@/components/deck/ColumnTombstone.vue'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import { useThemeStore } from '@/stores/theme'
@@ -437,8 +438,14 @@ onMounted(async () => {
     <!-- Render the selected column -->
     <template v-else>
       <component
+        v-if="COLUMN_COMPONENTS[selectedColumn.type]"
         :is="COLUMN_COMPONENTS[selectedColumn.type]"
         :column="selectedColumn"
+      />
+      <ColumnTombstone
+        v-else
+        :col-id="selectedColumn.id"
+        :type="selectedColumn.type"
       />
     </template>
 


### PR DESCRIPTION
## 概要

#794（UI 表面のレジストリ駆動化）のうち、#783（AiScript カラムクエリ）の前提となる部分を実装したリリース。

## 変更

- feat(safe-mode): 拡張を全停止して起動するセーフモードを追加 (#794 W1)
- feat(columns): カラム種別を実行時登録可能にする (#794 W2)
- refactor(aiscript): 登録解除を disposers に一本化し登録 ID を provider 名前空間に切る (#794 W3)
- chore: bump version to 1.28.0
- chore: regenerate openapi.json for 1.28.0

## ハイライト

**セーフモード** — `notedeck --safe-mode` で、プラグイン・ウィジェット・カスタム CSS・ユーザーテーマ・HEARTBEAT を全部止めて起動できる。壊れた拡張からの脱出ハッチ。判定は localStorage の 1 キーが正本で、解除は画面上部の警告バーから 1 手。

**カラム種別の実行時登録** — カラム種別が閉じたユニオンではなくなり、実行時に登録・解除できるようになった。未登録種別のカラムは捨てずに墓標を出す（プラグイン起動はデッキ復元より後なので、捨てる実装だと正常起動のたびにデッキ構成が削れる）。

**登録解除の規約** — プラグインからの全登録を単一の disposer 配列に集約し、停止時に一括解除する。

## 副次的に直った不具合

- `Nd:register_command` が全プラグイン共通の名前空間だったため、別のプラグインが同じ id を使うと**無言で後勝ち上書きされていた**。provider ごとに名前空間が分かれ、二重登録は先勝ちで拒否するようになった
- capability 層の手書き許可リストをレジストリ由来に置き換えた結果、取りこぼしていた種別が使えるようになった
  - `column.add` から `role` カラムを追加できるようになった
  - `windows.open` から `drive-file-detail` / `connections` / `connectionEdit` / `tutorial` を開けるようになった

## 検証

- テスト 2154 件 / 198 ファイル green
- `vue-tsc -b --noEmit` clean
- `cargo check` clean
- 実機起動は未検証


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Safe Mode startup options, including persistent settings, launch flags, and URL parameters.
  * Safe Mode prevents plugins, automation, custom themes, and custom CSS from running, with an option to exit and restart normally.
  * Added clearer notices and removal controls for unavailable or disabled extension columns.
  * Plugins can now register custom column types dynamically, with broader support in column, sidebar, and navigation features.
* **Bug Fixes**
  * Improved cleanup reliability and prevented failures from interrupting remaining cleanup tasks.
  * Improved handling of missing column and selectable-item definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->