### PR TITLE
Release v1.33.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.32.2",
+  "version": "1.32.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.32.3",
+  "version": "1.33.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
     "@discordapp/twemoji": "16.0.1",
-    "@tauri-apps/api": "~2.10.1",
+    "@tauri-apps/api": "~2.11.1",
     "@tauri-apps/cli": "^2.11.2",
     "@types/js-yaml": "^4.0.9",
     "@types/katex": "^0.16.8",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.5.0",
+    "@discordapp/twemoji": "16.0.1",
     "@tauri-apps/api": "~2.10.1",
     "@tauri-apps/cli": "^2.11.2",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@biomejs/biome':
         specifier: ^2.5.0
         version: 2.5.0
+      '@discordapp/twemoji':
+        specifier: 16.0.1
+        version: 16.0.1
       '@tauri-apps/api':
         specifier: ~2.10.1
         version: 2.10.1
@@ -443,6 +446,9 @@ packages:
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
+
+  '@discordapp/twemoji@16.0.1':
+    resolution: {integrity: sha512-figLiBWzjS5cyrAjLaGjM8AAaowO3qvK8rg5bA2dElB4qsaPMvBVlFDMO2d3x+nC1igt7kgWH4dvNmvvUHUF8w==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1355,6 +1361,9 @@ packages:
     resolution: {integrity: sha512-xpKtQZqFOuAPfQDbePIh9f48YKfmULV7z9C+anPBSHiOG4P+T3ct7Cx2AZOoUeXbxiDkz7SONANy1bB7p2uysg==}
     engines: {node: '>=20', pnpm: '>=8.6.0'}
 
+  '@twemoji/parser@16.0.0':
+    resolution: {integrity: sha512-jmuIjkp3OIaEemwMy3sArBwZSuZkRqmueGwRe2Zk4cFzbUJISFBJSZLDUUBNIgq3c+nY49ideYN2OiII6JUqwA==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -2072,6 +2081,10 @@ packages:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
 
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
   fs-minipass@3.0.3:
     resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2326,6 +2339,12 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@5.0.0:
+    resolution: {integrity: sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -3305,6 +3324,10 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4022,6 +4045,13 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0':
     optional: true
+
+  '@discordapp/twemoji@16.0.1':
+    dependencies:
+      '@twemoji/parser': 16.0.0
+      fs-extra: 8.1.0
+      jsonfile: 5.0.0
+      universalify: 0.1.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4993,6 +5023,8 @@ snapshots:
 
   '@thednp/dommatrix@3.0.4': {}
 
+  '@twemoji/parser@16.0.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -5722,6 +5754,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
   fs-minipass@3.0.3:
     dependencies:
       minipass: 7.1.3
@@ -6060,6 +6098,16 @@ snapshots:
       semver: 7.8.4
 
   jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@5.0.0:
+    dependencies:
+      universalify: 0.1.2
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonfile@6.2.1:
     dependencies:
@@ -7309,6 +7357,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  universalify@0.1.2: {}
 
   universalify@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ importers:
         specifier: 16.0.1
         version: 16.0.1
       '@tauri-apps/api':
-        specifier: ~2.10.1
-        version: 2.10.1
+        specifier: ~2.11.1
+        version: 2.11.1
       '@tauri-apps/cli':
         specifier: ^2.11.2
         version: 2.11.2
@@ -1247,9 +1247,6 @@ packages:
     resolution: {integrity: sha512-MWb9tNHjpar3sP34b8+3A4I5j9akveoPXIYqqp7/ipyWd49a/kso+1S1LqEmAVR/+g/k1WWTJC4ktvdCGWgXYQ==}
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
-
-  '@tauri-apps/api@2.10.1':
-    resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
   '@tauri-apps/api@2.11.1':
     resolution: {integrity: sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==}
@@ -4933,8 +4930,6 @@ snapshots:
     dependencies:
       '@tanstack/virtual-core': 3.17.1
       vue: 3.5.38(typescript@5.9.3)
-
-  '@tauri-apps/api@2.10.1': {}
 
   '@tauri-apps/api@2.11.1': {}
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.32.3"
+version = "1.33.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.32.2"
+version = "1.32.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -891,12 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,23 +1010,6 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "matches",
- "phf 0.10.1",
- "proc-macro2",
- "quote",
- "smallvec",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
@@ -1040,7 +1017,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
 ]
 
@@ -1111,6 +1088,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,19 +1115,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
  "syn 2.0.118",
 ]
 
@@ -1278,12 +1253,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
- "cssparser 0.36.0",
+ "cssparser",
  "foldhash 0.2.0",
- "html5ever 0.38.0",
+ "html5ever",
  "precomputed-hash",
- "selectors 0.36.1",
- "tendril 0.5.0",
+ "selectors",
+ "tendril",
 ]
 
 [[package]]
@@ -1608,16 +1583,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,15 +1664,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -1831,17 +1787,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1849,7 +1794,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2147,24 +2092,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
-dependencies = [
- "log",
- "mac",
- "markup5ever 0.14.1",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever 0.38.0",
+ "markup5ever",
 ]
 
 [[package]]
@@ -2725,18 +2658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kuchikiki"
-version = "0.8.8-speedreader"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
-dependencies = [
- "cssparser 0.29.6",
- "html5ever 0.29.1",
- "indexmap 2.14.0",
- "selectors 0.24.0",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,6 +2698,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2896,12 +2826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "mac-notification-sys"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,38 +2841,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
-dependencies = [
- "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
- "tendril 0.4.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "tendril 0.5.0",
+ "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
 ]
 
 [[package]]
@@ -2959,12 +2858,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -3036,7 +2929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -3052,9 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9fec5a4e89860383d778d10563a605838f8f0b2f9303868937e5ff32e86177"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -3065,10 +2958,10 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3135,12 +3028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3169,7 +3056,7 @@ dependencies = [
  "futures-util",
  "keyring-core",
  "linux-keyutils-keyring-store",
- "rand 0.9.4",
+ "rand",
  "refinery",
  "reqwest 0.12.28",
  "rusqlite",
@@ -3209,7 +3096,7 @@ dependencies = [
  "mime_guess",
  "ndk-context",
  "notecli",
- "rand 0.9.4",
+ "rand",
  "regex",
  "reqwest 0.12.28",
  "secrecy",
@@ -3764,62 +3651,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
-dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3828,38 +3666,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
-dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3869,21 +3677,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3892,38 +3686,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -3932,7 +3699,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.3",
+ "siphasher",
 ]
 
 [[package]]
@@ -4095,12 +3862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4219,7 +3980,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4268,57 +4029,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -4328,25 +4044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -4356,24 +4054,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4403,8 +4083,8 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand",
+ "rand_chacha",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -4540,7 +4220,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "serde",
- "siphasher 1.0.3",
+ "siphasher",
  "thiserror 2.0.18",
  "time",
  "toml 1.1.2+spec-1.1.0",
@@ -4983,38 +4663,20 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
-dependencies = [
- "bitflags 1.3.2",
- "cssparser 0.29.6",
- "derive_more 0.99.20",
- "fxhash",
- "log",
- "phf 0.8.0",
- "phf_codegen 0.8.0",
- "precomputed-hash",
- "servo_arc 0.2.0",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
  "bitflags 2.13.0",
- "cssparser 0.36.0",
- "derive_more 2.1.1",
+ "cssparser",
+ "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
- "servo_arc 0.4.3",
+ "servo_arc",
  "smallvec",
 ]
 
@@ -5208,16 +4870,6 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
-dependencies = [
- "nodrop",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
@@ -5302,12 +4954,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -5438,39 +5084,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -5479,8 +5100,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -5521,7 +5142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 
@@ -5580,15 +5200,16 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.8"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dbus",
  "dispatch2",
  "dlopen2",
  "dpi",
@@ -5599,13 +5220,14 @@ dependencies = [
  "libc",
  "log",
  "ndk",
- "ndk-context",
  "ndk-sys",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
  "tao-macros",
  "unicode-segmentation",
@@ -5646,9 +5268,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.10.3"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da77cc00fb9028caf5b5d4650f75e31f1ef3693459dfca7f7e506d1ecef0ba2d"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5888,7 +5510,7 @@ checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
 dependencies = [
  "log",
  "notify-rust",
- "rand 0.9.4",
+ "rand",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6016,9 +5638,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.1"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2826d79a3297ed08cd6ea7f412644ef58e32969504bc4fbd8d7dbeabc4445ea2"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -6041,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http",
@@ -6106,14 +5728,12 @@ dependencies = [
  "dom_query",
  "dunce",
  "glob",
- "html5ever 0.29.1",
  "http",
  "infer",
  "json-patch",
- "kuchikiki",
  "log",
  "memchr",
- "phf 0.13.1",
+ "phf",
  "plist",
  "proc-macro2",
  "quote",
@@ -6167,17 +5787,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -6639,9 +6248,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "045979e3f037cd18ad1cb2a419dfda133c5c29c9f3453370079f2255d46c257e"
 dependencies = [
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -6653,10 +6262,10 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6676,7 +6285,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -6713,7 +6322,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.4",
+ "rand",
  "web-time",
 ]
 
@@ -6978,12 +6587,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -7104,10 +6707,10 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -7738,9 +7341,9 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wry"
-version = "0.54.4"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a8135d8676225e5744de000d4dff5a082501bf7db6a1c1495034f8c314edbc"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.32.2"
+version = "1.32.3"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.32.3"
+version = "1.33.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.32.2"
+    "version": "1.32.3"
   },
   "paths": {
     "/api": {

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.32.3"
+    "version": "1.33.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -290,18 +290,14 @@ impl ImageCache {
             return Err("Only HTTPS URLs are allowed".to_string());
         }
 
-        // SSRF protection: block private/loopback IPs
-        if let Ok(parsed) = url::Url::parse(url) {
-            if let Some(host) = parsed.host_str() {
-                if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-                    if ip.is_loopback()
-                        || matches!(ip, std::net::IpAddr::V4(v4) if v4.is_private()
-                            || v4.is_link_local())
-                    {
-                        return Err("Private/loopback addresses are not allowed".to_string());
-                    }
-                }
-            }
+        // SSRF 防御は commands::http の validate_external_host に一元化
+        // (IP literal に加えて localhost / .local / .internal 等の hostname も
+        // 弾く)。DNS 解決結果の検証 + pinning は vault::ssrf の per-fetch
+        // resolver が要るため未適用 — 共有 client の経路では別途検討
+        {
+            let parsed = url::Url::parse(url).map_err(|e| format!("invalid url: {e}"))?;
+            let host = parsed.host_str().ok_or("url has no host")?;
+            crate::commands::validate_external_host(host)?;
         }
 
         // Circuit breaker: reject early if host is known-down
@@ -834,6 +830,30 @@ mod tests {
             (Instant::now() - Duration::from_secs(10), Duration::from_secs(5)),
         );
         assert!(!cache.is_negative_cached(url).await);
+    }
+
+    /// SSRF 防御は commands::http の validate_external_host に一元化。
+    /// IP literal だけでなく localhost / 予約 TLD などの hostname も
+    /// ネットワークに出る前に弾く (ローカル HTTP API からも叩ける面のため)
+    #[tokio::test]
+    async fn fetch_rejects_unsafe_hosts_before_network() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        for url in [
+            "https://localhost/a.png",
+            "https://127.0.0.1/a.png",
+            "https://[::1]/a.png",
+            "https://foo.internal/a.png",
+            "https://printer.local/a.png",
+        ] {
+            let err = cache
+                .fetch_streaming(url)
+                .await
+                .err()
+                .unwrap_or_else(|| panic!("should reject {url}"));
+            // 接続失敗 (ネットワークに出た) ではなく検証で弾いたことを確かめる
+            assert!(err.contains("not allowed"), "{url}: {err}");
+        }
     }
 
     /// circuit breaker で塞がれたホストもフェーズ 1 の即時失敗対象になること。

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -12,6 +12,13 @@ use tokio::sync::{watch, Mutex, RwLock, Semaphore};
 
 use crate::perf_config::SharedPerfConfig;
 
+/// メディア 1 件の取得予算 (接続〜ボディ読み切りまで)。共有 client の全体
+/// timeout (10s) より優先される。wry Android の custom protocol は応答を
+/// 10 秒で打ち切って panic するため (media_proxy::RESPONSE_DEADLINE 参照)、
+/// その内側で確実にエラーへ落とし、negative cache / circuit breaker に
+/// 学習させる。上流のストールを 10 秒付き合う価値のあるメディアは無い。
+const MEDIA_FETCH_TIMEOUT: Duration = Duration::from_secs(6);
+
 // Negative cache TTLs by error class
 const NEGATIVE_TTL_CLIENT: Duration = Duration::from_secs(24 * 60 * 60); // 4xx: 24h
 const NEGATIVE_TTL_SERVER: Duration = Duration::from_secs(2 * 60); // 5xx: 2min
@@ -288,7 +295,7 @@ impl ImageCache {
             .ok()
             .map(|u| format!("{}://{}/", u.scheme(), u.host_str().unwrap_or_default()));
 
-        let mut req = self.http_client.get(url);
+        let mut req = self.http_client.get(url).timeout(MEDIA_FETCH_TIMEOUT);
         if let Some(ref referer) = referer {
             req = req.header(reqwest::header::REFERER, referer);
         }

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -346,10 +346,12 @@ impl ImageCache {
             .map_err(|_| "Semaphore closed".to_string())?;
 
         // Start HTTP request (headers only, don't consume body yet)
-        // Some hosts (e.g. i.pximg.net) require a valid Referer header
+        // Some hosts (e.g. i.pximg.net) require a valid Referer header.
+        // scheme は入口で https 限定済みなので、元 URL から引き写さずに
+        // 固定する (http が混じる余地を型ではなくコードで断つ)
         let referer = url::Url::parse(url)
             .ok()
-            .map(|u| format!("{}://{}/", u.scheme(), u.host_str().unwrap_or_default()));
+            .and_then(|u| u.host_str().map(|h| format!("https://{h}/")));
 
         let mut req = self.http_client.get(url).timeout(MEDIA_FETCH_TIMEOUT);
         if let Some(ref referer) = referer {

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -73,6 +73,8 @@ pub struct ImageCache {
     negative_cache: Arc<RwLock<HashMap<String, (Instant, Duration)>>>,
     mem_cache: Arc<RwLock<MemCacheState>>,
     host_circuits: Arc<RwLock<HashMap<String, HostCircuitState>>>,
+    /// 二段階配信の背景 ensure (取得+変換) の重複防止 (cache_key 単位)
+    ensure_pending: Arc<Mutex<std::collections::HashSet<String>>>,
     perf: SharedPerfConfig,
 }
 
@@ -102,8 +104,66 @@ impl ImageCache {
                 total_size: 0,
             })),
             host_circuits: Arc::new(RwLock::new(HashMap::new())),
+            ensure_pending: Arc::new(Mutex::new(std::collections::HashSet::new())),
             perf,
         }
+    }
+
+    /// 変換結果 (variant) を cache_key 単位で保存する。オリジナルと同じ
+    /// .dat/.meta 形式なので sweep / clear / メモリ昇格がそのまま効く。
+    pub async fn store_variant(&self, key: &str, bytes: Vec<u8>, content_type: &str) {
+        let hash = hex_hash(key);
+        let data_path = self.cache_dir.join(format!("{hash}.dat"));
+        let meta_path = self.cache_dir.join(format!("{hash}.meta"));
+        let bytes_arc = Arc::new(bytes);
+
+        let bytes_for_disk = bytes_arc.clone();
+        let ct_for_disk = content_type.to_string();
+        tokio::task::spawn_blocking(move || {
+            std::fs::write(&data_path, &*bytes_for_disk).ok();
+            std::fs::write(&meta_path, &ct_for_disk).ok();
+        })
+        .await
+        .ok();
+
+        let max_item = self.perf.read().await.memory_cache_max_item;
+        if bytes_arc.len() <= max_item {
+            self.insert_mem_cache(&hash, &bytes_arc, content_type).await;
+        }
+    }
+
+    /// URL (または cache_key) が negative cache 中か。二段階配信のフェーズ 1 が
+    /// これを見ずに ensure を再発行すると、失敗イベント → img 再試行 → 失敗
+    /// イベントの無限ループになる。
+    pub async fn is_negative_cached(&self, url: &str) -> bool {
+        let neg = self.negative_cache.read().await;
+        match neg.get(&hex_hash(url)) {
+            Some((failed_at, ttl)) => failed_at.elapsed() < *ttl,
+            None => false,
+        }
+    }
+
+    /// 直近失敗 (negative cache) か既知のダウンホスト (circuit breaker) か。
+    /// 二段階配信のフェーズ 1 はこれが真なら ensure を発行せず即エラーを返す。
+    pub async fn is_fast_fail(&self, url: &str) -> bool {
+        if self.is_negative_cached(url).await {
+            return true;
+        }
+        if let Some(host) = Self::extract_host(url) {
+            if self.is_host_blocked(&host).await {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// ensure (背景取得+変換) の開始を予約する。既に進行中なら false。
+    pub async fn begin_ensure(&self, key: &str) -> bool {
+        self.ensure_pending.lock().await.insert(key.to_string())
+    }
+
+    pub async fn finish_ensure(&self, key: &str) {
+        self.ensure_pending.lock().await.remove(key);
     }
 
     async fn check_cache(
@@ -726,6 +786,85 @@ mod tests {
         let mem = cache.mem_cache.read().await;
         assert!(mem.entries.peek("a").is_none(), "LRU entry 'a' should be evicted");
         assert!(mem.entries.peek("b").is_some() || mem.entries.peek("c").is_some());
+    }
+
+    /// 変換結果 (variant) はオリジナルと同じ .dat/.meta 形式で cache_key の
+    /// ハッシュに保存し、check_cache_only で引けること。変換を毎回やり直すと
+    /// モバイルの CPU を秒単位で食い続ける (#855 の根本対策の一部)。
+    #[tokio::test]
+    async fn store_variant_roundtrips_via_check_cache_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        let key = "https://e.com/a.png|w=56|f=";
+        cache.store_variant(key, vec![9u8; 128], "image/webp").await;
+
+        let entry = cache
+            .check_cache_only(key)
+            .await
+            .expect("variant should be served from cache");
+        assert_eq!(entry.content_type, "image/webp");
+        // ディスクにも書かれている (プロセス再起動後も変換不要)
+        let dat = dir
+            .path()
+            .join("image_cache")
+            .join(format!("{}.dat", hex_hash(key)));
+        assert!(dat.exists());
+    }
+
+    /// 二段階配信のフェーズ 1 が「失敗直後の URL」へ ensure を再発行すると
+    /// 失敗イベント → 再試行 → 失敗イベントの無限ループになる。
+    /// negative cache を外から照会できることが再試行ループの遮断条件。
+    #[tokio::test]
+    async fn negative_cache_is_queryable_with_ttl() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        let url = "https://down.example/a.png";
+        assert!(!cache.is_negative_cached(url).await);
+
+        cache
+            .negative_cache
+            .write()
+            .await
+            .insert(hex_hash(url), (Instant::now(), Duration::from_secs(60)));
+        assert!(cache.is_negative_cached(url).await);
+
+        // TTL 切れは negative 扱いしない (自然回復)
+        cache.negative_cache.write().await.insert(
+            hex_hash(url),
+            (Instant::now() - Duration::from_secs(10), Duration::from_secs(5)),
+        );
+        assert!(!cache.is_negative_cached(url).await);
+    }
+
+    /// circuit breaker で塞がれたホストもフェーズ 1 の即時失敗対象になること。
+    /// (negative cache に入らない失敗経路なので、これを見落とすと ensure が
+    /// 高速に空振りし続ける)
+    #[tokio::test]
+    async fn fast_fail_covers_circuit_breaker() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        let url = "https://down.example/a.png";
+        assert!(!cache.is_fast_fail(url).await);
+
+        cache.host_circuits.write().await.insert(
+            "down.example".to_string(),
+            HostCircuitState {
+                consecutive_failures: 9,
+                tripped_at: Some(Instant::now()),
+            },
+        );
+        assert!(cache.is_fast_fail(url).await);
+    }
+
+    /// 同じ variant への ensure が並走しないこと (変換 CPU の二重払い防止)
+    #[tokio::test]
+    async fn ensure_dedup_via_begin_finish() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        assert!(cache.begin_ensure("k").await);
+        assert!(!cache.begin_ensure("k").await, "must not start twice");
+        cache.finish_ensure("k").await;
+        assert!(cache.begin_ensure("k").await, "finished key can start again");
     }
 
     /// `<stem>.dat` + `.meta` の対を作り、mtime を指定秒だけ過去にずらす

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -959,6 +959,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             streaming::StreamChatMessageUnreacted,
             os_notify::NotificationClicked,
             commands::ExportProgress,
+            media_proxy::MediaFetched,
         ])
 }
 

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -15,9 +15,31 @@
 use std::sync::Arc;
 
 use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
 use crate::image_cache::{hex_hash, CacheEntry, ImageCache, StreamingFetchResult};
+
+/// 二段階配信 (フェーズ 2) の背景取得が終わったことをフロントへ知らせる。
+/// mediaProxy.ts がこれを受けて該当 URL の `<img>` に再要求させる
+/// (成否によらず emit する。失敗時の再要求は negative cache が 502 で
+/// 受け止め、`onerror` フォールバックに繋がる)。
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, tauri_specta::Event)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaFetched {
+    pub url: String,
+    pub ok: bool,
+}
+
+/// 1×1 透明 GIF。キャッシュミス時の仮応答 (フェーズ 1)。
+/// 404 を返すと `<img>` の onerror が発火して MkAvatar などのフォールバック
+/// (プロキシ迂回で原寸直読み) を誤爆させるため、成功扱いの透明画像で場を
+/// 持たせ、取得完了イベントで差し替えさせる。
+const PLACEHOLDER_GIF: &[u8] = &[
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x44, 0x00, 0x3B,
+];
 
 /// 変換パラメータ込みのメディアリクエスト。
 /// 変換は画像にしか効かないが、効果音は変換なしで同じ経路を通る。
@@ -173,18 +195,23 @@ async fn apply_transform(
     .unwrap_or_else(|_| (Vec::new(), "application/octet-stream".to_string()))
 }
 
-/// キャッシュエントリ (メモリ or ディスク) をバイト列にする。
+/// キャッシュエントリ (メモリ or ディスク) を変換なしでバイト列にする。
+async fn entry_bytes(entry: &CacheEntry) -> Result<Vec<u8>, String> {
+    match &entry.mem_bytes {
+        // メモリキャッシュ側も同じ Arc を保持しているので複製は避けられない
+        Some(mem) => Ok(mem.as_ref().clone()),
+        None => tokio::fs::read(&entry.path)
+            .await
+            .map_err(|e| e.to_string()),
+    }
+}
+
+/// キャッシュエントリをバイト列にし、要求されていれば変換を適用する。
 pub async fn bytes_from_entry(
     entry: CacheEntry,
     req: &MediaRequest,
 ) -> Result<(Vec<u8>, String), String> {
-    let data = match entry.mem_bytes {
-        // メモリキャッシュ側も同じ Arc を保持しているので複製は避けられない
-        Some(mem) => mem.as_ref().clone(),
-        None => tokio::fs::read(&entry.path)
-            .await
-            .map_err(|e| e.to_string())?,
-    };
+    let data = entry_bytes(&entry).await?;
     Ok(apply_transform(data, entry.content_type, req).await)
 }
 
@@ -264,6 +291,9 @@ async fn handle_uri_request_inner(
     let Some(req) = MediaRequest::from_query(query) else {
         return error_response(tauri::http::StatusCode::BAD_REQUEST, "invalid url param");
     };
+    // wait=1: 上流取得を待つブロッキング応答 (上限は RESPONSE_DEADLINE)。
+    // fetch()/Audio 要素のようにプレースホルダを飲み込めない消費者 (効果音) 用。
+    let wait = url::form_urlencoded::parse(query.as_bytes()).any(|(k, v)| k == "wait" && v == "1");
 
     let etag = req.etag();
     // 条件付きリクエスト: 同じ ETag を持っているなら本文を送らない
@@ -290,32 +320,140 @@ async fn handle_uri_request_inner(
             "media cache not ready",
         );
     };
+    let cache = cache.inner().clone();
 
-    match load_bytes(cache.inner(), &req).await {
-        Ok((bytes, content_type)) => {
-            tracing::debug!(
-                url = %req.url,
-                bytes = bytes.len(),
-                content_type = %content_type,
-                "ndmedia: served"
-            );
-            tauri::http::Response::builder()
-                .status(tauri::http::StatusCode::OK)
-                .header("Content-Type", content_type)
-                .header("Cache-Control", CACHE_CONTROL)
-                .header("ETag", &etag)
-                // 効果音は fetch() + decodeAudioData で読むため CORS が要る。
-                // img と違い ACAO が無いと access control で弾かれる。
-                // custom protocol は WebView 内からしか到達できないので * で安全
-                .header("Access-Control-Allow-Origin", "*")
-                .body(bytes)
-                .unwrap_or_else(|_| internal_error())
-        }
-        Err(msg) => {
-            tracing::warn!(url = %req.url, error = %msg, "ndmedia: upstream fetch failed");
-            error_response(tauri::http::StatusCode::BAD_GATEWAY, &msg)
-        }
+    // ── フェーズ 1: ローカル (メモリ/ディスク) だけで応答する ──
+    // variant (変換結果) は cache_key で保存済みなので、ヒットすれば
+    // 変換なしの読み出しだけで返せる。ここが応答時間の実質上限になる。
+    let key = req.cache_key();
+    if let Some(entry) = cache.check_cache_only(&key).await {
+        return match entry_bytes(&entry).await {
+            Ok(bytes) => ok_response(bytes, &entry.content_type, &etag),
+            Err(msg) => {
+                tracing::warn!(url = %req.url, error = %msg, "ndmedia: cache read failed");
+                error_response(tauri::http::StatusCode::INTERNAL_SERVER_ERROR, &msg)
+            }
+        };
     }
+
+    if wait {
+        // ブロッキング経路 (従来動作)。効果音は初回でも実データが要る
+        return match load_bytes(&cache, &req).await {
+            Ok((bytes, content_type)) => ok_response(bytes, &content_type, &etag),
+            Err(msg) => {
+                tracing::warn!(url = %req.url, error = %msg, "ndmedia: upstream fetch failed");
+                error_response(tauri::http::StatusCode::BAD_GATEWAY, &msg)
+            }
+        };
+    }
+
+    // 失敗直後 (negative cache) / 既知のダウンホスト (circuit breaker) は
+    // ensure を発行せず即エラー。ここで遮断しないと「失敗イベント → img
+    // 再要求 → ensure → 失敗イベント」が空回りし続ける
+    if cache.is_fast_fail(&req.url).await {
+        return error_response(
+            tauri::http::StatusCode::BAD_GATEWAY,
+            "upstream recently failed",
+        );
+    }
+
+    // ── フェーズ 2: 取得+変換は背景で行い、即プレースホルダを返す ──
+    // wry Android は custom protocol を単一 Mutex で直列処理するため、
+    // ここで上流を待つと他の全メディア + 8KB 超の IPC 応答まで道連れになる。
+    // 完了は MediaFetched イベントで通知し、フロントが再要求してくる。
+    if cache.begin_ensure(&key).await {
+        tokio::spawn(ensure_media(app, cache, req));
+    }
+    placeholder_response()
+}
+
+/// 背景取得: オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して
+/// cache_key で保存し、完了イベントを emit する。
+///
+/// 変換が不要・不能でも必ず cache_key で保存する。保存しないとフェーズ 1 が
+/// 永遠にミスして ensure と完了イベントを打ち続ける。
+async fn ensure_media(app: AppHandle, cache: Arc<ImageCache>, req: MediaRequest) {
+    let key = req.cache_key();
+    let result = ensure_media_inner(&cache, &req).await;
+    cache.finish_ensure(&key).await;
+    if let Err(ref msg) = result {
+        tracing::warn!(url = %req.url, error = %msg, "ndmedia: background fetch failed");
+    }
+    use tauri_specta::Event;
+    MediaFetched {
+        url: req.url.clone(),
+        ok: result.is_ok(),
+    }
+    .emit(&app)
+    .ok();
+}
+
+async fn ensure_media_inner(cache: &ImageCache, req: &MediaRequest) -> Result<(), String> {
+    // オリジナルを取得 (キャッシュ or 上流)
+    let (data, content_type) = match cache.check_cache_only(&req.url).await {
+        Some(entry) => {
+            let content_type = entry.content_type.clone();
+            (entry_bytes(&entry).await?, content_type)
+        }
+        None => match cache.fetch_streaming(&req.url).await {
+            Ok(StreamingFetchResult::Cached(entry)) => {
+                let content_type = entry.content_type.clone();
+                (entry_bytes(&entry).await?, content_type)
+            }
+            Ok(StreamingFetchResult::Streaming {
+                byte_stream,
+                content_type,
+            }) => {
+                let mut all = Vec::with_capacity(65_536);
+                let mut stream = byte_stream;
+                while let Some(chunk) = stream.next().await {
+                    all.extend_from_slice(&chunk?);
+                }
+                (all, content_type)
+            }
+            Err(msg) => return Err(msg),
+        },
+    };
+
+    let (bytes, content_type) = if req.wants_transform() {
+        apply_transform(data, content_type, req).await
+    } else {
+        (data, content_type)
+    };
+    // fetch_streaming の背景タスクもオリジナルを書くが、それを待たずに emit
+    // すると再要求がミスする競合があるため、ここで確実に書き切ってから返す
+    cache.store_variant(&req.cache_key(), bytes, &content_type).await;
+    Ok(())
+}
+
+fn ok_response(
+    bytes: Vec<u8>,
+    content_type: &str,
+    etag: &str,
+) -> tauri::http::Response<Vec<u8>> {
+    tauri::http::Response::builder()
+        .status(tauri::http::StatusCode::OK)
+        .header("Content-Type", content_type)
+        .header("Cache-Control", CACHE_CONTROL)
+        .header("ETag", etag)
+        // 効果音は fetch() + decodeAudioData で読むため CORS が要る。
+        // img と違い ACAO が無いと access control で弾かれる。
+        // custom protocol は WebView 内からしか到達できないので * で安全
+        .header("Access-Control-Allow-Origin", "*")
+        .body(bytes)
+        .unwrap_or_else(|_| internal_error())
+}
+
+fn placeholder_response() -> tauri::http::Response<Vec<u8>> {
+    tauri::http::Response::builder()
+        .status(tauri::http::StatusCode::OK)
+        .header("Content-Type", "image/gif")
+        // 仮応答をどの層にもキャッシュさせない (本物はイベント後の再要求で返す)
+        .header("Cache-Control", "no-store")
+        .header("Access-Control-Allow-Origin", "*")
+        .header("X-ND-Pending", "1")
+        .body(PLACEHOLDER_GIF.to_vec())
+        .unwrap_or_else(|_| internal_error())
 }
 
 const CACHE_CONTROL: &str = "public, max-age=86400, immutable";
@@ -399,6 +537,14 @@ mod tests {
             .expect("should transform");
         assert_eq!(ct, "image/webp");
         assert!(!out.is_empty());
+    }
+
+    /// フェーズ 1 の仮応答が本物の画像としてデコードできること
+    /// (壊れたバイト列だと WebView が broken image を描いてしまう)
+    #[test]
+    fn placeholder_gif_is_valid_1x1() {
+        let img = image::load_from_memory(PLACEHOLDER_GIF).expect("must decode");
+        assert_eq!((img.width(), img.height()), (1, 1));
     }
 
     /// 寸法が大きすぎる画像はデコードを拒否して原本のまま返す (None)。

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -102,6 +102,40 @@ impl MediaRequest {
 /// これを超える原本は変換せずそのまま返す (WebView 側に委ねる)。
 const MAX_DECODE_DIMENSION: u32 = 8192;
 
+/// アニメーションの可能性があるか (ヘッダ走査のみ、デコードしない)。
+/// 変換 (リサイズ/再エンコード) はアニメーションを 1 フレーム目に潰すため、
+/// 真なら変換せず原本を素通しする。
+/// - GIF: 静的判定にはブロック走査が要るため一律アニメ扱い (Misskey の
+///   GIF 絵文字はほぼアニメーション)
+/// - APNG: IDAT より前に現れる acTL チャンク (CRC は検証しない)
+/// - WebP: ヘッダ近傍の ANIM チャンク
+fn may_be_animated(data: &[u8]) -> bool {
+    if data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a") {
+        return true;
+    }
+    if data.starts_with(&[0x89, b'P', b'N', b'G']) {
+        let mut pos = 8;
+        while pos + 8 <= data.len() {
+            let len = u32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]])
+                as usize;
+            let ctype = &data[pos + 4..pos + 8];
+            if ctype == b"acTL" {
+                return true;
+            }
+            if ctype == b"IDAT" {
+                return false;
+            }
+            pos = pos.saturating_add(12 + len); // len(4) + type(4) + data + crc(4)
+        }
+        return false;
+    }
+    if data.len() >= 16 && &data[0..4] == b"RIFF" && &data[8..12] == b"WEBP" {
+        // ANIM チャンクは VP8X 直後に来るのでヘッダ近傍だけ見れば足りる
+        return data[12..data.len().min(64)].windows(4).any(|w| w == b"ANIM");
+    }
+    false
+}
+
 /// ヘッダだけ読んで寸法を得る。判定できない形式は None。
 fn image_dimensions(data: &[u8]) -> Option<(u32, u32)> {
     image::ImageReader::new(std::io::Cursor::new(data))
@@ -121,6 +155,12 @@ pub fn transform_image(
     let needs_resize = max_width.is_some();
     let needs_webp = target_format == Some("webp");
     if !needs_resize && !needs_webp {
+        return None;
+    }
+
+    // アニメーションは変換で潰れるため、明示 format があっても素通し
+    // (壊れた静止画を返すより原本を返す方が正しい)
+    if may_be_animated(data) {
         return None;
     }
 
@@ -206,39 +246,6 @@ async fn entry_bytes(entry: &CacheEntry) -> Result<Vec<u8>, String> {
     }
 }
 
-/// キャッシュエントリをバイト列にし、要求されていれば変換を適用する。
-pub async fn bytes_from_entry(
-    entry: CacheEntry,
-    req: &MediaRequest,
-) -> Result<(Vec<u8>, String), String> {
-    let data = entry_bytes(&entry).await?;
-    Ok(apply_transform(data, entry.content_type, req).await)
-}
-
-/// キャッシュ → 上流の順に解決し、変換適用済みのバイト列を返す。
-pub async fn load_bytes(
-    cache: &ImageCache,
-    req: &MediaRequest,
-) -> Result<(Vec<u8>, String), String> {
-    if let Some(entry) = cache.check_cache_only(&req.url).await {
-        return bytes_from_entry(entry, req).await;
-    }
-    match cache.fetch_streaming(&req.url).await {
-        Ok(StreamingFetchResult::Cached(entry)) => bytes_from_entry(entry, req).await,
-        Ok(StreamingFetchResult::Streaming {
-            byte_stream,
-            content_type,
-        }) => {
-            let mut all = Vec::with_capacity(65_536);
-            let mut stream = byte_stream;
-            while let Some(chunk) = stream.next().await {
-                all.extend_from_slice(&chunk?);
-            }
-            Ok(apply_transform(all, content_type, req).await)
-        }
-        Err(msg) => Err(msg),
-    }
-}
 
 /// custom protocol の応答締切。
 ///
@@ -337,8 +344,10 @@ async fn handle_uri_request_inner(
     }
 
     if wait {
-        // ブロッキング経路 (従来動作)。効果音は初回でも実データが要る
-        return match load_bytes(&cache, &req).await {
+        // ブロッキング経路: プレースホルダを飲み込めない消費者 (効果音の
+        // fetch/Audio 要素) と、直列パイプ制約のない非 Android の単一トリップ
+        // 配信用。ensure と同じ経路なので変換結果 (variant) も永続化される
+        return match ensure_media_inner(&cache, &req).await {
             Ok((bytes, content_type)) => ok_response(bytes, &content_type, &etag),
             Err(msg) => {
                 tracing::warn!(url = %req.url, error = %msg, "ndmedia: upstream fetch failed");
@@ -388,7 +397,12 @@ async fn ensure_media(app: AppHandle, cache: Arc<ImageCache>, req: MediaRequest)
     .ok();
 }
 
-async fn ensure_media_inner(cache: &ImageCache, req: &MediaRequest) -> Result<(), String> {
+/// オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して cache_key で
+/// 永続化し、配信可能なバイト列と content-type を返す。
+async fn ensure_media_inner(
+    cache: &ImageCache,
+    req: &MediaRequest,
+) -> Result<(Vec<u8>, String), String> {
     // オリジナルを取得 (キャッシュ or 上流)
     let (data, content_type) = match cache.check_cache_only(&req.url).await {
         Some(entry) => {
@@ -422,8 +436,10 @@ async fn ensure_media_inner(cache: &ImageCache, req: &MediaRequest) -> Result<()
     };
     // fetch_streaming の背景タスクもオリジナルを書くが、それを待たずに emit
     // すると再要求がミスする競合があるため、ここで確実に書き切ってから返す
-    cache.store_variant(&req.cache_key(), bytes, &content_type).await;
-    Ok(())
+    cache
+        .store_variant(&req.cache_key(), bytes.clone(), &content_type)
+        .await;
+    Ok((bytes, content_type))
 }
 
 fn ok_response(
@@ -555,6 +571,71 @@ mod tests {
         // 高さ 2px なのでテスト自体のメモリは軽い
         let wide = png_bytes(MAX_DECODE_DIMENSION + 1, 2);
         assert!(transform_image(&wide, Some(56), Some("webp")).is_none());
+    }
+
+    /// アニメーションの可能性がある形式は変換で 1 フレーム目に潰れるため、
+    /// 明示 format があっても素通しする (壊れた静止画を返すより原本が正しい)
+    #[test]
+    fn animated_formats_pass_through_untouched() {
+        // GIF は静的判定にブロック走査が要るため一律素通し
+        let gif = {
+            let img = image::RgbaImage::from_pixel(100, 100, image::Rgba([1, 2, 3, 255]));
+            let mut buf = std::io::Cursor::new(Vec::new());
+            let mut enc = image::codecs::gif::GifEncoder::new(&mut buf);
+            enc.encode_frame(image::Frame::new(img)).expect("encode gif");
+            drop(enc);
+            buf.into_inner()
+        };
+        assert!(transform_image(&gif, Some(56), Some("webp")).is_none());
+
+        // APNG: IDAT より前の acTL チャンクで判定 (CRC は見ない)
+        let mut apng = png_bytes(100, 100);
+        let mut actl = Vec::new();
+        actl.extend_from_slice(&8u32.to_be_bytes());
+        actl.extend_from_slice(b"acTL");
+        actl.extend_from_slice(&[0u8; 12]); // frames(4) + plays(4) + crc(4)
+        apng.splice(33..33, actl); // IHDR 直後 (8 sig + 25 IHDR chunk)
+        assert!(may_be_animated(&apng));
+        assert!(transform_image(&apng, Some(56), Some("webp")).is_none());
+
+        // Animated WebP: ヘッダ近傍の ANIM チャンク
+        let mut awebp = Vec::new();
+        awebp.extend_from_slice(b"RIFF");
+        awebp.extend_from_slice(&[0u8; 4]);
+        awebp.extend_from_slice(b"WEBPVP8X");
+        awebp.extend_from_slice(&[0u8; 14]);
+        awebp.extend_from_slice(b"ANIM");
+        assert!(may_be_animated(&awebp));
+    }
+
+    /// 静止 PNG はアニメ扱いされない (変換が生き続けること)
+    #[test]
+    fn static_png_is_not_animated() {
+        assert!(!may_be_animated(&png_bytes(10, 10)));
+    }
+
+    /// wait (ブロッキング) 経路もキャッシュ済みオリジナルから変換して
+    /// variant を永続化し、バイト列を直接返すこと。これが無いと非 Android の
+    /// 単一トリップ配信が表示のたびに再変換で CPU を払い続ける
+    #[tokio::test]
+    async fn ensure_media_inner_transforms_cached_original_and_persists_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = crate::image_cache::ImageCache::new(dir.path());
+        let url = "https://e.com/a.png";
+        // オリジナルをキャッシュ済みにしておく (key == url)
+        cache
+            .store_variant(url, png_bytes(200, 200), "image/png")
+            .await;
+
+        let req = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56")
+            .expect("should parse");
+        let (bytes, content_type) = ensure_media_inner(&cache, &req)
+            .await
+            .expect("cached original should transform without network");
+        assert_eq!(content_type, "image/webp");
+        assert!(!bytes.is_empty());
+        // variant がフェーズ 1 (check_cache_only) で引ける
+        assert!(cache.check_cache_only(&req.cache_key()).await.is_some());
     }
 
     /// 効果音は変換パラメータを持たないので素通しになる

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -125,7 +125,9 @@ fn may_be_animated(data: &[u8]) -> bool {
             if ctype == b"IDAT" {
                 return false;
             }
-            pos = pos.saturating_add(12 + len); // len(4) + type(4) + data + crc(4)
+            // len(4) + type(4) + data + crc(4)。len は untrusted なので
+            // 32bit ターゲットでの加算オーバーフローも飽和させる
+            pos = pos.saturating_add(len.saturating_add(12));
         }
         return false;
     }
@@ -218,9 +220,9 @@ async fn apply_transform(
     data: Vec<u8>,
     content_type: String,
     req: &MediaRequest,
-) -> (Vec<u8>, String) {
+) -> Result<(Vec<u8>, String), String> {
     if !req.wants_transform() {
-        return (data, content_type);
+        return Ok((data, content_type));
     }
     let w = req.w;
     let format = req.format.clone();
@@ -231,8 +233,10 @@ async fn apply_transform(
         }
     })
     .await
-    // JoinError は closure の panic のみ (release は panic = "abort" が先に効く)
-    .unwrap_or_else(|_| (Vec::new(), "application/octet-stream".to_string()))
+    // JoinError は closure の panic のみ (release は panic = "abort" が先に
+    // 効く)。空バイト列を成功として返すと variant に永続化されて TTL の間
+    // 空画像を配り続けるため、エラーとして伝播する
+    .map_err(|e| format!("transform task failed: {e}"))
 }
 
 /// キャッシュエントリ (メモリ or ディスク) を変換なしでバイト列にする。
@@ -429,11 +433,7 @@ async fn ensure_media_inner(
         },
     };
 
-    let (bytes, content_type) = if req.wants_transform() {
-        apply_transform(data, content_type, req).await
-    } else {
-        (data, content_type)
-    };
+    let (bytes, content_type) = apply_transform(data, content_type, req).await?;
     // fetch_streaming の背景タスクもオリジナルを書くが、それを待たずに emit
     // すると再要求がミスする競合があるため、ここで確実に書き切ってから返す
     cache
@@ -612,6 +612,18 @@ mod tests {
     #[test]
     fn static_png_is_not_animated() {
         assert!(!may_be_animated(&png_bytes(10, 10)));
+    }
+
+    /// チャンク長は untrusted な入力。u32::MAX を仕込んだ PNG でも
+    /// 32bit ターゲット (armv7 Android) の加算オーバーフローで panic しない
+    #[test]
+    fn png_scan_survives_huge_chunk_length() {
+        let mut evil = Vec::new();
+        evil.extend_from_slice(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A]);
+        evil.extend_from_slice(&u32::MAX.to_be_bytes());
+        evil.extend_from_slice(b"IHDR");
+        evil.extend_from_slice(&[0u8; 32]);
+        assert!(!may_be_animated(&evil));
     }
 
     /// wait (ブロッキング) 経路もキャッシュ済みオリジナルから変換して

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -74,6 +74,12 @@ impl MediaRequest {
     }
 }
 
+/// デコードを許す寸法の上限 (px/辺)。ファイルサイズ上限 (20MB) 内でも
+/// 20000×20000 の PNG は RGBA 展開で 1.6GB に膨らみ、Android では malloc
+/// abort がログを残さずプロセスを殺す。変換対象はサムネイル用途なので
+/// これを超える原本は変換せずそのまま返す (WebView 側に委ねる)。
+const MAX_DECODE_DIMENSION: u32 = 8192;
+
 /// ヘッダだけ読んで寸法を得る。判定できない形式は None。
 fn image_dimensions(data: &[u8]) -> Option<(u32, u32)> {
     image::ImageReader::new(std::io::Cursor::new(data))
@@ -113,7 +119,14 @@ pub fn transform_image(
         }
     }
 
-    let img = image::load_from_memory(data).ok()?;
+    let mut reader = image::ImageReader::new(std::io::Cursor::new(data))
+        .with_guessed_format()
+        .ok()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(MAX_DECODE_DIMENSION);
+    limits.max_image_height = Some(MAX_DECODE_DIMENSION);
+    reader.limits(limits);
+    let img = reader.decode().ok()?;
 
     let img = if let Some(w) = max_width {
         if img.width() > w {
@@ -135,13 +148,29 @@ pub fn transform_image(
 }
 
 /// 要求されていれば変換を適用する。変換不要・失敗時 (効果音など) は元のまま返す。
-fn apply_transform(data: Vec<u8>, content_type: String, req: &MediaRequest) -> (Vec<u8>, String) {
-    if req.wants_transform() {
-        if let Some(transformed) = transform_image(&data, req.w, req.format.as_deref()) {
-            return transformed;
-        }
+///
+/// decode + WebP エンコードは端末によって CPU を数秒占有するため blocking pool
+/// へ逃がす。async ワーカー上で回すと他の応答 (IPC の channel-fetch を含む) まで
+/// 詰まり、Android では応答締切 (RESPONSE_DEADLINE) の超過に直結する。
+async fn apply_transform(
+    data: Vec<u8>,
+    content_type: String,
+    req: &MediaRequest,
+) -> (Vec<u8>, String) {
+    if !req.wants_transform() {
+        return (data, content_type);
     }
-    (data, content_type)
+    let w = req.w;
+    let format = req.format.clone();
+    tokio::task::spawn_blocking(move || {
+        match transform_image(&data, w, format.as_deref()) {
+            Some(transformed) => transformed,
+            None => (data, content_type),
+        }
+    })
+    .await
+    // JoinError は closure の panic のみ (release は panic = "abort" が先に効く)
+    .unwrap_or_else(|_| (Vec::new(), "application/octet-stream".to_string()))
 }
 
 /// キャッシュエントリ (メモリ or ディスク) をバイト列にする。
@@ -156,7 +185,7 @@ pub async fn bytes_from_entry(
             .await
             .map_err(|e| e.to_string())?,
     };
-    Ok(apply_transform(data, entry.content_type, req))
+    Ok(apply_transform(data, entry.content_type, req).await)
 }
 
 /// キャッシュ → 上流の順に解決し、変換適用済みのバイト列を返す。
@@ -178,11 +207,20 @@ pub async fn load_bytes(
             while let Some(chunk) = stream.next().await {
                 all.extend_from_slice(&chunk?);
             }
-            Ok(apply_transform(all, content_type, req))
+            Ok(apply_transform(all, content_type, req).await)
         }
         Err(msg) => Err(msg),
     }
 }
+
+/// custom protocol の応答締切。
+///
+/// wry の Android 実装は全 custom protocol を単一の Mutex で直列処理し、
+/// 各リクエストの応答を 10 秒で打ち切って `unwrap()` で panic する
+/// (wry-0.54.4 src/android/mod.rs:247 の `rx.recv_timeout(MAIN_PIPE_TIMEOUT)`)。
+/// `panic = "abort"` のためそのままプロセス即死になる。応答さえ返れば panic
+/// しないので、どの経路でもこの締切までに必ず何かを応答する。
+const RESPONSE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(7);
 
 /// custom protocol (`ndmedia:`) のハンドラ。
 ///
@@ -190,8 +228,36 @@ pub async fn load_bytes(
 /// `ndmedia://localhost/m?...`、Windows/Android は
 /// `http://ndmedia.localhost/m?...`) が、クエリの読み方は同じ。
 /// フロントは `convertFileSrc('m', 'ndmedia')` で組み立てる。
+///
+/// 実作業は detach したタスクに任せて RESPONSE_DEADLINE で応答だけ打ち切る。
+/// 途中キャンセルすると inflight 登録が宙に浮くため、作業自体は完走させる
+/// (キャッシュも温まるので、フロントの再要求はヒットで返せる)。
 pub async fn handle_uri_request(
     app: &AppHandle,
+    request: tauri::http::Request<Vec<u8>>,
+) -> tauri::http::Response<Vec<u8>> {
+    let query_for_log = request.uri().query().unwrap_or_default().to_string();
+    let app = app.clone();
+    let work = tokio::spawn(async move { handle_uri_request_inner(app, request).await });
+    match tokio::time::timeout(RESPONSE_DEADLINE, work).await {
+        Ok(Ok(response)) => response,
+        // JoinError: 実作業タスクの panic (release では panic = "abort" が先に効く)
+        Ok(Err(_)) => error_response(
+            tauri::http::StatusCode::INTERNAL_SERVER_ERROR,
+            "media task failed",
+        ),
+        Err(_) => {
+            tracing::warn!(query = %query_for_log, "ndmedia: response deadline exceeded");
+            error_response(
+                tauri::http::StatusCode::GATEWAY_TIMEOUT,
+                "media fetch deadline exceeded",
+            )
+        }
+    }
+}
+
+async fn handle_uri_request_inner(
+    app: AppHandle,
     request: tauri::http::Request<Vec<u8>>,
 ) -> tauri::http::Response<Vec<u8>> {
     let query = request.uri().query().unwrap_or_default();
@@ -333,6 +399,16 @@ mod tests {
             .expect("should transform");
         assert_eq!(ct, "image/webp");
         assert!(!out.is_empty());
+    }
+
+    /// 寸法が大きすぎる画像はデコードを拒否して原本のまま返す (None)。
+    /// ファイルサイズ上限 (20MB) 内でも巨大寸法 PNG は RGBA 展開でギガ単位に
+    /// 膨らみ、Android では malloc abort がログを残さずプロセスを殺す。
+    #[test]
+    fn refuses_decode_of_oversized_dimensions() {
+        // 高さ 2px なのでテスト自体のメモリは軽い
+        let wide = png_bytes(MAX_DECODE_DIMENSION + 1, 2);
+        assert!(transform_image(&wide, Some(56), Some("webp")).is_none());
     }
 
     /// 効果音は変換パラメータを持たないので素通しになる

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.32.2",
+  "version": "1.32.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.32.3",
+  "version": "1.33.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2438,6 +2438,7 @@ async permissionsLockdown() : Promise<Result<null, string>> {
 
 export const events = __makeEvents__<{
 exportProgress: ExportProgress,
+mediaFetched: MediaFetched,
 noteCaptureBatch: NoteCaptureBatch,
 notificationClicked: NotificationClicked,
 queryDelta: QueryDelta,
@@ -2447,6 +2448,7 @@ streamEnvelope: StreamEnvelope,
 streamStatus: StreamStatus
 }>({
 exportProgress: "export-progress",
+mediaFetched: "media-fetched",
 noteCaptureBatch: "note-capture-batch",
 notificationClicked: "notification-clicked",
 queryDelta: "query-delta",
@@ -2816,6 +2818,13 @@ export type HttpFetchResponse = { status: number; headers: Partial<{ [key in str
  */
 export type ImageCacheStats = { bytes: number; files: number }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
+/**
+ * 二段階配信 (フェーズ 2) の背景取得が終わったことをフロントへ知らせる。
+ * mediaProxy.ts がこれを受けて該当 URL の `<img>` に再要求させる
+ * (成否によらず emit する。失敗時の再要求は negative cache が 502 で
+ * 受け止め、`onerror` フォールバックに繋がる)。
+ */
+export type MediaFetched = { url: string; ok: boolean }
 /**
  * Misskey の `mutedWords` / `hardMutedWords` の 1 要素。
  * 文字列配列なら AND 語群（全語含むとマッチ）、文字列なら `/regex/flags` 形式の正規表現。

--- a/src/components/common/MkChatMessage.vue
+++ b/src/components/common/MkChatMessage.vue
@@ -9,7 +9,7 @@ import { USER_POPUP_HOVER, useHoverPopup } from '@/composables/useHoverPopup'
 import { useNavigation } from '@/composables/useNavigation'
 import { provideNoteAccountId } from '@/composables/useNoteContext'
 import { usePortal } from '@/composables/usePortal'
-import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const MkUserPopup = defineAsyncComponent(() => import('./MkUserPopup.vue'))
@@ -264,7 +264,7 @@ usePortal(lightboxPortalRef)
           </span>
           <img
             v-if="getReactionImageUrl(r.reaction)"
-            :src="proxyUrl(getReactionImageUrl(r.reaction)!)"
+            :src="proxyEmojiUrl(getReactionImageUrl(r.reaction)!)"
             :alt="r.reaction"
             :class="$style.reactionEmojiImg"
             decoding="async"

--- a/src/components/common/MkEmoji.vue
+++ b/src/components/common/MkEmoji.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useEmojiMute } from '@/composables/useEmojiMute'
-import { proxyUrl } from '@/utils/mediaProxy'
 import { char2twemojiUrl } from '@/utils/twemoji'
 
 const props = defineProps<{ emoji: string; ignoreMuted?: boolean }>()
@@ -12,8 +11,9 @@ const isMuted = computed(() => !props.ignoreMuted && isEmojiMuted(props.emoji))
 // 未解決のカスタム絵文字 (":name:" / ":name@host:") を twemoji URL に変換すると
 // 存在しない CDN パスへの 404 を量産するため、unknown 表示に落とす (#844)
 const isUnresolvedCustom = computed(() => props.emoji.startsWith(':'))
+// 同梱アセットのローカルパスなのでプロキシ不要
 const url = computed(() =>
-  isUnresolvedCustom.value ? undefined : proxyUrl(char2twemojiUrl(props.emoji)),
+  isUnresolvedCustom.value ? undefined : char2twemojiUrl(props.emoji),
 )
 const failed = ref(false)
 </script>

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -4,7 +4,7 @@ import { useEmojiMute } from '@/composables/useEmojiMute'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
 import { nyaizeTokens } from '@/utils/nyaize'
 import { isMemoUrl, isSafeUrl, openSafeUrl } from '@/utils/url'
@@ -438,7 +438,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Code Block --><div v-else-if="token.type === 'codeBlock'" :key="`cb-${i}-${highlighterLoaded}`" :class="$style.mfmCodeBlock" v-html="highlightCode(token.value, token.lang)"></div><!--
     --><!-- Inline Code --><code v-else-if="token.type === 'inlineCode'" :class="$style.mfmCode">{{ token.value }}</code><!--
     --><!-- Custom Emoji (muted #612) --><span v-else-if="token.type === 'customEmoji' && isEmojiMuted(token.shortcode)" class="custom-emoji _emojiMuted" :class="plain ? $style.customEmojiPlain : $style.customEmoji" role="img" :aria-label="`:${token.shortcode}:`" :title="`:${token.shortcode}: (ミュート中)`"></span><!--
-    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" /><!--
+    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" /><!--
     --><!-- Custom Emoji (unresolved — show fallback icon) --><img v-else-if="token.type === 'customEmoji'" src="/emoji-unknown.svg" :alt="`:${token.shortcode}:`" :title="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" /><!--
     --><!-- Unicode Emoji --><MkEmoji v-else-if="token.type === 'unicodeEmoji'" :emoji="token.value" class="twemoji" :class="$style.twemoji" /><!--
     --><!-- MFM Function: ruby --><ruby v-else-if="token.type === 'fn' && token.name === 'ruby' && rubyParts(token)">{{ rubyParts(token)![0] }}<rp>(</rp><rt>{{ rubyParts(token)![1] }}</rt><rp>)</rp></ruby><!--

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -38,7 +38,7 @@ import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
 import { formatTime } from '@/utils/formatTime'
-import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import {
   buildReactionsData,
   canRenoteNote,
@@ -884,7 +884,7 @@ function handlePickerReaction(reaction: string) {
               @mouseleave="reactionUsersRef?.hide()"
             >
               <span v-if="isEmojiMuted(r.reaction)" class="_emojiMuted" :class="$style.customEmoji" role="img" :aria-label="r.reaction" :title="`${r.reaction} (ミュート中)`" />
-              <img v-else-if="reactionUrls[r.reaction]" :src="proxyUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" />
+              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" />
               <img v-else-if="r.reaction.startsWith(':')" src="/emoji-unknown.svg" :alt="r.reaction" :title="r.reaction" :class="$style.customEmoji" />
               <MkEmoji v-else :emoji="r.reaction" :class="$style.reactionEmoji" />
               <span class="note-reaction-count" :class="$style.count">{{ r.count }}</span>

--- a/src/components/common/MkReactionPicker.vue
+++ b/src/components/common/MkReactionPicker.vue
@@ -9,7 +9,7 @@ import { useRecentEmojisStore } from '@/stores/recentEmojis'
 import { useIsCompactLayout } from '@/stores/ui'
 import { hapticLight } from '@/utils/haptics'
 import { isImeComposing } from '@/utils/ime'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { char2twemojiUrl } from '@/utils/twemoji'
 import MkReactionPickerSection from './MkReactionPickerSection.vue'
 
@@ -140,7 +140,8 @@ function isCustomEmoji(reaction: string): boolean {
 }
 
 function twemojiSrc(char: string): string {
-  return proxyUrl(char2twemojiUrl(char)) ?? char2twemojiUrl(char)
+  // 同梱アセットのローカルパスなのでプロキシ不要
+  return char2twemojiUrl(char)
 }
 
 function pickEmoji(emoji: string) {
@@ -245,7 +246,7 @@ onMounted(() => {
               :title="`:${emoji.name}:`"
               @click="pickCustom(emoji.name)"
             >
-              <img :src="emoji.url" :alt="emoji.name" :class="$style.pickerCustomImg" loading="lazy" />
+              <img :src="proxyEmojiUrl(emoji.url)" :alt="emoji.name" :class="$style.pickerCustomImg" decoding="async" loading="lazy" />
             </button>
           </div>
           <div v-if="searchResults.unicode.length > 0" :class="$style.pickerGrid">
@@ -275,9 +276,10 @@ onMounted(() => {
             >
               <img
                 v-if="isCustomEmoji(reaction)"
-                :src="resolveEmojiUrl(reaction) ?? ''"
+                :src="proxyEmojiUrl(resolveEmojiUrl(reaction)) ?? ''"
                 :alt="reaction"
                 :class="$style.pickerCustomImg"
+                decoding="async"
                 loading="lazy"
               />
               <img
@@ -308,9 +310,10 @@ onMounted(() => {
             >
               <img
                 v-if="isCustomEmoji(reaction)"
-                :src="resolveEmojiUrl(reaction) ?? ''"
+                :src="proxyEmojiUrl(resolveEmojiUrl(reaction)) ?? ''"
                 :alt="reaction"
                 :class="$style.pickerCustomImg"
+                decoding="async"
                 loading="lazy"
               />
               <img
@@ -342,7 +345,7 @@ onMounted(() => {
                 :title="`:${emoji.name}:`"
                 @click="pickCustom(emoji.name)"
               >
-                <img :src="emoji.url" :alt="emoji.name" :class="$style.pickerCustomImg" loading="lazy" />
+                <img :src="proxyEmojiUrl(emoji.url)" :alt="emoji.name" :class="$style.pickerCustomImg" decoding="async" loading="lazy" />
               </button>
             </div>
           </MkReactionPickerSection>

--- a/src/components/common/MkReactionUsersPopup.vue
+++ b/src/components/common/MkReactionUsersPopup.vue
@@ -7,7 +7,7 @@ import { useNativePopover } from '@/composables/useNativePopover'
 import { useNavigation } from '@/composables/useNavigation'
 import { useAccountsStore } from '@/stores/accounts'
 import { normalizeEmojiMuteKey } from '@/utils/emojiMute'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { extractColumnThemeVars } from '@/utils/themeVars'
 import MkAvatar from './MkAvatar.vue'
 import MkEmoji from './MkEmoji.vue'
@@ -167,7 +167,7 @@ onUnmounted(() => {
         />
         <img
           v-else-if="reactionUrl"
-          :src="proxyUrl(reactionUrl)"
+          :src="proxyEmojiUrl(reactionUrl)"
           :alt="reaction"
           :class="$style.reactionIcon"
           decoding="async"

--- a/src/components/common/NoteReactionUsersModal.vue
+++ b/src/components/common/NoteReactionUsersModal.vue
@@ -10,7 +10,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
 import { useUiStore } from '@/stores/ui'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import MkEmoji from './MkEmoji.vue'
 import MkMfm from './MkMfm.vue'
 
@@ -134,7 +134,7 @@ defineExpose({ open })
             @click="selectedReaction = r.reaction"
           >
             <span v-if="isEmojiMuted(r.reaction)" class="_emojiMuted" :class="$style.tabEmoji" role="img" :aria-label="r.reaction" :title="`${r.reaction} (ミュート中)`" />
-            <img v-else-if="reactionUrls[r.reaction]" :src="proxyUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.tabEmoji" decoding="async" loading="lazy" />
+            <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.tabEmoji" decoding="async" loading="lazy" />
             <MkEmoji v-else :emoji="r.reaction" :class="$style.tabEmoji" />
             <span :class="$style.tabCount">{{ r.count }}</span>
           </button>

--- a/src/components/deck/DeckEmojiColumn.vue
+++ b/src/components/deck/DeckEmojiColumn.vue
@@ -16,6 +16,7 @@ import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useEmojisStore } from '@/stores/emojis'
 import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
@@ -296,7 +297,7 @@ function getRowItems(index: number): ServerEmoji[] {
                   @click="copyEmojiCode(emoji)"
                   @contextmenu.prevent="openEmojiMenu(emoji, $event)"
                 >
-                  <img :src="emoji.url" :alt="emoji.name" :class="[$style.emojiImg, { [$style.emojiImgMuted]: isEmojiMuted(`:${emoji.name}:`) }]" loading="lazy" />
+                  <img :src="proxyEmojiUrl(emoji.url)" :alt="emoji.name" :class="[$style.emojiImg, { [$style.emojiImgMuted]: isEmojiMuted(`:${emoji.name}:`) }]" decoding="async" loading="lazy" />
                   <span v-if="copiedName === emoji.name" :class="$style.emojiCopiedBadge">Copied!</span>
                 </button>
               </div>

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -54,7 +54,7 @@ import { useWindowsStore } from '@/stores/windows'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
-import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
 import { getNoteUri } from '@/utils/noteUrl'
 import {
   CROSS_ACCOUNT_NOTIFICATION_KEY,
@@ -441,7 +441,9 @@ function getCachedReactionUrl(
 ): string | null {
   const key = `${notification.id}:${reaction}`
   const cached = reactionUrlLookup.get(key)
-  if (cached) return cached
+  // 返却時にプロキシへ通す (キャッシュには生 URL を保持 — proxyEmojiUrl を
+  // render 中に呼ぶことで二段階配信の再読込世代がリアクティブに効く)
+  if (cached) return proxyEmojiUrl(cached) ?? cached
   const note = notification.note
   const url = reactionUrlRaw(
     reaction,
@@ -450,7 +452,7 @@ function getCachedReactionUrl(
     notification._serverHost,
   )
   if (url) reactionUrlLookup.set(key, url)
-  return url
+  return url ? (proxyEmojiUrl(url) ?? url) : null
 }
 
 function getCachedTwemojiUrl(reaction: string): string | null {
@@ -459,7 +461,7 @@ function getCachedTwemojiUrl(reaction: string): string | null {
   const url =
     reaction.startsWith(':') && reaction.endsWith(':')
       ? null
-      : (proxyUrl(char2twemojiUrl(reaction)) ?? null)
+      : char2twemojiUrl(reaction)
   twemojiUrlLookup.set(reaction, url)
   return url
 }
@@ -1145,7 +1147,7 @@ onUnmounted(() => {
                       <template v-if="notif.type === 'reaction:grouped' && notif.reactions?.length">
                         <span v-for="reaction in uniqueReactions(notif.reactions)" :key="reaction" :class="$style.notifReaction">
                           <span v-if="isEmojiMuted(reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="reaction" :title="`${reaction} (ミュート中)`" />
-                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" loading="lazy" @error="onReactionImgError" />
+                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
                           <MkEmoji v-else :emoji="reaction" :class="$style.notifReactionEmoji" />
                         </span>
                       </template>
@@ -1222,7 +1224,7 @@ onUnmounted(() => {
                       <span :class="$style.notifLabel">{{ notificationLabel(notif.type) }}</span>
                       <span v-if="notif.type === 'reaction' && notif.reaction" :class="$style.notifReaction">
                         <span v-if="isEmojiMuted(notif.reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
-                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" loading="lazy" @error="onReactionImgError" />
+                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
                         <MkEmoji v-else :emoji="notif.reaction" :class="$style.notifReactionEmoji" />
                       </span>
                     </div>

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -42,7 +42,7 @@ import { useNoteStore } from '@/stores/notes'
 import { useSuspensionsStore } from '@/stores/suspensions'
 import { useIsCompactLayout } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { toggleReaction } from '@/utils/toggleReaction'
 import { webUiUrl } from '@/utils/url'
 
@@ -571,7 +571,7 @@ async function handlePosted(editedNoteId?: string) {
               />
               <img
                 v-else-if="reactionTypeUrl(rt)"
-                :src="proxyUrl(reactionTypeUrl(rt)!)"
+                :src="proxyEmojiUrl(reactionTypeUrl(rt)!)"
                 :alt="rt"
                 :class="$style.reactionChipEmoji"
                 decoding="async"

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -67,7 +67,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
 import { formatDate } from '@/utils/format'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { toggleReaction } from '@/utils/toggleReaction'
 import { openSafeUrl, webUiUrl } from '@/utils/url'
@@ -759,7 +759,7 @@ async function handlePosted(editedNoteId?: string) {
                 />
                 <img
                   v-else-if="getReactionEntryUrl(entry)"
-                  :src="proxyUrl(getReactionEntryUrl(entry)!)"
+                  :src="proxyEmojiUrl(getReactionEntryUrl(entry)!)"
                   :alt="entry.type"
                   :title="entry.type"
                   decoding="async"

--- a/src/composables/useNoteSound.ts
+++ b/src/composables/useNoteSound.ts
@@ -37,8 +37,9 @@ if (IS_MOBILE && !IS_ANDROID) {
 
 function getSoundUrl(host: string, soundType: string): string {
   const remoteUrl = `https://${host}/client-assets/sounds/${soundType}.mp3`
-  // 画像と同じプロキシに寄せる (モバイルのバイパスも同じ理由で不要になった)
-  return proxyUrl(remoteUrl) ?? remoteUrl
+  // 画像と同じプロキシに寄せる (モバイルのバイパスも同じ理由で不要になった)。
+  // fetch/Audio 要素は二段階配信のプレースホルダを飲み込めないので wait 指定
+  return proxyUrl(remoteUrl, { wait: true }) ?? remoteUrl
 }
 
 async function ensureBuffer(

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -36,15 +36,22 @@ beforeEach(() => {
   stubTauri((path, protocol) => `http://${protocol}.localhost/${path}`)
 })
 
+// defineProperty で書き換えた UA は unstubAllGlobals では戻らないため明示復元
+const ORIGINAL_UA = navigator.userAgent
+
 afterEach(() => {
+  stubUserAgent(ORIGINAL_UA)
   vi.unstubAllGlobals()
 })
 
 describe('proxyUrl', () => {
-  it('custom protocol の口に載せる', async () => {
+  // 非 Android の wait=1: Android の custom protocol だけが直列 + 10 秒フューズ
+  // (wry) なので二段階配信が必須。それ以外はブロッキングが安全なので、初回
+  // 表示から往復 1 回で本物を返す
+  it('custom protocol の口に載せる (非 Android は単一トリップ)', async () => {
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}`,
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
     )
   })
 
@@ -52,8 +59,15 @@ describe('proxyUrl', () => {
     stubTauri((path, protocol) => `${protocol}://localhost/${path}`)
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `ndmedia://localhost/m?url=${encodeURIComponent(REMOTE)}`,
+      `ndmedia://localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
     )
+  })
+
+  it('Android は二段階配信 (wait を付けない)', async () => {
+    stubUserAgent(ANDROID_UA)
+    const { proxyUrl } = await loadModule()
+    expect(proxyUrl(REMOTE)).toContain('ndmedia')
+    expect(proxyUrl(REMOTE)).not.toContain('wait=1')
   })
 
   it.each([
@@ -70,7 +84,7 @@ describe('proxyUrl', () => {
     vi.stubGlobal('__TAURI_INTERNALS__', undefined)
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}`,
+      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}&wait=1`,
     )
   })
 
@@ -85,18 +99,28 @@ describe('proxyUrl', () => {
 })
 
 describe('wait オプション (効果音などブロッキング消費者用)', () => {
-  it('wait=1 を付ける', async () => {
+  // 二段階配信の Android でも、fetch/Audio 要素はプレースホルダを飲み込め
+  // ないので明示 wait で従来のブロッキングに乗せる
+  it('Android でも明示 wait は wait=1 を付ける', async () => {
+    stubUserAgent(ANDROID_UA)
     const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE, { wait: true })).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
-    )
+    expect(proxyUrl(REMOTE, { wait: true })).toContain('wait=1')
+    const normal = proxyUrl(REMOTE)
+    expect(normal).not.toContain('wait=1')
+  })
+})
+
+describe('proxyEmojiUrl (カスタム絵文字の共通サムネイル口)', () => {
+  it('全文脈で同じ幅バケット (64px) に丸めてキャッシュを共有する', async () => {
+    const { proxyEmojiUrl, proxyThumbUrl } = await loadModule()
+    expect(proxyEmojiUrl(REMOTE)).toBe(proxyThumbUrl(REMOTE, 64))
+    expect(proxyEmojiUrl(REMOTE)).toContain('w=64')
   })
 
-  it('通常の URL とはキャッシュが混ざらない', async () => {
-    const { proxyUrl } = await loadModule()
-    const normal = proxyUrl(REMOTE)
-    expect(proxyUrl(REMOTE, { wait: true })).not.toBe(normal)
-    expect(proxyUrl(REMOTE)).toBe(normal)
+  it('https 以外は素通し (同梱 twemoji のローカルパス等)', async () => {
+    const { proxyEmojiUrl } = await loadModule()
+    expect(proxyEmojiUrl('/twemoji/1f600.svg')).toBe('/twemoji/1f600.svg')
+    expect(proxyEmojiUrl(null)).toBeUndefined()
   })
 })
 
@@ -135,10 +159,10 @@ describe('背景取得完了による再読込 (二段階配信)', () => {
 
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
-  it('幅だけを付ける', async () => {
+  it('幅だけを付ける (非 Android は wait も付く)', async () => {
     const { proxyThumbUrl } = await loadModule()
     expect(proxyThumbUrl(REMOTE, 56)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56`,
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56&wait=1`,
     )
   })
 

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -155,6 +155,19 @@ describe('背景取得完了による再読込 (二段階配信)', () => {
     handleMediaFetched(REMOTE)
     expect(proxyUrl(other)).not.toContain('&r=')
   })
+
+  it('世代マップは上限で古い順に捨てる (無限成長しない)', async () => {
+    const { proxyUrl, handleMediaFetched } = await loadModule()
+    // 上限 (テスト環境の既定 256) を超えて完了イベントを流す
+    handleMediaFetched(REMOTE)
+    for (let i = 0; i < 300; i++) {
+      handleMediaFetched(`https://example.com/e${i}.png`)
+    }
+    // 最古の REMOTE は追い出され、素の URL に戻る (キャッシュ済みなので実害なし)
+    expect(proxyUrl(REMOTE)).not.toContain('&r=')
+    // 直近のものは世代付きのまま
+    expect(proxyUrl('https://example.com/e299.png')).toContain('&r=1')
+  })
 })
 
 describe('proxyThumbUrl', () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -84,6 +84,55 @@ describe('proxyUrl', () => {
   })
 })
 
+describe('wait オプション (効果音などブロッキング消費者用)', () => {
+  it('wait=1 を付ける', async () => {
+    const { proxyUrl } = await loadModule()
+    expect(proxyUrl(REMOTE, { wait: true })).toBe(
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
+    )
+  })
+
+  it('通常の URL とはキャッシュが混ざらない', async () => {
+    const { proxyUrl } = await loadModule()
+    const normal = proxyUrl(REMOTE)
+    expect(proxyUrl(REMOTE, { wait: true })).not.toBe(normal)
+    expect(proxyUrl(REMOTE)).toBe(normal)
+  })
+})
+
+describe('背景取得完了による再読込 (二段階配信)', () => {
+  // フェーズ 1 はキャッシュミス時に透明プレースホルダを返す。取得完了イベント
+  // で URL の世代を進め、テンプレート再評価 → <img> 再要求で本物に差し替える
+  it('media-fetched で世代番号が付き、再度の完了でさらに進む', async () => {
+    const { proxyUrl, handleMediaFetched } = await loadModule()
+    const base = proxyUrl(REMOTE) ?? ''
+    expect(base).not.toBe('')
+    expect(base).not.toContain('&r=')
+
+    handleMediaFetched(REMOTE)
+    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
+
+    handleMediaFetched(REMOTE)
+    expect(proxyUrl(REMOTE)).toBe(`${base}&r=2`)
+  })
+
+  it('世代はサムネイル URL (幅違い) にも波及する', async () => {
+    const { proxyThumbUrl, handleMediaFetched } = await loadModule()
+    const base = proxyThumbUrl(REMOTE, 56) ?? ''
+    expect(base).not.toBe('')
+    handleMediaFetched(REMOTE)
+    expect(proxyThumbUrl(REMOTE, 56)).toBe(`${base}&r=1`)
+    expect(proxyThumbUrl(REMOTE, 112)).toContain('&r=1')
+  })
+
+  it('無関係の URL には影響しない', async () => {
+    const { proxyUrl, handleMediaFetched } = await loadModule()
+    const other = 'https://example.com/other.png'
+    handleMediaFetched(REMOTE)
+    expect(proxyUrl(other)).not.toContain('&r=')
+  })
+})
+
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
   it('幅だけを付ける', async () => {

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -41,6 +41,13 @@ const proxyUrlCache = new Map<string, string>()
 const mediaVersions = reactive(new Map<string, number>())
 
 export function handleMediaFetched(url: string) {
+  // proxyUrlCache と同じ上限で古い順に捨てる (無限成長させない)。
+  // 追い出された URL は素の URL に戻るだけで、実体はキャッシュ済みなので
+  // 表示は壊れない
+  if (!mediaVersions.has(url) && mediaVersions.size >= getProxyCacheMax()) {
+    const oldest = mediaVersions.keys().next().value
+    if (oldest !== undefined) mediaVersions.delete(oldest)
+  }
   mediaVersions.set(url, (mediaVersions.get(url) ?? 0) + 1)
 }
 

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -19,6 +19,14 @@ import { usePerformanceStore } from '@/stores/performance'
  */
 const HTTP_FALLBACK_BASE = 'http://127.0.0.1:19820/proxy/image'
 
+/**
+ * Android の custom protocol だけは直列 + 10 秒フューズ (wry) のため、ミス時
+ * に上流を待てない → 二段階配信 (プレースホルダ + media-fetched 再要求)。
+ * それ以外のプラットフォームはブロッキングでも安全なので wait=1 を既定にし、
+ * 初回表示から往復 1 回で本物を返す (単一トリップ)。
+ */
+const IS_ANDROID = /Android/i.test(navigator.userAgent)
+
 let proxyBase: string | null = null
 const proxyUrlCache = new Map<string, string>()
 
@@ -96,11 +104,12 @@ export function proxyUrl(
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
   ensureFetchedListener()
-  const cacheKey = opts?.wait ? `${url}|wait` : url
+  const wait = opts?.wait || !IS_ANDROID
+  const cacheKey = wait ? `${url}|wait` : url
   let cached = proxyUrlCache.get(cacheKey)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${opts?.wait ? '&wait=1' : ''}`
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${wait ? '&wait=1' : ''}`
     proxyUrlCache.set(cacheKey, cached)
   }
   return withVersion(cached, url)
@@ -121,12 +130,26 @@ export function proxyThumbUrl(
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
   ensureFetchedListener()
+  const wait = !IS_ANDROID
   const key = `${url}|w=${width}`
   let cached = proxyUrlCache.get(key)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}`
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}${wait ? '&wait=1' : ''}`
     proxyUrlCache.set(key, cached)
   }
   return withVersion(cached, url)
+}
+
+/**
+ * カスタム絵文字の共通サムネイル口。
+ *
+ * 表示は ~20px なので retina 込みで 64px に丸め、全文脈 (ノート本文/
+ * ピッカー/リアクション面) で同じ variant キャッシュを共有する。
+ * アニメ絵文字はプロキシ側が変換を素通しするので壊れない。
+ */
+export function proxyEmojiUrl(
+  url: string | null | undefined,
+): string | undefined {
+  return proxyThumbUrl(url, 64)
 }

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -1,4 +1,6 @@
 import { convertFileSrc } from '@tauri-apps/api/core'
+import { reactive } from 'vue'
+import { events } from '@/bindings'
 import { usePerformanceStore } from '@/stores/performance'
 
 /**
@@ -19,6 +21,42 @@ const HTTP_FALLBACK_BASE = 'http://127.0.0.1:19820/proxy/image'
 
 let proxyBase: string | null = null
 const proxyUrlCache = new Map<string, string>()
+
+/**
+ * 二段階配信 (プロキシ側) の再読込機構。
+ *
+ * キャッシュミス時、プロキシは上流を待たず透明プレースホルダを即返し、
+ * 取得完了を media-fetched イベントで知らせてくる。ここで URL の世代番号を
+ * 進めると、テンプレート内の proxyUrl 呼び出しが再評価されて `&r=N` 付きの
+ * 新 URL になり、`<img>` が自然に再要求する (呼び出し箇所の変更は不要)。
+ */
+const mediaVersions = reactive(new Map<string, number>())
+
+export function handleMediaFetched(url: string) {
+  mediaVersions.set(url, (mediaVersions.get(url) ?? 0) + 1)
+}
+
+let listenerStarted = false
+function ensureFetchedListener() {
+  if (listenerStarted) return
+  listenerStarted = true
+  try {
+    events.mediaFetched
+      .listen(({ payload }) => handleMediaFetched(payload.url))
+      .catch(() => {
+        // Tauri 外 (pnpm dev のブラウザ確認) ではイベント購読できない
+      })
+  } catch {
+    // 同上
+  }
+}
+
+/** 世代番号が進んでいれば `&r=N` を付けて別 URL 化する */
+function withVersion(base: string, url: string): string {
+  // 未登録キーの get も reactive の依存として追跡される (後の set で再評価)
+  const v = mediaVersions.get(url)
+  return v ? `${base}&r=${v}` : base
+}
 
 function getProxyBase(): string {
   if (proxyBase !== null) return proxyBase
@@ -46,15 +84,26 @@ function evictIfFull() {
   }
 }
 
-export function proxyUrl(url: string | null | undefined): string | undefined {
+export function proxyUrl(
+  url: string | null | undefined,
+  opts?: {
+    /**
+     * 上流取得をブロッキングで待つ (プレースホルダを返さない)。
+     * fetch() や Audio 要素のように透明 GIF を飲み込めない消費者 (効果音) 用。
+     */
+    wait?: boolean
+  },
+): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
-  let cached = proxyUrlCache.get(url)
+  ensureFetchedListener()
+  const cacheKey = opts?.wait ? `${url}|wait` : url
+  let cached = proxyUrlCache.get(cacheKey)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}`
-    proxyUrlCache.set(url, cached)
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${opts?.wait ? '&wait=1' : ''}`
+    proxyUrlCache.set(cacheKey, cached)
   }
-  return cached
+  return withVersion(cached, url)
 }
 
 /**
@@ -71,6 +120,7 @@ export function proxyThumbUrl(
   width: number,
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
+  ensureFetchedListener()
   const key = `${url}|w=${width}`
   let cached = proxyUrlCache.get(key)
   if (!cached) {
@@ -78,5 +128,5 @@ export function proxyThumbUrl(
     cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}`
     proxyUrlCache.set(key, cached)
   }
-  return cached
+  return withVersion(cached, url)
 }

--- a/src/utils/twemoji.ts
+++ b/src/utils/twemoji.ts
@@ -1,7 +1,12 @@
-const TWEMOJI_BASE =
-  'https://cdn.jsdelivr.net/gh/jdecked/twemoji@v15.1.0/assets/svg'
+/**
+ * 同梱 Twemoji (@discordapp/twemoji、vite.config.ts の twemojiAssets が配る)。
+ * CDN 個別取得はピッカー初回表示で数千リクエストをメディアプロキシに浴びせる
+ * 要因だった (#855)。相対パスなので proxyUrl は素通しし、Tauri ではアプリ
+ * アセットとして即応答される。
+ */
+const TWEMOJI_BASE = '/twemoji'
 
-/** Convert a Unicode emoji character to a Twemoji CDN SVG URL */
+/** Convert a Unicode emoji character to a bundled Twemoji SVG URL */
 export function char2twemojiUrl(char: string): string {
   let codes = Array.from(char, (x) => x.codePointAt(0)?.toString(16))
   if (!codes.includes('200d')) codes = codes.filter((x) => x !== 'fe0f')

--- a/tests/utils/twemoji.test.ts
+++ b/tests/utils/twemoji.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest'
 import { char2twemojiUrl, splitTextWithEmoji } from '@/utils/twemoji'
 
-const BASE = 'https://cdn.jsdelivr.net/gh/jdecked/twemoji@v15.1.0/assets/svg'
+// 同梱 Twemoji (@discordapp/twemoji) のパス。CDN 個別取得はピッカー初回表示で
+// 数千リクエストをメディアプロキシに浴びせる要因だった (#855)。ここで固定する
+// ファイル名規約 (fe0f の扱い) は同梱アセットの実ファイル名と一致している
+const BASE = '/twemoji'
 
 describe('char2twemojiUrl', () => {
   it('converts simple emoji', () => {
     // 😀 = U+1F600
     expect(char2twemojiUrl('😀')).toBe(`${BASE}/1f600.svg`)
+  })
+
+  it('CDN を参照しない (ローカル同梱)', () => {
+    expect(char2twemojiUrl('😀')).not.toContain('https://')
   })
 
   it('strips variation selector when no ZWJ', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { cpSync, readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import vue from '@vitejs/plugin-vue'
 import JSON5 from 'json5'
@@ -218,6 +218,47 @@ function injectAppVersion(): Plugin {
   }
 }
 
+/**
+ * Unicode 絵文字の Twemoji SVG を同梱して `/twemoji/` で配る (#855)。
+ * CDN (jsdelivr) から 1 絵文字 1 リクエストで取る方式は、ピッカー初回表示で
+ * 数千リクエストがメディアプロキシに殺到する要因だった。アセットは Misskey
+ * 本家と同系の Discord fork (@discordapp/twemoji)。
+ */
+function twemojiAssets(): Plugin {
+  const src = resolve(
+    import.meta.dirname,
+    'node_modules/@discordapp/twemoji/dist/svg',
+  )
+  let outDir = 'dist'
+  return {
+    name: 'nd-twemoji-assets',
+    configResolved(config) {
+      outDir = config.build.outDir
+    },
+    configureServer(server) {
+      server.middlewares.use('/twemoji', (req, res, next) => {
+        const name = (req.url ?? '').split('?')[0]?.replace(/^\//, '') ?? ''
+        // コードポイント列のファイル名のみ許可 (パストラバーサル防止)
+        if (!/^[0-9a-f-]+\.svg$/.test(name)) return next()
+        try {
+          const data = readFileSync(resolve(src, name))
+          res.setHeader('Content-Type', 'image/svg+xml')
+          res.setHeader('Cache-Control', 'public, max-age=3600')
+          res.end(data)
+        } catch {
+          res.statusCode = 404
+          res.end()
+        }
+      })
+    },
+    writeBundle() {
+      cpSync(src, resolve(import.meta.dirname, outDir, 'twemoji'), {
+        recursive: true,
+      })
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
     vue(),
@@ -226,6 +267,7 @@ export default defineConfig({
     subsetTablerIcons(),
     preloadTablerFont(),
     injectAppVersion(),
+    twemojiAssets(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
## v1.33.0

Android のクラッシュ根治とメディア配信の作り替え。

### 🐛 Fixes

- **fix(media): wry Android の 10 秒フューズによるプロセス即死を止血** (20ade870)
  wry の Android 実装は custom protocol の応答を 10 秒で打ち切って panic する。応答締切 7s / フェッチ予算 6s / spawn_blocking / デコード寸法上限で、どの経路でも panic に到達しないようにした
- **fix(media): ndmedia を二段階配信にして直列パイプの占有を根絶** (e3563e5c)
  キャッシュヒットは即応答、ミスは透明プレースホルダ + 背景取得 + `media-fetched` イベントで `<img>` を自然再要求。変換結果 (variant) をディスクに永続化し再変換を排除

### ⚡ Performance

- **perf(media): 画像表示の高速化** (7fe1e10f)
  非 Android は単一トリップ配信 (往復 1 回)。アニメ絵文字 (GIF/APNG/Animated WebP) をヘッダ走査で検出して変換素通し。カスタム絵文字を w=64 固定バケットの `proxyEmojiUrl` に全 10 箇所統一 (通知カラムは従来プロキシ皆無だった)

### ♻️ Changes

- **refactor(emoji): twemoji を同梱に切替え CDN 個別取得をやめる** (c8a51b94)
  @discordapp/twemoji 16.0.1 の SVG 3,846 個を同梱 (+8.8MB、圧縮後 +2〜3MB)。ピッカー初回の数千リクエストが消滅
- **chore: windowing 層のピンを外し tauri 2.11.5 / wry 0.55.1 へ** (a86dd5e7)
  wry 0.55.0 の custom protocol panic 修正 (上流 PR #1699) を取り込み。⚠️ **前回この組み合わせで Android 起動クラッシュ (ndk_context) の前科あり — publish 前に draft の APK を sideload して起動確認すること**

Closes #855

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media proxy now serves a placeholder immediately, completes fetch/transcode in the background, then notifies the app when media is ready.
  * Added background media completion event support and improved cache variant persistence/deduplication.
  * Bundled Twemoji assets are served locally for more consistent emoji rendering.
* **Bug Fixes**
  * Strengthened safety checks for external media and safer image processing (reject likely animations, enforce decode size limits).
  * Prevented unbounded growth in media cache-busting generation tracking.
* **Chores**
  * Released version **1.33.0** with updated app/platform configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->