### PR TITLE
Release v1.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.33.3",
+  "version": "1.33.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.33.3"
+version = "1.33.4"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.33.3"
+version = "1.33.4"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -28,8 +28,6 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
-import java.net.HttpURLConnection
-import java.net.URL
 import java.util.concurrent.TimeUnit
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -50,6 +48,12 @@ class MainActivity : TauriActivity() {
      */
     private const val EMOJI_CANVAS_W = 728
     private const val EMOJI_CANVAS_H = 128
+
+    /** decode 後の長辺の上限。large icon の表示サイズには十分 */
+    private const val AVATAR_MAX_DIM = 512
+
+    /** 絵文字 (big picture) の decode 上限。カンバス幅の 728px を賄える値 */
+    private const val EMOJI_MAX_DIM = 1024
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -100,8 +104,13 @@ class MainActivity : TauriActivity() {
    * しか渡せず (attachments は Android 側で無視される)、サーバーから取ってくる
    * 動的画像を添付できないため自前で組む。配置はデスクトップ (user-notify) と
    * 揃える:
-   *   avatarUrl -> large icon   (アクターのアバター。Windows の appLogoOverride)
-   *   imageUrl  -> big picture  (リアクションのカスタム絵文字。Windows のインライン画像)
+   *   avatarPath -> large icon   (アクターのアバター。Windows の appLogoOverride)
+   *   imagePath  -> big picture  (リアクションのカスタム絵文字。Windows のインライン画像)
+   *
+   * 画像は Rust 側が ImageCache (ディスクキャッシュ・サイズ上限・negative
+   * cache) を通してローカルファイル化済み。ここではネットワークに触れず
+   * decode するだけ。decode は inSampleSize で寸法を抑える — 上限なしの
+   * 原寸デコードは OutOfMemoryError でプロセスごと落ちる。
    *
    * クリック遷移は plugin の extra + JS onAction ではなく notedeck:// deep link
    * で行う (NotificationWorker と同じ経路。アプリ終了中のタップでも遷移できる)。
@@ -111,10 +120,10 @@ class MainActivity : TauriActivity() {
     title: String,
     body: String?,
     deepLink: String?,
-    avatarUrl: String?,
-    imageUrl: String?,
+    avatarPath: String?,
+    imagePath: String?,
   ) {
-    // 画像フェッチがあるので UI スレッドを塞がない
+    // Bitmap decode があるので UI スレッドを塞がない
     Thread {
       try {
         val builder = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
@@ -125,8 +134,10 @@ class MainActivity : TauriActivity() {
           .setContentIntent(buildContentIntent(id, deepLink))
         if (body != null) builder.setContentText(body)
 
-        avatarUrl?.let { fetchBitmap(it) }?.let { builder.setLargeIcon(circleCrop(it)) }
-        imageUrl?.let { fetchBitmap(it) }?.let {
+        avatarPath?.let { decodeBounded(it, AVATAR_MAX_DIM) }?.let {
+          builder.setLargeIcon(circleCrop(it))
+        }
+        imagePath?.let { decodeBounded(it, EMOJI_MAX_DIM) }?.let {
           builder.setStyle(
             NotificationCompat.BigPictureStyle().bigPicture(normalizeEmojiHeight(it))
           )
@@ -135,7 +146,9 @@ class MainActivity : TauriActivity() {
         val manager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE)
           as NotificationManager
         manager.notify(id, builder.build())
-      } catch (e: Exception) {
+      } catch (e: Throwable) {
+        // OutOfMemoryError 等の Error も含めて握る。生 Thread の未捕捉
+        // Throwable は uncaughtExceptionHandler がプロセスを殺す
         Log.w(TAG, "Failed to show notification", e)
       }
     }.start()
@@ -157,19 +170,24 @@ class MainActivity : TauriActivity() {
     )
   }
 
-  private fun fetchBitmap(url: String): Bitmap? {
+  /**
+   * 寸法を抑えてローカルファイルを decode する。まず bounds だけ読み、
+   * 長辺が maxDim に収まる inSampleSize を選んでから本体を decode する
+   * (Android 標準のサブサンプリングパターン)。任意の巨大寸法でもメモリを
+   * 確保しない。壊れた画像・寸法 0 は null (画像なしで通知を出す)。
+   */
+  private fun decodeBounded(path: String, maxDim: Int): Bitmap? {
     return try {
-      val conn = URL(url).openConnection() as HttpURLConnection
-      try {
-        conn.connectTimeout = 5_000
-        conn.readTimeout = 5_000
-        if (conn.responseCode != 200) return null
-        conn.inputStream.use { BitmapFactory.decodeStream(it) }
-      } finally {
-        conn.disconnect()
+      val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+      BitmapFactory.decodeFile(path, bounds)
+      if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
+      var sample = 1
+      while (bounds.outWidth / (sample * 2) >= maxDim || bounds.outHeight / (sample * 2) >= maxDim) {
+        sample *= 2
       }
-    } catch (e: Exception) {
-      Log.w(TAG, "Failed to fetch image: $url", e)
+      BitmapFactory.decodeFile(path, BitmapFactory.Options().apply { inSampleSize = sample })
+    } catch (e: Throwable) {
+      Log.w(TAG, "Failed to decode image: $path", e)
       null
     }
   }

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.33.3"
+    "version": "1.33.4"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -59,13 +59,19 @@ pub fn set_status_bar_style(light_background: bool) {
             let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
             let mut env = vm.attach_current_thread()?;
             let activity = unsafe { jni::objects::JObject::from_raw(ctx.context().cast()) };
-            env.call_method(
+            let call = env.call_method(
                 &activity,
                 "setStatusBarStyle",
                 "(Z)V",
                 &[jni::objects::JValue::Bool(light_background as u8)],
-            )?;
-            Ok(())
+            );
+            // 失敗時に JVM 側の pending exception を残すと、同一スレッドの
+            // 次の JNI 呼び出しで ART が abort する (プロセス即死)。必ずクリア
+            if call.is_err() && env.exception_check().unwrap_or(false) {
+                let _ = env.exception_describe();
+                let _ = env.exception_clear();
+            }
+            call.map(|_| ())
         })();
         if let Err(e) = result {
             tracing::warn!("[status-bar] JNI call failed: {e}");

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -24,6 +24,19 @@ const NEGATIVE_TTL_CLIENT: Duration = Duration::from_secs(24 * 60 * 60); // 4xx:
 const NEGATIVE_TTL_SERVER: Duration = Duration::from_secs(2 * 60); // 5xx: 2min
 const NEGATIVE_TTL_NETWORK: Duration = Duration::from_secs(5); // timeout/conn: 5s
 
+/// HTTP エラー status ごとの (negative cache TTL, host circuit breaker に
+/// 数えるか)。4xx はその URL 固有の問題 (辞書落ち絵文字の 404 等) なので
+/// host には数えない — 数えると 404 が数件連なるだけでそのサーバーの全
+/// メディアが circuit breaker で死ぬ。429 はホスト側の圧力なので、24h では
+/// なく短い TTL で引きつつ host にも数える。
+fn classify_http_failure(status: u16) -> (Duration, bool) {
+    match status {
+        429 => (NEGATIVE_TTL_SERVER, true),
+        400..=499 => (NEGATIVE_TTL_CLIENT, false),
+        _ => (NEGATIVE_TTL_SERVER, true),
+    }
+}
+
 // Fallback defaults (used when perf_config is not available, e.g. in tests)
 const DEFAULT_MEMORY_CACHE_MAX_ITEM: usize = 256 * 1024;
 const DEFAULT_MEMORY_CACHE_MAX_TOTAL: usize = 32 * 1024 * 1024;
@@ -359,19 +372,15 @@ impl ImageCache {
         }
         let resp = req.send().await.map_err(|e| {
             let msg = format!("Fetch failed: {e:#}");
-            self.record_negative_and_notify(url, &hash, &tx, &msg, NEGATIVE_TTL_NETWORK);
+            self.record_negative_and_notify(url, &hash, &tx, &msg, NEGATIVE_TTL_NETWORK, true);
             msg
         })?;
 
         if !resp.status().is_success() {
             let status = resp.status().as_u16();
-            let ttl = if (400..500).contains(&status) {
-                NEGATIVE_TTL_CLIENT
-            } else {
-                NEGATIVE_TTL_SERVER
-            };
+            let (ttl, count_toward_circuit) = classify_http_failure(status);
             let msg = format!("HTTP {status}");
-            self.record_negative_and_notify(url, &hash, &tx, &msg, ttl);
+            self.record_negative_and_notify(url, &hash, &tx, &msg, ttl, count_toward_circuit);
             return Err(msg);
         }
 
@@ -379,8 +388,9 @@ impl ImageCache {
 
         if let Some(cl) = resp.content_length() {
             if cl > max_file_bytes {
+                // その URL 固有の問題なので host には数えない
                 let msg = "File too large".to_string();
-                self.record_negative_and_notify(url, &hash, &tx, &msg, NEGATIVE_TTL_CLIENT);
+                self.record_negative_and_notify(url, &hash, &tx, &msg, NEGATIVE_TTL_CLIENT, false);
                 return Err(msg);
             }
         }
@@ -546,6 +556,7 @@ impl ImageCache {
         tx: &watch::Sender<Option<Result<CacheEntry, String>>>,
         msg: &str,
         ttl: Duration,
+        count_toward_circuit: bool,
     ) {
         let neg = self.negative_cache.clone();
         let inflight = self.inflight.clone();
@@ -561,8 +572,9 @@ impl ImageCache {
                 .await
                 .insert(hash.clone(), (Instant::now(), ttl));
             inflight.lock().await.remove(&hash);
-            // Update host circuit breaker
-            if !host.is_empty() {
+            // Update host circuit breaker (network/5xx/429 のみ — 分類は
+            // classify_http_failure 参照)
+            if count_toward_circuit && !host.is_empty() {
                 let mut circuits = host_circuits.write().await;
                 let state = circuits.entry(host).or_insert(HostCircuitState {
                     consecutive_failures: 0,
@@ -713,6 +725,19 @@ pub fn hex_hash(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// 4xx (404 等) は URL 固有の問題なので host circuit breaker に数えない。
+    /// 数えると辞書落ち絵文字の 404 が数件連なるだけでサーバーの全メディアが
+    /// 60 秒死ぬ。429 はホスト圧力なので短 TTL + circuit 加算。
+    #[test]
+    fn http_failure_classification() {
+        assert_eq!(classify_http_failure(404), (NEGATIVE_TTL_CLIENT, false));
+        assert_eq!(classify_http_failure(403), (NEGATIVE_TTL_CLIENT, false));
+        // 429 を 24h 封印すると一時的なレート制限で絵文字が丸 1 日消える
+        assert_eq!(classify_http_failure(429), (NEGATIVE_TTL_SERVER, true));
+        assert_eq!(classify_http_failure(500), (NEGATIVE_TTL_SERVER, true));
+        assert_eq!(classify_http_failure(502), (NEGATIVE_TTL_SERVER, true));
+    }
 
     #[test]
     fn hex_hash_deterministic() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ mod crash_report;
 mod image_cache;
 mod media_proxy;
 mod migrations;
+mod notify_media;
 mod ogp;
 mod os_notify;
 mod perf_config;

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -100,7 +100,8 @@ impl MediaRequest {
 /// 20000×20000 の PNG は RGBA 展開で 1.6GB に膨らみ、Android では malloc
 /// abort がログを残さずプロセスを殺す。変換対象はサムネイル用途なので
 /// これを超える原本は変換せずそのまま返す (WebView 側に委ねる)。
-const MAX_DECODE_DIMENSION: u32 = 8192;
+/// os_notify (デスクトップ通知画像の PNG 変換) も同じ上限を使う。
+pub(crate) const MAX_DECODE_DIMENSION: u32 = 8192;
 
 /// アニメーションの可能性があるか (ヘッダ走査のみ、デコードしない)。
 /// 変換 (リサイズ/再エンコード) はアニメーションを 1 フレーム目に潰すため、
@@ -403,7 +404,8 @@ async fn ensure_media(app: AppHandle, cache: Arc<ImageCache>, req: MediaRequest)
 
 /// オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して cache_key で
 /// 永続化し、配信可能なバイト列と content-type を返す。
-async fn ensure_media_inner(
+/// notify_media (OS 通知の画像取得) も同じ口を使う。
+pub(crate) async fn ensure_media_inner(
     cache: &ImageCache,
     req: &MediaRequest,
 ) -> Result<(Vec<u8>, String), String> {

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -36,9 +36,9 @@ pub struct MediaFetched {
 /// (プロキシ迂回で原寸直読み) を誤爆させるため、成功扱いの透明画像で場を
 /// 持たせ、取得完了イベントで差し替えさせる。
 const PLACEHOLDER_GIF: &[u8] = &[
-    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x00, 0x00,
-    0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x44, 0x00, 0x3B,
+    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x00, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x44, 0x00, 0x3B,
 ];
 
 /// 変換パラメータ込みのメディアリクエスト。
@@ -134,7 +134,9 @@ fn may_be_animated(data: &[u8]) -> bool {
     }
     if data.len() >= 16 && &data[0..4] == b"RIFF" && &data[8..12] == b"WEBP" {
         // ANIM チャンクは VP8X 直後に来るのでヘッダ近傍だけ見れば足りる
-        return data[12..data.len().min(64)].windows(4).any(|w| w == b"ANIM");
+        return data[12..data.len().min(64)]
+            .windows(4)
+            .any(|w| w == b"ANIM");
     }
     false
 }
@@ -227,11 +229,9 @@ async fn apply_transform(
     }
     let w = req.w;
     let format = req.format.clone();
-    tokio::task::spawn_blocking(move || {
-        match transform_image(&data, w, format.as_deref()) {
-            Some(transformed) => transformed,
-            None => (data, content_type),
-        }
+    tokio::task::spawn_blocking(move || match transform_image(&data, w, format.as_deref()) {
+        Some(transformed) => transformed,
+        None => (data, content_type),
     })
     .await
     // JoinError は closure の panic のみ (release は panic = "abort" が先に
@@ -250,7 +250,6 @@ async fn entry_bytes(entry: &CacheEntry) -> Result<Vec<u8>, String> {
             .map_err(|e| e.to_string()),
     }
 }
-
 
 /// custom protocol の応答締切。
 ///
@@ -305,7 +304,10 @@ async fn handle_uri_request_inner(
     };
     // wait=1: 上流取得を待つブロッキング応答 (上限は RESPONSE_DEADLINE)。
     // fetch()/Audio 要素のようにプレースホルダを飲み込めない消費者 (効果音) 用。
+    // soft=1 (wait と併用): 待ちはソフト予算までで、超過したらプレースホルダ +
+    // MediaFetched の二段階配信へ降格してよい (非 Android の画像用)。
     let wait = url::form_urlencoded::parse(query.as_bytes()).any(|(k, v)| k == "wait" && v == "1");
+    let soft = url::form_urlencoded::parse(query.as_bytes()).any(|(k, v)| k == "soft" && v == "1");
 
     let etag = req.etag();
     // 条件付きリクエスト: 同じ ETag を持っているなら本文を送らない
@@ -348,10 +350,14 @@ async fn handle_uri_request_inner(
         };
     }
 
+    if wait && soft {
+        return soft_wait_response(app, cache, req, &etag).await;
+    }
+
     if wait {
         // ブロッキング経路: プレースホルダを飲み込めない消費者 (効果音の
-        // fetch/Audio 要素) と、直列パイプ制約のない非 Android の単一トリップ
-        // 配信用。ensure と同じ経路なので変換結果 (variant) も永続化される
+        // fetch/Audio 要素) 用。ensure と同じ経路なので変換結果 (variant) も
+        // 永続化される
         return match ensure_media_inner(&cache, &req).await {
             Ok((bytes, content_type)) => ok_response(bytes, &content_type, &etag),
             Err(msg) => {
@@ -379,6 +385,67 @@ async fn handle_uri_request_inner(
         tokio::spawn(ensure_media(app, cache, req));
     }
     placeholder_response()
+}
+
+/// ソフト予算付きブロッキング (非 Android の画像) の待ち時間上限。
+///
+/// キャッシュ済み・軽い取得はこの予算内に収まり単一トリップで返る。
+/// セマフォ枯渇 (大量絵文字バースト・プリフェッチ競合) や遅い上流では
+/// 予算超過でプレースホルダに降格し、二段階配信 (MediaFetched → 再要求)
+/// が引き継ぐ。以前はここが RESPONSE_DEADLINE (7s) までのフルブロッキング
+/// だったため、バースト時に `<img>` が 7 秒空白のまま → 504 → onerror の
+/// unknown 固定化、という経路になっていた。
+const SOFT_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_millis(1500);
+
+/// wait=1&soft=1 の応答。予算内に取得できれば本物を返し、超過したら
+/// プレースホルダへ降格する。取得タスクは応答後も完走し、降格した場合
+/// (受信側 drop) のみ MediaFetched を emit して `<img>` に再要求させる
+/// (予算内に返せた場合の emit は余計な世代 bump = 再読込になるので送らない)。
+///
+/// begin_ensure の重複排除は使わない: 同一 key の同時要求は fetch_streaming
+/// の inflight dedup が上流アクセスを 1 本にまとめるので、重複するのは
+/// 軽い変換だけ。ここで dedup すると「後着がプレースホルダを受け取ったのに
+/// 完了イベントが来ない」競合を生む。
+async fn soft_wait_response(
+    app: AppHandle,
+    cache: Arc<ImageCache>,
+    req: MediaRequest,
+    etag: &str,
+) -> tauri::http::Response<Vec<u8>> {
+    // 失敗直後 (negative cache) / 既知のダウンホストは即エラー。hard wait と
+    // 違い、ここで遮断しないと「プレースホルダ → 失敗イベント → 再要求」の
+    // 空回りに合流する
+    if cache.is_fast_fail(&req.url).await {
+        return error_response(
+            tauri::http::StatusCode::BAD_GATEWAY,
+            "upstream recently failed",
+        );
+    }
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Result<(Vec<u8>, String), String>>();
+    tokio::spawn(async move {
+        let result = ensure_media_inner(&cache, &req).await;
+        if let Err(ref msg) = result {
+            tracing::warn!(url = %req.url, error = %msg, "ndmedia: soft-wait fetch failed");
+        }
+        if let Err(result) = done_tx.send(result) {
+            // 受信側が予算超過でプレースホルダに降格済み → 完了イベントで
+            // 再要求させる (成否によらず emit — 失敗は negative cache が
+            // 502 で受け止め、onerror → バックオフ再試行に繋がる)
+            use tauri_specta::Event;
+            MediaFetched {
+                url: req.url.clone(),
+                ok: result.is_ok(),
+            }
+            .emit(&app)
+            .ok();
+        }
+    });
+    match tokio::time::timeout(SOFT_WAIT_BUDGET, done_rx).await {
+        Ok(Ok(Ok((bytes, content_type)))) => ok_response(bytes, &content_type, etag),
+        Ok(Ok(Err(msg))) => error_response(tauri::http::StatusCode::BAD_GATEWAY, &msg),
+        // 予算超過 (or 取得タスクの panic — release では abort が先に効く)
+        _ => placeholder_response(),
+    }
 }
 
 /// 背景取得: オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して
@@ -444,11 +511,7 @@ pub(crate) async fn ensure_media_inner(
     Ok((bytes, content_type))
 }
 
-fn ok_response(
-    bytes: Vec<u8>,
-    content_type: &str,
-    etag: &str,
-) -> tauri::http::Response<Vec<u8>> {
+fn ok_response(bytes: Vec<u8>, content_type: &str, etag: &str) -> tauri::http::Response<Vec<u8>> {
     tauri::http::Response::builder()
         .status(tauri::http::StatusCode::OK)
         .header("Content-Type", content_type)
@@ -476,7 +539,10 @@ fn placeholder_response() -> tauri::http::Response<Vec<u8>> {
 
 const CACHE_CONTROL: &str = "public, max-age=86400, immutable";
 
-fn error_response(status: tauri::http::StatusCode, message: &str) -> tauri::http::Response<Vec<u8>> {
+fn error_response(
+    status: tauri::http::StatusCode,
+    message: &str,
+) -> tauri::http::Response<Vec<u8>> {
     tauri::http::Response::builder()
         .status(status)
         // 失敗も fetch 側で読めるようにする (CORS で潰れると原因が見えない)
@@ -496,8 +562,9 @@ mod tests {
 
     #[test]
     fn parses_url_with_transform_params() {
-        let req = MediaRequest::from_query("url=https%3A%2F%2Fexample.com%2Fa.png&w=56&format=webp")
-            .expect("should parse");
+        let req =
+            MediaRequest::from_query("url=https%3A%2F%2Fexample.com%2Fa.png&w=56&format=webp")
+                .expect("should parse");
         assert_eq!(req.url, "https://example.com/a.png");
         assert_eq!(req.w, Some(56));
         assert_eq!(req.format.as_deref(), Some("webp"));
@@ -584,7 +651,8 @@ mod tests {
             let img = image::RgbaImage::from_pixel(100, 100, image::Rgba([1, 2, 3, 255]));
             let mut buf = std::io::Cursor::new(Vec::new());
             let mut enc = image::codecs::gif::GifEncoder::new(&mut buf);
-            enc.encode_frame(image::Frame::new(img)).expect("encode gif");
+            enc.encode_frame(image::Frame::new(img))
+                .expect("encode gif");
             drop(enc);
             buf.into_inner()
         };
@@ -641,8 +709,8 @@ mod tests {
             .store_variant(url, png_bytes(200, 200), "image/png")
             .await;
 
-        let req = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56")
-            .expect("should parse");
+        let req =
+            MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").expect("should parse");
         let (bytes, content_type) = ensure_media_inner(&cache, &req)
             .await
             .expect("cached original should transform without network");

--- a/src-tauri/src/notify_media.rs
+++ b/src-tauri/src/notify_media.rs
@@ -1,0 +1,152 @@
+//! OS 通知に添付するメディアの取得口。
+//!
+//! 通知画像 (アバター・リアクション絵文字) は WebView の外 (OS の通知
+//! システム) で描画されるため custom protocol (`ndmedia`) を通せない。
+//! かつては各プラットフォームが独自に fetch していた (Android は Kotlin の
+//! HttpURLConnection で原寸 DL、デスクトップは os_notify 専用の reqwest) が、
+//! ImageCache の防御 (ディスク/メモリキャッシュ・in-flight dedup・negative
+//! cache・circuit breaker・サイズ上限) が一切効かない経路だった。ここに
+//! 一元化し、消費者へはキャッシュ済みのローカルファイル/バイト列を渡す。
+//! decode やプレゼンテーション変換 (円形クロップ・カンバス正規化) は
+//! 各プラットフォームのデコーダに残す (アニメーション対応形式が違うため)。
+
+use std::path::PathBuf;
+
+use crate::image_cache::ImageCache;
+use crate::media_proxy::MediaRequest;
+
+/// リアクション通知に添付するカスタム絵文字画像の URL。
+/// 本家 sw (create-notification.ts) と同じ `/emoji/<name>.webp` 形式で、
+/// `@.` の local マーカーごとサーバーが解決する。Unicode 絵文字 (コロン
+/// なし) は本文に出るので画像なし。パスは Url::set_path で percent-encode
+/// する (リアクション文字列は untrusted なので生で埋め込まない)。
+pub fn emoji_image_url(server_host: &str, reaction: &str) -> Option<String> {
+    if reaction.len() <= 2 || !reaction.starts_with(':') || !reaction.ends_with(':') {
+        return None;
+    }
+    let name = &reaction[1..reaction.len() - 1];
+    let mut url = url::Url::parse(&format!("https://{server_host}")).ok()?;
+    url.set_path(&format!("/emoji/{name}.webp"));
+    Some(url.to_string())
+}
+
+/// url を ImageCache 経由で取得し、キャッシュ済みローカルファイルのパスを
+/// 返す。`w` があれば静止画をサムネイル化した variant (webp) を指す。
+/// アニメーションは変換で潰れるため素通しされ、原本のパスが返る。
+/// 失敗はすべて None (画像なしで通知を出す)。
+#[cfg_attr(not(target_os = "android"), allow(dead_code))]
+pub async fn ensure_local_file(cache: &ImageCache, url: &str, w: Option<u32>) -> Option<PathBuf> {
+    let req = MediaRequest {
+        url: url.to_string(),
+        w,
+        format: None,
+    };
+    let key = req.cache_key();
+    if let Some(entry) = cache.check_cache_only(&key).await {
+        return Some(entry.path);
+    }
+    crate::media_proxy::ensure_media_inner(cache, &req)
+        .await
+        .ok()?;
+    // ensure_media_inner は変換の要不要によらず必ず cache_key で永続化する
+    // ので、直後の lookup はヒットする
+    cache.check_cache_only(&key).await.map(|entry| entry.path)
+}
+
+/// url を ImageCache 経由で取得し、バイト列で返す (デスクトップの PNG
+/// 再エンコード用)。失敗は None (画像なしで通知を出す)。
+#[cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(dead_code))]
+pub async fn ensure_bytes(cache: &ImageCache, url: &str) -> Option<Vec<u8>> {
+    let req = MediaRequest {
+        url: url.to_string(),
+        w: None,
+        format: None,
+    };
+    crate::media_proxy::ensure_media_inner(cache, &req)
+        .await
+        .ok()
+        .map(|(bytes, _content_type)| bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emoji_image_url_builds_sw_compatible_path() {
+        assert_eq!(
+            emoji_image_url("misskey.example", ":meow:").as_deref(),
+            Some("https://misskey.example/emoji/meow.webp")
+        );
+        // local マーカー (@.) はサーバーが解決するのでそのまま渡す
+        assert_eq!(
+            emoji_image_url("misskey.example", ":meow@.:").as_deref(),
+            Some("https://misskey.example/emoji/meow@..webp")
+        );
+        // リモート絵文字の host 部もパスとして素通し (本家 sw と同じ)
+        assert_eq!(
+            emoji_image_url("misskey.example", ":meow@remote.example:").as_deref(),
+            Some("https://misskey.example/emoji/meow@remote.example.webp")
+        );
+    }
+
+    #[test]
+    fn emoji_image_url_rejects_non_custom_reactions() {
+        assert_eq!(emoji_image_url("misskey.example", "🎉"), None);
+        assert_eq!(emoji_image_url("misskey.example", "::"), None);
+        assert_eq!(emoji_image_url("misskey.example", ":"), None);
+        assert_eq!(emoji_image_url("misskey.example", ""), None);
+    }
+
+    #[test]
+    fn emoji_image_url_percent_encodes_unsafe_chars() {
+        // 名前に URL として不正な文字が混ざっても壊れた URL を作らない
+        assert_eq!(
+            emoji_image_url("misskey.example", ":a b:").as_deref(),
+            Some("https://misskey.example/emoji/a%20b.webp")
+        );
+    }
+
+    fn png_bytes(w: u32, h: u32) -> Vec<u8> {
+        let img = image::RgbaImage::from_pixel(w, h, image::Rgba([10, 20, 30, 255]));
+        let mut buf = Vec::new();
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut std::io::Cursor::new(&mut buf), image::ImageFormat::Png)
+            .expect("encode png");
+        buf
+    }
+
+    #[tokio::test]
+    async fn ensure_local_file_returns_variant_and_original_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        let url = "https://e.com/a.png";
+        // オリジナルをキャッシュ済みにしておく (ネットワーク不要で完結)
+        cache
+            .store_variant(url, png_bytes(200, 200), "image/png")
+            .await;
+
+        // w 指定 → リサイズ variant のパスが返り、実在する
+        let variant = ensure_local_file(&cache, url, Some(64))
+            .await
+            .expect("variant path");
+        assert!(variant.exists());
+
+        // 変換なし → オリジナルのパス
+        let original = ensure_local_file(&cache, url, None)
+            .await
+            .expect("original path");
+        assert!(original.exists());
+        assert_ne!(variant, original);
+    }
+
+    #[tokio::test]
+    async fn ensure_local_file_fails_closed_on_unfetchable_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        // 未キャッシュ + SSRF ガードで弾かれる host → None (画像なしで通知)
+        assert!(ensure_local_file(&cache, "https://localhost/x.png", None)
+            .await
+            .is_none());
+    }
+}

--- a/src-tauri/src/os_notify.rs
+++ b/src-tauri/src/os_notify.rs
@@ -107,11 +107,15 @@ mod desktop {
 
     /// OS 通知を表示する。context があればクリック時の遷移ペイロードとして
     /// user_info に積み、media があればアバター/絵文字画像を添付する。
+    /// 画像の取得は ImageCache (ディスク/メモリキャッシュ・negative cache・
+    /// circuit breaker・サイズ上限) を通す。cache が None (未初期化) なら
+    /// 画像なしで表示する。
     pub fn show(
         title: &str,
         body: Option<&str>,
         context: Option<&NotificationClicked>,
         media: Option<&super::NotifyMedia>,
+        cache: Option<Arc<crate::image_cache::ImageCache>>,
     ) {
         // 未初期化 (ユニットテスト等) は no-op
         let Some(manager) = MANAGER.get() else {
@@ -140,17 +144,21 @@ mod desktop {
         let manager = Arc::clone(manager);
         let media = media.cloned();
         std::thread::spawn(move || {
-            if let Some(media) = media {
-                if let Some(path) = media.icon_url.as_deref().and_then(fetch_to_cache) {
+            if let (Some(media), Some(cache)) = (media, cache) {
+                if let Some(path) = media
+                    .icon_url
+                    .as_deref()
+                    .and_then(|url| fetch_to_cache(&cache, url))
+                {
                     builder = builder.set_icon(path).set_icon_round_crop(true);
                 }
                 if let Some(url) = media.image_url.as_deref() {
                     // Windows のみ高さを揃える (normalize_emoji_height 参照)。
                     // Linux は ImageData ヒントで小さな枠に収まるので原寸のまま。
                     #[cfg(target_os = "windows")]
-                    let path = cache_png(url, "-emoji", normalize_emoji_height);
+                    let path = cache_png(&cache, url, "-emoji", normalize_emoji_height);
                     #[cfg(not(target_os = "windows"))]
-                    let path = fetch_to_cache(url);
+                    let path = fetch_to_cache(&cache, url);
                     if let Some(path) = path {
                         builder = builder.set_image(path);
                     }
@@ -162,22 +170,15 @@ mod desktop {
         });
     }
 
-    fn http_client() -> &'static reqwest::Client {
-        static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
-        CLIENT.get_or_init(|| {
-            reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(4))
-                .build()
-                .unwrap_or_default()
-        })
-    }
-
-    /// 画像 URL を fetch して PNG に再エンコードし、キャッシュパスを返す。
+    /// 画像 URL を PNG に再エンコードし、キャッシュパスを返す。
     /// Misskey のアバター/絵文字は webp が多いが Windows toast は webp を
     /// 表示できないため、常に PNG へ変換する。失敗はすべて None (画像なしで
     /// 通知を出す)。
-    fn fetch_to_cache(url: &str) -> Option<std::path::PathBuf> {
-        cache_png(url, "", |img| {
+    fn fetch_to_cache(
+        cache: &crate::image_cache::ImageCache,
+        url: &str,
+    ) -> Option<std::path::PathBuf> {
+        cache_png(cache, url, "", |img| {
             // 通知アイコンには十分な解像度に抑える (メモリ・ディスク節約)
             if img.width() > 512 || img.height() > 512 {
                 img.thumbnail(512, 512)
@@ -187,9 +188,11 @@ mod desktop {
         })
     }
 
-    /// fetch → transform → PNG 保存。suffix はキャッシュキーの区別用
-    /// (同じ URL でも変換後の画像は別ファイルになる)。
+    /// ImageCache 経由で取得 → decode (寸法上限あり) → transform → PNG 保存。
+    /// suffix はキャッシュキーの区別用 (同じ URL でも変換後の画像は別ファイル
+    /// になる)。専用スレッド上なので block_on してよい。
     fn cache_png(
+        cache: &crate::image_cache::ImageCache,
         url: &str,
         suffix: &str,
         transform: impl FnOnce(image::DynamicImage) -> image::DynamicImage,
@@ -200,14 +203,17 @@ mod desktop {
         if path.exists() {
             return Some(path);
         }
-        let bytes = tauri::async_runtime::block_on(async {
-            let resp = http_client().get(url).send().await.ok()?;
-            if !resp.status().is_success() {
-                return None;
-            }
-            resp.bytes().await.ok()
-        })?;
-        let img = transform(image::load_from_memory(&bytes).ok()?);
+        let bytes = tauri::async_runtime::block_on(crate::notify_media::ensure_bytes(cache, url))?;
+        // 寸法上限なしの decode は巨大 PNG の RGBA 展開でメモリを食い潰す。
+        // ndmedia の変換 (media_proxy::transform_image) と同じ上限を掛ける
+        let mut reader = image::ImageReader::new(std::io::Cursor::new(&bytes))
+            .with_guessed_format()
+            .ok()?;
+        let mut limits = image::Limits::default();
+        limits.max_image_width = Some(crate::media_proxy::MAX_DECODE_DIMENSION);
+        limits.max_image_height = Some(crate::media_proxy::MAX_DECODE_DIMENSION);
+        reader.limits(limits);
+        let img = transform(reader.decode().ok()?);
         img.save_with_format(&path, image::ImageFormat::Png).ok()?;
         Some(path)
     }
@@ -280,7 +286,10 @@ pub fn decode_protocol_url(url: &str) -> Option<NotificationClicked> {
             return None;
         }
     };
-    if !matches!(resp.action, user_notify::NotificationResponseAction::Default) {
+    if !matches!(
+        resp.action,
+        user_notify::NotificationResponseAction::Default
+    ) {
         return None;
     }
     Some(NotificationClicked {

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -118,11 +118,15 @@ fn show_os_notification<R: tauri::Runtime>(
     media: Option<&NotifyMedia>,
     host: Option<&str>,
 ) {
-    // Linux / Windows: user-notify 経由 (クリック遷移 + 画像添付, #754)
+    // Linux / Windows: user-notify 経由 (クリック遷移 + 画像添付, #754)。
+    // 画像取得は ImageCache を通す (setup 前の呼び出しでは None = 画像なし)
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
-        let _ = (app, host);
-        crate::os_notify::show(title, body, context, media);
+        let _ = host;
+        let cache = app
+            .try_state::<std::sync::Arc<crate::image_cache::ImageCache>>()
+            .map(|s| s.inner().clone());
+        crate::os_notify::show(title, body, context, media, cache);
     }
 
     // macOS: user-notify は署名済み bundle 必須のため plugin 経路を維持
@@ -145,53 +149,137 @@ fn show_os_notification<R: tauri::Runtime>(
     // 動的画像を添付できないため。配置はデスクトップと同じ (icon=アバター,
     // image=絵文字)。クリック遷移は plugin の extra + JS onAction ではなく
     // notedeck:// deep link で行う (NotificationWorker と同じ経路)。
+    //
+    // 画像は ImageCache 経由でローカルファイル化してから Kotlin にパスを渡す。
+    // 以前は Kotlin 側が生 URL を HttpURLConnection で fetch + 原寸デコード
+    // していたが、キャッシュ・サイズ上限・失敗学習が一切効かず、巨大画像の
+    // OutOfMemoryError (Kotlin の catch (Exception) では捕まえられない) で
+    // プロセスごと落ちる経路だった。取得は emitter (WS 読みループ) を
+    // 塞がないよう spawn したタスクで行う。
     #[cfg(target_os = "android")]
     {
-        let _ = app;
-        let deep_link = host.and_then(|host| android_deep_link(host, context));
-        let result = (|| -> std::result::Result<(), jni::errors::Error> {
-            use jni::objects::{JObject, JValue};
+        // 通知の large icon の表示上限は 64dp 程度。3x 密度でも足りる幅の
+        // variant を要求する (静止画のみ縮小、アニメーションは原本素通し)
+        const AVATAR_MAX_WIDTH: u32 = 256;
 
-            let ctx = ndk_context::android_context();
-            let vm = unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) }?;
-            let mut env = vm.attach_current_thread()?;
-            let activity = unsafe { JObject::from_raw(ctx.context().cast()) };
-
-            // Option<&str> → Java の String / null
-            fn jstr<'a>(
-                env: &mut jni::JNIEnv<'a>,
-                s: Option<&str>,
-            ) -> std::result::Result<JObject<'a>, jni::errors::Error> {
-                match s {
-                    Some(s) => Ok(env.new_string(s)?.into()),
-                    None => Ok(JObject::null()),
+        let deep_link = host.and_then(|h| android_deep_link(h, context));
+        let app = app.clone();
+        let title = title.to_string();
+        let body = body.map(str::to_string);
+        let icon_url = media.and_then(|m| m.icon_url.clone());
+        let image_url = media.and_then(|m| m.image_url.clone());
+        tauri::async_runtime::spawn(async move {
+            // ImageCache は setup で manage される。未登録 (起動直後) なら
+            // 画像なしで通知だけ出す
+            let cache = app
+                .try_state::<std::sync::Arc<crate::image_cache::ImageCache>>()
+                .map(|s| s.inner().clone());
+            let (icon_path, image_path) = match cache {
+                Some(cache) => {
+                    let icon = match icon_url {
+                        Some(u) => {
+                            crate::notify_media::ensure_local_file(
+                                &cache,
+                                &u,
+                                Some(AVATAR_MAX_WIDTH),
+                            )
+                            .await
+                        }
+                        None => None,
+                    };
+                    // 絵文字はアニメーション保持のため変換なし (原本)。decode の
+                    // メモリ安全は Kotlin 側の inSampleSize が担保する
+                    let image = match image_url {
+                        Some(u) => crate::notify_media::ensure_local_file(&cache, &u, None).await,
+                        None => None,
+                    };
+                    (icon, image)
                 }
-            }
+                None => (None, None),
+            };
+            show_android_notification(
+                &title,
+                body.as_deref(),
+                deep_link.as_deref(),
+                icon_path.as_deref().and_then(|p| p.to_str()),
+                image_path.as_deref().and_then(|p| p.to_str()),
+            );
+        });
+    }
+}
 
-            let j_title = jstr(&mut env, Some(title))?;
-            let j_body = jstr(&mut env, body)?;
-            let j_link = jstr(&mut env, deep_link.as_deref())?;
-            let j_avatar = jstr(&mut env, media.and_then(|m| m.icon_url.as_deref()))?;
-            let j_image = jstr(&mut env, media.and_then(|m| m.image_url.as_deref()))?;
+/// MainActivity.showRichNotification を JNI で呼ぶ。avatar_path / image_path
+/// は ImageCache のローカルファイル (URL ではない)。
+#[cfg(target_os = "android")]
+fn show_android_notification(
+    title: &str,
+    body: Option<&str>,
+    deep_link: Option<&str>,
+    avatar_path: Option<&str>,
+    image_path: Option<&str>,
+) {
+    use jni::objects::{JObject, JValue};
 
-            env.call_method(
-                &activity,
-                "showRichNotification",
-                "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
-                &[
-                    JValue::Int(next_notification_id()),
-                    JValue::Object(&j_title),
-                    JValue::Object(&j_body),
-                    JValue::Object(&j_link),
-                    JValue::Object(&j_avatar),
-                    JValue::Object(&j_image),
-                ],
-            )?;
-            Ok(())
-        })();
-        if let Err(e) = result {
-            tracing::warn!("[notification] JNI call failed: {e}");
+    let ctx = ndk_context::android_context();
+    let vm = match unsafe { jni::JavaVM::from_raw(ctx.vm().cast()) } {
+        Ok(vm) => vm,
+        Err(e) => {
+            tracing::warn!("[notification] JavaVM unavailable: {e}");
+            return;
         }
+    };
+    let mut env = match vm.attach_current_thread() {
+        Ok(env) => env,
+        Err(e) => {
+            tracing::warn!("[notification] attach_current_thread failed: {e}");
+            return;
+        }
+    };
+    let activity = unsafe { JObject::from_raw(ctx.context().cast()) };
+
+    // Option<&str> → Java の String / null
+    fn jstr<'a>(
+        env: &mut jni::JNIEnv<'a>,
+        s: Option<&str>,
+    ) -> std::result::Result<JObject<'a>, jni::errors::Error> {
+        match s {
+            Some(s) => Ok(env.new_string(s)?.into()),
+            None => Ok(JObject::null()),
+        }
+    }
+
+    let result = (|| -> std::result::Result<(), jni::errors::Error> {
+        let j_title = jstr(&mut env, Some(title))?;
+        let j_body = jstr(&mut env, body)?;
+        let j_link = jstr(&mut env, deep_link)?;
+        let j_avatar = jstr(&mut env, avatar_path)?;
+        let j_image = jstr(&mut env, image_path)?;
+
+        env.call_method(
+            &activity,
+            "showRichNotification",
+            "(ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+            &[
+                JValue::Int(next_notification_id()),
+                JValue::Object(&j_title),
+                JValue::Object(&j_body),
+                JValue::Object(&j_link),
+                JValue::Object(&j_avatar),
+                JValue::Object(&j_image),
+            ],
+        )?;
+        Ok(())
+    })();
+    if let Err(e) = result {
+        // Err を warn するだけで済ませると JVM 側の pending exception が残り、
+        // 同一スレッドの次の JNI 呼び出しで ART が "called with pending
+        // exception" として abort する (プロセス即死)。必ずクリアする
+        // (describe で logcat に原因を残す)
+        if env.exception_check().unwrap_or(false) {
+            let _ = env.exception_describe();
+            let _ = env.exception_clear();
+        }
+        tracing::warn!("[notification] JNI call failed: {e}");
     }
 }
 
@@ -373,8 +461,7 @@ impl<R: tauri::Runtime> TauriEmitter<R> {
         // 通知メディア: 本家 web push (icon=アバター, badge=絵文字) に倣い、
         // icon = アクターのアバター、リアクションのカスタム絵文字 (":name:" /
         // ":name@host:") はフルカラー画像として添付。Unicode 絵文字は本文に
-        // 出るので画像なし。絵文字 URL は本家 sw と同じ /emoji/<name>.webp
-        // (name は "@." の local マーカーごとサーバーが解決する)。
+        // 出るので画像なし。URL の形式は notify_media::emoji_image_url 参照。
         let media = {
             let icon_url = notification
                 .user
@@ -383,11 +470,7 @@ impl<R: tauri::Runtime> TauriEmitter<R> {
             let image_url = (notif_type == "reaction")
                 .then_some(notification.reaction.as_deref())
                 .flatten()
-                .filter(|r| r.len() > 2 && r.starts_with(':') && r.ends_with(':'))
-                .map(|r| {
-                    let name = &r[1..r.len() - 1];
-                    format!("https://{}/emoji/{}.webp", notification.server_host, name)
-                });
+                .and_then(|r| crate::notify_media::emoji_image_url(&notification.server_host, r));
             (icon_url.is_some() || image_url.is_some()).then_some(NotifyMedia {
                 icon_url,
                 image_url,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.33.3",
+  "version": "1.33.4",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -3,7 +3,10 @@ import { computed, useCssModule } from 'vue'
 import { useEmojiMute } from '@/composables/useEmojiMute'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
-import { onCustomEmojiImgError } from '@/utils/emojiImgError'
+import {
+  onCustomEmojiImgError,
+  onCustomEmojiImgLoad,
+} from '@/utils/emojiImgError'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
@@ -439,7 +442,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Code Block --><div v-else-if="token.type === 'codeBlock'" :key="`cb-${i}-${highlighterLoaded}`" :class="$style.mfmCodeBlock" v-html="highlightCode(token.value, token.lang)"></div><!--
     --><!-- Inline Code --><code v-else-if="token.type === 'inlineCode'" :class="$style.mfmCode">{{ token.value }}</code><!--
     --><!-- Custom Emoji (muted #612) --><span v-else-if="token.type === 'customEmoji' && isEmojiMuted(token.shortcode)" class="custom-emoji _emojiMuted" :class="plain ? $style.customEmojiPlain : $style.customEmoji" role="img" :aria-label="`:${token.shortcode}:`" :title="`:${token.shortcode}: (ミュート中)`"></span><!--
-    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" /><!--
+    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" @load="onCustomEmojiImgLoad" /><!--
     --><!-- Custom Emoji (unresolved — show fallback icon) --><img v-else-if="token.type === 'customEmoji'" src="/emoji-unknown.svg" :alt="`:${token.shortcode}:`" :title="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" /><!--
     --><!-- Unicode Emoji --><MkEmoji v-else-if="token.type === 'unicodeEmoji'" :emoji="token.value" class="twemoji" :class="$style.twemoji" /><!--
     --><!-- MFM Function: ruby --><ruby v-else-if="token.type === 'fn' && token.name === 'ruby' && rubyParts(token)">{{ rubyParts(token)![0] }}<rp>(</rp><rt>{{ rubyParts(token)![1] }}</rt><rp>)</rp></ruby><!--

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -3,6 +3,7 @@ import { computed, useCssModule } from 'vue'
 import { useEmojiMute } from '@/composables/useEmojiMute'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
@@ -438,7 +439,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Code Block --><div v-else-if="token.type === 'codeBlock'" :key="`cb-${i}-${highlighterLoaded}`" :class="$style.mfmCodeBlock" v-html="highlightCode(token.value, token.lang)"></div><!--
     --><!-- Inline Code --><code v-else-if="token.type === 'inlineCode'" :class="$style.mfmCode">{{ token.value }}</code><!--
     --><!-- Custom Emoji (muted #612) --><span v-else-if="token.type === 'customEmoji' && isEmojiMuted(token.shortcode)" class="custom-emoji _emojiMuted" :class="plain ? $style.customEmojiPlain : $style.customEmoji" role="img" :aria-label="`:${token.shortcode}:`" :title="`:${token.shortcode}: (ミュート中)`"></span><!--
-    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" /><!--
+    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" /><!--
     --><!-- Custom Emoji (unresolved — show fallback icon) --><img v-else-if="token.type === 'customEmoji'" src="/emoji-unknown.svg" :alt="`:${token.shortcode}:`" :title="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" /><!--
     --><!-- Unicode Emoji --><MkEmoji v-else-if="token.type === 'unicodeEmoji'" :emoji="token.value" class="twemoji" :class="$style.twemoji" /><!--
     --><!-- MFM Function: ruby --><ruby v-else-if="token.type === 'fn' && token.name === 'ruby' && rubyParts(token)">{{ rubyParts(token)![0] }}<rp>(</rp><rt>{{ rubyParts(token)![1] }}</rt><rp>)</rp></ruby><!--

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -3,10 +3,7 @@ import { computed, useCssModule } from 'vue'
 import { useEmojiMute } from '@/composables/useEmojiMute'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
-import {
-  onCustomEmojiImgError,
-  onCustomEmojiImgLoad,
-} from '@/utils/emojiImgError'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { proxyEmojiUrl } from '@/utils/mediaProxy'
 import { type MfmToken, parseMfm } from '@/utils/mfm'
@@ -442,7 +439,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
     --><!-- Code Block --><div v-else-if="token.type === 'codeBlock'" :key="`cb-${i}-${highlighterLoaded}`" :class="$style.mfmCodeBlock" v-html="highlightCode(token.value, token.lang)"></div><!--
     --><!-- Inline Code --><code v-else-if="token.type === 'inlineCode'" :class="$style.mfmCode">{{ token.value }}</code><!--
     --><!-- Custom Emoji (muted #612) --><span v-else-if="token.type === 'customEmoji' && isEmojiMuted(token.shortcode)" class="custom-emoji _emojiMuted" :class="plain ? $style.customEmojiPlain : $style.customEmoji" role="img" :aria-label="`:${token.shortcode}:`" :title="`:${token.shortcode}: (ミュート中)`"></span><!--
-    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" @load="onCustomEmojiImgLoad" /><!--
+    --><!-- Custom Emoji (resolved) --><img v-else-if="token.type === 'customEmoji' && emojiUrls[token.shortcode]" :src="proxyEmojiUrl(emojiUrls[token.shortcode]!)" :alt="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" /><!--
     --><!-- Custom Emoji (unresolved — show fallback icon) --><img v-else-if="token.type === 'customEmoji'" src="/emoji-unknown.svg" :alt="`:${token.shortcode}:`" :title="`:${token.shortcode}:`" class="custom-emoji" :class="plain ? $style.customEmojiPlain : $style.customEmoji" /><!--
     --><!-- Unicode Emoji --><MkEmoji v-else-if="token.type === 'unicodeEmoji'" :emoji="token.value" class="twemoji" :class="$style.twemoji" /><!--
     --><!-- MFM Function: ruby --><ruby v-else-if="token.type === 'fn' && token.name === 'ruby' && rubyParts(token)">{{ rubyParts(token)![0] }}<rp>(</rp><rt>{{ rubyParts(token)![1] }}</rt><rp>)</rp></ruby><!--

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -37,7 +37,10 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
-import { onCustomEmojiImgError } from '@/utils/emojiImgError'
+import {
+  onCustomEmojiImgError,
+  onCustomEmojiImgLoad,
+} from '@/utils/emojiImgError'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import {
@@ -899,7 +902,7 @@ function handlePickerReaction(reaction: string) {
               @mouseleave="reactionUsersRef?.hide()"
             >
               <span v-if="isEmojiMuted(r.reaction)" class="_emojiMuted" :class="$style.customEmoji" role="img" :aria-label="r.reaction" :title="`${r.reaction} (ミュート中)`" />
-              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" />
+              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" @load="onCustomEmojiImgLoad" />
               <img v-else-if="r.reaction.startsWith(':')" src="/emoji-unknown.svg" :alt="r.reaction" :title="r.reaction" :class="$style.customEmoji" />
               <MkEmoji v-else :emoji="r.reaction" :class="$style.reactionEmoji" />
               <span class="note-reaction-count" :class="$style.count">{{ r.count }}</span>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -37,6 +37,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import {
@@ -884,7 +885,7 @@ function handlePickerReaction(reaction: string) {
               @mouseleave="reactionUsersRef?.hide()"
             >
               <span v-if="isEmojiMuted(r.reaction)" class="_emojiMuted" :class="$style.customEmoji" role="img" :aria-label="r.reaction" :title="`${r.reaction} (ミュート中)`" />
-              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="(e: Event) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg' }" />
+              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" />
               <img v-else-if="r.reaction.startsWith(':')" src="/emoji-unknown.svg" :alt="r.reaction" :title="r.reaction" :class="$style.customEmoji" />
               <MkEmoji v-else :emoji="r.reaction" :class="$style.reactionEmoji" />
               <span class="note-reaction-count" :class="$style.count">{{ r.count }}</span>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -369,7 +369,16 @@ const sortedReactions = computed(() => {
   const counts = recountedCounts.value
   const visible = counts
     ? sorted
-        .map((r) => ({ ...r, count: counts[r.reaction] ?? 0 }))
+        .map((r) => ({
+          ...r,
+          // 自分のリアクションはミュート除外 (数え直し) の対象外。楽観的
+          // 更新の直後は古い列挙に自分がまだ居らず count 0 → チップごと
+          // 消えるため、最低 1 を保証する
+          count:
+            r.reaction === effectiveNote.value.myReaction
+              ? Math.max(counts[r.reaction] ?? 0, 1)
+              : (counts[r.reaction] ?? 0),
+        }))
         .filter((r) => r.count > 0)
     : sorted
   const urls = reactionsData.value.urls
@@ -538,6 +547,8 @@ function handleReactionClick(
     spawnRipple(rect.left + rect.width / 2, rect.top + rect.height / 2)
     spawnReactionEffect(btn)
   }
+  // 自分の操作による変化は IntersectionObserver の発火を待たず即描画する
+  reactionsVisible.value = true
   emit('react', reaction, effectiveNote.value)
 }
 
@@ -580,6 +591,9 @@ function handlePickerReaction(reaction: string) {
     void reactAs(crossTarget.accountId, effectiveNote.value, reaction)
     return
   }
+  // 0 → 1 個目のリアクションは reactionsArea 自体が今から生まれるため、
+  // IntersectionObserver の発火を待つと空箱が見える。自分の操作は即描画
+  reactionsVisible.value = true
   emit('react', reaction, effectiveNote.value)
   // Wait for optimistic update (RAF) + Vue render to complete,
   // then spawn floating effect on the newly created button.

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -37,10 +37,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useServersStore } from '@/stores/servers'
 import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
-import {
-  onCustomEmojiImgError,
-  onCustomEmojiImgLoad,
-} from '@/utils/emojiImgError'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import {
@@ -902,7 +899,7 @@ function handlePickerReaction(reaction: string) {
               @mouseleave="reactionUsersRef?.hide()"
             >
               <span v-if="isEmojiMuted(r.reaction)" class="_emojiMuted" :class="$style.customEmoji" role="img" :aria-label="r.reaction" :title="`${r.reaction} (ミュート中)`" />
-              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" @load="onCustomEmojiImgLoad" />
+              <img v-else-if="reactionUrls[r.reaction]" :src="proxyEmojiUrl(reactionUrls[r.reaction]!)" :alt="r.reaction" :class="$style.customEmoji" decoding="async" loading="lazy" @error="onCustomEmojiImgError" />
               <img v-else-if="r.reaction.startsWith(':')" src="/emoji-unknown.svg" :alt="r.reaction" :title="r.reaction" :class="$style.customEmoji" />
               <MkEmoji v-else :emoji="r.reaction" :class="$style.reactionEmoji" />
               <span class="note-reaction-count" :class="$style.count">{{ r.count }}</span>

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -428,7 +428,10 @@ async function handleReactionCrossAccount(
   if (!adapter) return
   const { toggleReaction } = await import('@/utils/toggleReaction')
   try {
-    await toggleReaction(adapter.api, target, reaction)
+    // スレッドは deep reactive (ref) なので、差分の代入で反映される
+    await toggleReaction(adapter.api, target, reaction, (patch) => {
+      Object.assign(target, patch)
+    })
   } catch {
     // ignore
   }

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -52,10 +52,7 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
-import {
-  onCustomEmojiImgError,
-  onCustomEmojiImgLoad,
-} from '@/utils/emojiImgError'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
@@ -484,10 +481,8 @@ function getCachedTwemojiUrl(reaction: string): string | null {
 }
 
 // 解決済み URL のロード失敗 (リモート鯖ダウン・プロキシ 502 等) は unknown 表示に
-// 落とし、バックオフ再試行を申告する (#844)。@load はプレースホルダ滞留の
-// 自己修復 (透明 1×1 のまま MediaFetched を取りこぼした場合)
+// 落とし、バックオフ再試行を申告する (#844)
 const onReactionImgError = onCustomEmojiImgError
-const onReactionImgLoad = onCustomEmojiImgLoad
 
 const NOTIFICATION_ICONS: Record<string, string> = {
   reaction: 'mood-plus',
@@ -1136,8 +1131,8 @@ onUnmounted(() => {
                     />
                     <template v-if="entry.reaction">
                       <span v-if="isEmojiMuted(entry.reaction)" :class="$style.notifSubIconMuted" role="img" :aria-label="entry.reaction" :title="`${entry.reaction} (ミュート中)`" />
-                      <img v-else-if="getCachedReactionUrl(entry.reaction, notif)" :src="getCachedReactionUrl(entry.reaction, notif)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
-                      <img v-else-if="getCachedTwemojiUrl(entry.reaction)" :src="getCachedTwemojiUrl(entry.reaction)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                      <img v-else-if="getCachedReactionUrl(entry.reaction, notif)" :src="getCachedReactionUrl(entry.reaction, notif)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
+                      <img v-else-if="getCachedTwemojiUrl(entry.reaction)" :src="getCachedTwemojiUrl(entry.reaction)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
                       <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
                     </template>
                     <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
@@ -1164,7 +1159,7 @@ onUnmounted(() => {
                       <template v-if="notif.type === 'reaction:grouped' && notif.reactions?.length">
                         <span v-for="reaction in uniqueReactions(notif.reactions)" :key="reaction" :class="$style.notifReaction">
                           <span v-if="isEmojiMuted(reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="reaction" :title="`${reaction} (ミュート中)`" />
-                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
                           <MkEmoji v-else :emoji="reaction" :class="$style.notifReactionEmoji" />
                         </span>
                       </template>
@@ -1223,8 +1218,8 @@ onUnmounted(() => {
                   />
                   <template v-if="notif.type === 'reaction' && notif.reaction">
                     <span v-if="isEmojiMuted(notif.reaction)" :class="$style.notifSubIconMuted" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
-                    <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
-                    <img v-else-if="getCachedTwemojiUrl(notif.reaction)" :src="getCachedTwemojiUrl(notif.reaction)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                    <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
+                    <img v-else-if="getCachedTwemojiUrl(notif.reaction)" :src="getCachedTwemojiUrl(notif.reaction)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
                     <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
                   </template>
                   <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
@@ -1241,7 +1236,7 @@ onUnmounted(() => {
                       <span :class="$style.notifLabel">{{ notificationLabel(notif.type) }}</span>
                       <span v-if="notif.type === 'reaction' && notif.reaction" :class="$style.notifReaction">
                         <span v-if="isEmojiMuted(notif.reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
-                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
                         <MkEmoji v-else :emoji="notif.reaction" :class="$style.notifReactionEmoji" />
                       </span>
                     </div>

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -52,7 +52,10 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
-import { onCustomEmojiImgError } from '@/utils/emojiImgError'
+import {
+  onCustomEmojiImgError,
+  onCustomEmojiImgLoad,
+} from '@/utils/emojiImgError'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
@@ -481,8 +484,10 @@ function getCachedTwemojiUrl(reaction: string): string | null {
 }
 
 // 解決済み URL のロード失敗 (リモート鯖ダウン・プロキシ 502 等) は unknown 表示に
-// 落とし、バックオフ再試行を申告する (#844)
+// 落とし、バックオフ再試行を申告する (#844)。@load はプレースホルダ滞留の
+// 自己修復 (透明 1×1 のまま MediaFetched を取りこぼした場合)
 const onReactionImgError = onCustomEmojiImgError
+const onReactionImgLoad = onCustomEmojiImgLoad
 
 const NOTIFICATION_ICONS: Record<string, string> = {
   reaction: 'mood-plus',
@@ -1131,8 +1136,8 @@ onUnmounted(() => {
                     />
                     <template v-if="entry.reaction">
                       <span v-if="isEmojiMuted(entry.reaction)" :class="$style.notifSubIconMuted" role="img" :aria-label="entry.reaction" :title="`${entry.reaction} (ミュート中)`" />
-                      <img v-else-if="getCachedReactionUrl(entry.reaction, notif)" :src="getCachedReactionUrl(entry.reaction, notif)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
-                      <img v-else-if="getCachedTwemojiUrl(entry.reaction)" :src="getCachedTwemojiUrl(entry.reaction)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
+                      <img v-else-if="getCachedReactionUrl(entry.reaction, notif)" :src="getCachedReactionUrl(entry.reaction, notif)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                      <img v-else-if="getCachedTwemojiUrl(entry.reaction)" :src="getCachedTwemojiUrl(entry.reaction)!" :alt="entry.reaction" :title="entry.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
                       <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
                     </template>
                     <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
@@ -1159,7 +1164,7 @@ onUnmounted(() => {
                       <template v-if="notif.type === 'reaction:grouped' && notif.reactions?.length">
                         <span v-for="reaction in uniqueReactions(notif.reactions)" :key="reaction" :class="$style.notifReaction">
                           <span v-if="isEmojiMuted(reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="reaction" :title="`${reaction} (ミュート中)`" />
-                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
+                          <img v-else-if="getCachedReactionUrl(reaction, notif)" :src="getCachedReactionUrl(reaction, notif)!" :alt="reaction" :title="reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
                           <MkEmoji v-else :emoji="reaction" :class="$style.notifReactionEmoji" />
                         </span>
                       </template>
@@ -1218,8 +1223,8 @@ onUnmounted(() => {
                   />
                   <template v-if="notif.type === 'reaction' && notif.reaction">
                     <span v-if="isEmojiMuted(notif.reaction)" :class="$style.notifSubIconMuted" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
-                    <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
-                    <img v-else-if="getCachedTwemojiUrl(notif.reaction)" :src="getCachedTwemojiUrl(notif.reaction)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" />
+                    <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
+                    <img v-else-if="getCachedTwemojiUrl(notif.reaction)" :src="getCachedTwemojiUrl(notif.reaction)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifSubIconEmoji" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
                     <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
                   </template>
                   <i v-else :class="[`ti ti-${notificationIcon(notif.type)}`, $style.notifSubIcon]" :style="{ background: notificationColor(notif.type) }" />
@@ -1236,7 +1241,7 @@ onUnmounted(() => {
                       <span :class="$style.notifLabel">{{ notificationLabel(notif.type) }}</span>
                       <span v-if="notif.type === 'reaction' && notif.reaction" :class="$style.notifReaction">
                         <span v-if="isEmojiMuted(notif.reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
-                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
+                        <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" @load="onReactionImgLoad" />
                         <MkEmoji v-else :emoji="notif.reaction" :class="$style.notifReactionEmoji" />
                       </span>
                     </div>

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -42,6 +42,7 @@ import { usePortal } from '@/composables/usePortal'
 import { useReadMarker } from '@/composables/useReadMarker'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getStreamHealth } from '@/core/streamHealth'
+import { syncNotificationNotes } from '@/services/notificationNoteSync'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
@@ -261,11 +262,9 @@ const notifications = shallowRef<NormalizedNotification[]>([])
 // 表示に届かない。mutation のたびに store 側の最新オブジェクトへ差し替えて
 // 反映する (shallowRef なので配列ごと新しくする)
 setOnNotesMutated(() => {
-  notifications.value = notifications.value.map((n) => {
-    if (!n.note) return n
-    const latest = noteStore.get(n.note.id)
-    return latest && latest !== n.note ? { ...n, note: latest } : n
-  })
+  notifications.value = syncNotificationNotes(notifications.value, (id) =>
+    noteStore.get(id),
+  )
 })
 
 // 前回読了位置マーカー (#750) — タイムラインと同じ localStorage 方式

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -111,6 +111,7 @@ const {
   handlers,
   scroller,
   onScroll,
+  setOnNotesMutated,
 } = useColumnSetup(() => props.column)
 
 const isLoggedOut = computed(() => account.value?.hasToken === false)
@@ -254,6 +255,18 @@ function closeUserPopup() {
 const perfStore = usePerformanceStore()
 const deckStore = useDeckStore()
 const notifications = shallowRef<NormalizedNotification[]>([])
+
+// リアクション等の楽観的更新 (handlers.reaction) は noteStore に入るが、
+// このカラムは notification.note を独自保持しているため store の変更が
+// 表示に届かない。mutation のたびに store 側の最新オブジェクトへ差し替えて
+// 反映する (shallowRef なので配列ごと新しくする)
+setOnNotesMutated(() => {
+  notifications.value = notifications.value.map((n) => {
+    if (!n.note) return n
+    const latest = noteStore.get(n.note.id)
+    return latest && latest !== n.note ? { ...n, note: latest } : n
+  })
+})
 
 // 前回読了位置マーカー (#750) — タイムラインと同じ localStorage 方式
 const { viewMarkerId } = useReadMarker(

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -52,6 +52,7 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
+import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { AppError } from '@/utils/errors'
 import { formatTime } from '@/utils/formatTime'
 import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
@@ -466,11 +467,9 @@ function getCachedTwemojiUrl(reaction: string): string | null {
   return url
 }
 
-// 解決済み URL のロード失敗 (リモート鯖ダウン・プロキシ 502 等) は unknown 表示に落とす (#844)
-function onReactionImgError(e: Event) {
-  const img = e.target as HTMLImageElement
-  if (!img.src.endsWith('/emoji-unknown.svg')) img.src = '/emoji-unknown.svg'
-}
+// 解決済み URL のロード失敗 (リモート鯖ダウン・プロキシ 502 等) は unknown 表示に
+// 落とし、バックオフ再試行を申告する (#844)
+const onReactionImgError = onCustomEmojiImgError
 
 const NOTIFICATION_ICONS: Record<string, string> = {
   reaction: 'mood-plus',

--- a/src/components/window/ClipDetailContent.vue
+++ b/src/components/window/ClipDetailContent.vue
@@ -13,6 +13,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useToast } from '@/stores/toast'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import { toggleReaction } from '@/utils/toggleReaction'
 import { webUiUrl } from '@/utils/url'
 
 const props = defineProps<{
@@ -62,6 +63,25 @@ const { filterVisible } = useNoteVisibility()
 const visibleNotes = computed(() =>
   filterVisible(notes.value, { ignoreSuspension: isOwnClip.value }),
 )
+
+async function handleReaction(reaction: string, target: NormalizedNote) {
+  if (!adapter) return
+  try {
+    await toggleReaction(adapter.api, target, reaction, (patch) => {
+      // shallowRef 保持なので新オブジェクトへの差し替えで反映する
+      notes.value = notes.value.map((n) =>
+        n.id === target.id
+          ? { ...n, ...patch }
+          : n.renote?.id === target.id
+            ? { ...n, renote: { ...n.renote, ...patch } }
+            : n,
+      )
+    })
+  } catch (e) {
+    const err = AppError.from(e)
+    toast.show(`リアクションに失敗しました（${err.displayCode}）`, 'error')
+  }
+}
 
 const clipWebUrl = computed(() => {
   if (!clip.value || !account.value?.host) return undefined
@@ -187,6 +207,7 @@ onMounted(async () => {
           :key="note.id"
           :note="note"
           :account-id="accountId"
+          @react="handleReaction"
         />
         <div v-if="notesLoading" :class="$style.notesLoading">
           <LoadingSpinner />

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -239,7 +239,10 @@ function reactionTypeUrl(type: string): string | null {
 async function handleReaction(reaction: string, target: NormalizedNote) {
   if (!adapter) return
   try {
-    await toggleReaction(adapter.api, target, reaction)
+    // note は deep reactive (ref) なので、差分の代入で反映される
+    await toggleReaction(adapter.api, target, reaction, (patch) => {
+      Object.assign(target, patch)
+    })
   } catch (e) {
     error.value = AppError.from(e)
   }

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -520,7 +520,24 @@ function handleComposeToUser(acct: string) {
 async function handleReaction(reaction: string, note: NormalizedNote) {
   if (!adapter.value) return
   try {
-    await toggleReaction(adapter.value.api, note, reaction)
+    await toggleReaction(adapter.value.api, note, reaction, (patch) => {
+      // 各面とも shallowRef 保持 (非 reactive オブジェクト) なので、
+      // 新オブジェクトへの差し替えで反映する。note がどの面から来たかは
+      // 追わず、全面を id で差し替える (リノートに包まれた表示も含む)
+      const updated = { ...note, ...patch }
+      const swap = (n: NormalizedNote) =>
+        n.id === note.id
+          ? updated
+          : n.renote?.id === note.id
+            ? { ...n, renote: updated }
+            : n
+      pinnedNotes.value = pinnedNotes.value.map(swap)
+      filesNotes.value = filesNotes.value.map(swap)
+      reactionEntries.value = reactionEntries.value.map((e) =>
+        e.note.id === note.id ? { ...e, note: updated } : e,
+      )
+      notesListRef.value?.replaceNote(note.id, updated)
+    })
   } catch (e) {
     error.value = AppError.from(e)
   }

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -169,7 +169,11 @@ export function useColumnSetup(
   async function handleReaction(reaction: string, note: NormalizedNote) {
     if (!adapter || checkOffline()) return
     try {
-      await toggleReaction(adapter.api, note, reaction, notifyMutationFor(note))
+      await toggleReaction(adapter.api, note, reaction, (patch) => {
+        // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
+        noteStore.update(note.id, { ...note, ...patch })
+        customMutatedFn?.()
+      })
       if (!getColumn().soundMuted) actionSound.play()
     } catch (e) {
       const err = AppError.from(e)

--- a/src/composables/useEmojiResolver.ts
+++ b/src/composables/useEmojiResolver.ts
@@ -12,7 +12,7 @@ export function useEmojiResolver() {
   ): string | null {
     const base = shortcode.replace(/@\.$/, '')
     const withDot = `${base}@.`
-    return (
+    const url =
       emojis[shortcode] ||
       emojis[base] ||
       emojis[withDot] ||
@@ -20,7 +20,10 @@ export function useEmojiResolver() {
       reactionEmojis[base] ||
       reactionEmojis[withDot] ||
       emojisStore.resolve(serverHost, base)
-    )
+    // どの層でも解決できない = 辞書が古い可能性 (起動後に追加された絵文字)。
+    // store に報告してデバウンス付きの取り直しをトリガーする
+    if (!url) emojisStore.reportMiss(serverHost, base)
+    return url
   }
 
   /** Resolve reaction key (e.g. ":emoji:") to URL, or null for Unicode emoji */

--- a/src/composables/useImagePrefetch.dom.test.ts
+++ b/src/composables/useImagePrefetch.dom.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NormalizedNote } from '@/adapters/types'
+
+vi.mock('@/stores/performance', () => ({
+  usePerformanceStore: () => ({
+    get: (key: string) => (key === 'cssBlurLevel' ? 5 : 500),
+  }),
+}))
+
+/** new Image() を記録するスタブ。onload/onerror を後から発火できる */
+class FakeImage {
+  static instances: FakeImage[] = []
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+  private _src = ''
+  constructor() {
+    FakeImage.instances.push(this)
+  }
+  set src(v: string) {
+    this._src = v
+  }
+  get src() {
+    return this._src
+  }
+}
+
+function note(id: string, fileCount: number): NormalizedNote {
+  return {
+    renote: null,
+    text: id,
+    files: Array.from({ length: fileCount }, (_, i) => ({
+      type: 'image/png',
+      isSensitive: false,
+      thumbnailUrl: `https://media.example/${id}-${i}.png`,
+      url: `https://media.example/${id}-${i}-orig.png`,
+    })),
+  } as unknown as NormalizedNote
+}
+
+async function loadModule() {
+  vi.resetModules()
+  return await import('@/composables/useImagePrefetch')
+}
+
+describe('prefetchNoteImages の同時実行絞り', () => {
+  beforeEach(() => {
+    FakeImage.instances = []
+    vi.stubGlobal('Image', FakeImage)
+  })
+
+  it('同時に発火する Image は上限までに絞られる', async () => {
+    const { prefetchNoteImages } = await loadModule()
+    prefetchNoteImages([note('a', 4), note('b', 4), note('c', 4)])
+    // 12 件エンキューされるが、同時に走るのは 4 件まで
+    expect(FakeImage.instances.length).toBe(4)
+  })
+
+  it('完了 (load/error) するたびに次をキューから流す', async () => {
+    const { prefetchNoteImages } = await loadModule()
+    prefetchNoteImages([note('a', 4), note('b', 4)])
+    expect(FakeImage.instances.length).toBe(4)
+
+    FakeImage.instances[0]?.onload?.()
+    expect(FakeImage.instances.length).toBe(5)
+
+    FakeImage.instances[1]?.onerror?.()
+    expect(FakeImage.instances.length).toBe(6)
+  })
+
+  it('同じ URL は一度しかプリフェッチしない', async () => {
+    const { prefetchNoteImages } = await loadModule()
+    prefetchNoteImages([note('a', 2)])
+    prefetchNoteImages([note('a', 2)])
+    // 2 回呼んでも Image は 2 件 (dedup)
+    expect(FakeImage.instances.length).toBe(2)
+  })
+})

--- a/src/composables/useImagePrefetch.ts
+++ b/src/composables/useImagePrefetch.ts
@@ -11,6 +11,45 @@ import { isSafeUrl } from '@/utils/url'
 
 const prefetchedUrls = new Set<string>()
 
+/**
+ * プリフェッチの同時実行上限。バックエンドの取得セマフォ (30 並列) は
+ * 絵文字・アバターと共有なので、先読みの添付画像で埋めると、いま見えて
+ * いる面の画像がソフト予算 (media_proxy::SOFT_WAIT_BUDGET) 超過に
+ * 押し出される。先読みは急がないので細く流す。
+ */
+const MAX_CONCURRENT_PREFETCH = 4
+
+/** 高速スクロールで陳腐化した先読みを溜め込まない上限 (古い順に捨てる) */
+const MAX_QUEUE = 100
+
+let activePrefetches = 0
+const prefetchQueue: string[] = []
+
+function pumpPrefetchQueue() {
+  while (
+    activePrefetches < MAX_CONCURRENT_PREFETCH &&
+    prefetchQueue.length > 0
+  ) {
+    const url = prefetchQueue.shift()
+    if (url === undefined) break
+    activePrefetches++
+    const img = new Image()
+    const done = () => {
+      activePrefetches--
+      pumpPrefetchQueue()
+    }
+    img.onload = done
+    img.onerror = done
+    img.src = url
+  }
+}
+
+function enqueuePrefetch(url: string) {
+  if (prefetchQueue.length >= MAX_QUEUE) prefetchQueue.shift()
+  prefetchQueue.push(url)
+  pumpPrefetchQueue()
+}
+
 function getTrackedMax(): number {
   try {
     return usePerformanceStore().get('prefetchTrackedMax')
@@ -56,8 +95,7 @@ export function prefetchNoteImages(notes: NormalizedNote[]): void {
       if (prefetchedUrls.has(url)) continue
       evictOldest()
       prefetchedUrls.add(url)
-      const img = new Image()
-      img.src = url
+      enqueuePrefetch(url)
     }
   }
 }

--- a/src/services/notificationNoteSync.test.ts
+++ b/src/services/notificationNoteSync.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
+import { syncNotificationNotes } from '@/services/notificationNoteSync'
+
+function makeNote(partial: Partial<NormalizedNote> = {}): NormalizedNote {
+  return {
+    id: 'n1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    text: 'hello',
+    user: {
+      id: 'u-author',
+      username: 'author',
+      name: 'Author',
+      host: null,
+      avatarUrl: null,
+    },
+    reactions: {},
+    reactionEmojis: {},
+    myReaction: null,
+    renoteCount: 0,
+    repliesCount: 0,
+    visibility: 'public',
+    ...partial,
+  } as NormalizedNote
+}
+
+function makeNotif(note?: NormalizedNote): NormalizedNotification {
+  return {
+    id: 'notif1',
+    _accountId: 'acc1',
+    _serverHost: 'example.com',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    type: 'reaction',
+    note,
+  }
+}
+
+describe('syncNotificationNotes', () => {
+  it('store の最新オブジェクトへ差し替える', () => {
+    const notif = makeNotif(makeNote())
+    const latest = makeNote({ reactions: { '👍': 1 } })
+
+    const result = syncNotificationNotes([notif], (id) =>
+      id === 'n1' ? latest : undefined,
+    )
+
+    expect(result[0]?.note).toBe(latest)
+  })
+
+  it('pure renote 経由でリアクションされた内側ノートも差し替える', () => {
+    const inner = makeNote({ id: 'inner', text: 'original' })
+    const outer = makeNote({
+      id: 'outer',
+      text: null,
+      renoteId: 'inner',
+      renote: inner,
+    })
+    const notif = makeNotif(outer)
+    // MkNote は pure renote の内側ノートを emit するので、noteStore は
+    // 内側の id で更新される (外側 'outer' は store に無い)
+    const latestInner = makeNote({
+      id: 'inner',
+      text: 'original',
+      reactions: { '👍': 1 },
+    })
+
+    const result = syncNotificationNotes([notif], (id) =>
+      id === 'inner' ? latestInner : undefined,
+    )
+
+    expect(result[0]?.note?.renote).toBe(latestInner)
+    expect(result[0]?.note?.id).toBe('outer')
+  })
+
+  it('変化が無ければ同一オブジェクトを返す (無駄な再描画を避ける)', () => {
+    const note = makeNote()
+    const notif = makeNotif(note)
+
+    const result = syncNotificationNotes([notif], (id) =>
+      id === 'n1' ? note : undefined,
+    )
+
+    expect(result[0]).toBe(notif)
+  })
+
+  it('note を持たない通知 (フォロー等) はそのまま通す', () => {
+    const notif = makeNotif(undefined)
+
+    const result = syncNotificationNotes([notif], () => undefined)
+
+    expect(result[0]).toBe(notif)
+  })
+
+  it('外側が一致する場合は内側を見ない (二重差し替えしない)', () => {
+    const inner = makeNote({ id: 'inner' })
+    const outer = makeNote({
+      id: 'outer',
+      text: null,
+      renoteId: 'inner',
+      renote: inner,
+    })
+    const notif = makeNotif(outer)
+    const latestOuter = makeNote({
+      id: 'outer',
+      text: null,
+      renoteId: 'inner',
+      renote: inner,
+      reactions: { '👍': 1 },
+    })
+
+    const result = syncNotificationNotes([notif], (id) =>
+      id === 'outer' ? latestOuter : makeNote({ id: 'unexpected' }),
+    )
+
+    expect(result[0]?.note).toBe(latestOuter)
+  })
+})

--- a/src/services/notificationNoteSync.ts
+++ b/src/services/notificationNoteSync.ts
@@ -1,0 +1,32 @@
+/**
+ * 通知カラムが独自保持する `notification.note` を noteStore の最新へ揃える規則。
+ *
+ * 通知カラムは note を noteStore 経由ではなく自分の配列に持つため、
+ * 楽観的更新 (toggleReaction) やストリーム適用が store に入っても表示へ
+ * 届かない。mutation のたびにここを通して最新オブジェクトへ差し替える。
+ *
+ * pure renote (リノート通知等) では MkNote が内側のノートを emit するので
+ * store は内側の id で更新される。外側の id しか照会しないと、リノート通知
+ * でリアクションを押しても表示が更新されない。`handlePosted` の編集反映と
+ * 同じく renoteId でも引き当てる。
+ */
+
+import type { NormalizedNote, NormalizedNotification } from '@/adapters/types'
+
+export function syncNotificationNotes(
+  notifications: NormalizedNotification[],
+  getNote: (id: string) => NormalizedNote | undefined,
+): NormalizedNotification[] {
+  return notifications.map((n) => {
+    if (!n.note) return n
+    const latest = getNote(n.note.id)
+    if (latest && latest !== n.note) return { ...n, note: latest }
+    if (n.note.renoteId) {
+      const latestRenote = getNote(n.note.renoteId)
+      if (latestRenote && latestRenote !== n.note.renote) {
+        return { ...n, note: { ...n.note, renote: latestRenote } }
+      }
+    }
+    return n
+  })
+}

--- a/src/services/streamUpdateMerge.test.ts
+++ b/src/services/streamUpdateMerge.test.ts
@@ -156,6 +156,20 @@ describe('mergeNoteUpdate', () => {
     expect(merged).toBeNull()
   })
 
+  it('guest (myUserId なし) では userId 欠落イベントを自分扱いしない', () => {
+    // userId を載せないサーバー実装がある。myUserId undefined × userId
+    // undefined の一致を「自分」と誤判定すると、ゲスト閲覧で myReaction が
+    // 立ってしまう。他人のリアクションとしてカウントだけ増やす
+    const note = makeNote()
+    const merged = mergeNoteUpdate(
+      note,
+      { type: 'reacted', noteId: 'n1', body: { reaction: '👍' } },
+      undefined,
+    )
+    expect(merged?.reactions['👍']).toBe(1)
+    expect(merged?.myReaction).toBeNull()
+  })
+
   it('自ユーザの unreacted: myReaction 一致なら取消を自己修復する (カウントは触らない)', () => {
     // カウントは「楽観減算済みの echo」と「別デバイス操作」を区別できない
     // ため触らず、myReaction だけ取り消す (二重減算の回帰を防ぐ)

--- a/src/services/streamUpdateMerge.test.ts
+++ b/src/services/streamUpdateMerge.test.ts
@@ -42,14 +42,58 @@ describe('mergeNoteUpdate', () => {
     expect(note.reactions['👍']).toBe(1)
   })
 
-  it('自ユーザの reacted は無視する (楽観的更新と二重加算しない)', () => {
-    const note = makeNote()
+  it('自ユーザの reacted: 楽観反映済み (myReaction 一致) の echo は無視する', () => {
+    const note = makeNote({ reactions: { '👍': 1 }, myReaction: '👍' })
     const merged = mergeNoteUpdate(
       note,
       { type: 'reacted', noteId: 'n1', body: { userId: 'me', reaction: '👍' } },
       'me',
     )
     expect(merged).toBeNull()
+  })
+
+  it('自ユーザの reacted: ローカルマーカー (@.) の形式差でも echo と判定する', () => {
+    // 楽観更新はピッカー形式 (:meow:)、サーバーイベントは :meow@.: で
+    // 届くことがある。素の一致比較だと二重加算になる
+    const note = makeNote({ reactions: { ':meow:': 1 }, myReaction: ':meow:' })
+    const merged = mergeNoteUpdate(
+      note,
+      {
+        type: 'reacted',
+        noteId: 'n1',
+        body: { userId: 'me', reaction: ':meow@.:' },
+      },
+      'me',
+    )
+    expect(merged).toBeNull()
+  })
+
+  it('自ユーザの reacted: 楽観未反映なら自己修復する (加算 + myReaction 設定)', () => {
+    // 楽観的更新が効かない面 (別ウィンドウ・別デバイス操作の反映) では、
+    // 自分のイベントが唯一の反映経路になる
+    const note = makeNote({ reactions: { '👍': 1 } })
+    const merged = mergeNoteUpdate(
+      note,
+      { type: 'reacted', noteId: 'n1', body: { userId: 'me', reaction: '🎉' } },
+      'me',
+    )
+    expect(merged?.reactions['🎉']).toBe(1)
+    expect(merged?.myReaction).toBe('🎉')
+  })
+
+  it('自ユーザの reacted: 形式違いの既存キーがあれば合流する (別チップを作らない)', () => {
+    const note = makeNote({ reactions: { ':meow:': 2 } })
+    const merged = mergeNoteUpdate(
+      note,
+      {
+        type: 'reacted',
+        noteId: 'n1',
+        body: { userId: 'me', reaction: ':meow@.:' },
+      },
+      'me',
+    )
+    expect(merged?.reactions[':meow:']).toBe(3)
+    expect(merged?.reactions[':meow@.:']).toBeUndefined()
   })
 
   it('カスタム絵文字はコロンを剥がして reactionEmojis に記録する', () => {
@@ -99,7 +143,7 @@ describe('mergeNoteUpdate', () => {
     expect(merged?.reactions['🎉']).toBe(2)
   })
 
-  it('自ユーザの unreacted は無視する', () => {
+  it('自ユーザの unreacted: 楽観反映済み (myReaction null) の echo は無視する', () => {
     const merged = mergeNoteUpdate(
       makeNote({ reactions: { '👍': 1 } }),
       {
@@ -110,6 +154,23 @@ describe('mergeNoteUpdate', () => {
       'me',
     )
     expect(merged).toBeNull()
+  })
+
+  it('自ユーザの unreacted: myReaction 一致なら取消を自己修復する (カウントは触らない)', () => {
+    // カウントは「楽観減算済みの echo」と「別デバイス操作」を区別できない
+    // ため触らず、myReaction だけ取り消す (二重減算の回帰を防ぐ)
+    const note = makeNote({ reactions: { '👍': 2 }, myReaction: '👍' })
+    const merged = mergeNoteUpdate(
+      note,
+      {
+        type: 'unreacted',
+        noteId: 'n1',
+        body: { userId: 'me', reaction: '👍' },
+      },
+      'me',
+    )
+    expect(merged?.myReaction).toBeNull()
+    expect(merged?.reactions['👍']).toBe(2)
   })
 
   it('pollVoted は該当 choice の票を増やし、自分の投票なら isVoted を立てる', () => {

--- a/src/services/streamUpdateMerge.ts
+++ b/src/services/streamUpdateMerge.ts
@@ -61,8 +61,33 @@ export function chatUpdateSig(event: ChatMessageUpdateEvent): string {
 }
 
 /**
- * noteUpdated イベントをノートへ適用した新オブジェクトを返す。
- * 適用不要 (自ユーザの reaction = 楽観的更新と二重になる / 対象なし) は null。
+ * reactions キーの正規化: ローカルマーカー (`:name@.:` → `:name:`) を剥がす。
+ * 楽観的更新はピッカー形式 (`:name:`)、サーバーイベントは正規形で届くことが
+ * あるため、素の一致比較では自己イベントの echo 判定とキー合流に失敗する。
+ */
+function normalizeReactionKey(key: string): string {
+  return key.replace(/@\.:$/, ':')
+}
+
+/** reaction と (形式差を含めて) 同一視できる既存キーを探す。無ければそのまま */
+function findReactionKey(
+  reactions: Record<string, number>,
+  reaction: string,
+): string {
+  if (reaction in reactions) return reaction
+  const norm = normalizeReactionKey(reaction)
+  for (const key of Object.keys(reactions)) {
+    if (normalizeReactionKey(key) === norm) return key
+  }
+  return reaction
+}
+
+/**
+ * noteUpdated イベントをノートへ適用した新オブジェクトを返す。適用不要は null。
+ *
+ * 自ユーザのイベントは楽観的更新 (toggleReaction) の echo なら無視し、
+ * 楽観が反映されていない場合 (別ウィンドウ・別デバイスからの操作、楽観の
+ * 効かない面) は自己修復として適用する。
  */
 export function mergeNoteUpdate(
   note: NormalizedNote,
@@ -72,7 +97,18 @@ export function mergeNoteUpdate(
   switch (event.type) {
     case 'reacted': {
       const reaction = event.body.reaction
-      if (!reaction || event.body.userId === myUserId) return null
+      if (!reaction) return null
+      const isMine = event.body.userId === myUserId
+      if (isMine) {
+        // 楽観反映済みの echo → 二重加算しない
+        if (
+          note.myReaction &&
+          normalizeReactionKey(note.myReaction) ===
+            normalizeReactionKey(reaction)
+        ) {
+          return null
+        }
+      }
       let newReactionEmojis = note.reactionEmojis
       if (event.body.emoji) {
         // Strip colons to match API convention (reactionEmojis keys have no colons)
@@ -86,22 +122,39 @@ export function mergeNoteUpdate(
             : event.body.emoji.url
         newReactionEmojis = { ...note.reactionEmojis, [shortcode]: emojiUrl }
       }
+      // 形式違いの既存キー (:name: と :name@.:) は合流させ、別チップを作らない
+      const key = findReactionKey(note.reactions, reaction)
       return {
         ...note,
         reactions: {
           ...note.reactions,
-          [reaction]: (note.reactions[reaction] ?? 0) + 1,
+          [key]: (note.reactions[key] ?? 0) + 1,
         },
         reactionEmojis: newReactionEmojis,
+        ...(isMine ? { myReaction: reaction } : {}),
       }
     }
     case 'unreacted': {
       const reaction = event.body.reaction
-      if (!reaction || event.body.userId === myUserId) return null
+      if (!reaction) return null
+      if (event.body.userId === myUserId) {
+        // 自分の取消: myReaction が一致するなら自己修復として取り消す。
+        // カウントは「楽観減算済みの echo」と「別デバイス操作」を区別できない
+        // ため触らない (二重減算の方が害が大きい)。既に null なら echo
+        if (
+          note.myReaction &&
+          normalizeReactionKey(note.myReaction) ===
+            normalizeReactionKey(reaction)
+        ) {
+          return { ...note, myReaction: null }
+        }
+        return null
+      }
+      const key = findReactionKey(note.reactions, reaction)
       const newReactions = { ...note.reactions }
-      const count = (newReactions[reaction] ?? 0) - 1
-      if (count <= 0) delete newReactions[reaction]
-      else newReactions[reaction] = count
+      const count = (newReactions[key] ?? 0) - 1
+      if (count <= 0) delete newReactions[key]
+      else newReactions[key] = count
       return { ...note, reactions: newReactions }
     }
     case 'pollVoted': {

--- a/src/services/streamUpdateMerge.ts
+++ b/src/services/streamUpdateMerge.ts
@@ -98,7 +98,9 @@ export function mergeNoteUpdate(
     case 'reacted': {
       const reaction = event.body.reaction
       if (!reaction) return null
-      const isMine = event.body.userId === myUserId
+      // myUserId != null: guest (undefined) × userId 欠落イベントの undefined
+      // 同士一致を「自分」と誤判定しない (pollVoted と同じ規約)
+      const isMine = myUserId != null && event.body.userId === myUserId
       if (isMine) {
         // 楽観反映済みの echo → 二重加算しない
         if (
@@ -137,7 +139,7 @@ export function mergeNoteUpdate(
     case 'unreacted': {
       const reaction = event.body.reaction
       if (!reaction) return null
-      if (event.body.userId === myUserId) {
+      if (myUserId != null && event.body.userId === myUserId) {
         // 自分の取消: myReaction が一致するなら自己修復として取り消す。
         // カウントは「楽観減算済みの echo」と「別デバイス操作」を区別できない
         // ため触らない (二重減算の方が害が大きい)。既に null なら echo

--- a/src/stores/emojis.dom.test.ts
+++ b/src/stores/emojis.dom.test.ts
@@ -180,4 +180,29 @@ describe('useEmojisStore', () => {
     const store = useEmojisStore()
     expect(store.resolve(HOST, 'meow')).toBeNull()
   })
+
+  it('hosts を欠く v2 の localStorage でもストアが初期化できる', () => {
+    localStorage.setItem('emojis_cache', JSON.stringify({ version: 2 }))
+    const store = useEmojisStore()
+    expect(store.resolve(HOST, 'meow')).toBeNull()
+  })
+
+  it('壊れた host エントリは飛ばし、正常な分だけ復元する', () => {
+    localStorage.setItem(
+      'emojis_cache',
+      JSON.stringify({
+        version: 2,
+        hosts: {
+          'broken.example': { fetchedAt: 0 },
+          [HOST]: {
+            fetchedAt: 1,
+            emojis: { meow: `https://${HOST}/files/meow.webp` },
+          },
+        },
+      }),
+    )
+    const store = useEmojisStore()
+    expect(store.resolve('broken.example', 'meow')).toBeNull()
+    expect(store.resolve(HOST, 'meow')).toBe(`https://${HOST}/files/meow.webp`)
+  })
 })

--- a/src/stores/emojis.dom.test.ts
+++ b/src/stores/emojis.dom.test.ts
@@ -1,0 +1,183 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ServerEmoji } from '@/adapters/types'
+import { useEmojisStore } from '@/stores/emojis'
+
+vi.mock('@/stores/performance', () => ({
+  usePerformanceStore: () => ({ get: () => 10 }),
+}))
+
+const HOST = 'misskey.example'
+
+function emoji(name: string): ServerEmoji {
+  return {
+    name,
+    url: `https://${HOST}/files/${name}.webp`,
+    category: null,
+    aliases: [],
+  }
+}
+
+/** ensureLoaded の fetcher promise を解決させる */
+async function flush() {
+  await vi.advanceTimersByTimeAsync(0)
+}
+
+describe('useEmojisStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.useFakeTimers()
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('ensureLoaded で取得した絵文字を resolve できる', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    expect(store.resolve(HOST, 'meow')).toBe(`https://${HOST}/files/meow.webp`)
+    // ローカルマーカー付きキーでも引ける
+    expect(store.resolve(HOST, 'meow@.')).toBe(
+      `https://${HOST}/files/meow.webp`,
+    )
+  })
+
+  it('未解決の reportMiss がデバウンス後に再取得し、新しい絵文字が解決できるようになる', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce([emoji('old')])
+      .mockResolvedValue([emoji('old'), emoji('brand_new')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    expect(store.resolve(HOST, 'brand_new')).toBeNull()
+
+    store.reportMiss(HOST, 'brand_new')
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(store.resolve(HOST, 'brand_new')).toBe(
+      `https://${HOST}/files/brand_new.webp`,
+    )
+  })
+
+  it('再取得しても存在しない名前は以後 refetch をトリガーしない', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+
+    store.reportMiss(HOST, 'ghost')
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+
+    // 同じ名前の miss はもう再取得を起こさない (空振りループ防止)
+    store.reportMiss(HOST, 'ghost')
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('リモート形式 (name@host) の miss は refetch をトリガーしない', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+
+    store.reportMiss(HOST, 'meow@remote.example')
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('ensureLoaded していない host の miss は何もしない', async () => {
+    const store = useEmojisStore()
+    store.reportMiss('unknown.example', 'meow')
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+    // fetcher が無いので何も起きない (例外にならないことの確認)
+    expect(store.resolve('unknown.example', 'meow')).toBeNull()
+  })
+
+  it('クールダウン内の新たな miss は次の再取得までまとめて遅延される', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+
+    store.reportMiss(HOST, 'first')
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+
+    // 直後の別の miss はデバウンスではなくクールダウン明けまで待つ
+    store.reportMiss(HOST, 'second')
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+    expect(fetcher).toHaveBeenCalledTimes(3)
+  })
+
+  it('取得済みでも 24 時間経過後の ensureLoaded は背景で再取得する', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    // 24 時間以内は何もしない
+    store.ensureLoaded(HOST, fetcher)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(25 * 60 * 60_000)
+    store.ensureLoaded(HOST, fetcher)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('fetcher が失敗しても pending が残らず、バックオフ後に再試行できる', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    expect(store.resolve(HOST, 'meow')).toBeNull()
+
+    // バックオフ (30s) 前は再試行しない
+    store.ensureLoaded(HOST, fetcher)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(31_000)
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(store.resolve(HOST, 'meow')).toBe(`https://${HOST}/files/meow.webp`)
+  })
+
+  it('localStorage に v2 形式で永続化し、別インスタンスで復元できる', async () => {
+    const store = useEmojisStore()
+    const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+    store.ensureLoaded(HOST, fetcher)
+    await flush()
+    // persist は debounce される
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    setActivePinia(createPinia())
+    const restored = useEmojisStore()
+    expect(restored.resolve(HOST, 'meow')).toBe(
+      `https://${HOST}/files/meow.webp`,
+    )
+  })
+
+  it('旧形式 (v1) の localStorage は捨てて再取得に任せる', () => {
+    localStorage.setItem(
+      'emojis_cache',
+      JSON.stringify({ [HOST]: { meow: 'https://old.example/meow.webp' } }),
+    )
+    const store = useEmojisStore()
+    expect(store.resolve(HOST, 'meow')).toBeNull()
+  })
+})

--- a/src/stores/emojis.ts
+++ b/src/stores/emojis.ts
@@ -5,6 +5,24 @@ import { usePerformanceStore } from '@/stores/performance'
 import { createDebouncedPersist } from '@/utils/debouncedPersist'
 import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
 
+/** 初回取得失敗のリトライバックオフ */
+const RETRY_BACKOFF_MS = 30_000
+
+/** miss 報告から再取得までのデバウンス (バースト中の miss をまとめる) */
+const MISS_DEBOUNCE_MS = 3_000
+
+/** miss 駆動の再取得の最短間隔 (host 単位) */
+const REFRESH_COOLDOWN_MS = 5 * 60_000
+
+/** これより古い辞書は ensureLoaded 時に背景で取り直す (絵文字画像の差し替えを拾う) */
+const STALE_AFTER_MS = 24 * 60 * 60_000
+
+/** localStorage の永続化形式。旧形式 (バージョンなし) は捨てて再取得に任せる */
+interface PersistedCacheV2 {
+  version: 2
+  hosts: Record<string, { fetchedAt: number; emojis: Record<string, string> }>
+}
+
 export const useEmojisStore = defineStore('emojis', () => {
   const perfStore = usePerformanceStore()
 
@@ -19,27 +37,47 @@ export const useEmojisStore = defineStore('emojis', () => {
   // Backoff: track failed hosts to avoid immediate retry
   const failedHosts = new Map<string, number>()
 
+  // ── miss 駆動の再取得 (#新規絵文字が再起動まで出ない問題の解消) ──
+  // 辞書は「一度取ったら終わり」ではなく、未解決 shortcode の報告を
+  // シグナルに取り直す。以下はすべて非 reactive (描画中の resolve から
+  // 呼ばれるため、reactive 状態に触れて再描画ループを作らない)。
+  const fetchers = new Map<string, () => Promise<ServerEmoji[]>>()
+  const fetchedAt = new Map<string, number>()
+  const missedNames = new Map<string, Set<string>>()
+  // 再取得しても辞書に現れなかった名前 (本当に存在しない)。空振りの
+  // refetch ループを防ぐ。辞書に現れた時点で解放する
+  const unknownNames = new Map<string, Set<string>>()
+  const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  const lastRefreshAt = new Map<string, number>()
+
   // Load shortcode→url cache from localStorage (for offline emoji resolution)
   function loadFromStorage() {
-    const obj = getStorageJson<Record<string, Record<string, string>> | null>(
+    const obj = getStorageJson<PersistedCacheV2 | null>(
       STORAGE_KEYS.emojisCache,
       null,
     )
-    if (!obj) return
+    if (obj?.version !== 2) return
     const map = new Map<string, Record<string, string>>()
-    for (const [host, lookup] of Object.entries(obj)) {
-      map.set(host, lookup)
+    for (const [host, entry] of Object.entries(obj.hosts)) {
+      map.set(host, entry.emojis)
+      fetchedAt.set(host, entry.fetchedAt)
     }
     cache.value = map
   }
 
   function persistToStorage() {
     try {
-      const obj: Record<string, Record<string, string>> = {}
+      const hosts: PersistedCacheV2['hosts'] = {}
       for (const [host, lookup] of cache.value) {
-        obj[host] = lookup
+        hosts[host] = {
+          fetchedAt: fetchedAt.get(host) ?? Date.now(),
+          emojis: lookup,
+        }
       }
-      setStorageJson(STORAGE_KEYS.emojisCache, obj)
+      setStorageJson(STORAGE_KEYS.emojisCache, {
+        version: 2,
+        hosts,
+      } satisfies PersistedCacheV2)
     } catch {
       // storage full, ignore
     }
@@ -60,6 +98,7 @@ export const useEmojisStore = defineStore('emojis', () => {
     const nextCache = new Map(cache.value)
     nextCache.set(host, lookup)
     cache.value = nextCache
+    fetchedAt.set(host, Date.now())
 
     // emojiList: only keep the most recent hosts to bound memory
     const nextList = new Map(emojiList.value)
@@ -70,23 +109,36 @@ export const useEmojisStore = defineStore('emojis', () => {
     }
     emojiList.value = nextList
 
-    pending.delete(host)
+    // 辞書に現れた unknown は解放する (再登録された絵文字を拾えるように)
+    const unknown = unknownNames.get(host)
+    if (unknown) {
+      for (const name of unknown) {
+        if (lookup[name] !== undefined || lookup[`${name}@.`] !== undefined) {
+          unknown.delete(name)
+        }
+      }
+    }
 
     // Persist shortcode→url cache for offline use (debounced)
     schedulePersist()
   }
 
-  const RETRY_BACKOFF_MS = 30_000
-
   function ensureLoaded(
     host: string,
     fetcher: () => Promise<ServerEmoji[]>,
   ): void {
+    // miss 駆動 / 経年リフレッシュ用に常に保持 (最新の fetcher で上書き)
+    fetchers.set(host, fetcher)
     if (
       (cache.value.has(host) && emojiList.value.has(host)) ||
       pending.has(host)
-    )
+    ) {
+      const at = fetchedAt.get(host)
+      if (at !== undefined && Date.now() - at > STALE_AFTER_MS) {
+        scheduleRefresh(host)
+      }
       return
+    }
     const failedAt = failedHosts.get(host)
     if (failedAt && Date.now() - failedAt < RETRY_BACKOFF_MS) return
     const p = fetcher()
@@ -97,9 +149,79 @@ export const useEmojisStore = defineStore('emojis', () => {
       .catch((e) => {
         console.warn('[emojis] failed to fetch:', host, e)
         failedHosts.set(host, Date.now())
+      })
+      .finally(() => {
+        // 成功パスの例外でも pending を残さない (残ると永久に再取得不能)
         pending.delete(host)
       })
     pending.set(host, p)
+  }
+
+  /**
+   * 解決できなかった shortcode の報告。デバウンス + クールダウン付きで
+   * host の辞書を取り直す。アプリ起動後にサーバーへ追加された絵文字は
+   * ここを通らないと再起動まで永久に unknown のままになる。
+   * 描画中 (computed) から呼ばれるため、reactive 状態には触れない。
+   */
+  function reportMiss(host: string, shortcode: string): void {
+    // リモート絵文字 (name@host) はローカル辞書に決して現れない
+    if (shortcode.includes('@')) return
+    if (!fetchers.has(host)) return
+    if (unknownNames.get(host)?.has(shortcode)) return
+    let missed = missedNames.get(host)
+    if (!missed) {
+      missed = new Set()
+      missedNames.set(host, missed)
+    }
+    if (missed.has(shortcode)) return
+    missed.add(shortcode)
+    scheduleRefresh(host)
+  }
+
+  function scheduleRefresh(host: string): void {
+    if (refreshTimers.has(host)) return
+    const last = lastRefreshAt.get(host)
+    const cooldownLeft =
+      last !== undefined
+        ? Math.max(0, last + REFRESH_COOLDOWN_MS - Date.now())
+        : 0
+    const delay = Math.max(MISS_DEBOUNCE_MS, cooldownLeft)
+    refreshTimers.set(
+      host,
+      setTimeout(() => {
+        refreshTimers.delete(host)
+        void refresh(host)
+      }, delay),
+    )
+  }
+
+  async function refresh(host: string): Promise<void> {
+    const fetcher = fetchers.get(host)
+    if (!fetcher) return
+    lastRefreshAt.set(host, Date.now())
+    const missed = missedNames.get(host)
+    missedNames.delete(host)
+    try {
+      const emojis = await fetcher()
+      set(host, emojis)
+      // 取り直しても存在しなかった名前は隔離する
+      if (missed) {
+        const lookup = cache.value.get(host) ?? {}
+        for (const name of missed) {
+          if (lookup[name] === undefined && lookup[`${name}@.`] === undefined) {
+            let unknown = unknownNames.get(host)
+            if (!unknown) {
+              unknown = new Set()
+              unknownNames.set(host, unknown)
+            }
+            unknown.add(name)
+          }
+        }
+      }
+    } catch (e) {
+      console.warn('[emojis] refresh failed:', host, e)
+      // unknown には入れない — 次の miss がクールダウン付きで再試行する
+    }
   }
 
   function resolve(host: string, shortcode: string): string | null {
@@ -117,5 +239,14 @@ export const useEmojisStore = defineStore('emojis', () => {
     return cache.value.has(host)
   }
 
-  return { cache, emojiList, set, ensureLoaded, resolve, getEmojiList, has }
+  return {
+    cache,
+    emojiList,
+    set,
+    ensureLoaded,
+    reportMiss,
+    resolve,
+    getEmojiList,
+    has,
+  }
 })

--- a/src/stores/emojis.ts
+++ b/src/stores/emojis.ts
@@ -57,10 +57,17 @@ export const useEmojisStore = defineStore('emojis', () => {
       null,
     )
     if (obj?.version !== 2) return
+    // localStorage は外から壊せる (手編集・書き込み途中の切断)。ここは store
+    // setup 内なので throw するとストアごと初期化に失敗する。version が
+    // 合っていても形は信用しない。壊れた host は飛ばして再取得に任せる
+    // (undefined を混ぜると has() が true を返し、以後取得を skip してしまう)
+    if (typeof obj.hosts !== 'object' || obj.hosts === null) return
     const map = new Map<string, Record<string, string>>()
     for (const [host, entry] of Object.entries(obj.hosts)) {
+      if (typeof entry?.emojis !== 'object' || entry.emojis === null) continue
       map.set(host, entry.emojis)
-      fetchedAt.set(host, entry.fetchedAt)
+      if (typeof entry.fetchedAt === 'number')
+        fetchedAt.set(host, entry.fetchedAt)
     }
     cache.value = map
   }

--- a/src/utils/emojiImgError.ts
+++ b/src/utils/emojiImgError.ts
@@ -1,4 +1,4 @@
-import { markMediaFailed } from '@/utils/mediaProxy'
+import { ensurePlaceholderRecovery, markMediaFailed } from '@/utils/mediaProxy'
 
 /**
  * カスタム絵文字 `<img>` の onerror 共通ハンドラ (#844)。
@@ -14,6 +14,21 @@ export function onCustomEmojiImgError(e: Event): void {
   const raw = proxiedRawUrl(img.src)
   if (raw) markMediaFailed(raw)
   img.src = '/emoji-unknown.svg'
+}
+
+/**
+ * カスタム絵文字 `<img>` の @load 共通ハンドラ。
+ *
+ * 二段階配信の透明プレースホルダ (1×1) を掴んだままの滞留を申告する。
+ * MediaFetched イベントを取りこぼすと onerror も発火しないまま透明が
+ * 固定化するため、@load 側から自己修復に乗せる (mediaProxy の
+ * ensurePlaceholderRecovery 参照)。実画像 (1×1 でない) は何もしない。
+ */
+export function onCustomEmojiImgLoad(e: Event): void {
+  const img = e.target as HTMLImageElement
+  if (img.naturalWidth !== 1 || img.naturalHeight !== 1) return
+  const raw = proxiedRawUrl(img.src)
+  if (raw) ensurePlaceholderRecovery(raw)
 }
 
 /** プロキシ URL (`...?url=<encoded>`) から元 URL を取り出す */

--- a/src/utils/emojiImgError.ts
+++ b/src/utils/emojiImgError.ts
@@ -1,4 +1,4 @@
-import { ensurePlaceholderRecovery, markMediaFailed } from '@/utils/mediaProxy'
+import { markMediaFailed, proxiedRawUrl } from '@/utils/mediaProxy'
 
 /**
  * カスタム絵文字 `<img>` の onerror 共通ハンドラ (#844)。
@@ -16,26 +16,6 @@ export function onCustomEmojiImgError(e: Event): void {
   img.src = '/emoji-unknown.svg'
 }
 
-/**
- * カスタム絵文字 `<img>` の @load 共通ハンドラ。
- *
- * 二段階配信の透明プレースホルダ (1×1) を掴んだままの滞留を申告する。
- * MediaFetched イベントを取りこぼすと onerror も発火しないまま透明が
- * 固定化するため、@load 側から自己修復に乗せる (mediaProxy の
- * ensurePlaceholderRecovery 参照)。実画像 (1×1 でない) は何もしない。
- */
-export function onCustomEmojiImgLoad(e: Event): void {
-  const img = e.target as HTMLImageElement
-  if (img.naturalWidth !== 1 || img.naturalHeight !== 1) return
-  const raw = proxiedRawUrl(img.src)
-  if (raw) ensurePlaceholderRecovery(raw)
-}
-
-/** プロキシ URL (`...?url=<encoded>`) から元 URL を取り出す */
-function proxiedRawUrl(src: string): string | null {
-  try {
-    return new URL(src).searchParams.get('url')
-  } catch {
-    return null
-  }
-}
+// プレースホルダ滞留 (透明 1×1 のまま MediaFetched を取りこぼす) の自己修復は
+// mediaProxy の installPlaceholderWatchdog が document capture で全 <img> を
+// 一括監視する — 個別の @load 配線は不要

--- a/src/utils/emojiImgError.ts
+++ b/src/utils/emojiImgError.ts
@@ -1,0 +1,26 @@
+import { markMediaFailed } from '@/utils/mediaProxy'
+
+/**
+ * カスタム絵文字 `<img>` の onerror 共通ハンドラ (#844)。
+ *
+ * unknown アイコンに落としつつ、プロキシへ失敗を申告してバックオフ再試行
+ * させる。再試行で世代付き URL に変わると :src バインドが再評価され、
+ * unknown アイコンから自然に復帰する。src の DOM 書き換えだけだと一過性の
+ * 失敗 (リモート鯖の瞬断・プロキシ 502/504) がセッション中固定化する。
+ */
+export function onCustomEmojiImgError(e: Event): void {
+  const img = e.target as HTMLImageElement
+  if (img.src.endsWith('/emoji-unknown.svg')) return
+  const raw = proxiedRawUrl(img.src)
+  if (raw) markMediaFailed(raw)
+  img.src = '/emoji-unknown.svg'
+}
+
+/** プロキシ URL (`...?url=<encoded>`) から元 URL を取り出す */
+function proxiedRawUrl(src: string): string | null {
+  try {
+    return new URL(src).searchParams.get('url')
+  } catch {
+    return null
+  }
+}

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -170,6 +170,76 @@ describe('背景取得完了による再読込 (二段階配信)', () => {
   })
 })
 
+describe('失敗申告によるバックオフ再試行 (markMediaFailed)', () => {
+  // @error の DOM 書き換え (unknown アイコンへの差し替え) は :src バインドが
+  // 変わらない限り戻らず、一過性の 502/504 がセッション中固定化していた。
+  // 失敗を申告するとバックオフ後に世代番号が進み、バインド再評価で自然復帰する
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('バックオフ後に世代番号を進めて <img> に再要求させる', async () => {
+    const { proxyUrl, markMediaFailed } = await loadModule()
+    const base = proxyUrl(REMOTE)
+    markMediaFailed(REMOTE)
+    // バックオフ前は変わらない (失敗直後の連打再要求を避ける)
+    expect(proxyUrl(REMOTE)).toBe(base)
+    vi.advanceTimersByTime(8_000)
+    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
+  })
+
+  it('タイマー待ち中の重複申告は 1 回の再試行にまとまる', async () => {
+    const { proxyUrl, markMediaFailed } = await loadModule()
+    markMediaFailed(REMOTE)
+    markMediaFailed(REMOTE)
+    markMediaFailed(REMOTE)
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+
+  it('再試行は上限で打ち切る (無限リトライしない)', async () => {
+    const { proxyUrl, markMediaFailed } = await loadModule()
+    for (let i = 0; i < 10; i++) {
+      markMediaFailed(REMOTE)
+      vi.advanceTimersByTime(10 * 60_000)
+    }
+    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
+    expect(r).toBe(3)
+  })
+
+  it('取得成功で失敗カウントがリセットされ、次の失敗からまた再試行できる', async () => {
+    const { proxyUrl, markMediaFailed, handleMediaFetched } = await loadModule()
+    for (let i = 0; i < 10; i++) {
+      markMediaFailed(REMOTE)
+      vi.advanceTimersByTime(10 * 60_000)
+    }
+    // 成功イベント → リセット (世代も 1 進む: 3 + 1 = 4)
+    handleMediaFetched(REMOTE, true)
+    markMediaFailed(REMOTE)
+    vi.advanceTimersByTime(10 * 60_000)
+    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
+    expect(r).toBe(5)
+  })
+
+  it('失敗の完了イベント (ok=false) ではリセットしない', async () => {
+    const { proxyUrl, markMediaFailed, handleMediaFetched } = await loadModule()
+    for (let i = 0; i < 10; i++) {
+      markMediaFailed(REMOTE)
+      vi.advanceTimersByTime(10 * 60_000)
+    }
+    handleMediaFetched(REMOTE, false)
+    markMediaFailed(REMOTE)
+    vi.advanceTimersByTime(10 * 60_000)
+    // ok=false の世代 bump (+1) だけで、リトライは復活しない
+    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
+    expect(r).toBe(4)
+  })
+})
+
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
   it('幅だけを付ける (非 Android は wait も付く)', async () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -48,10 +48,12 @@ describe('proxyUrl', () => {
   // 非 Android の wait=1: Android の custom protocol だけが直列 + 10 秒フューズ
   // (wry) なので二段階配信が必須。それ以外はブロッキングが安全なので、初回
   // 表示から往復 1 回で本物を返す
-  it('custom protocol の口に載せる (非 Android は単一トリップ)', async () => {
+  // soft=1: 画像の wait は最適化にすぎないので、プロキシ側は予算超過時に
+  // プレースホルダへ降格してよい (効果音の hard wait と区別する)
+  it('custom protocol の口に載せる (非 Android は単一トリップ + soft 降格可)', async () => {
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
     )
   })
 
@@ -59,7 +61,7 @@ describe('proxyUrl', () => {
     stubTauri((path, protocol) => `${protocol}://localhost/${path}`)
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `ndmedia://localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1`,
+      `ndmedia://localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
     )
   })
 
@@ -84,7 +86,7 @@ describe('proxyUrl', () => {
     vi.stubGlobal('__TAURI_INTERNALS__', undefined)
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toBe(
-      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}&wait=1`,
+      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
     )
   })
 
@@ -107,6 +109,12 @@ describe('wait オプション (効果音などブロッキング消費者用)',
     expect(proxyUrl(REMOTE, { wait: true })).toContain('wait=1')
     const normal = proxyUrl(REMOTE)
     expect(normal).not.toContain('wait=1')
+  })
+
+  it('明示 wait (効果音) には soft を付けない — プレースホルダを飲み込めない', async () => {
+    const { proxyUrl } = await loadModule()
+    expect(proxyUrl(REMOTE, { wait: true })).not.toContain('soft=1')
+    expect(proxyUrl(REMOTE, { wait: true })).toContain('wait=1')
   })
 })
 
@@ -242,10 +250,10 @@ describe('失敗申告によるバックオフ再試行 (markMediaFailed)', () =
 
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
-  it('幅だけを付ける (非 Android は wait も付く)', async () => {
+  it('幅だけを付ける (非 Android は wait + soft も付く)', async () => {
     const { proxyThumbUrl } = await loadModule()
     expect(proxyThumbUrl(REMOTE, 56)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56&wait=1`,
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56&wait=1&soft=1`,
     )
   })
 

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -248,6 +248,61 @@ describe('失敗申告によるバックオフ再試行 (markMediaFailed)', () =
   })
 })
 
+describe('プレースホルダ滞留の自己修復 (ensurePlaceholderRecovery)', () => {
+  // 二段階配信は「透明プレースホルダ → MediaFetched → 再要求」で完結するが、
+  // イベントを取りこぼすと透明 GIF のまま固まり、onerror も発火しないため
+  // 再試行機構 (markMediaFailed) の対象外になる。<img> の @load で
+  // プレースホルダ (1×1) を掴んだことを申告し、一定時間内に世代が進まなければ
+  // 自力で再要求させる
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('世代が進まないまま滞留したら自力で世代を進める', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    const base = proxyUrl(REMOTE)
+    ensurePlaceholderRecovery(REMOTE)
+    expect(proxyUrl(REMOTE)).toBe(base)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
+  })
+
+  it('MediaFetched で世代が進んでいれば何もしない (正常経路に譲る)', async () => {
+    const { proxyUrl, handleMediaFetched, ensurePlaceholderRecovery } =
+      await loadModule()
+    ensurePlaceholderRecovery(REMOTE)
+    handleMediaFetched(REMOTE)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+    vi.advanceTimersByTime(10 * 60_000)
+    // watchdog による余計な bump (&r=2) は起きない
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+
+  it('タイマー待ち中の重複申告は 1 本にまとまる', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    ensurePlaceholderRecovery(REMOTE)
+    ensurePlaceholderRecovery(REMOTE)
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+
+  it('再要求でまたプレースホルダを掴んだら再申告できる (取得完了まで収束)', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+    // 再要求後もまだ取得中 → @load が再度申告 → もう一周
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=2')
+  })
+})
+
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
   it('幅だけを付ける (非 Android は wait + soft も付く)', async () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -301,6 +301,31 @@ describe('プレースホルダ滞留の自己修復 (ensurePlaceholderRecovery)
     vi.advanceTimersByTime(4_000)
     expect(proxyUrl(REMOTE)).toContain('&r=2')
   })
+
+  it('自己修復は上限で打ち切る (本当に 1×1 の画像で無限ループしない)', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    // 本物が 1×1 の画像は再要求してもずっと 1×1 → 毎回 @load から申告される
+    for (let i = 0; i < 10; i++) {
+      ensurePlaceholderRecovery(REMOTE)
+      vi.advanceTimersByTime(4_000)
+    }
+    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
+    expect(r).toBe(3)
+  })
+
+  it('取得成功 (MediaFetched ok) で自己修復の試行回数がリセットされる', async () => {
+    const { proxyUrl, handleMediaFetched, ensurePlaceholderRecovery } =
+      await loadModule()
+    for (let i = 0; i < 10; i++) {
+      ensurePlaceholderRecovery(REMOTE)
+      vi.advanceTimersByTime(4_000)
+    }
+    handleMediaFetched(REMOTE, true) // r=4
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
+    expect(r).toBe(5)
+  })
 })
 
 describe('proxyThumbUrl', () => {

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -40,7 +40,7 @@ const proxyUrlCache = new Map<string, string>()
  */
 const mediaVersions = reactive(new Map<string, number>())
 
-export function handleMediaFetched(url: string) {
+function bumpMediaVersion(url: string) {
   // proxyUrlCache と同じ上限で古い順に捨てる (無限成長させない)。
   // 追い出された URL は素の URL に戻るだけで、実体はキャッシュ済みなので
   // 表示は壊れない
@@ -51,13 +51,54 @@ export function handleMediaFetched(url: string) {
   mediaVersions.set(url, (mediaVersions.get(url) ?? 0) + 1)
 }
 
+export function handleMediaFetched(url: string, ok = true) {
+  if (ok) {
+    // 取得成功 → 失敗カウントをリセット (以後の失敗からまた再試行できる)
+    const entry = mediaFailures.get(url)
+    if (entry?.timer != null) clearTimeout(entry.timer)
+    mediaFailures.delete(url)
+  }
+  bumpMediaVersion(url)
+}
+
+/**
+ * `<img>` の onerror 側からの失敗申告。
+ *
+ * @error ハンドラは src を unknown アイコンへ DOM 書き換えするが、それだけ
+ * だと :src バインドが変わる契機がなく、一過性の 502/504 がセッション中
+ * 固定化する。ここでバックオフ後に世代番号を進めるとバインドが再評価され、
+ * `<img>` が再要求して自然復帰する。負のキャッシュが生きている間の再試行は
+ * プロキシが即 502 で受けるので安価に失敗し、次のバックオフに進む。
+ * 上限に達したら諦める (回復は取得成功イベントのリセット任せ)。
+ */
+const MEDIA_RETRY_BACKOFF_MS = [8_000, 40_000, 180_000] as const
+
+const mediaFailures = new Map<
+  string,
+  { retries: number; timer: ReturnType<typeof setTimeout> | null }
+>()
+
+export function markMediaFailed(url: string): void {
+  const entry = mediaFailures.get(url) ?? { retries: 0, timer: null }
+  if (entry.timer !== null || entry.retries >= MEDIA_RETRY_BACKOFF_MS.length) {
+    return
+  }
+  const delay = MEDIA_RETRY_BACKOFF_MS[entry.retries] ?? 0
+  entry.timer = setTimeout(() => {
+    entry.timer = null
+    entry.retries += 1
+    bumpMediaVersion(url)
+  }, delay)
+  mediaFailures.set(url, entry)
+}
+
 let listenerStarted = false
 function ensureFetchedListener() {
   if (listenerStarted) return
   listenerStarted = true
   try {
     events.mediaFetched
-      .listen(({ payload }) => handleMediaFetched(payload.url))
+      .listen(({ payload }) => handleMediaFetched(payload.url, payload.ok))
       .catch(() => {
         // Tauri 外 (pnpm dev のブラウザ確認) ではイベント購読できない
       })

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -153,11 +153,15 @@ export function proxyUrl(
   if (!url?.startsWith('https://')) return url ?? undefined
   ensureFetchedListener()
   const wait = opts?.wait || !IS_ANDROID
-  const cacheKey = wait ? `${url}|wait` : url
+  // 画像の wait は最適化にすぎないので soft を付け、プロキシ側が予算超過時に
+  // プレースホルダ + MediaFetched の二段階配信へ降格できるようにする。
+  // 明示 wait (効果音の fetch/Audio) はプレースホルダを飲み込めないので hard
+  const soft = wait && !opts?.wait
+  const cacheKey = soft ? `${url}|soft` : wait ? `${url}|wait` : url
   let cached = proxyUrlCache.get(cacheKey)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${wait ? '&wait=1' : ''}`
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${wait ? '&wait=1' : ''}${soft ? '&soft=1' : ''}`
     proxyUrlCache.set(cacheKey, cached)
   }
   return withVersion(cached, url)
@@ -178,12 +182,13 @@ export function proxyThumbUrl(
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
   ensureFetchedListener()
+  // 画像は常に soft (予算超過でプレースホルダ降格可 — proxyUrl 参照)
   const wait = !IS_ANDROID
   const key = `${url}|w=${width}`
   let cached = proxyUrlCache.get(key)
   if (!cached) {
     evictIfFull()
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}${wait ? '&wait=1' : ''}`
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}${wait ? '&wait=1&soft=1' : ''}`
     proxyUrlCache.set(key, cached)
   }
   return withVersion(cached, url)

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -53,10 +53,11 @@ function bumpMediaVersion(url: string) {
 
 export function handleMediaFetched(url: string, ok = true) {
   if (ok) {
-    // 取得成功 → 失敗カウントをリセット (以後の失敗からまた再試行できる)
+    // 取得成功 → 失敗カウント・自己修復の試行回数をリセット
     const entry = mediaFailures.get(url)
     if (entry?.timer != null) clearTimeout(entry.timer)
     mediaFailures.delete(url)
+    placeholderRecoveryCounts.delete(url)
   }
   bumpMediaVersion(url)
 }
@@ -105,9 +106,17 @@ export function markMediaFailed(url: string): void {
  */
 const PLACEHOLDER_RECHECK_MS = 4_000
 
+/** 自力再要求の上限。本当に 1×1 の画像 (再要求しても 1×1 のまま) で
+ * 無限ループしないための打ち切り。取得成功でリセットされる */
+const PLACEHOLDER_RECOVERY_MAX = 3
+
 const placeholderTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const placeholderRecoveryCounts = new Map<string, number>()
 
 export function ensurePlaceholderRecovery(url: string): void {
+  if ((placeholderRecoveryCounts.get(url) ?? 0) >= PLACEHOLDER_RECOVERY_MAX) {
+    return
+  }
   if (placeholderTimers.has(url)) return
   const versionAtSchedule = mediaVersions.get(url) ?? 0
   placeholderTimers.set(
@@ -116,16 +125,64 @@ export function ensurePlaceholderRecovery(url: string): void {
       placeholderTimers.delete(url)
       // MediaFetched が正常に届いて世代が進んでいれば何もしない
       if ((mediaVersions.get(url) ?? 0) === versionAtSchedule) {
+        placeholderRecoveryCounts.set(
+          url,
+          (placeholderRecoveryCounts.get(url) ?? 0) + 1,
+        )
         bumpMediaVersion(url)
       }
     }, PLACEHOLDER_RECHECK_MS),
   )
 }
 
+/**
+ * プロキシ URL (`...?url=<encoded>`) から元 URL を取り出す。
+ * プロキシ経由でない (ローカルアセット等) は null。
+ */
+export function proxiedRawUrl(src: string): string | null {
+  try {
+    return new URL(src).searchParams.get('url')
+  } catch {
+    return null
+  }
+}
+
+/**
+ * プレースホルダ滞留の全画像監視。
+ *
+ * 二段階配信 (Android 全画像 / デスクトップの soft 降格) はアバター・添付・
+ * ピッカーなどあらゆる `<img>` を通るため、個別コンポーネントに @load を
+ * 配線するのではなく document の capture で一括して拾う (load イベントは
+ * バブルしないが capture では捕捉できる)。1×1 = プレースホルダを掴んだ
+ * `<img>` を自己修復に乗せ、実画像が載ったら試行回数をリセットする。
+ */
+function installPlaceholderWatchdog() {
+  try {
+    document.addEventListener(
+      'load',
+      (e) => {
+        const img = e.target as HTMLImageElement | null
+        if (img?.tagName !== 'IMG') return
+        const raw = proxiedRawUrl(img.currentSrc || img.src)
+        if (!raw) return
+        if (img.naturalWidth === 1 && img.naturalHeight === 1) {
+          ensurePlaceholderRecovery(raw)
+        } else {
+          placeholderRecoveryCounts.delete(raw)
+        }
+      },
+      true,
+    )
+  } catch {
+    // document の無い環境 (ユニットテストの node 側等) では何もしない
+  }
+}
+
 let listenerStarted = false
 function ensureFetchedListener() {
   if (listenerStarted) return
   listenerStarted = true
+  installPlaceholderWatchdog()
   try {
     events.mediaFetched
       .listen(({ payload }) => handleMediaFetched(payload.url, payload.ok))

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -92,6 +92,36 @@ export function markMediaFailed(url: string): void {
   mediaFailures.set(url, entry)
 }
 
+/**
+ * プレースホルダ滞留の自己修復 (`<img>` の @load からの申告)。
+ *
+ * 二段階配信は「透明プレースホルダ → MediaFetched → 再要求」で完結するが、
+ * イベントを取りこぼす (Android の WebView フリーズ復帰等) と透明 GIF の
+ * まま固まる。プレースホルダは正常な 200 応答なので onerror が発火せず、
+ * markMediaFailed の再試行にも乗らない。@load で 1×1 を掴んだことを申告し、
+ * 一定時間内に世代が進まなければ自力で進めて再要求させる。再要求がまた
+ * プレースホルダなら @load が再申告するので、取得完了まで自然に収束する
+ * (取得失敗は 502 → onerror → markMediaFailed 側が引き継ぐ)。
+ */
+const PLACEHOLDER_RECHECK_MS = 4_000
+
+const placeholderTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+export function ensurePlaceholderRecovery(url: string): void {
+  if (placeholderTimers.has(url)) return
+  const versionAtSchedule = mediaVersions.get(url) ?? 0
+  placeholderTimers.set(
+    url,
+    setTimeout(() => {
+      placeholderTimers.delete(url)
+      // MediaFetched が正常に届いて世代が進んでいれば何もしない
+      if ((mediaVersions.get(url) ?? 0) === versionAtSchedule) {
+        bumpMediaVersion(url)
+      }
+    }, PLACEHOLDER_RECHECK_MS),
+  )
+}
+
 let listenerStarted = false
 function ensureFetchedListener() {
   if (listenerStarted) return

--- a/src/utils/toggleReaction.ts
+++ b/src/utils/toggleReaction.ts
@@ -6,40 +6,64 @@ interface ReactionApi {
   deleteReaction(noteId: string): Promise<void>
 }
 
+/** 楽観的更新の差分。apply コールバックが表示側の保持形態に応じて反映する */
+export interface ReactionPatch {
+  reactions: Record<string, number>
+  myReaction: string | null
+}
+
+/** reactions から 1 減算した新オブジェクト (0 でキーごと削除) */
+function decremented(
+  reactions: Record<string, number>,
+  key: string,
+): Record<string, number> {
+  const next = { ...reactions }
+  if ((next[key] ?? 0) > 1) next[key] = (next[key] ?? 0) - 1
+  else delete next[key]
+  return next
+}
+
+/**
+ * リアクションのトグル (追加 / 取消 / 切替) を楽観的更新つきで行う。
+ *
+ * note は読み取り専用 — mutate せず、差分を `apply` に渡す。呼び出し元は
+ * 自分の保持形態 (noteStore / deep ref / shallowRef の配列) に応じて
+ * 「新しいオブジェクトへの差し替え」として反映する。以前は note を直接
+ * mutate していたため、shallowRef で保持する面 (プロフィール・通知カラム
+ * 等) では Vue が変更を検知できず、押しても表示が変わらなかった。
+ * `patch.reactions` は常に新オブジェクトなので、reactions の参照を watch
+ * する購読 (#575 の数え直し等) も確実に発火する。
+ *
+ * 失敗時は元の状態を apply し直してから throw する。
+ */
 export async function toggleReaction(
   api: ReactionApi,
   note: NormalizedNote,
   reaction: string,
-  onMutated?: () => void,
+  apply: (patch: ReactionPatch) => void,
 ): Promise<void> {
   hapticLight()
   const prevReaction = note.myReaction
-  const prevCounts = { ...note.reactions }
+  const prevPatch: ReactionPatch = {
+    reactions: { ...note.reactions },
+    myReaction: prevReaction ?? null,
+  }
 
   try {
     if (prevReaction === reaction) {
-      // Optimistic: remove reaction
-      if ((note.reactions[reaction] ?? 0) > 1) {
-        note.reactions[reaction] = (note.reactions[reaction] ?? 0) - 1
-      } else {
-        delete note.reactions[reaction]
-      }
-      note.myReaction = null
-      onMutated?.()
-
+      // 取消
+      apply({
+        reactions: decremented(note.reactions, reaction),
+        myReaction: null,
+      })
       await api.deleteReaction(note.id)
     } else {
-      // Optimistic: switch or add reaction
-      if (prevReaction) {
-        if ((note.reactions[prevReaction] ?? 0) > 1) {
-          note.reactions[prevReaction] = (note.reactions[prevReaction] ?? 0) - 1
-        } else {
-          delete note.reactions[prevReaction]
-        }
-      }
-      note.reactions[reaction] = (note.reactions[reaction] ?? 0) + 1
-      note.myReaction = reaction
-      onMutated?.()
+      // 追加 / 切替
+      const next = prevReaction
+        ? decremented(note.reactions, prevReaction)
+        : { ...note.reactions }
+      next[reaction] = (next[reaction] ?? 0) + 1
+      apply({ reactions: next, myReaction: reaction })
 
       if (prevReaction) {
         await api.deleteReaction(note.id)
@@ -48,9 +72,7 @@ export async function toggleReaction(
     }
   } catch (e) {
     // Rollback to previous state on failure
-    note.reactions = prevCounts
-    note.myReaction = prevReaction
-    onMutated?.()
+    apply(prevPatch)
     throw e
   }
 }

--- a/tests/utils/toggleReaction.test.ts
+++ b/tests/utils/toggleReaction.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { NormalizedNote } from '@/adapters/types'
-import { toggleReaction } from '@/utils/toggleReaction'
+import { type ReactionPatch, toggleReaction } from '@/utils/toggleReaction'
 
 function makeNote(overrides: Partial<NormalizedNote> = {}): NormalizedNote {
   return {
@@ -38,17 +38,48 @@ function makeApi() {
   }
 }
 
+/** apply された差分を状態として追跡する (呼び出し元の反映を模す) */
+function track(note: NormalizedNote) {
+  const state: ReactionPatch = {
+    reactions: note.reactions,
+    myReaction: note.myReaction ?? null,
+  }
+  const patches: ReactionPatch[] = []
+  const apply = (p: ReactionPatch) => {
+    patches.push(p)
+    state.reactions = p.reactions
+    state.myReaction = p.myReaction
+  }
+  return { state, patches, apply }
+}
+
 describe('toggleReaction', () => {
   it('adds a new reaction optimistically', async () => {
     const api = makeApi()
     const note = makeNote()
+    const { state, apply } = track(note)
 
-    await toggleReaction(api, note, '👍')
+    await toggleReaction(api, note, '👍', apply)
 
-    expect(note.myReaction).toBe('👍')
-    expect(note.reactions['👍']).toBe(1)
+    expect(state.myReaction).toBe('👍')
+    expect(state.reactions['👍']).toBe(1)
     expect(api.createReaction).toHaveBeenCalledWith('note1', '👍')
     expect(api.deleteReaction).not.toHaveBeenCalled()
+  })
+
+  it('note は mutate せず、新しい reactions オブジェクトで apply する', async () => {
+    // shallowRef 保持の面 (プロフィール・通知カラム等) が差し替えを検知
+    // できるよう、mutate ではなく新オブジェクトの差分として渡す
+    const api = makeApi()
+    const note = makeNote({ reactions: { '🎉': 1 } })
+    const { state, apply } = track(note)
+
+    await toggleReaction(api, note, '👍', apply)
+
+    expect(note.reactions).toEqual({ '🎉': 1 })
+    expect(note.myReaction).toBeNull()
+    expect(state.reactions).not.toBe(note.reactions)
+    expect(state.reactions).toEqual({ '🎉': 1, '👍': 1 })
   })
 
   it('removes an existing reaction optimistically', async () => {
@@ -57,28 +88,38 @@ describe('toggleReaction', () => {
       reactions: { '👍': 1 },
       myReaction: '👍',
     })
+    const { state, apply } = track(note)
 
-    await toggleReaction(api, note, '👍')
+    await toggleReaction(api, note, '👍', apply)
 
-    expect(note.myReaction).toBeNull()
-    expect(note.reactions['👍']).toBeUndefined()
+    expect(state.myReaction).toBeNull()
+    expect(state.reactions['👍']).toBeUndefined()
     expect(api.deleteReaction).toHaveBeenCalledWith('note1')
   })
 
-  it('switches reaction (removes old, adds new)', async () => {
+  it('switches reaction (removes old, adds new; delete → create の順)', async () => {
     const api = makeApi()
+    const calls: string[] = []
+    api.deleteReaction.mockImplementation(async () => {
+      calls.push('delete')
+    })
+    api.createReaction.mockImplementation(async () => {
+      calls.push('create')
+    })
     const note = makeNote({
       reactions: { '👍': 1 },
       myReaction: '👍',
     })
+    const { state, apply } = track(note)
 
-    await toggleReaction(api, note, '❤️')
+    await toggleReaction(api, note, '❤️', apply)
 
-    expect(note.myReaction).toBe('❤️')
-    expect(note.reactions['👍']).toBeUndefined()
-    expect(note.reactions['❤️']).toBe(1)
+    expect(state.myReaction).toBe('❤️')
+    expect(state.reactions['👍']).toBeUndefined()
+    expect(state.reactions['❤️']).toBe(1)
     expect(api.deleteReaction).toHaveBeenCalledWith('note1')
     expect(api.createReaction).toHaveBeenCalledWith('note1', '❤️')
+    expect(calls).toEqual(['delete', 'create'])
   })
 
   it('decrements count instead of deleting when count > 1', async () => {
@@ -87,22 +128,24 @@ describe('toggleReaction', () => {
       reactions: { '👍': 3 },
       myReaction: '👍',
     })
+    const { state, apply } = track(note)
 
-    await toggleReaction(api, note, '👍')
+    await toggleReaction(api, note, '👍', apply)
 
-    expect(note.myReaction).toBeNull()
-    expect(note.reactions['👍']).toBe(2)
+    expect(state.myReaction).toBeNull()
+    expect(state.reactions['👍']).toBe(2)
   })
 
   it('rolls back on API failure', async () => {
     const api = makeApi()
     api.createReaction.mockRejectedValue(new Error('fail'))
     const note = makeNote()
+    const { state, apply } = track(note)
 
-    await expect(toggleReaction(api, note, '👍')).rejects.toThrow('fail')
+    await expect(toggleReaction(api, note, '👍', apply)).rejects.toThrow('fail')
 
-    expect(note.myReaction).toBeNull()
-    expect(note.reactions['👍']).toBeUndefined()
+    expect(state.myReaction).toBeNull()
+    expect(state.reactions['👍']).toBeUndefined()
   })
 
   it('rolls back switch on API failure', async () => {
@@ -112,11 +155,12 @@ describe('toggleReaction', () => {
       reactions: { '👍': 1 },
       myReaction: '👍',
     })
+    const { state, apply } = track(note)
 
-    await expect(toggleReaction(api, note, '❤️')).rejects.toThrow('fail')
+    await expect(toggleReaction(api, note, '❤️', apply)).rejects.toThrow('fail')
 
-    expect(note.myReaction).toBe('👍')
-    expect(note.reactions['👍']).toBe(1)
-    expect(note.reactions['❤️']).toBeUndefined()
+    expect(state.myReaction).toBe('👍')
+    expect(state.reactions['👍']).toBe(1)
+    expect(state.reactions['❤️']).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 変更内容

### 修正
- fix(notify): 通知画像の取得を ImageCache に一元化し Android のクラッシュ経路を塞ぐ
- fix(emoji): 新規カスタム絵文字の永久空白と失敗の固定化を解消
- fix(reaction): 自分のリアクションが UI に即反映されない問題を解消
- fix(media): 二段階配信のプレースホルダ滞留に自己修復を追加 (Android)
- fix(media): 最終点検で見つかった回復漏れ 3 件を塞ぐ
- fix(notify): リノート通知のリアクションが UI に反映されない問題を解消

### パフォーマンス
- perf(media): デスクトップの wait をソフト予算化しバースト時の空白を解消

### その他
- chore: bump version to 1.33.4

## ローカル検証

- `pnpm typecheck` — 通過
- `pnpm test` — 217 files / 2399 tests 全通過


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reaction updates with accurate counts, optimistic feedback, rollback handling, and synchronization across views.
  * Added reaction support for notes shown in clip details.
  * Improved custom emoji resolution, caching, refresh, and fallback handling.
  * Improved media loading with caching, placeholder recovery, retries, and bounded image prefetching.
  * Android notifications now support local avatar and emoji images.

* **Bug Fixes**
  * Fixed notification and reaction updates not appearing consistently across views.
  * Improved handling of failed media, emoji images, and status-bar operations.

* **Chores**
  * Updated the application version to 1.33.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->