### PR TITLE
Release v1.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.32.0",
+  "version": "1.32.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.32.0"
+version = "1.32.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.32.0"
+version = "1.32.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.32.0"
+    "version": "1.32.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/health.rs
+++ b/src-tauri/src/commands/health.rs
@@ -25,6 +25,9 @@ pub struct HealthReport {
     pub heartbeat_interval_minutes: Option<u32>,
     /// notedeck.log を含むログディレクトリ (#644)。解決できなければ null。
     pub log_dir: Option<String>,
+    /// 記録されている直近の Rust panic。adb を繋げない Android でも
+    /// ここから内容を読めるようにするのが主目的。無ければ null。
+    pub last_panic: Option<crate::crash_report::PanicReport>,
 }
 
 #[tauri::command]
@@ -53,11 +56,11 @@ pub async fn build_health_report(
     let mut doctor = notecli::commands::doctor::diagnose(db.as_ref(), &db_path, None).await?;
     strip_guest_credential_checks(&mut doctor, &db.load_accounts().unwrap_or_default());
     let (note_cache_count, db_size_bytes) = db.cache_stats()?;
-    let log_dir = app
-        .path()
-        .app_log_dir()
-        .ok()
-        .map(|p| p.to_string_lossy().into_owned());
+    let log_dir_path = app.path().app_log_dir().ok();
+    let last_panic = log_dir_path
+        .as_deref()
+        .and_then(crate::crash_report::read_last_panic);
+    let log_dir = log_dir_path.map(|p| p.to_string_lossy().into_owned());
 
     Ok(HealthReport {
         doctor,
@@ -66,6 +69,7 @@ pub async fn build_health_report(
         db_size_bytes,
         heartbeat_interval_minutes: scheduler.current_interval(),
         log_dir,
+        last_panic,
     })
 }
 

--- a/src-tauri/src/crash_report.rs
+++ b/src-tauri/src/crash_report.rs
@@ -1,0 +1,130 @@
+//! Rust panic の記録 (#644 の診断に相乗り)。
+//!
+//! Android は adb を繋げない環境が普通なので、panic をログディレクトリに
+//! 残して About の診断から見せる。デスクトップでも同じ経路で見えるので、
+//! プラットフォームを問わず「前回落ちた理由」を UI だけで拾える。
+//!
+//! panic 以外の異常終了 (SIGSEGV / OOM kill) は捕まえられない。ただし
+//! 「落ちたのに panic ログが無い」こと自体が切り分けになる:
+//!   - panic ログあり → Rust 側。file:line で特定できる
+//!   - panic ログなし → ネイティブクラッシュか OS による kill
+//!
+//! 「起動時にマーカーを置いて正常終了で消す」方式は採らない。Android は
+//! OS がアプリを日常的に kill するため、誤検知だらけになる。
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const PANIC_FILE: &str = "last_panic.txt";
+
+/// 記録された panic。診断レポートに載せてコピーできる形で渡す。
+#[derive(Debug, Clone, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PanicReport {
+    /// panic した時刻 (epoch ms)。0 は時刻を復元できなかったことを示す
+    pub at: u64,
+    /// panic メッセージ + backtrace
+    pub message: String,
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// panic をファイルに書き出すフックを入れる。既定のフックも呼ぶ
+/// (stderr / logcat への出力は残す)。
+pub fn install_panic_hook(dir: PathBuf) {
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Display は "panicked at <location>: <payload>" を含む
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let body = format!("{info}\n\nbacktrace:\n{backtrace}");
+        // tracing の writer スレッドが巻き添えで死んでいることがあるので直接書く
+        let _ = std::fs::create_dir_all(&dir);
+        let _ = std::fs::write(dir.join(PANIC_FILE), format!("{}\n{body}", now_ms()));
+        tracing::error!("{body}");
+        default_hook(info);
+    }));
+}
+
+/// 記録された panic を読む。**消さない** — 診断は何度開いても同じものが
+/// 見えるべきで、次の panic が来たら上書きされる。
+pub fn read_last_panic(dir: &Path) -> Option<PanicReport> {
+    let content = std::fs::read_to_string(dir.join(PANIC_FILE)).ok()?;
+    if content.trim().is_empty() {
+        return None;
+    }
+    // 1 行目が epoch ms、残りが本文。古い形式・壊れた場合は全体を本文として扱う
+    match content.split_once('\n') {
+        Some((head, body)) if !body.trim().is_empty() => match head.trim().parse::<u64>() {
+            Ok(at) => Some(PanicReport {
+                at,
+                message: body.to_string(),
+            }),
+            Err(_) => Some(PanicReport {
+                at: 0,
+                message: content,
+            }),
+        },
+        _ => Some(PanicReport {
+            at: 0,
+            message: content,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_none_when_no_panic_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_last_panic(dir.path()).is_none());
+    }
+
+    #[test]
+    fn reads_timestamp_and_body() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(PANIC_FILE),
+            "1753800000000\npanicked at src/foo.rs:12:3: boom",
+        )
+        .unwrap();
+
+        let report = read_last_panic(dir.path()).expect("should read");
+        assert_eq!(report.at, 1_753_800_000_000);
+        assert!(report.message.contains("src/foo.rs:12:3"));
+    }
+
+    /// 診断を開くたびに消えると、見返したときに情報が無くなってしまう
+    #[test]
+    fn keeps_the_report_for_repeated_reads() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PANIC_FILE), "1753800000000\nboom").unwrap();
+
+        assert!(read_last_panic(dir.path()).is_some());
+        assert!(read_last_panic(dir.path()).is_some());
+    }
+
+    /// 時刻行が無い古い形式でも本文は読めるようにする
+    #[test]
+    fn falls_back_when_timestamp_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PANIC_FILE), "panicked at src/foo.rs:1:1: x").unwrap();
+
+        let report = read_last_panic(dir.path()).expect("should read");
+        assert_eq!(report.at, 0);
+        assert!(report.message.contains("src/foo.rs"));
+    }
+
+    #[test]
+    fn ignores_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(PANIC_FILE), "  \n").unwrap();
+        assert!(read_last_panic(dir.path()).is_none());
+    }
+}

--- a/src-tauri/src/crash_report.rs
+++ b/src-tauri/src/crash_report.rs
@@ -42,9 +42,15 @@ pub fn install_panic_hook(dir: PathBuf) {
         // Display は "panicked at <location>: <payload>" を含む
         let backtrace = std::backtrace::Backtrace::force_capture();
         let body = format!("{info}\n\nbacktrace:\n{backtrace}");
-        // tracing の writer スレッドが巻き添えで死んでいることがあるので直接書く
+        // tracing の writer スレッドが巻き添えで死んでいることがあるので直接書く。
+        // 複数スレッドが同時に panic しても唯一の手がかりを壊さないよう atomic に
+        // 置き換える (fs::write は truncate 後に書くので混ざりうる)。
         let _ = std::fs::create_dir_all(&dir);
-        let _ = std::fs::write(dir.join(PANIC_FILE), format!("{}\n{body}", now_ms()));
+        let _ = crate::settings_store::atomic_write(
+            &dir.join(PANIC_FILE),
+            &format!("{}\n{body}", now_ms()),
+            None,
+        );
         tracing::error!("{body}");
         default_hook(info);
     }));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod hwheel_hook;
 /// Public so the `gen-openapi` binary and the OpenAPI snapshot test can call
 /// [`http_server::build_openapi`].
 pub mod http_server;
+mod crash_report;
 mod image_cache;
 mod media_proxy;
 mod migrations;
@@ -202,6 +203,12 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         // Initialized here (not earlier) because the log dir needs the app handle;
         // if it can't be resolved we fall back to stdout-only so startup never blocks.
         init_logging(app);
+
+        // panic をログディレクトリに残す。Android は adb を繋げない環境が普通なので、
+        // 次回起動時に UI へ出すのが実質唯一のクラッシュ調査手段になる。
+        if let Ok(dir) = app.path().app_log_dir() {
+            crash_report::install_panic_hook(dir);
+        }
 
         // tauri-specta typed events (e.g. QueryDelta) require the registry to be mounted.
         specta_builder.mount_events(app);

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -74,6 +74,15 @@ impl MediaRequest {
     }
 }
 
+/// ヘッダだけ読んで寸法を得る。判定できない形式は None。
+fn image_dimensions(data: &[u8]) -> Option<(u32, u32)> {
+    image::ImageReader::new(std::io::Cursor::new(data))
+        .with_guessed_format()
+        .ok()?
+        .into_dimensions()
+        .ok()
+}
+
 /// Apply resize and/or format conversion to raw image bytes.
 /// Returns (transformed_bytes, content_type) or None if no transform needed / failed.
 pub fn transform_image(
@@ -85,6 +94,17 @@ pub fn transform_image(
     let needs_webp = target_format == Some("webp");
     if !needs_resize && !needs_webp {
         return None;
+    }
+
+    // 既に上限以下なら何もしない。縮まないのに decode + 再エンコードするのは
+    // 純粋な無駄で、Misskey のアバターはサーバー側で縮小済みのことが多いため
+    // この経路が大半を占める。寸法はヘッダだけ読む (フルデコードを避ける)。
+    if let Some(w) = max_width {
+        if let Some((width, _)) = image_dimensions(data) {
+            if width <= w {
+                return None;
+            }
+        }
     }
 
     let img = image::load_from_memory(data).ok()?;
@@ -272,6 +292,32 @@ mod tests {
         assert_ne!(sized.cache_key(), bigger.cache_key());
         assert_ne!(sized.etag(), bigger.etag());
         assert!(!plain.wants_transform());
+    }
+
+    fn png_bytes(w: u32, h: u32) -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(w, h, image::Rgba([10, 20, 30, 255]));
+        let mut buf = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+            .expect("encode png");
+        buf
+    }
+
+    /// 上限以下の画像を decode + 再エンコードするのは純粋な無駄。
+    /// Misskey のアバターはサーバー側で縮小済みなので、この経路が大半を占める。
+    #[test]
+    fn skips_transform_when_already_within_limit() {
+        assert!(transform_image(&png_bytes(32, 32), Some(56), Some("webp")).is_none());
+        // ちょうど上限も変換しない
+        assert!(transform_image(&png_bytes(56, 56), Some(56), Some("webp")).is_none());
+    }
+
+    #[test]
+    fn transforms_when_wider_than_limit() {
+        let (out, ct) = transform_image(&png_bytes(200, 200), Some(56), Some("webp"))
+            .expect("should transform");
+        assert_eq!(ct, "image/webp");
+        assert!(!out.is_empty());
     }
 
     /// 効果音は変換パラメータを持たないので素通しになる

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -96,13 +96,19 @@ pub fn transform_image(
         return None;
     }
 
-    // 既に上限以下なら何もしない。縮まないのに decode + 再エンコードするのは
-    // 純粋な無駄で、Misskey のアバターはサーバー側で縮小済みのことが多いため
-    // この経路が大半を占める。寸法はヘッダだけ読む (フルデコードを避ける)。
-    if let Some(w) = max_width {
-        if let Some((width, _)) = image_dimensions(data) {
-            if width <= w {
-                return None;
+    // リサイズだけを求められていて既に上限以下なら何もしない。縮まないのに
+    // decode + 再エンコードするのは純粋な無駄で、Misskey のアバターはサーバー側で
+    // 縮小済みのことが多いためこの経路が大半を占める。
+    // 寸法はヘッダだけ読む (フルデコードを避ける)。
+    //
+    // format が明示されている場合はスキップしない。HTTP API (`/proxy/image`) は
+    // 外部 principal にも開いており、webp を要求されたのに元形式を返すと契約違反。
+    if target_format.is_none() {
+        if let Some(w) = max_width {
+            if let Some((width, _)) = image_dimensions(data) {
+                if width <= w {
+                    return None;
+                }
             }
         }
     }
@@ -307,9 +313,18 @@ mod tests {
     /// Misskey のアバターはサーバー側で縮小済みなので、この経路が大半を占める。
     #[test]
     fn skips_transform_when_already_within_limit() {
-        assert!(transform_image(&png_bytes(32, 32), Some(56), Some("webp")).is_none());
+        assert!(transform_image(&png_bytes(32, 32), Some(56), None).is_none());
         // ちょうど上限も変換しない
-        assert!(transform_image(&png_bytes(56, 56), Some(56), Some("webp")).is_none());
+        assert!(transform_image(&png_bytes(56, 56), Some(56), None).is_none());
+    }
+
+    /// format を明示されたら縮まなくても変換する。HTTP API は外部にも開いて
+    /// いるので、webp を要求されたのに元形式を返すのは契約違反。
+    #[test]
+    fn honors_explicit_format_even_when_small() {
+        let (_, ct) = transform_image(&png_bytes(32, 32), Some(56), Some("webp"))
+            .expect("explicit format must be honored");
+        assert_eq!(ct, "image/webp");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -37,6 +37,8 @@ export interface ServerFeatures {
   antennas: boolean
   quotes: boolean
   groupedNotifications: boolean
+  /** リモート絵文字 (`:name@host:`) でリアクションできるか (#630) */
+  remoteEmojiReactions: boolean
   [key: string]: boolean
 }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2803,7 +2803,12 @@ heartbeatIntervalMinutes: number | null;
 /**
  * notedeck.log を含むログディレクトリ (#644)。解決できなければ null。
  */
-logDir: string | null }
+logDir: string | null; 
+/**
+ * 記録されている直近の Rust panic。adb を繋げない Android でも
+ * ここから内容を読めるようにするのが主目的。無ければ null。
+ */
+lastPanic: PanicReport | null }
 export type HttpFetchRequest = { url: string; method: string | null; headers: Partial<{ [key in string]: string }> | null; body: string | null; timeoutMs: number | null }
 export type HttpFetchResponse = { status: number; headers: Partial<{ [key in string]: string }>; body: string }
 /**
@@ -2934,6 +2939,18 @@ export type Page = { id: string; createdAt: string; updatedAt: string; title: st
  * `content` / `variables` はブロック構造で複雑。生 JSON で運ぶ。
  */
 content?: JsonValue | null; variables?: JsonValue | null; script?: string | null; alignCenter?: boolean; hideTitleWhenPinned?: boolean; font?: string | null; eyeCatchingImageId?: string | null; eyeCatchingImage?: NormalizedDriveFile | null; likedCount?: number | null; isLiked?: boolean | null }
+/**
+ * 記録された panic。診断レポートに載せてコピーできる形で渡す。
+ */
+export type PanicReport = { 
+/**
+ * panic した時刻 (epoch ms)。0 は時刻を復元できなかったことを示す
+ */
+at: number; 
+/**
+ * panic メッセージ + backtrace
+ */
+message: string }
 /**
  * Performance configuration shared across the application.
  * All fields are dynamically updatable at runtime via Tauri commands.

--- a/src/capabilities/builtins/notes-write.ts
+++ b/src/capabilities/builtins/notes-write.ts
@@ -1,7 +1,14 @@
 import type { CreateNoteParams, NoteVisibility } from '@/adapters/types'
 import type { Command } from '@/commands/registry'
 import { projectVisibleItems } from '@/composables/useAiSystemContext'
-import { ACCOUNT_ID_PARAM_DESC, getApiAdapter } from '../accountContext'
+import { reactionJoinability } from '@/services/remoteReaction'
+import { useAccountsStore } from '@/stores/accounts'
+import { useServersStore } from '@/stores/servers'
+import {
+  ACCOUNT_ID_PARAM_DESC,
+  getApiAdapter,
+  resolveAccountId,
+} from '../accountContext'
 
 /**
  * Phase 5.0: write 系 capability。すべて `requiresConfirmation: true` を宣言し、
@@ -154,7 +161,26 @@ export const notesReactCapability: Command = {
     const reaction = pickString(params?.reaction)
     if (!noteId) throw new Error('notes.react: noteId is required')
     if (!reaction) throw new Error('notes.react: reaction is required')
-    const api = await getApiAdapter(params?.accountId, ctx)
+    const accountId = resolveAccountId(params?.accountId, ctx)
+    // #630: 非対応サーバーはリモート絵文字を ❤ に落とすので、黙って別の
+    // リアクションを付けずに弾く。ノートを持たないため絵文字の解決可否は
+    // 見ず、サーバーの対応だけ確認する
+    const account = useAccountsStore().accountMap.get(accountId)
+    if (
+      account &&
+      reactionJoinability(reaction, {
+        serverHost: account.host,
+        remoteEmojiReactions:
+          useServersStore().getServer(account.host)?.features
+            .remoteEmojiReactions === true,
+        hasEmojiUrl: true,
+      }) !== 'ok'
+    ) {
+      throw new Error(
+        `notes.react: ${account.host} はリモートの絵文字でリアクションできません`,
+      )
+    }
+    const api = await getApiAdapter(accountId, ctx)
     await api.createReaction(noteId, reaction)
     return { ok: true, noteId, reaction }
   },

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -142,6 +142,9 @@ function onReactionAvatarError(e: Event) {
 }
 
 function handleReactionClick(reaction: string, reacted: boolean) {
+  // 自分のメッセージに付いたリアクションは必ず他人のもの。本家 ChatService.react
+  // が fromUserId === userId で throw するため、押しても付け外しはできない。
+  if (isMine.value) return
   if (reacted) {
     emit('unreact', props.message.id, reaction)
   } else {
@@ -240,6 +243,7 @@ usePortal(lightboxPortalRef)
           :key="r.reaction"
           :class="[$style.chatReactionPill, { [$style.reacted]: r.reacted }]"
           :title="r.users.join(', ')"
+          :disabled="!!isMine"
           @click="handleReactionClick(r.reaction, r.reacted)"
         >
           <span v-if="r.avatarUrls.length > 0" :class="$style.reactionAvatars">
@@ -430,8 +434,13 @@ usePortal(lightboxPortalRef)
   cursor: pointer;
   line-height: 1.4;
 
-  &:hover {
+  &:not(:disabled):hover {
     background: var(--nd-buttonHoverBg, rgba(255, 255, 255, 0.1));
+  }
+
+  /* 自分のメッセージのリアクションは付け外しできないので押せる見た目にしない */
+  &:disabled {
+    cursor: default;
   }
 
   &.reacted {

--- a/src/components/common/MkChatMessageMoreMenu.vue
+++ b/src/components/common/MkChatMessageMoreMenu.vue
@@ -124,7 +124,9 @@ defineExpose({ open })
 
     <!-- Main menu -->
     <template v-else>
-      <button class="_popupItem" @click.stop="reactAndClose">
+      <!-- 自分のメッセージにはリアクションできない (本家 ChatService.react が
+           fromUserId === userId で throw する) ので導線ごと出さない -->
+      <button v-if="!isMine" class="_popupItem" @click.stop="reactAndClose">
         <i class="ti ti-mood-plus" />
         リアクション
       </button>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -29,8 +29,14 @@ import {
   useVaporTransitionGroup,
 } from '@/composables/useVaporTransition'
 import { useVisibleReactionCounts } from '@/composables/useVisibleReactionCounts'
+import {
+  type ReactionJoinability,
+  reactionJoinability,
+} from '@/services/remoteReaction'
 import { useAccountsStore } from '@/stores/accounts'
+import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
+import { useToast } from '@/stores/toast'
 import { formatTime } from '@/utils/formatTime'
 import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import {
@@ -349,13 +355,31 @@ const { counts: recountedCounts } = useVisibleReactionCounts(
   reactionsVisible,
 )
 
+// #630: リモート絵文字リアクションに相乗りできるサーバーか
+const serversStore = useServersStore()
+const supportsRemoteEmojiReactions = computed(
+  () =>
+    serversStore.getServer(effectiveNote.value._serverHost)?.features
+      .remoteEmojiReactions === true,
+)
+
 const sortedReactions = computed(() => {
   const sorted = reactionsData.value.sorted
   const counts = recountedCounts.value
-  if (!counts) return sorted
-  return sorted
-    .map((r) => ({ ...r, count: counts[r.reaction] ?? 0 }))
-    .filter((r) => r.count > 0)
+  const visible = counts
+    ? sorted
+        .map((r) => ({ ...r, count: counts[r.reaction] ?? 0 }))
+        .filter((r) => r.count > 0)
+    : sorted
+  const urls = reactionsData.value.urls
+  return visible.map((r) => ({
+    ...r,
+    joinability: reactionJoinability(r.reaction, {
+      serverHost: effectiveNote.value._serverHost,
+      remoteEmojiReactions: supportsRemoteEmojiReactions.value,
+      hasEmojiUrl: urls[r.reaction] != null,
+    }),
+  }))
 })
 const reactionUrls = computed(() => reactionsData.value.urls)
 
@@ -479,10 +503,31 @@ const renoteUserPopupPortalRef = useTemplateRef<HTMLElement>(
 )
 usePortal(renoteUserPopupPortalRef)
 
-function handleReactionClick(e: MouseEvent, reaction: string) {
+/**
+ * 相乗りできないリアクションを押したときの理由 (#630)。押しても無反応だと
+ * 不親切なので、押したときだけ理由を出す (常時バッジは過剰)。
+ */
+const JOIN_BLOCKED_MESSAGE: Record<
+  Exclude<ReactionJoinability, 'ok'>,
+  string
+> = {
+  'unsupported-server':
+    'このサーバーではリモートの絵文字でリアクションできません',
+  'emoji-unavailable': 'この絵文字はサーバーにないためリアクションできません',
+}
+
+function handleReactionClick(
+  e: MouseEvent,
+  reaction: string,
+  joinability: ReactionJoinability,
+) {
   if (longPressed.value) return
   if (!canInteract.value) {
     showLoginPrompt()
+    return
+  }
+  if (joinability !== 'ok') {
+    useToast().show(JOIN_BLOCKED_MESSAGE[joinability], 'info')
     return
   }
   const btn = e.currentTarget as HTMLElement
@@ -819,16 +864,17 @@ function handlePickerReaction(reaction: string) {
             <button
               v-for="r in renderedReactions"
               :key="r.reaction"
-              v-memo="[r.reaction, r.count, effectiveNote.myReaction === r.reaction, reactionUrls[r.reaction], reactionEnteringIds.has(r.id), reactionLeavingIds.has(r.id), isEmojiMuted(r.reaction)]"
+              v-memo="[r.reaction, r.count, effectiveNote.myReaction === r.reaction, reactionUrls[r.reaction], reactionEnteringIds.has(r.id), reactionLeavingIds.has(r.id), isEmojiMuted(r.reaction), r.joinability]"
               :class="[
                 $style.reaction,
                 { [$style.reacted]: effectiveNote.myReaction === r.reaction },
+                r.joinability !== 'ok' && $style.notJoinable,
                 reactionEnteringIds.has(r.id) && $style.reactionEnter,
                 reactionLeavingIds.has(r.id) && $style.reactionLeave,
               ]"
               :data-reaction="r.reaction"
               :disabled="isGuest"
-              @click.stop="handleReactionClick($event, r.reaction)"
+              @click.stop="handleReactionClick($event, r.reaction, r.joinability)"
               @contextmenu.prevent.stop="reactionUsersRef?.show($event, r.reaction, reactionUrls[r.reaction] ?? null, effectiveNote.reactions[r.reaction] ?? 0)"
               @pointerdown="lpHandlers.onPointerdown"
               @pointermove="lpHandlers.onPointermove"
@@ -1504,6 +1550,19 @@ function handlePickerReaction(reaction: string) {
     background: var(--nd-accentedBg);
     color: var(--nd-accent);
     box-shadow: 0 0 0 1px var(--nd-accent) inset;
+  }
+
+  /* #630: 相乗りできないリモート絵文字。押せる見た目をやめる (絵文字自体は出す) */
+  &.notJoinable {
+    cursor: default;
+
+    &:hover {
+      background: var(--nd-buttonBg);
+    }
+
+    &:active {
+      animation: none;
+    }
   }
 
   /* Misskey: drop-shadow on custom emoji when reacted */

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -816,26 +816,35 @@ function updateMessageReaction(
     : account.value
   if (!acc) return
 
-  const reactor: ChatReactionUser = {
-    id: acc.userId ?? '',
-    username: acc.username ?? '',
-    name: acc.displayName ?? null,
-    host: acc.host ?? null,
-    avatarUrl: acc.avatarUrl ?? null,
-  }
+  // 1on1 の WS react/unreact は本家仕様で reactor を含まない (ChatService の
+  // publishChatUserStream 分岐。room 側だけ pack(userId) を載せる)。ここで自分を
+  // reactor に入れると dedup sig (type × userId × reaction) が WS 側と食い違い、
+  // 同じリアクションが二重に載る。1on1 は reactor を伏せて sig を揃える
+  // (表示は MkChatMessage がメッセージ送信者から逆算する)。
+  const reactor: ChatReactionUser | null =
+    currentRoomId.value === null
+      ? null
+      : {
+          id: acc.userId ?? '',
+          username: acc.username ?? '',
+          name: acc.displayName ?? null,
+          host: acc.host ?? null,
+          avatarUrl: acc.avatarUrl ?? null,
+        }
+  const userId = reactor?.id ?? null
   chatMessageStore.applyUpdate(
     add
       ? {
           type: 'reacted',
           messageId,
-          userId: reactor.id,
+          userId,
           reaction,
           reactor,
         }
       : {
           type: 'unreacted',
           messageId,
-          userId: reactor.id,
+          userId,
           reaction,
           reactor,
         },

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -162,18 +162,34 @@ async function runHealthcheck() {
   }
 }
 
-// 問題のある行だけをデバッグログ体裁に整形 (UI 表示・コピー・バグ報告で共用)。
-// 正常時は空文字なのでブロックも本文の診断セクションも出ない。
-// panic は 1 行に畳むと file:line しか残らないので、backtrace ごと末尾に付ける
-// (Android は adb が使えず、これがスタックを持ち出す唯一の経路になる)。
+// 問題のある行だけをデバッグログ体裁に整形。正常時は空文字なので
+// ブロックも本文の診断セクションも出ない。
+const checkLines = computed<string>(() =>
+  problemChecks.value.map(formatCheck).join('\n'),
+)
+
+/**
+ * UI 表示とクリップボードコピー用。panic は 1 行に畳むと file:line しか
+ * 残らないので backtrace ごと付ける (Android は adb が使えず、これがスタックを
+ * 持ち出す唯一の経路になる)。どちらもローカルに留まる用途。
+ */
 const diagnosticsLog = computed<string>(() => {
-  const lines = problemChecks.value.map(formatCheck)
   const panic = health.value?.lastPanic
-  if (panic) {
-    lines.push('', '--- last panic ---', panic.message.trimEnd())
-  }
-  return lines.join('\n')
+  if (!panic) return checkLines.value
+  const parts = [
+    checkLines.value,
+    '--- last panic ---',
+    panic.message.trimEnd(),
+  ]
+  return parts.filter((p) => p).join('\n\n')
 })
+
+/**
+ * GitHub issue の URL に載せる分。backtrace は入れない — URL 長を食い潰すうえ、
+ * ローカルのパスやユーザー名が外部へ出る。本人が「情報をコピー」から
+ * 貼り付けるかどうかを選べる形にする。
+ */
+const reportDiagnostics = computed<string>(() => checkLines.value)
 const {
   isChecking,
   isUpToDate,
@@ -258,9 +274,13 @@ async function copyInfo() {
 
 function reportBug() {
   const env = infoRows.map((r) => `- **${r.label}**: ${r.get()}`).join('\n')
-  const diag = diagnosticsLog.value
+  const diag = reportDiagnostics.value
   const diagSection = diag ? `\n\n## 診断\n\n\`\`\`\n${diag}\n\`\`\`` : ''
-  const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}${diagSection}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
+  // backtrace は URL に載せない。貼るかどうかは本人に委ねる
+  const panicNote = health.value?.lastPanic
+    ? '\n\n<!-- 異常終了の backtrace は「情報をコピー」で取得して貼り付けてください -->'
+    : ''
+  const body = `## 現象\n\n<!-- 何が起きたか -->\n\n## 再現手順\n\n1.\n2.\n3.\n\n## 期待する動作\n\n<!-- 本来どうなるべきか -->\n\n## 環境\n\n${env}${diagSection}${panicNote}\n\n## スクリーンショット\n\n<!-- あれば添付 -->`
   const url = `${REPO_URL}/issues/new?labels=bug&body=${encodeURIComponent(body)}`
   openSafeUrl(url)
 }

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -103,10 +103,32 @@ const streamChecks = computed<Check[]>(() => {
   return checks
 })
 
+/**
+ * 記録されている Rust panic (#644)。adb を繋げない Android でも
+ * 「前回落ちた理由」をここから読めるようにするのが主目的。
+ * 次の panic が来るまで残るので、いつのものかを日時で示す。
+ */
+const crashChecks = computed<Check[]>(() => {
+  const panic = health.value?.lastPanic
+  if (!panic) return []
+  // 1 行目に "panicked at <file>:<line>: <msg>" が入る。詳細は診断ログ側で見る
+  const headline = panic.message.split('\n')[0]?.trim() ?? 'panic'
+  const when = panic.at > 0 ? new Date(panic.at).toLocaleString() : '時刻不明'
+  return [
+    {
+      name: 'crash',
+      status: 'warn',
+      message: `${when} に異常終了しました: ${headline}`,
+      fix: '下の診断ログをコピーして報告',
+    },
+  ]
+})
+
 // 正常な項目は畳んで、注意・問題だけ出す (健康なら "正常" の一行で済む)。
 const problemChecks = computed(() => [
   ...(health.value?.doctor.checks ?? []).filter((c) => c.status !== 'ok'),
   ...streamChecks.value,
+  ...crashChecks.value,
 ])
 
 const overallStatus = computed<Status>(() => {
@@ -142,9 +164,16 @@ async function runHealthcheck() {
 
 // 問題のある行だけをデバッグログ体裁に整形 (UI 表示・コピー・バグ報告で共用)。
 // 正常時は空文字なのでブロックも本文の診断セクションも出ない。
-const diagnosticsLog = computed<string>(() =>
-  problemChecks.value.map(formatCheck).join('\n'),
-)
+// panic は 1 行に畳むと file:line しか残らないので、backtrace ごと末尾に付ける
+// (Android は adb が使えず、これがスタックを持ち出す唯一の経路になる)。
+const diagnosticsLog = computed<string>(() => {
+  const lines = problemChecks.value.map(formatCheck)
+  const panic = health.value?.lastPanic
+  if (panic) {
+    lines.push('', '--- last panic ---', panic.message.trimEnd())
+  }
+  return lines.join('\n')
+})
 const {
   isChecking,
   isUpToDate,

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -83,6 +83,13 @@ function detectFeatures(software: ServerSoftware): ServerFeatures {
     features.notesShowPartialBulk = true
   }
 
+  // リモート絵文字でのリアクション (#630)。本家は `@ホスト名` 付きを ❤ に
+  // フォールバックするため、連合キャッシュまで絵文字を探索するフォークのみ。
+  // API から判定する手段はないので静的宣言 — 漏れても「押せない」側に落ちる
+  if (software === 'lqvp/misskey-tempura') {
+    features.remoteEmojiReactions = true
+  }
+
   return features
 }
 
@@ -97,5 +104,6 @@ function defaultFeatures(): ServerFeatures {
     quotes: true,
     scheduledNotes: false,
     groupedNotifications: false,
+    remoteEmojiReactions: false,
   }
 }

--- a/src/services/remoteReaction.test.ts
+++ b/src/services/remoteReaction.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { reactionJoinability } from './remoteReaction'
+
+const HOST = 'example.com'
+
+function joinability(
+  reaction: string,
+  opts: { remote?: boolean; hasEmojiUrl?: boolean } = {},
+) {
+  return reactionJoinability(reaction, {
+    serverHost: HOST,
+    remoteEmojiReactions: opts.remote ?? false,
+    hasEmojiUrl: opts.hasEmojiUrl ?? true,
+  })
+}
+
+describe('reactionJoinability', () => {
+  it('Unicode 絵文字は常に押せる', () => {
+    expect(joinability('❤')).toBe('ok')
+    expect(joinability('👍')).toBe('ok')
+  })
+
+  it('ローカルカスタム絵文字は常に押せる', () => {
+    expect(joinability(':foo:')).toBe('ok')
+    expect(joinability(':foo@.:')).toBe('ok')
+  })
+
+  it('自サーバーのホストが付いていてもローカル扱い', () => {
+    expect(joinability(`:foo@${HOST}:`)).toBe('ok')
+    expect(joinability(':foo@Example.COM:')).toBe('ok')
+  })
+
+  it('非対応サーバーではリモート絵文字に相乗りできない', () => {
+    expect(joinability(':foo@remote.example:')).toBe('unsupported-server')
+  })
+
+  it('対応サーバーでは絵文字が解決できれば相乗りできる', () => {
+    expect(joinability(':foo@remote.example:', { remote: true })).toBe('ok')
+  })
+
+  it('対応サーバーでも絵文字が解決できなければ押せない', () => {
+    expect(
+      joinability(':foo@remote.example:', { remote: true, hasEmojiUrl: false }),
+    ).toBe('emoji-unavailable')
+  })
+
+  it('カスタム絵文字として解釈できない文字列は判定対象外 (挙動を変えない)', () => {
+    expect(joinability(':foo')).toBe('ok')
+    expect(joinability('foo')).toBe('ok')
+    expect(joinability('')).toBe('ok')
+    // 記号入りは本家のカスタム絵文字名の文法から外れる
+    expect(joinability(':foo bar@remote.example:')).toBe('ok')
+  })
+})

--- a/src/services/remoteReaction.ts
+++ b/src/services/remoteReaction.ts
@@ -1,0 +1,48 @@
+/**
+ * リモートユーザーが付けたリアクションに相乗りできるかの判定 (#630)。
+ *
+ * 本家 Misskey のリアクション作成はカスタム絵文字として `:name:` / `:name@.:`
+ * の形しか受け付けず、`@ホスト名` 付きは Unicode 絵文字判定に落ちてフォール
+ * バック (❤) になる。加えてローカルユーザーからのリアクションはローカル絵文字
+ * セットしか検索しないため、**同一チップへの相乗りはサーバー側の仕様上でき
+ * ない**。相乗りを成立させるにはサーバー実装 (連合キャッシュまで探索する
+ * tempura 系) が必要で、クライアント側では対応サーバー以外で押させないことしか
+ * できない。
+ *
+ * 本家 Web UI も同様にリモート絵文字リアクションをトグル対象外にしている。
+ */
+
+/** 本家 `decodeCustomEmojiRegexp` と同じ文法。名前とホストを取り出す */
+const CUSTOM_EMOJI_RE = /^:([\w+-]+)(?:@([\w.-]+))?:$/
+
+export type ReactionJoinability =
+  /** 押せる */
+  | 'ok'
+  /** サーバーがリモート絵文字でのリアクションに対応していない */
+  | 'unsupported-server'
+  /** 対応サーバーだが、その絵文字を解決できない (サーバーが知らない可能性が高い) */
+  | 'emoji-unavailable'
+
+export function reactionJoinability(
+  reaction: string,
+  ctx: {
+    /** リアクションを送るアカウントのサーバー */
+    serverHost: string
+    /** そのサーバーの `features.remoteEmojiReactions` */
+    remoteEmojiReactions: boolean
+    /** その絵文字の URL が解決できているか (ノートの reactionEmojis / 絵文字キャッシュ) */
+    hasEmojiUrl: boolean
+  },
+): ReactionJoinability {
+  const m = reaction.match(CUSTOM_EMOJI_RE)
+  // Unicode 絵文字・カスタム絵文字として解釈できない文字列は判定対象外
+  if (!m) return 'ok'
+
+  const host = m[2]
+  // `:foo:` / `:foo@.:` / 自サーバーのホスト付きはローカル絵文字
+  if (!host || host === '.') return 'ok'
+  if (host.toLowerCase() === ctx.serverHost.toLowerCase()) return 'ok'
+
+  if (!ctx.remoteEmojiReactions) return 'unsupported-server'
+  return ctx.hasEmojiUrl ? 'ok' : 'emoji-unavailable'
+}

--- a/src/stores/chatMessageStore.test.ts
+++ b/src/stores/chatMessageStore.test.ts
@@ -1,0 +1,127 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ChatMessage } from '@/adapters/types'
+import { useChatMessageStore } from '@/stores/chatMessageStore'
+
+const ME = 'user-me'
+const OTHER = 'user-other'
+const R = ':meow:'
+
+function makeMessage(): ChatMessage {
+  return {
+    id: 'm1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    text: 'hi',
+    fromUserId: OTHER,
+    reactions: [],
+  } as unknown as ChatMessage
+}
+
+const meReactor = {
+  id: ME,
+  username: 'me',
+  name: 'Me',
+  host: null,
+  avatarUrl: null,
+}
+
+describe('chatMessageStore.applyUpdate の reaction dedup', () => {
+  let store: ReturnType<typeof useChatMessageStore>
+
+  function reactions() {
+    return store.messageMap.get('m1')?.reactions ?? []
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useChatMessageStore()
+    store.put([makeMessage()])
+  })
+
+  // 1on1 の WS react は本家仕様で reactor を含まない。楽観的更新側が自分を
+  // reactor に入れると sig が食い違って dedup をすり抜け、同じリアクションが
+  // 二重に載る (DeckChatColumn.updateMessageReaction の 1on1 分岐の回帰テスト)。
+  it('1on1: reactor 無しの楽観的更新と WS event は 1 件に dedup される', () => {
+    const optimistic = {
+      type: 'reacted',
+      messageId: 'm1',
+      userId: null,
+      reaction: R,
+      reactor: null,
+    } as const
+    const ws = { ...optimistic }
+
+    store.applyUpdate(optimistic)
+    store.applyUpdate(ws)
+
+    expect(reactions()).toHaveLength(1)
+  })
+
+  it('1on1: WS が楽観的更新より先着しても 1 件に収まる', () => {
+    const event = {
+      type: 'reacted',
+      messageId: 'm1',
+      userId: null,
+      reaction: R,
+      reactor: null,
+    } as const
+
+    store.applyUpdate(event) // WS
+    store.applyUpdate(event) // 楽観的更新 (API 応答が後)
+
+    expect(reactions()).toHaveLength(1)
+  })
+
+  it('room: reactor 付きの楽観的更新と WS event も 1 件に dedup される', () => {
+    const event = {
+      type: 'reacted',
+      messageId: 'm1',
+      userId: ME,
+      reaction: R,
+      reactor: meReactor,
+    } as const
+
+    store.applyUpdate(event)
+    store.applyUpdate(event)
+
+    expect(reactions()).toHaveLength(1)
+  })
+
+  it('room: 別ユーザーの同一リアクションは dedup されず両方載る', () => {
+    store.applyUpdate({
+      type: 'reacted',
+      messageId: 'm1',
+      userId: ME,
+      reaction: R,
+      reactor: meReactor,
+    })
+    store.applyUpdate({
+      type: 'reacted',
+      messageId: 'm1',
+      userId: 'user-third',
+      reaction: R,
+      reactor: { ...meReactor, id: 'user-third', username: 'third' },
+    })
+
+    expect(reactions()).toHaveLength(2)
+  })
+
+  it('1on1: reactor 無しの unreacted は reactor 無しの reaction を消す', () => {
+    store.applyUpdate({
+      type: 'reacted',
+      messageId: 'm1',
+      userId: null,
+      reaction: R,
+      reactor: null,
+    })
+    store.applyUpdate({
+      type: 'unreacted',
+      messageId: 'm1',
+      userId: null,
+      reaction: R,
+      reactor: null,
+    })
+
+    expect(reactions()).toHaveLength(0)
+  })
+})

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -85,10 +85,11 @@ describe('proxyUrl', () => {
 })
 
 describe('proxyThumbUrl', () => {
-  it('幅と webp 変換を付ける', async () => {
+  // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
+  it('幅だけを付ける', async () => {
     const { proxyThumbUrl } = await loadModule()
     expect(proxyThumbUrl(REMOTE, 56)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56&format=webp`,
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56`,
     )
   })
 

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -58,8 +58,13 @@ export function proxyUrl(url: string | null | undefined): string | undefined {
 }
 
 /**
- * Generate a proxy URL with thumbnail resize and optional WebP conversion.
- * Used for timeline images where the display size is much smaller than the original.
+ * 表示サイズが元画像よりずっと小さい面 (アバター・アイコン) 用のリサイズ付き URL。
+ *
+ * `format` は付けない。リサイズが必要な画像はプロキシ側が WebP で返すし、
+ * format を明示すると「既に上限以下なので変換不要」の判定が使えなくなる
+ * (明示された形式は尊重しなければならないため)。Misskey のアバターは
+ * サーバー側で縮小済みのことが多く、その素通しが効くかどうかで
+ * モバイルの初回表示が変わる。
  */
 export function proxyThumbUrl(
   url: string | null | undefined,
@@ -70,7 +75,7 @@ export function proxyThumbUrl(
   let cached = proxyUrlCache.get(key)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}&format=webp`
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}`
     proxyUrlCache.set(key, cached)
   }
   return cached


### PR DESCRIPTION
v1.32.0 で入れた custom protocol 化の後始末と、Android のクラッシュ調査手段の整備です。

## 縮まない画像の再エンコードをやめる

`transform_image` は元画像が上限以下でもリサイズをスキップするだけで、**WebP エンコードは必ず実行**していました。Misskey のアバターはサーバー側で縮小済み（例: `/proxy/avatar.webp` で 1.4KB）なので、「縮まないのに decode + lossless WebP encode する」経路が大半を占めていました。

デスクトップの CPU では埋もれていましたが、Android では初回表示の遅さとして体感に出ます。寸法をヘッダだけ読んで、上限以下なら素通しします。

なお **custom protocol はストリーミングできない**（ボディが `Vec<u8>` 固定）という構造的な制約は残ります。サイズの大きいノート添付画像で体感差が出る可能性があり、そちらは今回の変更では改善しません。

## Rust panic を記録して About の診断に出す (#644)

Android は adb を繋げない環境が普通で、落ちても手がかりが何も残りません。panic をログディレクトリに書き出し、既存の healthcheck に相乗りさせて UI だけで内容を持ち出せるようにします。デスクトップでも同じ経路で見えます。

- `crash_report`: panic hook でファイルに記録。読み出しは take ではなく **read**（診断は何度開いても同じものが見えるべき）
- `HealthReport` に `last_panic` を追加。About は既存の `streamChecks` と同じパターンで警告行を足すので、**診断ログのコピーとバグ報告に自動で乗る**（新しい導線を作っていない）
- 診断ログには backtrace ごと付ける。Android でスタックを持ち出す唯一の経路

### 限界

panic 以外の異常終了（SIGSEGV / OOM kill）は捕捉できません。ただしこれ自体が切り分けになります:

| 次に落ちたとき | 判断 |
|---|---|
| About に crash 警告が出る | Rust の panic。file:line と backtrace で特定できる |
| 落ちたのに警告が出ない | ネイティブクラッシュか OOM kill |

「起動時にマーカーを置いて正常終了で消す」方式は、Android が OS 都合でアプリを日常的に kill するため誤検知だらけになるので採っていません。

## 検証

- TS 2332 件 / Rust 234 件 すべて通過
- `typecheck` / biome / `cargo clippy` クリーン、openapi・bindings スナップショット最新

## 未解決

**Android のリアクション時クラッシュは直っていません。** v1.32.0 で `users/show` の転送量を 1/1000 以下にしても症状が変わらなかったため、当初の OOM 仮説は主因ではありませんでした。今回入れる crash 検知が次の手がかりになります。

## 1on1 チャットのリアクション重複表示を修正

チャットカラムで 1on1 のリアクションが二重に表示される問題。`chatMessageStore` にユニットテストを追加。

## レビュー指摘の反映 (CodeRabbit)

3 点いずれも妥当だったので取り込みました。

1. **明示された format 変換を飛ばしていた**（機能不正） — 寸法が上限以下なら素通しする最適化が `format=webp` の明示要求まで無視していました。`/proxy/image` は外部 principal にも開いているため契約違反です。素通しは format 未指定時に限定し、あわせて `proxyThumbUrl` から `format=webp` を外しました（付けたままだと素通しが一切効かず、モバイルの初回表示を軽くする目的を達成できません。リサイズが必要な画像はプロキシ側が WebP で返すので出力は変わりません）
2. **panic レポートの書き込みが atomic でなかった**（データ完全性） — `fs::write` は truncate 後に書くため、複数スレッドが同時に panic すると唯一の手がかりが壊れえます。既存の `settings_store::atomic_write` に寄せました
3. **backtrace が GitHub issue の URL に丸ごと乗っていた**（プライバシー） — `reportBug` は診断ログをそのまま URL に埋めるため、backtrace に含まれるローカルのパスやユーザー名が外部へ出ます。URL 長も食い潰します。UI 表示とクリップボードコピー（ローカル）は backtrace ごと、issue 本文はチェック行のみに分けました


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rust panic (“crash”) diagnostics to the self-diagnosis view, including localized timing and log-copy/report support.
* **Bug Fixes**
  * Improved reaction updates for 1on1 chats to better match streaming behavior and avoid duplicate reaction rendering.
  * Adjusted thumbnail proxy behavior to avoid forcing WebP conversion when resizing by width.
* **Performance**
  * Skip image resize work when the image is already within the configured width limit (for resize-only requests).
* **Tests**
  * Expanded/updated coverage for reaction deduplication and media proxy behavior.
* **Chores**
  * Bumped app version to **1.32.1** (client and Tauri configs).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->