### PR TITLE
ci(android): スモークテストのスクリプトを dash 互換にする

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -160,8 +160,10 @@ jobs:
           arch: x86_64
           target: google_apis
           disable-animations: true
+          # このスクリプトは sh (dash) で実行される。bash 固有の構文
+          # (set -o pipefail など) を書くと構文エラーで即死する
           script: |
-            set -euo pipefail
+            set -eu
             APK=$(find apk -name '*x86_64*-release-*.apk' | head -1)
             if [ -z "$APK" ]; then
               echo "ERROR: x86_64 APK not found" >&2
@@ -174,14 +176,17 @@ jobs:
             adb logcat -c
             adb shell monkey -p com.notedeck.desktop -c android.intent.category.LAUNCHER 1
 
-            # 起動直後の native crash は数秒以内に出る。生存を確認する
+            # 起動直後の native crash は数秒以内に出る。生存を確認する。
+            # pidof はプロセスが無いと非 0 で終わるので set -e に巻き込まれ
+            # ないよう || true で受ける
             sleep 20
-            if ! adb shell pidof com.notedeck.desktop > /dev/null; then
+            PID=$(adb shell pidof com.notedeck.desktop 2>/dev/null | tr -d '\r\n' || true)
+            if [ -z "$PID" ]; then
               echo "::error::アプリが起動後 20 秒以内に終了した (起動クラッシュ)"
-              adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80
+              adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80 || true
               exit 1
             fi
-            echo "アプリは 20 秒間生存した"
+            echo "アプリは 20 秒間生存した (pid $PID)"
 
   # 起動確認を通った APK だけをリリースに載せる。build ジョブから直接
   # アップロードすると、smoke-test が落ちても壊れた APK が添付されてしまい


### PR DESCRIPTION
## What

エミュレータ起動スモークテストのスクリプトを dash 互換にする。

## Why

`android-emulator-runner` はスクリプトを `sh` (dash) で実行するため、bash 固有の `set -o pipefail` が構文エラーになっていた:

```
/usr/bin/sh: 1: set: Illegal option -o pipefail
```

エミュレータは正常に起動していた (Boot completed in 39418 ms) が、その直後にスクリプトごと落ちるため、**APK のインストールも起動も一度も試されないまま** smoke-test が fail していた (v1.33.1)。ゲート自体は正しく働き publish は skip されたので、壊れた APK が添付される事故は防がれている。

`pidof` はプロセスが無いと非 0 で終わるため `set -e` に巻き込まれる問題も併せて修正。

## Test

- `dash -n` で構文検証: pass
- `shellcheck -s dash` : 指摘なし