### PR TITLE
ci(android): スモークテストを動作する形に修正し、未署名 APK の配布を止める

### DIFF
--- a/.github/scripts/android-smoke-test.sh
+++ b/.github/scripts/android-smoke-test.sh
@@ -15,9 +15,13 @@ APK_DIR=${1:-apk}
 # 起動直後の native crash は数秒以内に出る
 SURVIVE_SECONDS=${2:-20}
 
-APK=$(find "$APK_DIR" -name '*x86_64*-release-*.apk' | head -1)
+# 署名済みだけを対象にする。Android は未署名 APK の install を
+# INSTALL_PARSE_FAILED_NO_CERTIFICATES で拒否するため、`-release-*.apk` の
+# ような緩い glob で unsigned / aligned を掴むとテストが成立しない
+APK=$(find "$APK_DIR" -name '*x86_64*-release-signed.apk' | head -1)
 if [ -z "$APK" ]; then
-  echo "ERROR: x86_64 の APK が見つからない ($APK_DIR)" >&2
+  echo "ERROR: 署名済みの x86_64 APK が見つからない ($APK_DIR)" >&2
+  echo "配布物は署名が必須。keystore の設定を確認すること" >&2
   find "$APK_DIR" -name '*.apk' >&2 || true
   exit 1
 fi

--- a/.github/scripts/android-smoke-test.sh
+++ b/.github/scripts/android-smoke-test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Android の起動スモークテスト (#858)。
+#
+# 起動直後の native crash はアプリ内の診断ログにも残らず、About ウィンドウ
+# すら開けないため、実際にエミュレータで起動させる以外に検出手段がない。
+# v1.33.0 はそれを検出できずに公開まで到達した。
+#
+# このファイルを独立させているのは、android-emulator-runner が `script:` を
+# **1 行ずつ別々の `sh -c` で実行する**ため。複数行の if/then/fi は成立せず、
+# 変数も行をまたいで保持されない。ワークフロー側からは 1 行で呼ぶこと。
+set -euo pipefail
+
+PACKAGE=com.notedeck.desktop
+APK_DIR=${1:-apk}
+# 起動直後の native crash は数秒以内に出る
+SURVIVE_SECONDS=${2:-20}
+
+APK=$(find "$APK_DIR" -name '*x86_64*-release-*.apk' | head -1)
+if [ -z "$APK" ]; then
+  echo "ERROR: x86_64 の APK が見つからない ($APK_DIR)" >&2
+  find "$APK_DIR" -name '*.apk' >&2 || true
+  exit 1
+fi
+
+echo "installing $APK"
+adb install -r "$APK"
+
+adb logcat -c
+adb shell monkey -p "$PACKAGE" -c android.intent.category.LAUNCHER 1
+
+sleep "$SURVIVE_SECONDS"
+
+# pidof はプロセスが無いと非 0 で終わるので set -e に巻き込ませない
+PID=$(adb shell pidof "$PACKAGE" 2>/dev/null | tr -d '\r\n' || true)
+if [ -z "$PID" ]; then
+  echo "::error::アプリが起動後 ${SURVIVE_SECONDS} 秒以内に終了した (起動クラッシュ)"
+  adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80 || true
+  exit 1
+fi
+
+echo "アプリは ${SURVIVE_SECONDS} 秒間生存した (pid $PID)"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -192,9 +192,10 @@ jobs:
 
           for FLAVOR_DIR in apk/*/release; do
             FLAVOR=$(basename "$(dirname "$FLAVOR_DIR")")
-            # 署名済みを優先し、無ければ未署名を配る (既存の挙動を踏襲)
+            # 署名済みのみを配る。未署名 APK は Android が
+            # INSTALL_PARSE_FAILED_NO_CERTIFICATES で install を拒否するため、
+            # フォールバックで配っても利用者はインストールできない
             APKS=("$FLAVOR_DIR"/*-release-signed.apk)
-            [ ${#APKS[@]} -eq 0 ] && APKS=("$FLAVOR_DIR"/*-release-unsigned.apk)
             [ ${#APKS[@]} -eq 0 ] && continue
             cp "${APKS[0]}" "NoteDeck-${VERSION}-android-${FLAVOR}.apk"
           done

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -160,33 +160,10 @@ jobs:
           arch: x86_64
           target: google_apis
           disable-animations: true
-          # このスクリプトは sh (dash) で実行される。bash 固有の構文
-          # (set -o pipefail など) を書くと構文エラーで即死する
-          script: |
-            set -eu
-            APK=$(find apk -name '*x86_64*-release-*.apk' | head -1)
-            if [ -z "$APK" ]; then
-              echo "ERROR: x86_64 APK not found" >&2
-              find apk -name '*.apk' >&2 || true
-              exit 1
-            fi
-            echo "installing $APK"
-            adb install -r "$APK"
-
-            adb logcat -c
-            adb shell monkey -p com.notedeck.desktop -c android.intent.category.LAUNCHER 1
-
-            # 起動直後の native crash は数秒以内に出る。生存を確認する。
-            # pidof はプロセスが無いと非 0 で終わるので set -e に巻き込まれ
-            # ないよう || true で受ける
-            sleep 20
-            PID=$(adb shell pidof com.notedeck.desktop 2>/dev/null | tr -d '\r\n' || true)
-            if [ -z "$PID" ]; then
-              echo "::error::アプリが起動後 20 秒以内に終了した (起動クラッシュ)"
-              adb logcat -d -t 300 | grep -iE 'notedeck|FATAL|AndroidRuntime|libc|DEBUG' | tail -80 || true
-              exit 1
-            fi
-            echo "アプリは 20 秒間生存した (pid $PID)"
+          # このアクションは script を 1 行ずつ別々の `sh -c` で実行する。
+          # 複数行の if/then/fi は成立せず変数も行をまたがないため、
+          # 本体はファイルに置いて 1 行で呼ぶ (詳細はスクリプト側の説明)
+          script: bash .github/scripts/android-smoke-test.sh apk 20
 
   # 起動確認を通った APK だけをリリースに載せる。build ジョブから直接
   # アップロードすると、smoke-test が落ちても壊れた APK が添付されてしまい


### PR DESCRIPTION
## What

1. スモークテスト本体を `.github/scripts/android-smoke-test.sh` へ切り出す
2. 署名済み APK のみを対象にする（スモークテスト・配布の両方）

## Why

### 1. スクリプトが実行されていなかった

`android-emulator-runner` は `script:` を **1 行ずつ別々の `sh -c` で実行する**。複数行の `if/then/fi` が成立せず、変数も行をまたいで保持されない:

```
sh -c set -eu
sh -c APK=$(find apk ...)
sh -c if [ -z "$APK" ]; then
/usr/bin/sh: 1: Syntax error: end of file unexpected (expecting "fi")
```

v1.33.1 / v1.33.2 はこれで Android APK を添付できなかった。ファイルに切り出してワークフローからは 1 行で呼ぶ。

### 2. 未署名 APK を掴んでいた（配布側にも同じ問題）

`*-release-*.apk` の glob が signed / unsigned / aligned すべてに一致し、`find` の順序で未署名を拾って install が `INSTALL_PARSE_FAILED_NO_CERTIFICATES` で失敗していた。

**配布側 (`publish` の Rename APKs) にも同じ問題があった。** 署名済みが無いとき未署名にフォールバックして配る実装だったが、未署名 APK は Android がインストールを拒否するため利用者は入れられない。フォールバックを外し署名済みのみを配る。

## Test

- `shellcheck` / `bash -n` : 指摘なし
- unsigned / aligned / signed が混在する実構成 + adb スタブで、正常系 (exit 0)・クラッシュ検出 (exit 1)・署名済み選択をローカル検証
- **実地検証 (workflow_dispatch, run 30604129795): smoke-test success**

  ```
  installing apk/x86_64/release/app-x86_64-release-signed.apk
  アプリは 20 秒間生存した (pid 3385)
  ```

  エミュレータ上でアプリが実際に起動し 20 秒生存。**#858 の起動クラッシュ修正が効いていることの実地確認になっている。**