### PR TITLE
Release v1.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.33.4",
+  "version": "1.34.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3158,7 +3158,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.6.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=8a9b9969c239620f571f31a972cdecd6944f88fb#8a9b9969c239620f571f31a972cdecd6944f88fb"
+source = "git+https://github.com/notedeck-dev/notecli?rev=77fd53104fc73d797c04da2c04897ede5be4886b#77fd53104fc73d797c04da2c04897ede5be4886b"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.33.4"
+version = "1.34.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3158,7 +3158,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.6.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=a529c4f2520cb42385cb6cba0fab04a4945ae18d#a529c4f2520cb42385cb6cba0fab04a4945ae18d"
+source = "git+https://github.com/notedeck-dev/notecli?rev=8a9b9969c239620f571f31a972cdecd6944f88fb#8a9b9969c239620f571f31a972cdecd6944f88fb"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.33.4"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "a529c4f2520cb42385cb6cba0fab04a4945ae18d", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "8a9b9969c239620f571f31a972cdecd6944f88fb", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "notedeck"
-version = "1.33.4"
+version = "1.34.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "8a9b9969c239620f571f31a972cdecd6944f88fb", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "77fd53104fc73d797c04da2c04897ede5be4886b", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -295,7 +295,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Server-sent event stream (`text/event-stream`). Each event carries an `event:` type and a JSON `data:` payload typed as `SseEventPayload` — the `event:` name selects the variant (`note` / `mention` / `note-updated` / `note-capture-updated` / `notification` / `main-{eventType}` / `chat` / `chat-deleted` / `chat-reacted` / `chat-unreacted` / `status`). The `type` query param filters by event-name prefix.",
+            "description": "Server-sent event stream (`text/event-stream`). Each event carries an `event:` type and a JSON `data:` payload typed as `SseEventPayload` — the `event:` name selects the variant (`note` / `mention` / `note-updated` / `note-capture-updated` / `notification` / `main-{eventType}` / `chat` / `chat-deleted` / `chat-reacted` / `chat-unreacted` / `status` / `emoji-changed`). The `type` query param filters by event-name prefix.",
             "content": {
               "text/event-stream": {
                 "schema": {
@@ -1826,6 +1826,15 @@
           }
         }
       },
+      "EmojiChangeKind": {
+        "type": "string",
+        "description": "broadcast チャネルの絵文字辞書変更の種別。",
+        "enum": [
+          "added",
+          "updated",
+          "deleted"
+        ]
+      },
       "NormalizedDriveFile": {
         "type": "object",
         "required": [
@@ -2690,6 +2699,35 @@
           }
         }
       },
+      "ServerEmoji": {
+        "type": "object",
+        "description": "Emoji info exposed to the frontend via Tauri commands.",
+        "required": [
+          "name",
+          "url",
+          "aliases"
+        ],
+        "properties": {
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "category": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
       "SseEventPayload": {
         "oneOf": [
           {
@@ -2724,9 +2762,12 @@
           },
           {
             "$ref": "#/components/schemas/StreamStatusEvent"
+          },
+          {
+            "$ref": "#/components/schemas/StreamEmojiChangedEvent"
           }
         ],
-        "description": "SSE `data:` payload の union (#781 Phase 4)。discriminator は SSE の\n`event:` フィールド (out-of-band) なので untagged oneOf として文書化する。\n`event:` 名と variant の対応:\nnote/mention → StreamNote/StreamMentionEvent、note-updated →\nStreamNoteUpdatedEvent、note-capture-updated → StreamNoteCaptureEvent、\nnotification → StreamNotificationEvent、main-{eventType} → StreamMainEvent、\nchat → StreamChatMessageEvent、chat-deleted / chat-reacted / chat-unreacted →\nStreamChatMessage{Deleted,Reacted,Unreacted}Event、status → StreamStatusEvent"
+        "description": "SSE `data:` payload の union (#781 Phase 4)。discriminator は SSE の\n`event:` フィールド (out-of-band) なので untagged oneOf として文書化する。\n`event:` 名と variant の対応:\nnote/mention → StreamNote/StreamMentionEvent、note-updated →\nStreamNoteUpdatedEvent、note-capture-updated → StreamNoteCaptureEvent、\nnotification → StreamNotificationEvent、main-{eventType} → StreamMainEvent、\nchat → StreamChatMessageEvent、chat-deleted / chat-reacted / chat-unreacted →\nStreamChatMessage{Deleted,Reacted,Unreacted}Event、status → StreamStatusEvent、\nemoji-changed → StreamEmojiChangedEvent"
       },
       "StreamChatMessageDeletedEvent": {
         "type": "object",
@@ -2840,6 +2881,34 @@
           "reconnecting",
           "disconnected"
         ]
+      },
+      "StreamEmojiChangedEvent": {
+        "type": "object",
+        "description": "サーバー全体配信 (broadcast) の絵文字辞書変更 (#889)。\n本家は emojiAdded / emojiUpdated / emojiDeleted を channel ラップなしの\nトップレベル type で全接続に配る。",
+        "required": [
+          "accountId",
+          "host",
+          "change",
+          "emojis"
+        ],
+        "properties": {
+          "accountId": {
+            "type": "string"
+          },
+          "change": {
+            "$ref": "#/components/schemas/EmojiChangeKind"
+          },
+          "emojis": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerEmoji"
+            }
+          },
+          "host": {
+            "type": "string",
+            "description": "絵文字辞書のキーになるサーバー host"
+          }
+        }
       },
       "StreamMainEvent": {
         "type": "object",

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.33.4"
+    "version": "1.34.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -305,8 +305,8 @@ impl ImageCache {
 
         // SSRF 防御は commands::http の validate_external_host に一元化
         // (IP literal に加えて localhost / .local / .internal 等の hostname も
-        // 弾く)。DNS 解決結果の検証 + pinning は vault::ssrf の per-fetch
-        // resolver が要るため未適用 — 共有 client の経路では別途検討
+        // 弾く)。DNS 解決結果の検証 (rebinding 対策) は共有 client に装着した
+        // vault::ssrf::ValidatingResolver が接続前に行う (#857)
         {
             let parsed = url::Url::parse(url).map_err(|e| format!("invalid url: {e}"))?;
             let host = parsed.host_str().ok_or("url has no host")?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,7 +250,9 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         // Shared HTTP client (struct construction — fast, no I/O)。
         // ValidatingResolver (#857): メディア・OGP の全 egress で名前解決の
         // 結果を接続前に検証し、private / loopback へ解決される公開ホスト名
-        // (DNS rebinding) を弾く。接続プール・並列取得はそのまま
+        // (DNS rebinding) を弾く。接続プール・並列取得はそのまま。
+        // build 失敗時は起動を止める — Client::default() は resolver も timeout も
+        // redirect 制限も持たないので、黙って防御なしで動き続けることになる
         let shared_http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .pool_max_idle_per_host(8)
@@ -258,8 +260,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
             .redirect(reqwest::redirect::Policy::limited(5))
             .dns_resolver(std::sync::Arc::new(vault::ssrf::ValidatingResolver))
-            .build()
-            .unwrap_or_default();
+            .build()?;
         app.manage(shared_http.clone());
 
         // HEARTBEAT scheduler (#411): per-AI-column tokio interval task。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -247,13 +247,17 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         let shared_perf_bg = shared_perf.clone();
         app.manage(shared_perf);
 
-        // Shared HTTP client (struct construction — fast, no I/O)
+        // Shared HTTP client (struct construction — fast, no I/O)。
+        // ValidatingResolver (#857): メディア・OGP の全 egress で名前解決の
+        // 結果を接続前に検証し、private / loopback へ解決される公開ホスト名
+        // (DNS rebinding) を弾く。接続プール・並列取得はそのまま
         let shared_http = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(10))
             .pool_max_idle_per_host(8)
             .pool_idle_timeout(std::time::Duration::from_secs(60))
             .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
             .redirect(reqwest::redirect::Policy::limited(5))
+            .dns_resolver(std::sync::Arc::new(vault::ssrf::ValidatingResolver))
             .build()
             .unwrap_or_default();
         app.manage(shared_http.clone());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -958,6 +958,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             streaming::StreamStatus,
             streaming::StreamChatMessageReacted,
             streaming::StreamChatMessageUnreacted,
+            streaming::StreamEmojiChanged,
             os_notify::NotificationClicked,
             commands::ExportProgress,
             media_proxy::MediaFetched,

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -32,6 +32,10 @@ pub struct StreamChatMessageReacted(pub notecli::streaming::StreamChatMessageRea
 #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
 pub struct StreamChatMessageUnreacted(pub notecli::streaming::StreamChatMessageUnreactedEvent);
 
+/// broadcast の絵文字辞書変更 (#889)。絵文字ストアが購読して push 反映する。
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct StreamEmojiChanged(pub notecli::streaming::StreamEmojiChangedEvent);
+
 #[cfg(target_os = "android")]
 const NOTIFICATION_CHANNEL_ID: &str = "notedeck_notifications";
 
@@ -644,6 +648,7 @@ impl<R: tauri::Runtime> FrontendEmitter for TauriEmitter<R> {
             E::ChatMessageUnreacted(e) => StreamChatMessageUnreacted((**e).clone())
                 .emit(&self.app)
                 .err(),
+            E::EmojiChanged(e) => StreamEmojiChanged((**e).clone()).emit(&self.app).err(),
             _ => None,
         };
         if let Some(e) = dedicated {

--- a/src-tauri/src/vault/ssrf.rs
+++ b/src-tauri/src/vault/ssrf.rs
@@ -16,6 +16,36 @@ use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 
 use crate::commands::{check_ip_safe, validate_external_host};
 
+/// host を名前解決し、全 IP を `check_ip_safe` で検証して返す共通処理。
+///
+/// 1 つでも危険な IP があれば host 全体を deny (Happy Eyeballs で危険な IP に
+/// 接続される可能性を排除)。名前解決は blocking なので spawn_blocking に逃がす。
+async fn resolve_and_validate(
+    host: &str,
+) -> Result<Vec<IpAddr>, Box<dyn std::error::Error + Send + Sync>> {
+    let host_for_lookup = host.to_string();
+    let resolved: Vec<IpAddr> = tokio::task::spawn_blocking(move || {
+        (host_for_lookup.as_str(), 0u16)
+            .to_socket_addrs()
+            .map(|iter| iter.map(|sa| sa.ip()).collect::<Vec<_>>())
+    })
+    .await
+    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?
+    .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?;
+
+    for ip in &resolved {
+        if let Err(reason) = check_ip_safe(*ip) {
+            return Err(Box::from(format!(
+                "host {host} resolved to a blocked address: {reason}"
+            )));
+        }
+    }
+    if resolved.is_empty() {
+        return Err(Box::from(format!("host {host} did not resolve")));
+    }
+    Ok(resolved)
+}
+
 /// 1 回の fetch スコープで DNS を pin する resolver。
 ///
 /// `vault_fetch` ごとに 1 インスタンス生成すること。redirect を跨いでも
@@ -45,34 +75,35 @@ impl Resolve for PinningResolver {
                 return Ok(addrs);
             }
 
-            // 名前解決は blocking。spawn_blocking に逃がす。
-            let host_for_lookup = host.clone();
-            let resolved: Vec<IpAddr> = tokio::task::spawn_blocking(move || {
-                (host_for_lookup.as_str(), 0u16)
-                    .to_socket_addrs()
-                    .map(|iter| iter.map(|sa| sa.ip()).collect::<Vec<_>>())
-            })
-            .await
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?
-            .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { Box::from(e.to_string()) })?;
-
-            // 解決された IP を 1 つずつ検証する。1 つでも危険なら host 全体を deny
-            // (Happy Eyeballs で危険な IP に接続される可能性を排除)。
-            for ip in &resolved {
-                if let Err(reason) = check_ip_safe(*ip) {
-                    return Err(Box::from(format!(
-                        "host {host} resolved to a blocked address: {reason}"
-                    )));
-                }
-            }
-            if resolved.is_empty() {
-                return Err(Box::from(format!("host {host} did not resolve")));
-            }
+            let resolved = resolve_and_validate(&host).await?;
 
             cache
                 .lock()
                 .unwrap()
                 .insert(host.clone(), resolved.clone());
+            let addrs: Addrs = Box::new(resolved.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+            Ok(addrs)
+        })
+    }
+}
+
+/// 長寿命の共有 client (メディアプロキシ・OGP) 用: 解決のたびに検証する
+/// resolver (#857)。
+///
+/// PinningResolver と違い結果をキャッシュしない — 長寿命 client で永続 pin
+/// すると正当な IP 変更に追随できず、エントリも無限に積もる。rebinding 防御は
+/// pin ではなく構造で成立する: resolver が返した (検証済みの) IP がそのまま
+/// 接続に使われるため、検証と実接続の解決結果が食い違う余地がない。攻撃者が
+/// 再解決で private IP を返しても、その解決自体が検証で弾かれる。redirect の
+/// 各 hop でも呼ばれるため、リダイレクト先の内部宛ても同様に弾く。
+#[derive(Clone)]
+pub struct ValidatingResolver;
+
+impl Resolve for ValidatingResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        let host = name.as_str().to_string();
+        Box::pin(async move {
+            let resolved = resolve_and_validate(&host).await?;
             let addrs: Addrs = Box::new(resolved.into_iter().map(|ip| SocketAddr::new(ip, 0)));
             Ok(addrs)
         })
@@ -127,6 +158,23 @@ mod tests {
 
         let off = reqwest::Url::parse("https://evil.com/x").unwrap();
         assert!(validate_redirect_url(&off, &allowed).is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_and_validate_rejects_loopback_resolution() {
+        // localhost は /etc/hosts で必ず loopback に解決される。「hostname の
+        // 文字列検査は通るが解決先が内部」という DNS rebinding 相当のケースを
+        // 接続前に弾けることの検証 (#857)
+        let err = resolve_and_validate("localhost").await.unwrap_err();
+        assert!(err.to_string().contains("blocked address"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn resolve_and_validate_rejects_private_ip_literal() {
+        for host in ["127.0.0.1", "10.0.0.1", "169.254.169.254", "192.168.1.1"] {
+            let err = resolve_and_validate(host).await.unwrap_err();
+            assert!(err.to_string().contains("blocked address"), "{host}: {err}");
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.33.4",
+  "version": "1.34.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2444,6 +2444,7 @@ notificationClicked: NotificationClicked,
 queryDelta: QueryDelta,
 streamChatMessageReacted: StreamChatMessageReacted,
 streamChatMessageUnreacted: StreamChatMessageUnreacted,
+streamEmojiChanged: StreamEmojiChanged,
 streamEnvelope: StreamEnvelope,
 streamStatus: StreamStatus
 }>({
@@ -2454,6 +2455,7 @@ notificationClicked: "notification-clicked",
 queryDelta: "query-delta",
 streamChatMessageReacted: "stream-chat-message-reacted",
 streamChatMessageUnreacted: "stream-chat-message-unreacted",
+streamEmojiChanged: "stream-emoji-changed",
 streamEnvelope: "stream-envelope",
 streamStatus: "stream-status"
 })
@@ -2727,6 +2729,10 @@ export type CreatedApiToken = { meta: ApiTokenMeta;
  */
 token: string }
 export type CreatedDriveFolder = { id: string; name: string; parentId?: string | null }
+/**
+ * broadcast チャネルの絵文字辞書変更の種別。
+ */
+export type EmojiChangeKind = "added" | "updated" | "deleted"
 /**
  * `notes_cache` の eviction policy。 デフォルトは「ほぼ永続保存」 — notedeck の
  * 「過去ノートを一瞬でローカル検索」という UX を尊重し、 暴走防止の hard cap
@@ -3203,6 +3209,20 @@ export type StreamChatMessageUnreactedEvent = { accountId: string; subscriptionI
  */
 export type StreamConnectionState = "connected" | "reconnecting" | "disconnected"
 /**
+ * broadcast の絵文字辞書変更 (#889)。絵文字ストアが購読して push 反映する。
+ */
+export type StreamEmojiChanged = StreamEmojiChangedEvent
+/**
+ * サーバー全体配信 (broadcast) の絵文字辞書変更 (#889)。
+ * 本家は emojiAdded / emojiUpdated / emojiDeleted を channel ラップなしの
+ * トップレベル type で全接続に配る。
+ */
+export type StreamEmojiChangedEvent = { accountId: string; 
+/**
+ * 絵文字辞書のキーになるサーバー host
+ */
+host: string; change: EmojiChangeKind; emojis: ServerEmoji[] }
+/**
  * 統合チャネル (イベント名 "stream-envelope")。全イベントを { kind, payload }
  * の tagged union で流す。Inspector の raw tap と未読カウンタが購読する。
  * 名前が notecli::streaming::StreamEvent と衝突すると specta の TS 出力が
@@ -3215,7 +3235,7 @@ export type StreamEnvelope = StreamEvent
  * 歴史的ワイヤ形 `{ kind, payload }` と一致する。Box は serde/specta とも
  * 透過 (variant 間サイズ差の抑制、clippy::large_enum_variant)。
  */
-export type StreamEvent = { kind: "stream-note"; payload: StreamNoteEvent } | { kind: "stream-notification"; payload: StreamNotificationEvent } | { kind: "stream-mention"; payload: StreamMentionEvent } | { kind: "stream-main-event"; payload: StreamMainEvent } | { kind: "stream-note-updated"; payload: StreamNoteUpdatedEvent } | { kind: "stream-note-capture-updated"; payload: StreamNoteCaptureEvent } | { kind: "stream-chat-message"; payload: StreamChatMessageEvent } | { kind: "stream-chat-message-deleted"; payload: StreamChatMessageDeletedEvent } | { kind: "stream-chat-message-reacted"; payload: StreamChatMessageReactedEvent } | { kind: "stream-chat-message-unreacted"; payload: StreamChatMessageUnreactedEvent } | { kind: "stream-status"; payload: StreamStatusEvent }
+export type StreamEvent = { kind: "stream-note"; payload: StreamNoteEvent } | { kind: "stream-notification"; payload: StreamNotificationEvent } | { kind: "stream-mention"; payload: StreamMentionEvent } | { kind: "stream-main-event"; payload: StreamMainEvent } | { kind: "stream-note-updated"; payload: StreamNoteUpdatedEvent } | { kind: "stream-note-capture-updated"; payload: StreamNoteCaptureEvent } | { kind: "stream-chat-message"; payload: StreamChatMessageEvent } | { kind: "stream-chat-message-deleted"; payload: StreamChatMessageDeletedEvent } | { kind: "stream-chat-message-reacted"; payload: StreamChatMessageReactedEvent } | { kind: "stream-chat-message-unreacted"; payload: StreamChatMessageUnreactedEvent } | { kind: "stream-status"; payload: StreamStatusEvent } | { kind: "stream-emoji-changed"; payload: StreamEmojiChangedEvent }
 export type StreamMainEvent = { accountId: string; subscriptionId: string; eventType: string; body: JsonValue }
 export type StreamMentionEvent = { accountId: string; subscriptionId: string; note: NormalizedNote }
 export type StreamNoteCaptureEvent = ({ updateType: "reacted"; body: NoteReactedBody } | { updateType: "unreacted"; body: NoteUnreactedBody } | { updateType: "pollVoted"; body: NotePollVotedBody } | { updateType: "deleted"; body: NoteDeletedBody }) & { accountId: string; noteId: string }

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -58,7 +58,12 @@ const {
   getAdapter,
   postForm,
   handlers,
-} = useColumnSetup(() => props.column)
+} = useColumnSetup(() => props.column, {
+  // 照会結果は noteStore ではなくローカルの deep ref (result / ancestors /
+  // children) に保持しているため、差分は対象オブジェクトへ直接代入して
+  // 反映する (cross-account 側の handleReactionCrossAccount と同じ規則)
+  applyNotePatch: (note, patch) => Object.assign(note, patch),
+})
 
 const accountsStore = useAccountsStore()
 

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -447,7 +447,10 @@ async function handleVoteCrossAccount(choice: number, target: NormalizedNote) {
   if (!adapter) return
   const { votePoll } = await import('@/utils/votePoll')
   try {
-    await votePoll(adapter.api, target, choice)
+    // スレッドは deep reactive (ref) なので、差分の代入で反映される
+    await votePoll(adapter.api, target, choice, (patch) => {
+      Object.assign(target, patch)
+    })
   } catch {
     // ignore
   }

--- a/src/components/window/ClipDetailContent.vue
+++ b/src/components/window/ClipDetailContent.vue
@@ -64,22 +64,42 @@ const visibleNotes = computed(() =>
   filterVisible(notes.value, { ignoreSuspension: isOwnClip.value }),
 )
 
+/** 楽観的更新の差分を反映する。shallowRef 保持なので新オブジェクトへ差し替える */
+function applyNotePatch(
+  target: NormalizedNote,
+  patch: Partial<NormalizedNote>,
+) {
+  notes.value = notes.value.map((n) =>
+    n.id === target.id
+      ? { ...n, ...patch }
+      : n.renote?.id === target.id
+        ? { ...n, renote: { ...n.renote, ...patch } }
+        : n,
+  )
+}
+
 async function handleReaction(reaction: string, target: NormalizedNote) {
   if (!adapter) return
   try {
-    await toggleReaction(adapter.api, target, reaction, (patch) => {
-      // shallowRef 保持なので新オブジェクトへの差し替えで反映する
-      notes.value = notes.value.map((n) =>
-        n.id === target.id
-          ? { ...n, ...patch }
-          : n.renote?.id === target.id
-            ? { ...n, renote: { ...n.renote, ...patch } }
-            : n,
-      )
-    })
+    await toggleReaction(adapter.api, target, reaction, (patch) =>
+      applyNotePatch(target, patch),
+    )
   } catch (e) {
     const err = AppError.from(e)
     toast.show(`リアクションに失敗しました（${err.displayCode}）`, 'error')
+  }
+}
+
+async function handleVote(choice: number, target: NormalizedNote) {
+  if (!adapter) return
+  const { votePoll } = await import('@/utils/votePoll')
+  try {
+    await votePoll(adapter.api, target, choice, (patch) =>
+      applyNotePatch(target, patch),
+    )
+  } catch (e) {
+    const err = AppError.from(e)
+    toast.show(`投票に失敗しました（${err.displayCode}）`, 'error')
   }
 }
 
@@ -208,6 +228,7 @@ onMounted(async () => {
           :note="note"
           :account-id="accountId"
           @react="handleReaction"
+          @vote="handleVote"
         />
         <div v-if="notesLoading" :class="$style.notesLoading">
           <LoadingSpinner />

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -252,7 +252,10 @@ async function handleVote(choice: number, target: NormalizedNote) {
   if (!adapter) return
   const { votePoll } = await import('@/utils/votePoll')
   try {
-    await votePoll(adapter.api, target, choice)
+    // note は deep reactive (ref) なので、差分の代入で反映される
+    await votePoll(adapter.api, target, choice, (patch) => {
+      Object.assign(target, patch)
+    })
   } catch (e) {
     error.value = AppError.from(e)
   }

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -517,27 +517,34 @@ function handleComposeToUser(acct: string) {
   showPostForm.value = true
 }
 
+/**
+ * 楽観的更新の差分を全タブへ反映する。各面とも shallowRef 保持
+ * (非 reactive オブジェクト) なので、新オブジェクトへの差し替えで反映する。
+ * note がどの面から来たかは追わず、全面を id で差し替える
+ * (リノートに包まれた表示も含む)
+ */
+function applyNotePatch(note: NormalizedNote, patch: Partial<NormalizedNote>) {
+  const updated = { ...note, ...patch }
+  const swap = (n: NormalizedNote) =>
+    n.id === note.id
+      ? updated
+      : n.renote?.id === note.id
+        ? { ...n, renote: updated }
+        : n
+  pinnedNotes.value = pinnedNotes.value.map(swap)
+  filesNotes.value = filesNotes.value.map(swap)
+  reactionEntries.value = reactionEntries.value.map((e) =>
+    e.note.id === note.id ? { ...e, note: updated } : e,
+  )
+  notesListRef.value?.replaceNote(note.id, updated)
+}
+
 async function handleReaction(reaction: string, note: NormalizedNote) {
   if (!adapter.value) return
   try {
-    await toggleReaction(adapter.value.api, note, reaction, (patch) => {
-      // 各面とも shallowRef 保持 (非 reactive オブジェクト) なので、
-      // 新オブジェクトへの差し替えで反映する。note がどの面から来たかは
-      // 追わず、全面を id で差し替える (リノートに包まれた表示も含む)
-      const updated = { ...note, ...patch }
-      const swap = (n: NormalizedNote) =>
-        n.id === note.id
-          ? updated
-          : n.renote?.id === note.id
-            ? { ...n, renote: updated }
-            : n
-      pinnedNotes.value = pinnedNotes.value.map(swap)
-      filesNotes.value = filesNotes.value.map(swap)
-      reactionEntries.value = reactionEntries.value.map((e) =>
-        e.note.id === note.id ? { ...e, note: updated } : e,
-      )
-      notesListRef.value?.replaceNote(note.id, updated)
-    })
+    await toggleReaction(adapter.value.api, note, reaction, (patch) =>
+      applyNotePatch(note, patch),
+    )
   } catch (e) {
     error.value = AppError.from(e)
   }
@@ -547,7 +554,9 @@ async function handleVote(choice: number, target: NormalizedNote) {
   if (!adapter.value) return
   const { votePoll } = await import('@/utils/votePoll')
   try {
-    await votePoll(adapter.value.api, target, choice)
+    await votePoll(adapter.value.api, target, choice, (patch) =>
+      applyNotePatch(target, patch),
+    )
   } catch (e) {
     error.value = AppError.from(e)
   }

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -20,12 +20,18 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { toggleFavorite } from '@/utils/toggleFavorite'
-import { toggleReaction } from '@/utils/toggleReaction'
+import { type ReactionPatch, toggleReaction } from '@/utils/toggleReaction'
 import { votePoll } from '@/utils/votePoll'
 
 export interface ColumnSetupOptions {
   /** Reactive offline flag — when true, write operations are blocked */
   isOffline?: () => boolean
+  /**
+   * 楽観的更新の差分の適用先。既定は noteStore への差し替えだが、ノートを
+   * noteStore に置かない面 (照会カラムのローカル deep ref 等) は自分の
+   * 保持形態に合わせて差し替える。
+   */
+  applyNotePatch?: (note: NormalizedNote, patch: ReactionPatch) => void
 }
 
 export function useColumnSetup(
@@ -170,8 +176,12 @@ export function useColumnSetup(
     if (!adapter || checkOffline()) return
     try {
       await toggleReaction(adapter.api, note, reaction, (patch) => {
-        // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
-        noteStore.update(note.id, { ...note, ...patch })
+        if (options?.applyNotePatch) {
+          options.applyNotePatch(note, patch)
+        } else {
+          // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
+          noteStore.update(note.id, { ...note, ...patch })
+        }
         customMutatedFn?.()
       })
       if (!getColumn().soundMuted) actionSound.play()

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -20,18 +20,21 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { AppError } from '@/utils/errors'
 import { toggleFavorite } from '@/utils/toggleFavorite'
-import { type ReactionPatch, toggleReaction } from '@/utils/toggleReaction'
+import { toggleReaction } from '@/utils/toggleReaction'
 import { votePoll } from '@/utils/votePoll'
 
 export interface ColumnSetupOptions {
   /** Reactive offline flag — when true, write operations are blocked */
   isOffline?: () => boolean
   /**
-   * 楽観的更新の差分の適用先。既定は noteStore への差し替えだが、ノートを
-   * noteStore に置かない面 (照会カラムのローカル deep ref 等) は自分の
-   * 保持形態に合わせて差し替える。
+   * 楽観的更新の差分 (リアクション・投票) の適用先。既定は noteStore への
+   * 差し替えだが、ノートを noteStore に置かない面 (照会カラムのローカル
+   * deep ref 等) は自分の保持形態に合わせて差し替える。
    */
-  applyNotePatch?: (note: NormalizedNote, patch: ReactionPatch) => void
+  applyNotePatch?: (
+    note: NormalizedNote,
+    patch: Partial<NormalizedNote>,
+  ) => void
 }
 
 export function useColumnSetup(
@@ -172,18 +175,23 @@ export function useColumnSetup(
     return false
   }
 
+  /** 楽観的更新の差分を面の保持形態に反映する (既定は noteStore への差し替え) */
+  function applyPatch(note: NormalizedNote, patch: Partial<NormalizedNote>) {
+    if (options?.applyNotePatch) {
+      options.applyNotePatch(note, patch)
+    } else {
+      // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
+      noteStore.update(note.id, { ...note, ...patch })
+    }
+    customMutatedFn?.()
+  }
+
   async function handleReaction(reaction: string, note: NormalizedNote) {
     if (!adapter || checkOffline()) return
     try {
-      await toggleReaction(adapter.api, note, reaction, (patch) => {
-        if (options?.applyNotePatch) {
-          options.applyNotePatch(note, patch)
-        } else {
-          // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
-          noteStore.update(note.id, { ...note, ...patch })
-        }
-        customMutatedFn?.()
-      })
+      await toggleReaction(adapter.api, note, reaction, (patch) =>
+        applyPatch(note, patch),
+      )
       if (!getColumn().soundMuted) actionSound.play()
     } catch (e) {
       const err = AppError.from(e)
@@ -195,7 +203,9 @@ export function useColumnSetup(
   async function handlePollVote(choice: number, note: NormalizedNote) {
     if (!adapter || checkOffline()) return
     try {
-      await votePoll(adapter.api, note, choice, notifyMutationFor(note))
+      await votePoll(adapter.api, note, choice, (patch) =>
+        applyPatch(note, patch),
+      )
     } catch (e) {
       const err = AppError.from(e)
       console.error('[vote]', err.code, err.message)

--- a/src/composables/useImagePrefetch.dom.test.ts
+++ b/src/composables/useImagePrefetch.dom.test.ts
@@ -74,4 +74,40 @@ describe('prefetchNoteImages の同時実行絞り', () => {
     // 2 回呼んでも Image は 2 件 (dedup)
     expect(FakeImage.instances.length).toBe(2)
   })
+
+  it('キュー溢れで捨てた URL は「先読み済み」からも外れ、後で再度先読みできる (#893)', async () => {
+    const { prefetchNoteImages } = await loadModule()
+    // 105 件: 先頭 4 件が即実行、100 件でキューが埋まり、105 件目の投入で
+    // 最古のキュー項目 (x-4) が捨てられる
+    prefetchNoteImages([note('x', 105)])
+    expect(FakeImage.instances.length).toBe(4)
+
+    // 全件完了させてキューを流し切る (捨てられた x-4 は一度も取得されない)
+    for (let i = 0; i < FakeImage.instances.length; i++) {
+      FakeImage.instances[i]?.onload?.()
+    }
+    expect(FakeImage.instances.length).toBe(104)
+    const droppedUrl = encodeURIComponent('https://media.example/x-4.png')
+    expect(
+      FakeImage.instances.some((img) => img.src.includes(droppedUrl)),
+    ).toBe(false)
+
+    // 捨てられた URL を含むノートが再び近づいたら、先読みし直せる
+    prefetchNoteImages([
+      {
+        renote: null,
+        text: 'y',
+        files: [
+          {
+            type: 'image/png',
+            isSensitive: false,
+            thumbnailUrl: 'https://media.example/x-4.png',
+            url: 'https://media.example/x-4-orig.png',
+          },
+        ],
+      } as unknown as NormalizedNote,
+    ])
+    expect(FakeImage.instances.length).toBe(105)
+    expect(FakeImage.instances.at(-1)?.src).toContain(droppedUrl)
+  })
 })

--- a/src/composables/useImagePrefetch.ts
+++ b/src/composables/useImagePrefetch.ts
@@ -45,7 +45,12 @@ function pumpPrefetchQueue() {
 }
 
 function enqueuePrefetch(url: string) {
-  if (prefetchQueue.length >= MAX_QUEUE) prefetchQueue.shift()
+  if (prefetchQueue.length >= MAX_QUEUE) {
+    const dropped = prefetchQueue.shift()
+    // 捨てた分は一度も取得していないので「先読み済み」からも外す (#893)。
+    // 残したままだと、スクロールで戻ったときに永久にスキップされる
+    if (dropped !== undefined) prefetchedUrls.delete(dropped)
+  }
   prefetchQueue.push(url)
   pumpPrefetchQueue()
 }

--- a/src/services/streamUpdateMerge.test.ts
+++ b/src/services/streamUpdateMerge.test.ts
@@ -96,6 +96,56 @@ describe('mergeNoteUpdate', () => {
     expect(merged?.reactions[':meow@.:']).toBeUndefined()
   })
 
+  it('自ユーザの echo でも同梱の絵文字 URL は取り込む (カウントは進めない) (#891)', () => {
+    // リモート絵文字 (相乗り #630) は note.reactionEmojis が唯一の解決源。
+    // echo の抑止と同時に URL まで捨てると、自分が押した絵文字が
+    // 不明アイコンになる
+    const note = makeNote({
+      reactions: { ':wave@remote.example:': 1 },
+      myReaction: ':wave@remote.example:',
+    })
+    const merged = mergeNoteUpdate(
+      note,
+      {
+        type: 'reacted',
+        noteId: 'n1',
+        body: {
+          userId: 'me',
+          reaction: ':wave@remote.example:',
+          emoji: { name: 'wave@remote.example', url: 'https://r/wave.png' },
+        },
+      },
+      'me',
+    )
+    expect(merged?.reactions[':wave@remote.example:']).toBe(1)
+    expect(merged?.myReaction).toBe(':wave@remote.example:')
+    expect(merged?.reactionEmojis['wave@remote.example']).toBe(
+      'https://r/wave.png',
+    )
+  })
+
+  it('自ユーザの echo: 絵文字 URL に新情報が無ければ従来どおり無視する', () => {
+    const note = makeNote({
+      reactions: { ':wave@remote.example:': 1 },
+      myReaction: ':wave@remote.example:',
+      reactionEmojis: { 'wave@remote.example': 'https://r/wave.png' },
+    })
+    const merged = mergeNoteUpdate(
+      note,
+      {
+        type: 'reacted',
+        noteId: 'n1',
+        body: {
+          userId: 'me',
+          reaction: ':wave@remote.example:',
+          emoji: { name: 'wave@remote.example', url: 'https://r/wave.png' },
+        },
+      },
+      'me',
+    )
+    expect(merged).toBeNull()
+  })
+
   it('カスタム絵文字はコロンを剥がして reactionEmojis に記録する', () => {
     const note = makeNote()
     const merged = mergeNoteUpdate(

--- a/src/services/streamUpdateMerge.ts
+++ b/src/services/streamUpdateMerge.ts
@@ -101,16 +101,9 @@ export function mergeNoteUpdate(
       // myUserId != null: guest (undefined) × userId 欠落イベントの undefined
       // 同士一致を「自分」と誤判定しない (pollVoted と同じ規約)
       const isMine = myUserId != null && event.body.userId === myUserId
-      if (isMine) {
-        // 楽観反映済みの echo → 二重加算しない
-        if (
-          note.myReaction &&
-          normalizeReactionKey(note.myReaction) ===
-            normalizeReactionKey(reaction)
-        ) {
-          return null
-        }
-      }
+      // echo 抑止の判断より先に同梱の絵文字 URL を取り込む (#891)。リモート
+      // 絵文字 (相乗り #630) は reactionEmojis が唯一の解決源なので、抑止と
+      // 同時に捨てると自分が押した絵文字が不明アイコンになる
       let newReactionEmojis = note.reactionEmojis
       if (event.body.emoji) {
         // Strip colons to match API convention (reactionEmojis keys have no colons)
@@ -122,7 +115,21 @@ export function mergeNoteUpdate(
           typeof event.body.emoji === 'string'
             ? event.body.emoji
             : event.body.emoji.url
-        newReactionEmojis = { ...note.reactionEmojis, [shortcode]: emojiUrl }
+        if (note.reactionEmojis?.[shortcode] !== emojiUrl) {
+          newReactionEmojis = { ...note.reactionEmojis, [shortcode]: emojiUrl }
+        }
+      }
+      if (isMine) {
+        // 楽観反映済みの echo → 二重加算しない。絵文字 URL だけ新しければ
+        // カウントを進めずに反映する
+        if (
+          note.myReaction &&
+          normalizeReactionKey(note.myReaction) ===
+            normalizeReactionKey(reaction)
+        ) {
+          if (newReactionEmojis === note.reactionEmojis) return null
+          return { ...note, reactionEmojis: newReactionEmojis }
+        }
       }
       // 形式違いの既存キー (:name: と :name@.:) は合流させ、別チップを作らない
       const key = findReactionKey(note.reactions, reaction)

--- a/src/stores/emojis.dom.test.ts
+++ b/src/stores/emojis.dom.test.ts
@@ -187,6 +187,79 @@ describe('useEmojisStore', () => {
     expect(store.resolve(HOST, 'meow')).toBeNull()
   })
 
+  describe('push 反映 (applyServerChange #889)', () => {
+    it('added: 取得済み host の辞書とピッカーリストへ即反映する', async () => {
+      const store = useEmojisStore()
+      store.ensureLoaded(HOST, vi.fn().mockResolvedValue([emoji('old')]))
+      await flush()
+
+      store.applyServerChange(HOST, 'added', [emoji('brand_new')])
+
+      expect(store.resolve(HOST, 'brand_new')).toBe(
+        `https://${HOST}/files/brand_new.webp`,
+      )
+      expect(store.getEmojiList(HOST).map((e) => e.name)).toEqual([
+        'old',
+        'brand_new',
+      ])
+    })
+
+    it('updated: 画像 URL の差し替えが miss を経ずに反映される', async () => {
+      // 名前は解決できるため miss にならず、pull 型では経年リフレッシュまで
+      // 最大 24 時間古い画像が表示され続けていたケース
+      const store = useEmojisStore()
+      store.ensureLoaded(HOST, vi.fn().mockResolvedValue([emoji('meow')]))
+      await flush()
+
+      const v2 = `https://${HOST}/files/meow-v2.webp`
+      store.applyServerChange(HOST, 'updated', [
+        { name: 'meow', url: v2, category: null, aliases: [] },
+      ])
+
+      expect(store.resolve(HOST, 'meow')).toBe(v2)
+      expect(store.getEmojiList(HOST).find((e) => e.name === 'meow')?.url).toBe(
+        v2,
+      )
+    })
+
+    it('deleted: 辞書から消え、以後の reportMiss は refetch を起こさない', async () => {
+      const store = useEmojisStore()
+      const fetcher = vi.fn().mockResolvedValue([emoji('meow')])
+      store.ensureLoaded(HOST, fetcher)
+      await flush()
+
+      store.applyServerChange(HOST, 'deleted', [emoji('meow')])
+
+      expect(store.resolve(HOST, 'meow')).toBeNull()
+      expect(store.getEmojiList(HOST)).toEqual([])
+      // 削除済みと分かっているので miss 駆動の空振り refetch を起こさない
+      store.reportMiss(HOST, 'meow')
+      await vi.advanceTimersByTimeAsync(10 * 60_000)
+      expect(fetcher).toHaveBeenCalledTimes(1)
+    })
+
+    it('deleted 後に added が来たら復活する (unknown の解放)', async () => {
+      const store = useEmojisStore()
+      store.ensureLoaded(HOST, vi.fn().mockResolvedValue([emoji('meow')]))
+      await flush()
+
+      store.applyServerChange(HOST, 'deleted', [emoji('meow')])
+      expect(store.resolve(HOST, 'meow')).toBeNull()
+
+      store.applyServerChange(HOST, 'added', [emoji('meow')])
+      expect(store.resolve(HOST, 'meow')).toBe(
+        `https://${HOST}/files/meow.webp`,
+      )
+    })
+
+    it('未取得の host には適用しない (次の ensureLoaded が全量を取る)', () => {
+      const store = useEmojisStore()
+      store.applyServerChange(HOST, 'added', [emoji('meow')])
+      expect(store.has(HOST)).toBe(false)
+      expect(store.resolve(HOST, 'meow')).toBeNull()
+    })
+  })
+
   it('壊れた host エントリは飛ばし、正常な分だけ復元する', () => {
     localStorage.setItem(
       'emojis_cache',

--- a/src/stores/emojis.ts
+++ b/src/stores/emojis.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { shallowRef } from 'vue'
 import type { ServerEmoji } from '@/adapters/types'
+import { events } from '@/bindings'
 import { usePerformanceStore } from '@/stores/performance'
 import { createDebouncedPersist } from '@/utils/debouncedPersist'
 import { getStorageJson, STORAGE_KEYS, setStorageJson } from '@/utils/storage'
@@ -231,6 +232,82 @@ export const useEmojisStore = defineStore('emojis', () => {
     }
   }
 
+  /**
+   * ストリーミング broadcast (emojiAdded / emojiUpdated / emojiDeleted) の
+   * push 反映 (#889)。pull 型 (reportMiss + 経年リフレッシュ) はフォール
+   * バックとして残る。辞書が未取得の host には適用しない — 部分適用で
+   * 「取得済み」に見せると、次の ensureLoaded が全量取得を skip してしまう。
+   */
+  function applyServerChange(
+    host: string,
+    change: 'added' | 'updated' | 'deleted',
+    emojis: ServerEmoji[],
+  ): void {
+    const lookup = cache.value.get(host)
+    if (!lookup) return
+
+    const nextLookup = { ...lookup }
+    const unknown = unknownNames.get(host)
+    if (change === 'deleted') {
+      for (const e of emojis) {
+        delete nextLookup[e.name]
+        delete nextLookup[`${e.name}@.`]
+      }
+    } else {
+      for (const e of emojis) {
+        nextLookup[e.name] = e.url
+        // 再登録された絵文字を拾えるよう unknown から解放する
+        unknown?.delete(e.name)
+      }
+    }
+    const nextCache = new Map(cache.value)
+    nextCache.set(host, nextLookup)
+    cache.value = nextCache
+
+    if (change === 'deleted') {
+      // 削除済みと分かっている名前は隔離し、miss 駆動の空振り refetch を
+      // 起こさない (added が来たら上で解放される)
+      let u = unknownNames.get(host)
+      if (!u) {
+        u = new Set()
+        unknownNames.set(host, u)
+      }
+      for (const e of emojis) u.add(e.name)
+    }
+
+    // ピッカー/補完用リストも保持している host なら同期する
+    const list = emojiList.value.get(host)
+    if (list) {
+      let nextEntries: ServerEmoji[]
+      if (change === 'deleted') {
+        const gone = new Set(emojis.map((e) => e.name))
+        nextEntries = list.filter((e) => !gone.has(e.name))
+      } else {
+        const byName = new Map(list.map((e) => [e.name, e]))
+        for (const e of emojis) byName.set(e.name, e)
+        nextEntries = [...byName.values()]
+      }
+      const nextList = new Map(emojiList.value)
+      nextList.set(host, nextEntries)
+      emojiList.value = nextList
+    }
+
+    schedulePersist()
+  }
+
+  // push 反映の購読
+  try {
+    events.streamEmojiChanged
+      .listen(({ payload }) =>
+        applyServerChange(payload.host, payload.change, payload.emojis),
+      )
+      .catch(() => {
+        // Tauri 外 (pnpm dev のブラウザ確認・テスト) では購読できない
+      })
+  } catch {
+    // 同上
+  }
+
   function resolve(host: string, shortcode: string): string | null {
     const map = cache.value.get(host)
     if (!map) return null
@@ -252,6 +329,7 @@ export const useEmojisStore = defineStore('emojis', () => {
     set,
     ensureLoaded,
     reportMiss,
+    applyServerChange,
     resolve,
     getEmojiList,
     has,

--- a/src/utils/emojiImgError.ts
+++ b/src/utils/emojiImgError.ts
@@ -1,21 +1,13 @@
-import { markMediaFailed, proxiedRawUrl } from '@/utils/mediaProxy'
-
 /**
  * カスタム絵文字 `<img>` の onerror 共通ハンドラ (#844)。
  *
- * unknown アイコンに落としつつ、プロキシへ失敗を申告してバックオフ再試行
- * させる。再試行で世代付き URL に変わると :src バインドが再評価され、
- * unknown アイコンから自然に復帰する。src の DOM 書き換えだけだと一過性の
- * 失敗 (リモート鯖の瞬断・プロキシ 502/504) がセッション中固定化する。
+ * unknown アイコンへの DOM フォールバックだけを行う。失敗の申告
+ * (バックオフ再試行) は mediaProxy の installMediaWatchdog が document
+ * capture で全 `<img>` の error を一括して拾う — 再試行で世代付き URL に
+ * 変わると :src バインドが再評価され、unknown アイコンから自然に復帰する。
  */
 export function onCustomEmojiImgError(e: Event): void {
   const img = e.target as HTMLImageElement
   if (img.src.endsWith('/emoji-unknown.svg')) return
-  const raw = proxiedRawUrl(img.src)
-  if (raw) markMediaFailed(raw)
   img.src = '/emoji-unknown.svg'
 }
-
-// プレースホルダ滞留 (透明 1×1 のまま MediaFetched を取りこぼす) の自己修復は
-// mediaProxy の installPlaceholderWatchdog が document capture で全 <img> を
-// 一括監視する — 個別の @load 配線は不要

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -404,6 +404,43 @@ describe('プレースホルダ滞留の全画像監視 (installPlaceholderWatch
     expect(proxyUrl(REMOTE)).toContain('&r=4')
   })
 
+  it('プロキシ経由の IMG の error は失敗申告され、バックオフ後に再試行する', async () => {
+    // 以前は絵文字の onerror (onCustomEmojiImgError) だけが失敗を申告して
+    // いた。アバター・添付・OGP も同じ二段階配信を通るので、error も load と
+    // 同じ document capture で一括して拾う
+    const { proxyUrl } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    const img = document.createElement('img')
+    img.src = proxied
+    document.body.appendChild(img)
+    img.dispatchEvent(new Event('error'))
+    vi.advanceTimersByTime(8_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+
+  it('プロキシ経由でない IMG の error は申告しない', async () => {
+    const { proxyUrl } = await loadModule()
+    proxyUrl(REMOTE) // 監視を起動させる
+    const direct = 'https://example.com/broken.png'
+    const img = document.createElement('img')
+    img.src = direct
+    document.body.appendChild(img)
+    img.dispatchEvent(new Event('error'))
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(direct)).not.toContain('&r=')
+  })
+
+  it('IMG 以外の要素の error は申告しない', async () => {
+    const { proxyUrl } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    const video = document.createElement('video')
+    ;(video as unknown as { src: string }).src = proxied
+    document.body.appendChild(video)
+    video.dispatchEvent(new Event('error'))
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(REMOTE)).not.toContain('&r=')
+  })
+
   it('IMG 以外の要素の load では試行回数をリセットしない', async () => {
     const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
     const proxied = proxyUrl(REMOTE) ?? ''

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -328,6 +328,54 @@ describe('プレースホルダ滞留の自己修復 (ensurePlaceholderRecovery)
   })
 })
 
+describe('URL 単位の状態の追い出し (#893)', () => {
+  // 失敗回数と自己修復の試行回数は「取得成功」でしか消えないため、恒久的に
+  // 壊れた URL・本当に 1×1 の画像が長時間セッションで無限に積もっていた。
+  // 世代番号の表 (mediaVersions) と同じ「上限で古い順に捨てる」規則を適用する
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('失敗記録は上限で古い順に捨てられ、追い出された URL は再試行できる', async () => {
+    const { proxyUrl, markMediaFailed } = await loadModule()
+    // リトライ上限まで失敗を積む (retries=3 で打ち切り状態)
+    for (let i = 0; i < 10; i++) {
+      markMediaFailed(REMOTE)
+      vi.advanceTimersByTime(10 * 60_000)
+    }
+    // 上限 (テスト環境の既定 256) を超える数の別 URL が失敗を申告する
+    for (let i = 0; i < 300; i++) {
+      markMediaFailed(`https://example.com/f${i}.png`)
+    }
+    // 最古の REMOTE は追い出されているので、打ち切り状態が解けて再試行できる
+    markMediaFailed(REMOTE)
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=4')
+  })
+
+  it('自己修復の試行回数は上限で古い順に捨てられる', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    // 自己修復上限まで積む (count=3 で打ち切り状態)
+    for (let i = 0; i < 10; i++) {
+      ensurePlaceholderRecovery(REMOTE)
+      vi.advanceTimersByTime(4_000)
+    }
+    // 上限を超える数の別 URL が自己修復に乗る
+    for (let i = 0; i < 300; i++) {
+      ensurePlaceholderRecovery(`https://example.com/p${i}.png`)
+    }
+    vi.advanceTimersByTime(4_000)
+    // 最古の REMOTE は追い出されているので、打ち切り状態が解けて再修復できる
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+})
+
 describe('proxyThumbUrl', () => {
   // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
   it('幅だけを付ける (非 Android は wait + soft も付く)', async () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -328,6 +328,99 @@ describe('プレースホルダ滞留の自己修復 (ensurePlaceholderRecovery)
   })
 })
 
+describe('プレースホルダ滞留の全画像監視 (installPlaceholderWatchdog) #892', () => {
+  // 自己修復の関数を直接呼ぶのではなく、document capture の load 監視の
+  // 判断そのものを検証する: 全画像の読み込みを通る位置にあるため、ここが
+  // 壊れると「一部の画像がまれに空白のまま」という気づきにくい形で出る
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
+  })
+
+  /** 寸法を差し替えた要素を document に繋ぎ、load を capture へ流す */
+  function dispatchLoad(
+    tag: string,
+    src: string | undefined,
+    width?: number,
+    height?: number,
+  ) {
+    const el = document.createElement(tag)
+    if (width !== undefined) {
+      Object.defineProperty(el, 'naturalWidth', { value: width })
+      Object.defineProperty(el, 'naturalHeight', { value: height })
+    }
+    if (src !== undefined) (el as HTMLImageElement).src = src
+    document.body.appendChild(el)
+    el.dispatchEvent(new Event('load'))
+    return el
+  }
+
+  it('1×1 (プレースホルダ) を掴んだ IMG は自己修復に乗る', async () => {
+    const { proxyUrl } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    dispatchLoad('img', proxied, 1, 1)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=1')
+  })
+
+  it('実画像 (非 1×1) を掴んだら自己修復に乗せない', async () => {
+    const { proxyUrl } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    dispatchLoad('img', proxied, 200, 100)
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(REMOTE)).not.toContain('&r=')
+  })
+
+  it('プロキシ経由でない画像は 1×1 でも対象外', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    proxyUrl(REMOTE) // 監視を起動させる
+    const direct = 'https://example.com/tracker.png'
+    dispatchLoad('img', direct, 1, 1)
+    vi.advanceTimersByTime(10 * 60_000)
+    expect(proxyUrl(direct)).not.toContain('&r=')
+    // ensurePlaceholderRecovery が生きていることの対照 (テスト自体の空振り防止)
+    ensurePlaceholderRecovery(direct)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(direct)).toContain('&r=1')
+  })
+
+  it('実画像が載ったら試行回数をリセットし、再度の滞留から修復できる', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    // 上限まで自己修復を使い切る (count=3 で打ち切り状態)
+    for (let i = 0; i < 10; i++) {
+      ensurePlaceholderRecovery(REMOTE)
+      vi.advanceTimersByTime(4_000)
+    }
+    expect(proxyUrl(REMOTE)).toContain('&r=3')
+    // 実画像の load が届いたら試行回数がリセットされる
+    dispatchLoad('img', proxied, 200, 100)
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    expect(proxyUrl(REMOTE)).toContain('&r=4')
+  })
+
+  it('IMG 以外の要素の load では試行回数をリセットしない', async () => {
+    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
+    const proxied = proxyUrl(REMOTE) ?? ''
+    for (let i = 0; i < 10; i++) {
+      ensurePlaceholderRecovery(REMOTE)
+      vi.advanceTimersByTime(4_000)
+    }
+    expect(proxyUrl(REMOTE)).toContain('&r=3')
+    // video 要素は src と寸法を持つが、監視の対象は IMG だけ
+    dispatchLoad('video', proxied, 200, 100)
+    ensurePlaceholderRecovery(REMOTE)
+    vi.advanceTimersByTime(4_000)
+    // リセットされていないので打ち切り状態のまま (世代は進まない)
+    expect(proxyUrl(REMOTE)).toContain('&r=3')
+  })
+})
+
 describe('URL 単位の状態の追い出し (#893)', () => {
   // 失敗回数と自己修復の試行回数は「取得成功」でしか消えないため、恒久的に
   // 壊れた URL・本当に 1×1 の画像が長時間セッションで無限に積もっていた。

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -169,15 +169,20 @@ export function proxiedRawUrl(src: string): string | null {
 }
 
 /**
- * プレースホルダ滞留の全画像監視。
+ * 全画像の読み込み結果の一括監視。
  *
  * 二段階配信 (Android 全画像 / デスクトップの soft 降格) はアバター・添付・
- * ピッカーなどあらゆる `<img>` を通るため、個別コンポーネントに @load を
- * 配線するのではなく document の capture で一括して拾う (load イベントは
- * バブルしないが capture では捕捉できる)。1×1 = プレースホルダを掴んだ
- * `<img>` を自己修復に乗せ、実画像が載ったら試行回数をリセットする。
+ * ピッカーなどあらゆる `<img>` を通るため、個別コンポーネントに @load /
+ * @error を配線するのではなく document の capture で一括して拾う (load /
+ * error イベントはバブルしないが capture では捕捉できる)。
+ *
+ * - load: 1×1 = プレースホルダを掴んだ `<img>` を自己修復に乗せ、実画像が
+ *   載ったら試行回数をリセットする
+ * - error: 失敗を申告してバックオフ再試行に乗せる (一過性の 502/504 の
+ *   セッション中固定化を防ぐ)。unknown アイコン等への DOM フォールバックは
+ *   各コンポーネントの @error に残る
  */
-function installPlaceholderWatchdog() {
+function installMediaWatchdog() {
   try {
     document.addEventListener(
       'load',
@@ -194,6 +199,16 @@ function installPlaceholderWatchdog() {
       },
       true,
     )
+    document.addEventListener(
+      'error',
+      (e) => {
+        const img = e.target as HTMLImageElement | null
+        if (img?.tagName !== 'IMG') return
+        const raw = proxiedRawUrl(img.currentSrc || img.src)
+        if (raw) markMediaFailed(raw)
+      },
+      true,
+    )
   } catch {
     // document の無い環境 (ユニットテストの node 側等) では何もしない
   }
@@ -203,7 +218,7 @@ let listenerStarted = false
 function ensureFetchedListener() {
   if (listenerStarted) return
   listenerStarted = true
-  installPlaceholderWatchdog()
+  installMediaWatchdog()
   try {
     events.mediaFetched
       .listen(({ payload }) => handleMediaFetched(payload.url, payload.ok))

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -40,14 +40,27 @@ const proxyUrlCache = new Map<string, string>()
  */
 const mediaVersions = reactive(new Map<string, number>())
 
+/**
+ * URL 単位の状態表の共通追い出し規則: 新規キーの挿入前に、上限に達していたら
+ * 最古の 1 件を捨てる (#893)。取得成功でしか消えない表 (失敗回数・自己修復の
+ * 試行回数) も、この規則で長時間セッションの無限成長を防ぐ。
+ */
+function evictOldestIfFull(
+  map: Map<string, unknown>,
+  key: string,
+  onEvict?: (evicted: string) => void,
+) {
+  if (map.has(key) || map.size < getProxyCacheMax()) return
+  const oldest = map.keys().next().value
+  if (oldest === undefined) return
+  onEvict?.(oldest)
+  map.delete(oldest)
+}
+
 function bumpMediaVersion(url: string) {
-  // proxyUrlCache と同じ上限で古い順に捨てる (無限成長させない)。
   // 追い出された URL は素の URL に戻るだけで、実体はキャッシュ済みなので
   // 表示は壊れない
-  if (!mediaVersions.has(url) && mediaVersions.size >= getProxyCacheMax()) {
-    const oldest = mediaVersions.keys().next().value
-    if (oldest !== undefined) mediaVersions.delete(oldest)
-  }
+  evictOldestIfFull(mediaVersions, url)
   mediaVersions.set(url, (mediaVersions.get(url) ?? 0) + 1)
 }
 
@@ -90,6 +103,12 @@ export function markMediaFailed(url: string): void {
     entry.retries += 1
     bumpMediaVersion(url)
   }, delay)
+  // リトライ上限に達した URL は取得成功が来ない限り残り続けるため、
+  // 上限で追い出す。待機中のタイマーごと破棄する
+  evictOldestIfFull(mediaFailures, url, (evicted) => {
+    const old = mediaFailures.get(evicted)
+    if (old?.timer != null) clearTimeout(old.timer)
+  })
   mediaFailures.set(url, entry)
 }
 
@@ -125,6 +144,8 @@ export function ensurePlaceholderRecovery(url: string): void {
       placeholderTimers.delete(url)
       // MediaFetched が正常に届いて世代が進んでいれば何もしない
       if ((mediaVersions.get(url) ?? 0) === versionAtSchedule) {
+        // 本当に 1×1 の画像は取得成功でリセットされないため、上限で追い出す
+        evictOldestIfFull(placeholderRecoveryCounts, url)
         placeholderRecoveryCounts.set(
           url,
           (placeholderRecoveryCounts.get(url) ?? 0) + 1,
@@ -220,13 +241,6 @@ function getProxyCacheMax(): number {
   }
 }
 
-function evictIfFull() {
-  if (proxyUrlCache.size >= getProxyCacheMax()) {
-    const oldest = proxyUrlCache.keys().next().value
-    if (oldest !== undefined) proxyUrlCache.delete(oldest)
-  }
-}
-
 export function proxyUrl(
   url: string | null | undefined,
   opts?: {
@@ -247,7 +261,7 @@ export function proxyUrl(
   const cacheKey = soft ? `${url}|soft` : wait ? `${url}|wait` : url
   let cached = proxyUrlCache.get(cacheKey)
   if (!cached) {
-    evictIfFull()
+    evictOldestIfFull(proxyUrlCache, cacheKey)
     cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${wait ? '&wait=1' : ''}${soft ? '&soft=1' : ''}`
     proxyUrlCache.set(cacheKey, cached)
   }
@@ -274,7 +288,7 @@ export function proxyThumbUrl(
   const key = `${url}|w=${width}`
   let cached = proxyUrlCache.get(key)
   if (!cached) {
-    evictIfFull()
+    evictOldestIfFull(proxyUrlCache, key)
     cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}${wait ? '&wait=1&soft=1' : ''}`
     proxyUrlCache.set(key, cached)
   }

--- a/src/utils/toggleReaction.ts
+++ b/src/utils/toggleReaction.ts
@@ -49,6 +49,11 @@ export async function toggleReaction(
     myReaction: prevReaction ?? null,
   }
 
+  // 切替 (取消 → 付与) の途中経過。取消だけ成功して付与に失敗した場合、
+  // サーバーは「リアクション無し」なので、元へ巻き戻すと旧絵文字のカウントが
+  // 1 多いまま次の取得まで残る (#891)
+  let removedOnServer = false
+
   try {
     if (prevReaction === reaction) {
       // 取消
@@ -67,12 +72,20 @@ export async function toggleReaction(
 
       if (prevReaction) {
         await api.deleteReaction(note.id)
+        removedOnServer = true
       }
       await api.createReaction(note.id, reaction)
     }
   } catch (e) {
-    // Rollback to previous state on failure
-    apply(prevPatch)
+    if (removedOnServer && prevReaction) {
+      // サーバーの実状態 (取消のみ成立) に合わせてリアクション無しへ倒す
+      apply({
+        reactions: decremented(note.reactions, prevReaction),
+        myReaction: null,
+      })
+    } else {
+      apply(prevPatch)
+    }
     throw e
   }
 }

--- a/src/utils/votePoll.ts
+++ b/src/utils/votePoll.ts
@@ -1,15 +1,32 @@
-import type { NormalizedNote } from '@/adapters/types'
+import type { NormalizedNote, NormalizedPoll } from '@/adapters/types'
 import { hapticLight } from '@/utils/haptics'
 
 interface PollApi {
   votePoll(noteId: string, choice: number): Promise<void>
 }
 
+/** 楽観的更新の差分。apply コールバックが表示側の保持形態に応じて反映する */
+export interface PollPatch {
+  poll: NormalizedPoll
+}
+
+/**
+ * 投票を楽観的更新つきで行う (toggleReaction と同じ差分適用方式 #888)。
+ *
+ * note は読み取り専用 — mutate せず、差分を `apply` に渡す。呼び出し元は
+ * 自分の保持形態 (noteStore / deep ref / shallowRef の配列) に応じて
+ * 「新しいオブジェクトへの差し替え」として反映する。
+ *
+ * isVoted のみ楽観更新し、votes の +1 はストリーミングの pollVoted
+ * イベントに任せる (二重カウントを避けるため)。未接続時は次回取得で整合する。
+ *
+ * 失敗時は元の状態を apply し直してから throw する。
+ */
 export async function votePoll(
   api: PollApi,
   note: NormalizedNote,
   choice: number,
-  onMutated?: () => void,
+  apply: (patch: PollPatch) => void,
 ): Promise<void> {
   const poll = note.poll
   if (!poll) return
@@ -20,20 +37,22 @@ export async function votePoll(
   if (!poll.multiple && poll.choices.some((c) => c.isVoted)) return
 
   hapticLight()
-  const prevChoices = poll.choices.map((c) => ({ ...c }))
+  // note を mutate していないので、ロールバックは元の poll をそのまま返せる
+  const prevPatch: PollPatch = { poll }
 
-  // isVoted のみ楽観更新。votes の +1 はストリーミングの pollVoted イベントに任せる
-  // (二重カウントを避けるため)。ストリーミング未接続時は次回取得で整合する。
-  poll.choices = poll.choices.map((c, i) =>
-    i === choice ? { ...c, isVoted: true } : c,
-  )
-  onMutated?.()
+  apply({
+    poll: {
+      ...poll,
+      choices: poll.choices.map((c, i) =>
+        i === choice ? { ...c, isVoted: true } : c,
+      ),
+    },
+  })
 
   try {
     await api.votePoll(note.id, choice)
   } catch (e) {
-    poll.choices = prevChoices
-    onMutated?.()
+    apply(prevPatch)
     throw e
   }
 }

--- a/tests/utils/toggleReaction.test.ts
+++ b/tests/utils/toggleReaction.test.ts
@@ -148,9 +148,9 @@ describe('toggleReaction', () => {
     expect(state.reactions['👍']).toBeUndefined()
   })
 
-  it('rolls back switch on API failure', async () => {
+  it('切替の取消 (delete) 自体が失敗したら丸ごと元に巻き戻す', async () => {
     const api = makeApi()
-    api.createReaction.mockRejectedValue(new Error('fail'))
+    api.deleteReaction.mockRejectedValue(new Error('fail'))
     const note = makeNote({
       reactions: { '👍': 1 },
       myReaction: '👍',
@@ -160,6 +160,25 @@ describe('toggleReaction', () => {
     await expect(toggleReaction(api, note, '❤️', apply)).rejects.toThrow('fail')
 
     expect(state.myReaction).toBe('👍')
+    expect(state.reactions['👍']).toBe(1)
+    expect(state.reactions['❤️']).toBeUndefined()
+    expect(api.createReaction).not.toHaveBeenCalled()
+  })
+
+  it('切替の取消成功後に付与が失敗したら「リアクション無し」へ倒す (#891)', async () => {
+    // サーバー上は取消だけが成立している。元のリアクションに巻き戻すと
+    // 旧絵文字のカウントが 1 多いまま残り、次の取得まで直らない
+    const api = makeApi()
+    api.createReaction.mockRejectedValue(new Error('fail'))
+    const note = makeNote({
+      reactions: { '👍': 2 },
+      myReaction: '👍',
+    })
+    const { state, apply } = track(note)
+
+    await expect(toggleReaction(api, note, '❤️', apply)).rejects.toThrow('fail')
+
+    expect(state.myReaction).toBeNull()
     expect(state.reactions['👍']).toBe(1)
     expect(state.reactions['❤️']).toBeUndefined()
   })

--- a/tests/utils/votePoll.test.ts
+++ b/tests/utils/votePoll.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { NormalizedNote, NormalizedPoll } from '@/adapters/types'
+import { type PollPatch, votePoll } from '@/utils/votePoll'
+
+function makePoll(overrides: Partial<NormalizedPoll> = {}): NormalizedPoll {
+  return {
+    choices: [
+      { text: 'A', votes: 3, isVoted: false },
+      { text: 'B', votes: 1, isVoted: false },
+    ],
+    multiple: false,
+    expiresAt: null,
+    ...overrides,
+  }
+}
+
+function makeNote(overrides: Partial<NormalizedNote> = {}): NormalizedNote {
+  return {
+    id: 'note1',
+    text: 'poll note',
+    poll: makePoll(),
+    ...overrides,
+  } as NormalizedNote
+}
+
+function makeApi() {
+  return { votePoll: vi.fn().mockResolvedValue(undefined) }
+}
+
+/** apply された差分を状態として追跡する (呼び出し元の反映を模す) */
+function track(note: NormalizedNote) {
+  const state = { poll: note.poll }
+  const patches: PollPatch[] = []
+  const apply = (p: PollPatch) => {
+    patches.push(p)
+    state.poll = p.poll
+  }
+  return { state, patches, apply }
+}
+
+describe('votePoll (差分適用方式 #888)', () => {
+  it('isVoted のみ楽観更新する (votes はストリームの pollVoted に任せる)', async () => {
+    const api = makeApi()
+    const note = makeNote()
+    const { state, apply } = track(note)
+
+    await votePoll(api, note, 1, apply)
+
+    expect(state.poll?.choices[1]?.isVoted).toBe(true)
+    expect(state.poll?.choices[1]?.votes).toBe(1)
+    expect(state.poll?.choices[0]?.isVoted).toBe(false)
+    expect(api.votePoll).toHaveBeenCalledWith('note1', 1)
+  })
+
+  it('note は mutate せず、新しい poll オブジェクトで apply する', async () => {
+    // shallowRef 保持の面 (プロフィール・クリップ詳細等) が差し替えを
+    // 検知できるよう、mutate ではなく新オブジェクトの差分として渡す
+    const api = makeApi()
+    const note = makeNote()
+    const originalPoll = note.poll
+    const { state, apply } = track(note)
+
+    await votePoll(api, note, 0, apply)
+
+    expect(note.poll).toBe(originalPoll)
+    expect(note.poll?.choices[0]?.isVoted).toBe(false)
+    expect(state.poll).not.toBe(originalPoll)
+    expect(state.poll?.choices[0]?.isVoted).toBe(true)
+  })
+
+  it('失敗時は元の poll を apply し直してから throw する', async () => {
+    const api = makeApi()
+    api.votePoll.mockRejectedValue(new Error('fail'))
+    const note = makeNote()
+    const originalPoll = note.poll
+    const { state, apply } = track(note)
+
+    await expect(votePoll(api, note, 0, apply)).rejects.toThrow('fail')
+
+    expect(state.poll).toBe(originalPoll)
+    expect(state.poll?.choices[0]?.isVoted).toBe(false)
+  })
+
+  it.each([
+    ['poll が無い', makeNote({ poll: undefined }), 0],
+    [
+      '期限切れ',
+      makeNote({ poll: makePoll({ expiresAt: '2000-01-01T00:00:00Z' }) }),
+      0,
+    ],
+    ['該当 choice が無い', makeNote({ poll: makePoll({ choices: [] }) }), 0],
+    [
+      '同じ choice に投票済み',
+      makeNote({
+        poll: makePoll({
+          choices: [{ text: 'A', votes: 1, isVoted: true }],
+        }),
+      }),
+      0,
+    ],
+    [
+      '単一選択で別の choice に投票済み',
+      makeNote({
+        poll: makePoll({
+          choices: [
+            { text: 'A', votes: 1, isVoted: true },
+            { text: 'B', votes: 0, isVoted: false },
+          ],
+        }),
+      }),
+      1,
+    ],
+  ])('%s なら apply も API 呼び出しもしない', async (_name, note, choice) => {
+    const api = makeApi()
+    const { patches, apply } = track(note)
+
+    await votePoll(api, note, choice, apply)
+
+    expect(patches).toEqual([])
+    expect(api.votePoll).not.toHaveBeenCalled()
+  })
+
+  it('複数選択なら投票済みでも別の choice に投票できる', async () => {
+    const api = makeApi()
+    const note = makeNote({
+      poll: makePoll({
+        multiple: true,
+        choices: [
+          { text: 'A', votes: 1, isVoted: true },
+          { text: 'B', votes: 0, isVoted: false },
+        ],
+      }),
+    })
+    const { state, apply } = track(note)
+
+    await votePoll(api, note, 1, apply)
+
+    expect(state.poll?.choices[1]?.isVoted).toBe(true)
+    expect(api.votePoll).toHaveBeenCalledWith('note1', 1)
+  })
+})


### PR DESCRIPTION
## 変更内容

### 新機能
- feat(emoji): サーバーの絵文字追加・更新・削除を push で辞書に反映 (#889)
- feat: 言語サーバーを開発環境に同梱 (#896)
- feat: VS Code のワークスペース設定とデバッグ構成を共有 (#896)
- feat: 環境診断コマンド pnpm doctor を追加 (#896)

### セキュリティ
- fix(security): メディア・OGP の SSRF 防御を DNS 解決結果まで広げる (#857)
- fix(security): HTTP クライアントの build 失敗で SSRF 防御が外れる経路を塞ぐ

### 修正
- fix(poll): 投票の楽観的更新をリアクションと同じ差分適用方式に統一 (#888)
- fix(reaction): echo 抑止と切替失敗の突き合わせ不整合を解消 (#891)
- fix(reaction): 照会カラムの同一アカウント操作で表示が反映されない問題を修正
- fix(media): 失敗・先読み状態の長時間セッションのリークを解消 (#893)
- fix: biome 設定を導入版 2.5.0 に同期 (#896)

### リファクタリング・テスト
- refactor(media): 失敗申告を load と同じ全画像監視に統一
- test(media): プレースホルダ自己修復の全画像監視に配線テストを追加 (#892)

### CI・その他
- ci: PR の変更パスからラベルを自動付与 (labeler)
- ci: API 面を変更する PR に diff を自動コメント
- ci: release.yml が実在しないラベルを参照していたのを修正
- chore: pre-commit の typecheck を ts/vue が staged のときのみ実行 (#896)
- docs: 環境診断とエディタ/言語サーバーの節を追加 (#896)
- chore: bump version to 1.34.0
- chore: regenerate openapi.json for 1.34.0

## 依存関係

- notecli を v0.6.0 (`77fd531`) に更新。従来の pin は PR #45 のブランチコミットを指していたため、タグ付きのマージコミットに揃えた（コード内容の差分はなし）

## ローカル検証

- `pnpm lint` — 通過（warning のみ、エラーなし）
- `pnpm typecheck` — 通過
- `pnpm test` — 218 files / 2427 tests 全通過
- `cargo clippy --all-targets` — 警告なし
- `cargo test` — 通過（`bindings_snapshot_is_current` / `openapi_snapshot_is_current` を含む）

Closes #857
Closes #888
Closes #889
Closes #891
Closes #892
Closes #893


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added real-time synchronization for custom emoji additions, updates, and deletions.
  - Improved optimistic updates for reactions and poll votes across feeds, profiles, pinned notes, and threads.

- **Bug Fixes**
  - Fixed reaction state when switching reactions fails partway through.
  - Improved custom emoji loading retries and cache recovery.
  - Fixed image prefetching so evicted images can be fetched again.
  - Preserved custom emoji metadata from reaction updates without duplicating counts.

- **Security**
  - Strengthened protection against unsafe network destinations during media requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->