### PR TITLE
Release v1.28.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.28.1",
+  "version": "1.28.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.28.1"
+version = "1.28.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.28.1"
+version = "1.28.2"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.28.1"
+    "version": "1.28.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -1076,6 +1076,7 @@ function onPaste(e: ClipboardEvent) {
     <!-- Post form buttons picker (below post form) -->
     <MkPostFormButtonsPicker
       v-if="showPostFormButtonsPicker"
+      :style="formThemeVars"
       @close="showPostFormButtonsPicker = false"
     />
 

--- a/src/components/common/NoteReactionPickerPopup.vue
+++ b/src/components/common/NoteReactionPickerPopup.vue
@@ -145,7 +145,9 @@ defineExpose({ open })
 <style lang="scss" module>
 .reactionPickerPopup {
   position: fixed;
-  transform-origin: top right;
+  // 本家 (MkModal) はアンカーとの位置関係で起点を決める。ピッカーは常に
+  // トリガーの直下に出て水平方向はトリガーを跨ぐので center top 相当になる
+  transform-origin: center top;
   background: color-mix(in srgb, var(--nd-popup, var(--nd-panel)) 96%, transparent);
   border-radius: 12px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);

--- a/src/components/common/NoteReactionPickerPopup.vue
+++ b/src/components/common/NoteReactionPickerPopup.vue
@@ -24,7 +24,10 @@ const emit = defineEmits<{
 const $style = useCssModule()
 const { isCompactLayout: isCompact } = storeToRefs(useUiStore())
 const show = ref(false)
-const pos = ref({ x: 0, y: 0 })
+// 右端揃え。left + translateX(-100%) だと中身 (async component) がロード
+// されるまで幅 0 で左端が右端に来てしまい、初回だけ隣のカラムにはみ出して
+// から本来の位置に飛ぶ。right 指定なら幅に依存せず最初から確定する。
+const pos = ref({ right: 0, y: 0 })
 const theme = ref<Record<string, string>>({})
 const pickerRef = ref<HTMLElement | null>(null)
 const dialogRef = ref<HTMLDialogElement | null>(null)
@@ -78,7 +81,10 @@ function open(anchor: MouseEvent | HTMLElement) {
   const column = btn.closest(COLUMN_SELECTOR) as HTMLElement | null
   const colRect = column?.getBoundingClientRect()
   const rightEdge = colRect ? colRect.right - 8 : rect.right
-  pos.value = { x: rightEdge, y: rect.bottom + 4 }
+  pos.value = {
+    right: document.documentElement.clientWidth - rightEdge,
+    y: rect.bottom + 4,
+  }
   if (column) theme.value = extractThemeVars(column)
   if (show.value) {
     close()
@@ -102,7 +108,7 @@ defineExpose({ open })
     ref="pickerRef"
     popover="manual"
     :class="contentClass"
-    :style="{ ...theme, top: pos.y + 'px', left: pos.x + 'px' }"
+    :style="{ ...theme, top: pos.y + 'px', right: pos.right + 'px' }"
   >
     <MkReactionPicker
       :server-host="serverHost"
@@ -139,7 +145,7 @@ defineExpose({ open })
 <style lang="scss" module>
 .reactionPickerPopup {
   position: fixed;
-  transform: translateX(-100%);
+  transform-origin: top right;
   background: color-mix(in srgb, var(--nd-popup, var(--nd-panel)) 96%, transparent);
   border-radius: 12px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
@@ -148,7 +154,6 @@ defineExpose({ open })
 
   .mobileBackdrop & {
     position: static;
-    transform: none;
     width: 100%;
     border-radius: 16px 16px 0 0;
     box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
@@ -164,8 +169,8 @@ defineExpose({ open })
 /* Desktop popup content — scale + fade */
 .popupContentEnter { animation: reactionPickerIn 0.2s var(--nd-ease-spring); }
 .popupContentLeave { animation: reactionPickerOut var(--nd-duration-fast) var(--nd-ease-decel) forwards; }
-@keyframes reactionPickerIn { from { opacity: 0; transform: translateX(-100%) scale(0.85); } }
-@keyframes reactionPickerOut { to { opacity: 0; transform: translateX(-100%) scale(0.9); } }
+@keyframes reactionPickerIn { from { opacity: 0; transform: scale(0.85); } }
+@keyframes reactionPickerOut { to { opacity: 0; transform: scale(0.9); } }
 
 /* Mobile sheet backdrop */
 .sheetEnter { animation: sheetBdIn var(--nd-duration-base) var(--nd-ease-decel); }

--- a/src/components/common/PopupMenu.dom.test.ts
+++ b/src/components/common/PopupMenu.dom.test.ts
@@ -22,6 +22,16 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
       configurable: true,
       value: viewportWidth,
     })
+    // happy-dom はレイアウトを持たず clientWidth/Height が 0 になるため、
+    // はみ出し補正が常に発火しないよう明示する
+    Object.defineProperty(document.documentElement, 'clientWidth', {
+      configurable: true,
+      value: viewportWidth,
+    })
+    Object.defineProperty(document.documentElement, 'clientHeight', {
+      configurable: true,
+      value: 800,
+    })
     const pinia = createPinia()
     setActivePinia(pinia)
 
@@ -49,6 +59,26 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
     return new MouseEvent('click', { clientX: 100, clientY: 50 })
   }
 
+  // 位置確定は popover 表示後 (nextTick → rAF) なので両方待つ
+  async function flushPosition() {
+    await nextTick()
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)))
+  }
+
+  /** カラム外に置いたトリガーボタン (rect をモック) から open させる */
+  function mountTrigger(
+    menuRef: ReturnType<typeof mountMenu>,
+    rect: Partial<DOMRect>,
+  ) {
+    const trigger = document.createElement('button')
+    trigger.getBoundingClientRect = () => rect as DOMRect
+    document.body.appendChild(trigger)
+    const handler = (e: Event) => menuRef.value?.open(e as MouseEvent)
+    trigger.addEventListener('click', handler)
+    trigger.addEventListener('contextmenu', handler)
+    return trigger
+  }
+
   it('狭いビューポートでは設定メニューと同じ dialog ホストのシートとして描画される', async () => {
     const menuRef = mountMenu(375)
     menuRef.value?.open(openEvent())
@@ -71,7 +101,7 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
   it('広いビューポートでは従来どおり押下点にアンカーされる', async () => {
     const menuRef = mountMenu(1280)
     menuRef.value?.open(openEvent())
-    await nextTick()
+    await flushPosition()
 
     const root = container?.querySelector('[popover]') as HTMLElement
     expect(root).toBeTruthy()
@@ -80,6 +110,59 @@ describe('PopupMenu: compact レイアウトでボトムシート表示 (#764)',
     expect(root.style.left).toBe('104px')
     expect(root.style.top).toBe('60px')
     expect(container?.querySelector('dialog')).toBeNull()
+  })
+
+  it('ボタン押下時は本家と同じくボタンの水平中央揃え + 直下に開く', async () => {
+    const menuRef = mountMenu(1280)
+    const trigger = mountTrigger(menuRef, {
+      left: 400,
+      right: 424,
+      top: 100,
+      bottom: 124,
+      width: 24,
+      height: 24,
+    })
+
+    trigger.dispatchEvent(
+      new MouseEvent('click', { clientX: 410, clientY: 110, bubbles: true }),
+    )
+    await flushPosition()
+
+    const root = container?.querySelector('[popover]') as HTMLElement
+    // ボタン中央 (400 + 24/2 = 412) - メニュー幅/2 (テスト環境では 0)
+    expect(root.style.left).toBe('412px')
+    // ボタン直下
+    expect(root.style.top).toBe('124px')
+
+    trigger.remove()
+  })
+
+  it('右クリック時は本家と同じく押下点を左上頂点にする', async () => {
+    const menuRef = mountMenu(1280)
+    const trigger = mountTrigger(menuRef, {
+      left: 400,
+      right: 424,
+      top: 100,
+      bottom: 124,
+      width: 24,
+      height: 24,
+    })
+
+    trigger.dispatchEvent(
+      new MouseEvent('contextmenu', {
+        clientX: 100,
+        clientY: 50,
+        bubbles: true,
+      }),
+    )
+    await flushPosition()
+
+    const root = container?.querySelector('[popover]') as HTMLElement
+    // トリガー要素ではなく押下点が基準
+    expect(root.style.left).toBe('104px')
+    expect(root.style.top).toBe('60px')
+
+    trigger.remove()
   })
 
   it('シートの backdrop タップで閉じ、メニュー項目タップでは閉じない', async () => {

--- a/src/components/common/PopupMenu.vue
+++ b/src/components/common/PopupMenu.vue
@@ -17,6 +17,8 @@ const isCompact = useIsCompactLayout()
 
 const showMenu = ref(false)
 const menuPos = ref({ x: 0, y: 0 })
+// 押下点アンカー (右クリック) か、トリガー要素アンカー (ボタン押下) か
+const pointAnchored = ref(false)
 const menuTheme = ref<Record<string, string>>({})
 // desktop: popover 要素 = メニュー本体 / compact: シート本体 (dialog の子)
 const menuRef = ref<HTMLElement | null>(null)
@@ -83,19 +85,35 @@ function open(e: MouseEvent) {
   // ボトムシート (compact) は下端固定なので位置計算不要
   if (isCompact.value) return
 
+  // Misskey 本家と同じ 2 方式で配置する。
+  // 右クリック (MkContextMenu): 押下点をメニューの左上頂点にする
+  // ボタン押下 (MkModal の anchor x=center/y=bottom): ボタンの水平中央に
+  //   メニューの中央を合わせ、ボタン直下に出す
+  const anchorEl = e.type === 'contextmenu' ? null : el
+  // 拡大アニメーションの起点も本家に合わせる (押下点なら左上、ボタンなら上辺中央)
+  pointAnchored.value = anchorEl == null
   // 押下点に被ると最初のメニュー項目を誤タップしやすいので少し下にずらす
   menuPos.value = { x: e.clientX + 4, y: e.clientY + 10 }
 
   nextTick(() => {
-    const menu = menuRef.value
-    if (!menu) return
-    const rect = menu.getBoundingClientRect()
-    const vw = document.documentElement.clientWidth
-    const vh = document.documentElement.clientHeight
-    let { x, y } = menuPos.value
-    if (x + rect.width > vw) x = Math.max(8, vw - rect.width - 8)
-    if (y + rect.height > vh) y = Math.max(8, vh - rect.height - 8)
-    menuPos.value = { x, y }
+    // popover は showPopover() されるまで display:none で寸法が取れないため、
+    // 表示後の次フレーム (描画前) に測って位置を確定する
+    requestAnimationFrame(() => {
+      const menu = menuRef.value
+      if (!menu) return
+      const rect = menu.getBoundingClientRect()
+      const vw = document.documentElement.clientWidth
+      const vh = document.documentElement.clientHeight
+      let { x, y } = menuPos.value
+      if (anchorEl) {
+        const anchorRect = anchorEl.getBoundingClientRect()
+        x = anchorRect.left + anchorRect.width / 2 - rect.width / 2
+        y = anchorRect.bottom
+      }
+      if (x + rect.width > vw) x = vw - rect.width - 8
+      if (y + rect.height > vh) y = vh - rect.height - 8
+      menuPos.value = { x: Math.max(8, x), y: Math.max(8, y) }
+    })
   })
 }
 
@@ -130,7 +148,7 @@ defineExpose({ open, close, activateKeyboard })
       v-else-if="visible"
       ref="menuRef"
       popover="manual"
-      :class="[$style.popupMenu, entering && $style.contentEnter, leaving && $style.contentLeave]"
+      :class="[$style.popupMenu, pointAnchored && $style.pointAnchored, entering && $style.contentEnter, leaving && $style.contentLeave]"
       class="_popup nd-popup-content popup-menu"
       :style="{ ...menuTheme, top: menuPos.y + 'px', left: menuPos.x + 'px' }"
     >
@@ -147,6 +165,13 @@ defineExpose({ open, close, activateKeyboard })
   min-width: 200px;
   max-width: 300px;
   padding: 6px 0;
+  // ボタン直下に中央揃えで出るので上辺中央から開く (本家 MkModal と同じ)
+  transform-origin: center top;
+
+  // 押下点アンカー時は本家 MkContextMenu と同じく左上から開く
+  &.pointAnchored {
+    transform-origin: left top;
+  }
 }
 
 .sheet {


### PR DESCRIPTION
## 変更点

UI 修正のみのパッチリリース。

### Fixes

- fix(post-form): 投稿フォーム編集ピッカーがアカウントテーマに追従しない問題を修正
- fix(reaction): リアクションピッカー初回表示時に位置がジャンプする問題を修正
- fix(menu): ボタン押下時のメニュー位置を本家と同じアンカー方式にする
- fix(reaction): リアクションピッカーの拡大起点を本家仕様に合わせる

### 詳細

**投稿フォーム編集ピッカーのテーマ追従**
`MkPostFormButtonsPicker` は `formThemeVars` を持つ `data-post-form` の兄弟として置かれており、`--nd-*` が継承されずグローバルテーマに落ちていた。周囲のピッカー (drive / drafts / 絵文字) と同じく明示的に当てる。

**リアクションピッカーの初回位置**
`MkReactionPicker` が `defineAsyncComponent` のため初回はチャンクのロードが間に合わず幅 0 で表示され、`left + translateX(-100%)` の右端揃えが効かずに隣のカラムへはみ出してから飛んでいた。幅に依存しない `right` 指定へ変更。

**メニューの発生位置**
右クリックもボタン押下も一律で押下点を左上頂点にしていたが、本家は 2 方式に分かれている (`MkContextMenu` = 押下点 / `os.popupMenu` → `MkModal` の anchor `x=center, y=bottom` = ボタン中央揃え + 直下)。ボタン押下側を本家に合わせた。併せて位置補正を rAF に移動 — popover は `showPopover()` まで `display:none` で寸法が 0 になるため、画面端のはみ出し補正が事実上効いていなかった。

## テスト

- `pnpm vitest run`: 201 files / 2173 tests pass (PopupMenu に位置テストを 2 件追加)
- `pnpm typecheck`: pass
- biome: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved popup menu positioning for button clicks and context-menu interactions.
  * Popups now stay within the visible viewport and animate from the appropriate origin.
  * Reaction picker positioning is more reliable on desktop layouts.
  * Post form picker buttons now inherit the form’s theme styling.

* **Bug Fixes**
  * Corrected popup alignment and placement in different interaction scenarios.

* **Tests**
  * Added coverage for popup positioning after clicks and context-menu actions.

* **Chores**
  * Updated the application version to 1.28.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->