### PR TITLE
Release v1.32.2

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -962,6 +962,9 @@ NoteDeck の対応範囲は **Misskey 本家および「Misskey を名乗り続�
 **Misskey から名前が別物になったフォーク（Sharkey, CherryPick, Firefish, Iceshrimp 等）は対応していません。**
 
 対応可否は `src/adapters/registry.ts` の `FORKS` テーブル（`supported` フラグ）が単一の source of truth です。
+Misskey を名乗るフォークの多くは nodeinfo の `software.name` が `"misskey"` のままなので、
+misskey.io のフォーク (`MisskeyIO/misskey`) は nodeinfo 2.1 の `software.repository` で識別します。
+repository を返さないサーバー（nodeinfo 2.0 のみ）や、テーブルに無い小規模フォークは本家扱いにフォールバックします。
 未対応でも有名フォーク（Sharkey / CherryPick / Iceshrimp）は識別し、ログイン画面で「Sharkey は未対応です」と
 名指しで表示します（`unknown` 扱いにしない）。識別できないサーバーのみ「Misskey サーバーではないため未対応です」に落とします。
 未対応サーバーでもファビコンのプレビューは行います (#853)。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -961,6 +961,11 @@ session 一覧では `AiSessionKind` 別の icon 統一 (`chat` → `ti-message-
 NoteDeck の対応範囲は **Misskey 本家および「Misskey を名乗り続けるフォーク」** です（yamisskey, misskey-tempura 等）。
 **Misskey から名前が別物になったフォーク（Sharkey, CherryPick, Firefish, Iceshrimp 等）は対応していません。**
 
+対応可否は `src/adapters/registry.ts` の `FORKS` テーブル（`supported` フラグ）が単一の source of truth です。
+未対応でも有名フォーク（Sharkey / CherryPick / Iceshrimp）は識別し、ログイン画面で「Sharkey は未対応です」と
+名指しで表示します（`unknown` 扱いにしない）。識別できないサーバーのみ「Misskey サーバーではないため未対応です」に落とします。
+未対応サーバーでもファビコンのプレビューは行います (#853)。
+
 #### 自動検出で動くもの（コード変更不要）
 
 Misskey を名乗るフォークは追加の設定なしで自動的に認識されます。以下の機能は動的に検出されるため、コード変更なしで動作します:
@@ -986,18 +991,18 @@ export type ServerSoftware =
   | 'unknown'
 ```
 
-2. `src/adapters/registry.ts` — `resolveSoftware()` に検出ルールを追加
+2. `src/adapters/registry.ts` — `FORKS` テーブルにエントリを追加
 
 ```typescript
-// repository URL による検出（nodeinfo 2.1）
-if (ownerRepo === 'your-org/your-fork') return 'your-org/your-fork'
-// software.name によるフォールバック（nodeinfo 2.0）
-if (n === 'your-fork-name') return 'your-org/your-fork'
+{
+  id: 'your-org/your-fork',
+  displayName: 'Your Fork',
+  supported: true,          // 未対応フォークを識別だけしたい場合は false
+  names: ['your-fork-name'], // nodeinfo software.name (lowercase)
+}
 ```
 
-3. `src/stores/servers.ts` — `KNOWN_SOFTWARE` セットに追加
-
-4. `src/core/server.ts` — `detectFeatures()` にフォーク固有の capability を設定
+3. `src/core/server.ts` — `detectFeatures()` にフォーク固有の capability を設定
 
 ```typescript
 if (software === 'your-org/your-fork') {
@@ -1005,7 +1010,7 @@ if (software === 'your-org/your-fork') {
 }
 ```
 
-5. カスタムタイムラインのアイコンを追加する場合は `src/utils/customTimelines.ts` の `CUSTOM_TL_ICONS` に SVG パスを追加
+4. カスタムタイムラインのアイコンを追加する場合は `src/utils/customTimelines.ts` の `CUSTOM_TL_ICONS` に SVG パスを追加
 
 **PR を出す前に:**
 - `pnpm lint && pnpm typecheck && pnpm test` を通す

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.32.1",
+  "version": "1.32.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.32.1"
+version = "1.32.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.32.1"
+version = "1.32.2"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.32.1"
+    "version": "1.32.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.32.1",
+  "version": "1.32.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -25,13 +25,18 @@ interface ForkDefinition {
   displayName: string
   /** NoteDeck が対応しているか。未対応フォークは識別のみ行う (#853) */
   supported: boolean
-  /** nodeinfo software.name (lowercase) の一致候補 */
+  /**
+   * nodeinfo software.name (lowercase) の一致候補。Misskey 系フォークの多くは
+   * name を "misskey" のままにしているため、その場合は空にして repository で
+   * 識別する (nodeinfo 2.0 しか返さないサーバーでは本家扱いにフォールバック)。
+   */
   names: string[]
 }
 
 /**
  * 既知の Misskey 系ソフトウェア。対応するのは「Misskey を名乗り続けるフォーク」
  * のみ (STRATEGY.md)。名前が乖離したフォークも識別して「未対応」と名指しする。
+ * 個人サーバーの小規模フォークは本家扱いのままにする。
  */
 const FORKS: ForkDefinition[] = [
   {
@@ -39,6 +44,12 @@ const FORKS: ForkDefinition[] = [
     displayName: 'Misskey',
     supported: true,
     names: ['misskey'],
+  },
+  {
+    id: 'misskeyio/misskey',
+    displayName: 'Misskey.io',
+    supported: true,
+    names: [],
   },
   {
     id: 'yamisskey-dev/yamisskey',

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -19,15 +19,67 @@ export function registerAdapter(
 /** GitHub URL から owner/repo を抽出 */
 const GITHUB_REPO_RE = /github\.com\/([^/]+\/[^/]+)/
 
+interface ForkDefinition {
+  id: ServerSoftware
+  /** UI に出す表示名 */
+  displayName: string
+  /** NoteDeck が対応しているか。未対応フォークは識別のみ行う (#853) */
+  supported: boolean
+  /** nodeinfo software.name (lowercase) の一致候補 */
+  names: string[]
+}
+
+/**
+ * 既知の Misskey 系ソフトウェア。対応するのは「Misskey を名乗り続けるフォーク」
+ * のみ (STRATEGY.md)。名前が乖離したフォークも識別して「未対応」と名指しする。
+ */
+const FORKS: ForkDefinition[] = [
+  {
+    id: 'misskey-dev/misskey',
+    displayName: 'Misskey',
+    supported: true,
+    names: ['misskey'],
+  },
+  {
+    id: 'yamisskey-dev/yamisskey',
+    displayName: 'yamisskey',
+    supported: true,
+    names: ['yamisskey'],
+  },
+  {
+    id: 'lqvp/misskey-tempura',
+    displayName: 'Misskey tempura',
+    supported: true,
+    names: ['misskey-tempura', 'tempura'],
+  },
+  {
+    id: 'iceshrimp/iceshrimp',
+    displayName: 'Iceshrimp',
+    supported: false,
+    names: ['iceshrimp', 'iceshrimp.net'],
+  },
+  {
+    id: 'kokonect-link/cherrypick',
+    displayName: 'CherryPick',
+    supported: false,
+    names: ['cherrypick'],
+  },
+  {
+    id: 'sharkey/sharkey',
+    displayName: 'Sharkey',
+    supported: false,
+    names: ['sharkey'],
+  },
+]
+
 /**
  * nodeinfo から ServerSoftware (owner/repo 形式) を解決する。
  *
  * 検出優先順位:
  * 1. nodeinfo 2.1 の software.repository（GitHub URL から owner/repo を抽出）
  *    → "misskey" と名乗りつつ独自改変しているフォークも正確に識別可能
- * 2. software.name（フォールバック: nodeinfo 2.0 や repository 未設定の場合）
- *
- * Misskey を名乗り続けるフォーク（STRATEGY.md 参照）のみ対象。
+ * 2. software.name（フォールバック: nodeinfo 2.0 や repository 未設定の場合、
+ *    および GitHub 外でホストされているフォーク）
  */
 export function resolveSoftware(
   name: string,
@@ -38,21 +90,28 @@ export function resolveSoftware(
     const match = repositoryUrl.match(GITHUB_REPO_RE)
     if (match?.[1]) {
       const ownerRepo = match[1].toLowerCase().replace(/\.git$/, '')
-      // 既知のフォークなら型安全なリテラルを返す
-      if (ownerRepo === 'misskey-dev/misskey') return 'misskey-dev/misskey'
-      if (ownerRepo === 'yamisskey-dev/yamisskey')
-        return 'yamisskey-dev/yamisskey'
-      if (ownerRepo === 'lqvp/misskey-tempura') return 'lqvp/misskey-tempura'
+      const fork = FORKS.find((f) => f.id === ownerRepo)
+      if (fork) return fork.id
       // 未知だが Misskey 系なら本家扱い
     }
   }
 
   // 2. software.name によるフォールバック
   const n = name.toLowerCase()
-  if (n === 'yamisskey') return 'yamisskey-dev/yamisskey'
-  if (n === 'misskey-tempura' || n === 'tempura') return 'lqvp/misskey-tempura'
-  if (n === 'misskey' || n.includes('misskey')) return 'misskey-dev/misskey'
+  const fork = FORKS.find((f) => f.names.includes(n))
+  if (fork) return fork.id
+  if (n.includes('misskey')) return 'misskey-dev/misskey'
   return 'unknown'
+}
+
+/** NoteDeck が対応しているソフトウェアか。未対応フォーク・未知は false。 */
+export function isSupportedSoftware(software: ServerSoftware): boolean {
+  return FORKS.some((f) => f.id === software && f.supported)
+}
+
+/** UI 表示用のソフトウェア名。識別できていない場合は null。 */
+export function softwareDisplayName(software: ServerSoftware): string | null {
+  return FORKS.find((f) => f.id === software)?.displayName ?? null
 }
 
 export function createAdapter(

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -4,15 +4,22 @@
  * "misskey" と名乗りつつ独自改変しているフォークは自動検出できないため、
  * デフォルトは 'misskey-dev/misskey' にフォールバックする。
  *
+ * 未対応のフォーク (#853) も識別だけはして、UI で「未対応」と名指しできる
+ * ようにする。対応可否は registry.ts の isSupportedSoftware() が持つ。
+ *
  * 新しいフォークを追加する場合:
  * 1. ここにリテラルを追加
- * 2. registry.ts の resolveSoftware() に検出ルールを追加
+ * 2. registry.ts の FORKS テーブルに検出ルールと表示名を追加
  * 3. server.ts の detectFeatures() にフォーク固有の capability を設定
  */
 export type ServerSoftware =
   | 'misskey-dev/misskey'
   | 'yamisskey-dev/yamisskey'
   | 'lqvp/misskey-tempura'
+  // 名前が Misskey から乖離したフォーク。識別のみで未対応 (STRATEGY.md)
+  | 'iceshrimp/iceshrimp'
+  | 'kokonect-link/cherrypick'
+  | 'sharkey/sharkey'
   | 'unknown'
 
 export interface ServerInfo {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -14,6 +14,8 @@
  */
 export type ServerSoftware =
   | 'misskey-dev/misskey'
+  // Misskey を名乗り続けるフォーク
+  | 'misskeyio/misskey'
   | 'yamisskey-dev/yamisskey'
   | 'lqvp/misskey-tempura'
   // 名前が Misskey から乖離したフォーク。識別のみで未対応 (STRATEGY.md)

--- a/src/components/common/NoteReactionUsersModal.vue
+++ b/src/components/common/NoteReactionUsersModal.vue
@@ -177,11 +177,11 @@ defineExpose({ open })
 </template>
 
 <style lang="scss" module>
-.backdrop {
-  &.mobile {
-    align-items: flex-end;
-    justify-content: stretch;
-  }
+// `dialog._nativeDialog[open]` (global.css) が align-items: center を指定しており
+// クラスだけでは特異度で負けるため、ホストごと指定してシートを下端に寄せる
+:global(dialog._nativeDialog[open]).backdrop.mobile {
+  align-items: flex-end;
+  justify-content: stretch;
 }
 
 .modal {

--- a/src/components/window/LoginContent.vue
+++ b/src/components/window/LoginContent.vue
@@ -41,11 +41,8 @@ let currentSession: AuthSession | null = null
 // Vapor-compatible transition switches (replaces <Transition mode="out-in">)
 const stepSwitch = useVaporTransitionSwitch(step, { leaveDuration: 0 })
 
-const logoSrc = computed(() =>
-  serverStatus.value === 'ok' && serverInfo.value?.iconUrl
-    ? serverInfo.value.iconUrl
-    : 'default',
-)
+// 未対応のフォークでもサーバーのファビコンは表示する (#853)
+const logoSrc = computed(() => serverInfo.value?.iconUrl ?? 'default')
 const logoSwitch = useVaporTransitionSwitch(logoSrc, { leaveDuration: 200 })
 
 const subtitleSwitch = useVaporTransitionSwitch(serverStatus, {

--- a/src/composables/useServerPreview.ts
+++ b/src/composables/useServerPreview.ts
@@ -1,5 +1,5 @@
 import { type Ref, ref, watch } from 'vue'
-import { getRegisteredSoftware } from '@/adapters/registry'
+import { isSupportedSoftware, softwareDisplayName } from '@/adapters/registry'
 import type { ServerInfo } from '@/adapters/types'
 import { detectServer } from '@/core/server'
 
@@ -44,13 +44,17 @@ export function useServerPreview(host: Ref<string>, debounceMs = 350) {
       const info = await detectServer(trimmedHost)
       if (generation !== abortGeneration) return
 
-      if (getRegisteredSoftware().includes(info.software)) {
+      if (isSupportedSoftware(info.software)) {
         status.value = 'ok'
         serverInfo.value = info
       } else {
+        // 未対応でも serverInfo は保持する（ファビコン表示に使う #853）
         status.value = 'unsupported'
         serverInfo.value = info
-        errorMessage.value = `${info.software} は現在サポートされていません`
+        const name = softwareDisplayName(info.software)
+        errorMessage.value = name
+          ? `${name} は未対応です`
+          : 'Misskey サーバーではないため未対応です'
       }
     } catch {
       if (generation !== abortGeneration) return

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,4 +1,4 @@
-import { resolveSoftware } from '@/adapters/registry'
+import { isSupportedSoftware, resolveSoftware } from '@/adapters/registry'
 import type {
   ServerFeatures,
   ServerInfo,
@@ -77,7 +77,8 @@ export async function detectServer(host: string): Promise<ServerInfo> {
 function detectFeatures(software: ServerSoftware): ServerFeatures {
   const features = defaultFeatures()
 
-  if (software !== 'unknown') {
+  // 識別できても未対応のフォーク (#853) は本家由来の capability を宣言しない
+  if (isSupportedSoftware(software)) {
     features.scheduledNotes = true
     features.groupedNotifications = true
     features.notesShowPartialBulk = true

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   createAdapter,
   getRegisteredSoftware,
+  isSupportedSoftware,
   resolveSoftware,
+  softwareDisplayName,
 } from '@/adapters/registry'
 import type { ServerInfo } from '@/adapters/types'
 
@@ -63,5 +65,47 @@ describe('resolveSoftware', () => {
 
   it('returns unknown for non-misskey software', () => {
     expect(resolveSoftware('mastodon')).toBe('unknown')
+  })
+
+  it('identifies known but unsupported forks by software name (#853)', () => {
+    expect(resolveSoftware('sharkey')).toBe('sharkey/sharkey')
+    expect(resolveSoftware('cherrypick')).toBe('kokonect-link/cherrypick')
+    expect(resolveSoftware('iceshrimp')).toBe('iceshrimp/iceshrimp')
+    expect(resolveSoftware('iceshrimp.net')).toBe('iceshrimp/iceshrimp')
+  })
+
+  it('identifies unsupported forks by repository URL', () => {
+    expect(
+      resolveSoftware(
+        'cherrypick',
+        'https://github.com/kokonect-link/cherrypick',
+      ),
+    ).toBe('kokonect-link/cherrypick')
+  })
+})
+
+describe('isSupportedSoftware', () => {
+  it('accepts misskey and forks that keep the misskey name', () => {
+    expect(isSupportedSoftware('misskey-dev/misskey')).toBe(true)
+    expect(isSupportedSoftware('yamisskey-dev/yamisskey')).toBe(true)
+    expect(isSupportedSoftware('lqvp/misskey-tempura')).toBe(true)
+  })
+
+  it('rejects identified but unsupported forks and unknown software', () => {
+    expect(isSupportedSoftware('sharkey/sharkey')).toBe(false)
+    expect(isSupportedSoftware('kokonect-link/cherrypick')).toBe(false)
+    expect(isSupportedSoftware('iceshrimp/iceshrimp')).toBe(false)
+    expect(isSupportedSoftware('unknown')).toBe(false)
+  })
+})
+
+describe('softwareDisplayName', () => {
+  it('returns the display name of identified software', () => {
+    expect(softwareDisplayName('sharkey/sharkey')).toBe('Sharkey')
+    expect(softwareDisplayName('misskey-dev/misskey')).toBe('Misskey')
+  })
+
+  it('returns null for unidentified software', () => {
+    expect(softwareDisplayName('unknown')).toBe(null)
   })
 })

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -67,6 +67,13 @@ describe('resolveSoftware', () => {
     expect(resolveSoftware('mastodon')).toBe('unknown')
   })
 
+  it('identifies the misskey.io fork by repository URL', () => {
+    // software.name は "misskey" のままなので repository でしか分からない
+    expect(
+      resolveSoftware('misskey', 'https://github.com/MisskeyIO/misskey'),
+    ).toBe('misskeyio/misskey')
+  })
+
   it('identifies known but unsupported forks by software name (#853)', () => {
     expect(resolveSoftware('sharkey')).toBe('sharkey/sharkey')
     expect(resolveSoftware('cherrypick')).toBe('kokonect-link/cherrypick')
@@ -89,6 +96,7 @@ describe('isSupportedSoftware', () => {
     expect(isSupportedSoftware('misskey-dev/misskey')).toBe(true)
     expect(isSupportedSoftware('yamisskey-dev/yamisskey')).toBe(true)
     expect(isSupportedSoftware('lqvp/misskey-tempura')).toBe(true)
+    expect(isSupportedSoftware('misskeyio/misskey')).toBe(true)
   })
 
   it('rejects identified but unsupported forks and unknown software', () => {

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -71,6 +71,17 @@ describe('server detection', () => {
     expect(info.software).toBe('unknown')
   })
 
+  it('identifies unsupported forks without enabling capabilities (#853)', async () => {
+    mockDetect('sharkey')
+    const info = await detectServer('shark.example.com')
+
+    expect(info.software).toBe('sharkey/sharkey')
+    expect(info.features.scheduledNotes).toBe(false)
+    expect(info.features.groupedNotifications).toBe(false)
+    // 未対応でもファビコンは出す（ログイン画面のプレビュー用）
+    expect(info.iconUrl).toBe('https://example.com/favicon.ico')
+  })
+
   it('throws when detection fails (nodeinfo unreachable)', async () => {
     vi.mocked(commands.detectServer).mockResolvedValue({
       status: 'error',


### PR DESCRIPTION
## 変更内容

### Fix
- **fix(reaction): モバイルのリアクション一覧が中央に出る問題を修正** (e09d459f)
  `global.css` の `dialog._nativeDialog[open]` が `align-items: center` を指定しており、特異度でモジュールクラス `.backdrop.mobile` に勝っていたため、compact レイアウトでもシートが下端に寄らず画面中央に出ていた。ホストごと `:global(dialog._nativeDialog[open])` を付けて解消。

### Feature
- **feat(login): 未対応の有名 Misskey フォークを名指しで表示** (817d86af)
  Sharkey / CherryPick / Iceshrimp を unknown 扱いせず「Sharkey は未対応です」と明示。対応可否は `registry.ts` の FORKS テーブル (supported フラグ) に一元化し、adapter を持たない yamisskey / misskey-tempura を誤って未対応表示していた問題も解消。
- **feat(login): misskey.io のフォークを固有に識別** (22db5067)
  nodeinfo 2.1 の `software.repository` で misskey.io を固有の ServerSoftware として識別。repository が取れないサーバーは従来どおり本家扱いにフォールバック。

### Chore
- chore: bump version to 1.32.2
- chore: regenerate openapi.json for 1.32.2

---

Closes #852
Closes #853


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recognition for additional Misskey-related forks, including Misskey.io, Iceshrimp, Cherrypick, and Sharkey.
  * Unsupported forks are identified clearly while retaining server favicon previews.
  * Supported servers now receive capabilities based on explicit support status.

* **Bug Fixes**
  * Improved mobile reaction-user dialog layout.
  * Updated unsupported-server messaging and favicon display behavior.

* **Documentation**
  * Clarified fork detection, support evaluation, and adapter integration procedures.

* **Chores**
  * Updated the application version to 1.32.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->