### PR TITLE
Release v1.33.2

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -160,8 +160,10 @@ jobs:
           arch: x86_64
           target: google_apis
           disable-animations: true
+          # このスクリプトは sh (dash) で実行される。bash 固有の構文
+          # (set -o pipefail など) を書くと構文エラーで即死する
           script: |
-            set -euo pipefail
+            set -eu
             APK=$(find apk -name '*x86_64*-release-*.apk' | head -1)
             if [ -z "$APK" ]; then
               echo "ERROR: x86_64 APK not found" >&2
@@ -174,14 +176,17 @@ jobs:
             adb logcat -c
             adb shell monkey -p com.notedeck.desktop -c android.intent.category.LAUNCHER 1
 
-            # 起動直後の native crash は数秒以内に出る。生存を確認する
+            # 起動直後の native crash は数秒以内に出る。生存を確認する。
+            # pidof はプロセスが無いと非 0 で終わるので set -e に巻き込まれ
+            # ないよう || true で受ける
             sleep 20
-            if ! adb shell pidof com.notedeck.desktop > /dev/null; then
+            PID=$(adb shell pidof com.notedeck.desktop 2>/dev/null | tr -d '\r\n' || true)
+            if [ -z "$PID" ]; then
               echo "::error::アプリが起動後 20 秒以内に終了した (起動クラッシュ)"
-              adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80
+              adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80 || true
               exit 1
             fi
-            echo "アプリは 20 秒間生存した"
+            echo "アプリは 20 秒間生存した (pid $PID)"
 
   # 起動確認を通った APK だけをリリースに載せる。build ジョブから直接
   # アップロードすると、smoke-test が落ちても壊れた APK が添付されてしまい

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.33.1",
+  "version": "1.33.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.33.1"
+version = "1.33.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.33.1"
+version = "1.33.2"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.33.1"
+    "version": "1.33.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## v1.33.2 — Android 版の配布

v1.33.1 は CI の不具合により Android APK を添付できないまま公開された。その復旧リリース。デスクトップ版に機能的な変更はない。

### 👷 CI

- **ci(android): スモークテストのスクリプトを dash 互換にする**
  `android-emulator-runner` はスクリプトを `sh` (dash) で実行するため、bash 固有の `set -o pipefail` が構文エラーになっていた。エミュレータは正常に起動していた (Boot completed in 39418 ms) が、直後にスクリプトごと落ちるため **APK のインストールも起動も一度も試されないまま** smoke-test が fail し、Android APK が添付されなかった。

  ゲート (`build → smoke-test → publish`) は正しく働き、壊れた APK が添付される事故は防がれている。

  `dash -n` と `shellcheck -s dash` で構文を検証済み。

### ℹ️ Android の配布ファイル

v1.33.1 で入った ABI 分割がこのリリースで初めて実際に配布される。実機はほぼ `arm64`。

- `NoteDeck-1.33.2-android-arm64.apk` ← 通常はこちら (**97MB → 約 24MB**)
- `NoteDeck-1.33.2-android-arm.apk` (32bit ARM / 2017 年以前の端末)
- `NoteDeck-1.33.2-android-x86_64.apk` (Chromebook・エミュレータ)

### 関連

- #858 Android 起動クラッシュ (v1.33.1 で修正済み、本リリースで初めて Android 版として配布)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android emulator smoke-test reliability and compatibility.
  * Enhanced diagnostics by reporting relevant logs when the app terminates unexpectedly.
  * Added clearer success reporting after the app launches successfully.

* **Release**
  * Updated the application to version 1.33.2 for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->