### PR TITLE
Release v1.35.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.34.0",
+  "version": "1.35.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3157,8 +3157,8 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notecli"
-version = "0.6.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=d699961402acc624a37d3e6df1be302ab8e16f65#d699961402acc624a37d3e6df1be302ab8e16f65"
+version = "0.7.0"
+source = "git+https://github.com/notedeck-dev/notecli?rev=e235701690ae1e6c5a9bb0fd6fe89611eccdb4d1#e235701690ae1e6c5a9bb0fd6fe89611eccdb4d1"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.34.0"
+version = "1.35.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3158,7 +3158,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.6.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=77fd53104fc73d797c04da2c04897ede5be4886b#77fd53104fc73d797c04da2c04897ede5be4886b"
+source = "git+https://github.com/notedeck-dev/notecli?rev=d699961402acc624a37d3e6df1be302ab8e16f65#d699961402acc624a37d3e6df1be302ab8e16f65"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "notedeck"
-version = "1.34.0"
+version = "1.35.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "d699961402acc624a37d3e6df1be302ab8e16f65", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "e235701690ae1e6c5a9bb0fd6fe89611eccdb4d1", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.34.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "77fd53104fc73d797c04da2c04897ede5be4886b", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "d699961402acc624a37d3e6df1be302ab8e16f65", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.34.0"
+    "version": "1.35.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -2136,8 +2136,29 @@
               "null"
             ]
           },
+          "body": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "App notification body (for app type; notifications/create の body)"
+          },
           "createdAt": {
             "type": "string"
+          },
+          "header": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "App notification header (for app type; notifications/create の header)"
+          },
+          "icon": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "App notification icon URL (for app type; notifications/create の icon)"
           },
           "id": {
             "type": "string"

--- a/src-tauri/src/ai_chat_service.rs
+++ b/src-tauri/src/ai_chat_service.rs
@@ -147,10 +147,16 @@ struct AttemptError {
 
 impl AttemptError {
     fn terminal(message: String) -> Self {
-        Self { message, retryable: false }
+        Self {
+            message,
+            retryable: false,
+        }
     }
     fn retryable(message: String) -> Self {
-        Self { message, retryable: true }
+        Self {
+            message,
+            retryable: true,
+        }
     }
 }
 
@@ -207,8 +213,7 @@ fn streaming_client() -> &'static reqwest::Client {
 fn describe_stream_error(e: &reqwest::Error) -> String {
     use std::fmt::Write as _;
     let mut details = format!("stream error: {e}");
-    let mut source: Option<&(dyn std::error::Error + 'static)> =
-        std::error::Error::source(e);
+    let mut source: Option<&(dyn std::error::Error + 'static)> = std::error::Error::source(e);
     while let Some(s) = source {
         let _ = write!(details, " ⇐ {s}");
         source = s.source();
@@ -246,14 +251,10 @@ pub async fn start_stream(
         .connections
         .iter()
         .find(|c| c.id == req.connection_id)
-        .ok_or_else(|| {
-            NoteDeckError::InvalidInput("AI 接続が見つかりません".into())
-        })?
+        .ok_or_else(|| NoteDeckError::InvalidInput("AI 接続が見つかりません".into()))?
         .clone();
     let protocol = connection.protocol.ok_or_else(|| {
-        NoteDeckError::InvalidInput(
-            "選択された接続は AI プロバイダーではありません".into(),
-        )
+        NoteDeckError::InvalidInput("選択された接続は AI プロバイダーではありません".into())
     })?;
     let endpoint = connection.base_url.clone();
     let api_key = {
@@ -427,10 +428,8 @@ fn openai_message(m: &AiChatMessage) -> serde_json::Value {
     use serde_json::json;
 
     if let Some(tool_use_id) = m.tool_use_id.as_deref() {
-        let arguments = serde_json::to_string(
-            m.tool_use_input.as_ref().unwrap_or(&json!({})),
-        )
-        .unwrap_or_else(|_| "{}".to_string());
+        let arguments = serde_json::to_string(m.tool_use_input.as_ref().unwrap_or(&json!({})))
+            .unwrap_or_else(|_| "{}".to_string());
         let content_value = if m.content.is_empty() {
             serde_json::Value::Null
         } else {
@@ -554,17 +553,10 @@ async fn run_anthropic_attempt(
     // fresh な builder で始まる) ので、incomplete な tool_use_id が確定することはない。
     let mut tool_builder: Option<AnthropicToolUseBuilder> = None;
     while let Some(chunk) = stream.next().await {
-        let bytes =
-            chunk.map_err(|e| AttemptError::retryable(describe_stream_error(&e)))?;
+        let bytes = chunk.map_err(|e| AttemptError::retryable(describe_stream_error(&e)))?;
         buf.push_str(&String::from_utf8_lossy(&bytes));
         for block in parse_sse_blocks(&mut buf) {
-            handle_anthropic_block(
-                &block,
-                app,
-                &req.stream_id,
-                &mut tool_builder,
-                has_emitted,
-            );
+            handle_anthropic_block(&block, app, &req.stream_id, &mut tool_builder, has_emitted);
         }
     }
     Ok(())
@@ -652,10 +644,7 @@ fn handle_anthropic_block(
             }
         }
         "error" => {
-            if let Some(msg) = value
-                .pointer("/error/message")
-                .and_then(|v| v.as_str())
-            {
+            if let Some(msg) = value.pointer("/error/message").and_then(|v| v.as_str()) {
                 // SSE error イベントも UI に届く = このターンは透過リトライ不可
                 *has_emitted = true;
                 emit_error(app, stream_id, format!("Anthropic: {msg}"));
@@ -683,9 +672,7 @@ async fn run_openai_compat(
     let mut has_emitted = false;
     let mut attempt: u32 = 0;
     loop {
-        match run_openai_compat_attempt(req, endpoint, api_key, app, &mut has_emitted)
-            .await
-        {
+        match run_openai_compat_attempt(req, endpoint, api_key, app, &mut has_emitted).await {
             Ok(()) => return Ok(()),
             Err(e) => {
                 if has_emitted || !e.retryable || attempt >= MAX_TRANSPARENT_RETRIES {
@@ -759,8 +746,7 @@ async fn run_openai_compat_attempt(
     // Vec のままにしておくと将来複数対応への拡張が容易。
     let mut tool_builders: Vec<OpenAiToolCallBuilder> = Vec::new();
     'outer: while let Some(chunk) = stream.next().await {
-        let bytes =
-            chunk.map_err(|e| AttemptError::retryable(describe_stream_error(&e)))?;
+        let bytes = chunk.map_err(|e| AttemptError::retryable(describe_stream_error(&e)))?;
         buf.push_str(&String::from_utf8_lossy(&bytes));
         for block in parse_sse_blocks(&mut buf) {
             for line in block.lines() {
@@ -839,18 +825,12 @@ fn accumulate_openai_tool_calls(
                 b.id = id.to_string();
             }
         }
-        if let Some(name) = tc
-            .pointer("/function/name")
-            .and_then(|v| v.as_str())
-        {
+        if let Some(name) = tc.pointer("/function/name").and_then(|v| v.as_str()) {
             if !name.is_empty() {
                 b.name = name.to_string();
             }
         }
-        if let Some(args) = tc
-            .pointer("/function/arguments")
-            .and_then(|v| v.as_str())
-        {
+        if let Some(args) = tc.pointer("/function/arguments").and_then(|v| v.as_str()) {
             b.args_json_buf.push_str(args);
         }
     }

--- a/src-tauri/src/commands/admin.rs
+++ b/src-tauri/src/commands/admin.rs
@@ -133,10 +133,7 @@ pub async fn chat_cache_stats(app_state: State<'_, AppState>) -> Result<ChatCach
 
 #[tauri::command]
 #[specta::specta]
-pub async fn chat_cache_count(
-    app_state: State<'_, AppState>,
-    account_id: String,
-) -> Result<i64> {
+pub async fn chat_cache_count(app_state: State<'_, AppState>, account_id: String) -> Result<i64> {
     let db = app_state.db().await;
     db.chat_cache_count(&account_id)
 }

--- a/src-tauri/src/commands/charts.rs
+++ b/src-tauri/src/commands/charts.rs
@@ -5,7 +5,7 @@ use notecli::models::{
     ServerUsersChart, UserFollowingChart, UserNotesChart, UserPvChart,
 };
 
-use super::{AppState, Result, typed_request};
+use super::{typed_request, AppState, Result};
 
 // チャート系エンドポイントは public (未ログインでも閲覧可)。
 

--- a/src-tauri/src/commands/clips.rs
+++ b/src-tauri/src/commands/clips.rs
@@ -2,7 +2,7 @@ use tauri::State;
 
 use notecli::models::Clip;
 
-use super::{AppState, Result, typed_request};
+use super::{typed_request, AppState, Result};
 
 // 既存 `api_get_clips` (timeline.rs, clips/list 自分用) は notecli が直接
 // 型化メソッド `client.get_clips()` を提供している。ここでは clips/show・

--- a/src-tauri/src/commands/content.rs
+++ b/src-tauri/src/commands/content.rs
@@ -5,7 +5,9 @@ use tauri::State;
 use notecli::error::NoteDeckError;
 use notecli::models::{GalleryPost, Page, ServerEmoji};
 
-use super::{AppState, get_credentials, get_credentials_or_anon, Result, typed_request, validate_host};
+use super::{
+    get_credentials, get_credentials_or_anon, typed_request, validate_host, AppState, Result,
+};
 
 // --- Server metadata ---
 

--- a/src-tauri/src/commands/drafts.rs
+++ b/src-tauri/src/commands/drafts.rs
@@ -3,7 +3,7 @@ use tauri::State;
 
 use notecli::models::NoteDraft;
 
-use super::{AppState, Result, typed_request};
+use super::{typed_request, AppState, Result};
 
 // Misskey の create / update は `{ createdDraft: ... }` / `{ updatedDraft: ... }`
 // とラップして返すので、ここで剥がして直接 NoteDraft を返す。

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -36,8 +36,7 @@ const MAX_SEGMENTS: usize = 4;
 const INDEX_FILE: &str = ".notedeck-export.json";
 
 /// キャンセル要求済みの taskId。タスク終了時に掃除する
-static CANCELLED: LazyLock<Mutex<HashSet<String>>> =
-    LazyLock::new(|| Mutex::new(HashSet::new()));
+static CANCELLED: LazyLock<Mutex<HashSet<String>>> = LazyLock::new(|| Mutex::new(HashSet::new()));
 
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -319,8 +318,8 @@ fn sanitize_component(name: &str) -> String {
     }
     // Windows の予約デバイス名は拡張子付き ("CON.txt") でも無効なので退避する
     const RESERVED: [&str; 22] = [
-        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
-        "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
     ];
     let stem = trimmed.split('.').next().unwrap_or("");
     if RESERVED.iter().any(|r| stem.eq_ignore_ascii_case(r)) {
@@ -415,7 +414,10 @@ mod tests {
         assert_eq!(resolve_collision(dir, "a.jpg", &HashSet::new()), "a.jpg");
 
         std::fs::write(dir.join("a.jpg"), b"x").unwrap();
-        assert_eq!(resolve_collision(dir, "a.jpg", &HashSet::new()), "a (1).jpg");
+        assert_eq!(
+            resolve_collision(dir, "a.jpg", &HashSet::new()),
+            "a (1).jpg"
+        );
 
         let mut claimed = HashSet::new();
         claimed.insert("a (1).jpg".to_string());

--- a/src-tauri/src/commands/federation.rs
+++ b/src-tauri/src/commands/federation.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 use tauri::State;
 
-use super::{AppState, Result, typed_request};
+use super::{typed_request, AppState, Result};
 
 /// Misskey `federation/instances` / `federation/show-instance` の 1 件分。
 /// 本家 schema (packages/backend/src/models/Instance.ts) に準拠。

--- a/src-tauri/src/commands/heartbeat.rs
+++ b/src-tauri/src/commands/heartbeat.rs
@@ -152,9 +152,7 @@ pub async fn heartbeat_configure(
 /// global heartbeat を停止する。未登録なら no-op。
 #[tauri::command]
 #[specta::specta]
-pub async fn heartbeat_unconfigure(
-    scheduler: State<'_, Arc<HeartbeatScheduler>>,
-) -> Result<()> {
+pub async fn heartbeat_unconfigure(scheduler: State<'_, Arc<HeartbeatScheduler>>) -> Result<()> {
     scheduler.unregister();
     Ok(())
 }

--- a/src-tauri/src/commands/http.rs
+++ b/src-tauri/src/commands/http.rs
@@ -61,9 +61,7 @@ pub struct HttpFetchResponse {
 /// 検証 → reqwest 構築 → 送信 → response 整形 の単線。
 #[tauri::command]
 #[specta::specta]
-pub async fn http_fetch(
-    request: HttpFetchRequest,
-) -> Result<HttpFetchResponse, String> {
+pub async fn http_fetch(request: HttpFetchRequest) -> Result<HttpFetchResponse, String> {
     validate_external_url(&request.url)?;
 
     let method = parse_method(request.method.as_deref())?;
@@ -109,7 +107,10 @@ pub async fn http_fetch(
         req = req.body(body);
     }
 
-    let response = req.send().await.map_err(|e| format!("request failed: {e}"))?;
+    let response = req
+        .send()
+        .await
+        .map_err(|e| format!("request failed: {e}"))?;
     let status = response.status().as_u16();
     let mut headers = HashMap::new();
     for (name, value) in response.headers() {
@@ -153,11 +154,12 @@ fn parse_method(method: Option<&str>) -> Result<reqwest::Method, String> {
 /// hostname なら reserved TLD を弾く (= 一次防御)。DNS 解決後の IP 検証は
 /// http_fetch が注入する PinningResolver が担う (二次防御・rebinding 対策)。
 pub fn validate_external_url(url_str: &str) -> Result<(), String> {
-    let url =
-        reqwest::Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
+    let url = reqwest::Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
     let scheme = url.scheme();
     if scheme != "http" && scheme != "https" {
-        return Err(format!("only http / https schemes are allowed (got {scheme})"));
+        return Err(format!(
+            "only http / https schemes are allowed (got {scheme})"
+        ));
     }
     let host = url
         .host_str()

--- a/src-tauri/src/commands/lists.rs
+++ b/src-tauri/src/commands/lists.rs
@@ -2,7 +2,7 @@ use tauri::State;
 
 use notecli::models::UserList;
 
-use super::{AppState, Result, typed_request};
+use super::{typed_request, AppState, Result};
 
 // 既存 `api_get_user_lists` (timeline.rs, users/lists/list 自分用) は notecli の
 // `client.get_user_lists()` を経由する型化済みコマンド。ここでは

--- a/src-tauri/src/commands/messaging.rs
+++ b/src-tauri/src/commands/messaging.rs
@@ -73,9 +73,7 @@ pub async fn api_get_unread_notification_count(
     account_id: String,
 ) -> Result<i64> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client
-        .get_unread_notification_count(&host, &token)
-        .await
+    client.get_unread_notification_count(&host, &token).await
 }
 
 #[tauri::command]
@@ -85,9 +83,7 @@ pub async fn api_mark_all_notifications_as_read(
     account_id: String,
 ) -> Result<()> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client
-        .mark_all_notifications_as_read(&host, &token)
-        .await
+    client.mark_all_notifications_as_read(&host, &token).await
 }
 
 // --- Unread chat ---
@@ -312,8 +308,5 @@ pub async fn api_delete_chat_message(
     message_id: String,
 ) -> Result<()> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client
-        .delete_chat_message(&host, &token, &message_id)
-        .await
+    client.delete_chat_message(&host, &token, &message_id).await
 }
-

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -14,8 +14,8 @@ mod export;
 mod federation;
 mod health;
 mod heartbeat;
-mod lists;
 mod http;
+mod lists;
 mod messaging;
 mod settings;
 mod streaming;
@@ -42,8 +42,8 @@ pub use export::*;
 pub use federation::*;
 pub use health::*;
 pub use heartbeat::*;
-pub use lists::*;
 pub use http::*;
+pub use lists::*;
 pub use messaging::*;
 pub use settings::*;
 pub use streaming::*;
@@ -90,7 +90,12 @@ impl AppState {
     pub fn new() -> Self {
         let (tx, rx) = tokio::sync::watch::channel(None);
         let (db_tx, db_rx) = tokio::sync::watch::channel(None);
-        Self { rx, tx, db_rx, db_tx }
+        Self {
+            rx,
+            tx,
+            db_rx,
+            db_tx,
+        }
     }
 
     /// Called as soon as DB is ready (after migrations, before client).
@@ -105,7 +110,11 @@ impl AppState {
         let _ = self.db_tx.send(Some(Arc::clone(&db)));
         let server_info =
             notecli::server_info::ServerInfoService::new(Arc::clone(&db), Arc::clone(&client));
-        let _ = self.tx.send(Some(Arc::new(AppStateInner { db, client, server_info })));
+        let _ = self.tx.send(Some(Arc::new(AppStateInner {
+            db,
+            client,
+            server_info,
+        })));
     }
 
     /// Non-blocking check of full readiness (DB + MisskeyClient). Used by the
@@ -137,10 +146,7 @@ impl AppState {
 
     /// `ready()` + `get_credentials` の定型を 1 行に畳む (#782 R2)。
     /// db を後続で使わないコマンド用 — 使う場合は従来どおり `ready()` を使う。
-    pub async fn authed(
-        &self,
-        account_id: &str,
-    ) -> Result<(Arc<MisskeyClient>, String, String)> {
+    pub async fn authed(&self, account_id: &str) -> Result<(Arc<MisskeyClient>, String, String)> {
         let (db, client) = self.ready().await;
         let (host, token) = get_credentials(&db, account_id)?;
         Ok((client, host, token))
@@ -382,10 +388,7 @@ fn get_host(db: &Database, account_id: &str) -> Result<String> {
 /// Get credentials with anonymous fallback.
 /// Returns (host, token) where token is empty if not authenticated.
 /// Public Misskey endpoints work with empty token (skipped by notecli).
-pub(crate) fn get_credentials_or_anon(
-    db: &Database,
-    account_id: &str,
-) -> Result<(String, String)> {
+pub(crate) fn get_credentials_or_anon(db: &Database, account_id: &str) -> Result<(String, String)> {
     match get_credentials(db, account_id) {
         Ok(creds) => Ok(creds),
         Err(_) => Ok((get_host(db, account_id)?, String::new())),
@@ -588,10 +591,7 @@ mod tests {
         // 他テストと衝突しない値を使う (env はプロセス全体で共有されるため)
         // SAFETY: テスト専用。並行テストは別の値を検証しており影響しない。
         unsafe { std::env::set_var("NOTEDECK_E2E_ALLOW_HOSTS", "127.0.0.1:39821") };
-        assert_eq!(
-            validate_host("127.0.0.1:39821").unwrap(),
-            "127.0.0.1:39821"
-        );
+        assert_eq!(validate_host("127.0.0.1:39821").unwrap(), "127.0.0.1:39821");
         // 列挙外の loopback は引き続き拒否
         assert!(validate_host("127.0.0.1:39999").is_err());
         unsafe { std::env::remove_var("NOTEDECK_E2E_ALLOW_HOSTS") };

--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -11,8 +11,7 @@ use notecli::models::{
 };
 
 use super::{
-    extract_ogp_urls, get_credentials, get_credentials_or_anon, AppState, Result,
-    MAX_UPLOAD_BYTES,
+    extract_ogp_urls, get_credentials, get_credentials_or_anon, AppState, Result, MAX_UPLOAD_BYTES,
 };
 
 /// Maximum number of concurrent OGP prefetch requests per timeline load
@@ -96,9 +95,11 @@ fn spawn_ogp_prefetch(
                 }
             })
             .buffer_unordered(MAX_OGP_CONCURRENT)
-            .filter_map(|(url, data): (String, Option<crate::ogp::OgpData>)| async move {
-                data.map(|d| (url, d))
-            })
+            .filter_map(
+                |(url, data): (String, Option<crate::ogp::OgpData>)| async move {
+                    data.map(|d| (url, d))
+                },
+            )
             .collect()
             .await;
 
@@ -882,10 +883,7 @@ pub async fn api_search_notes_local(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn api_delete_cached_note(
-    app_state: State<'_, AppState>,
-    note_id: String,
-) -> Result<()> {
+pub async fn api_delete_cached_note(app_state: State<'_, AppState>, note_id: String) -> Result<()> {
     let db = app_state.db().await;
     db.delete_cached_note(&note_id)
 }
@@ -904,9 +902,7 @@ pub async fn api_verify_notes(
     note_ids: Vec<String>,
 ) -> Result<HashMap<String, NormalizedNote>> {
     if note_ids.len() > 200 {
-        return Err(NoteDeckError::InvalidInput(
-            "Too many note IDs".to_string(),
-        ));
+        return Err(NoteDeckError::InvalidInput("Too many note IDs".to_string()));
     }
     let (client, host, token) = app_state.authed_or_anon(&account_id).await?;
 
@@ -923,9 +919,7 @@ pub async fn api_verify_notes(
         })
         .buffer_unordered(MAX_VERIFY_CONCURRENT)
         .filter_map(
-            |(id, note): (String, Option<NormalizedNote>)| async move {
-                note.map(|n| (id, n))
-            },
+            |(id, note): (String, Option<NormalizedNote>)| async move { note.map(|n| (id, n)) },
         )
         .collect()
         .await;

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -7,7 +7,7 @@ use notecli::models::{
     Page, TimelineOptions, UserReaction,
 };
 
-use super::{AppState, get_credentials_or_anon, Result, typed_request, validate_host};
+use super::{get_credentials_or_anon, typed_request, validate_host, AppState, Result};
 
 // --- User profile ---
 
@@ -68,9 +68,7 @@ pub async fn api_get_user_notes_filtered(
     params: serde_json::Value,
 ) -> Result<serde_json::Value> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client
-        .get_user_notes_filtered(&host, &token, params)
-        .await
+    client.get_user_notes_filtered(&host, &token, params).await
 }
 
 #[tauri::command]
@@ -102,9 +100,7 @@ pub async fn api_get_user_achievements(
     user_id: String,
 ) -> Result<serde_json::Value> {
     let (client, host, token) = app_state.authed_or_anon(&account_id).await?;
-    client
-        .get_user_achievements(&host, &token, &user_id)
-        .await
+    client.get_user_achievements(&host, &token, &user_id).await
 }
 
 #[tauri::command]
@@ -198,7 +194,9 @@ pub async fn api_update_user_memo(
     memo: String,
 ) -> Result<()> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client.update_user_memo(&host, &token, &user_id, &memo).await
+    client
+        .update_user_memo(&host, &token, &user_id, &memo)
+        .await
 }
 
 #[tauri::command]
@@ -627,4 +625,3 @@ pub async fn api_get_user_gallery_by(
     let (client, host, token) = app_state.authed_or_anon(&account_id).await?;
     typed_request(&client, &host, &token, "users/gallery/posts", params).await
 }
-

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -188,11 +188,7 @@ pub async fn save_image_to_file(app: tauri::AppHandle, url: String) -> Result<bo
         .unwrap_or("image")
         .to_string();
 
-    let ext = file_name
-        .rsplit('.')
-        .next()
-        .unwrap_or("png")
-        .to_lowercase();
+    let ext = file_name.rsplit('.').next().unwrap_or("png").to_lowercase();
 
     let filter_label = match ext.as_str() {
         "jpg" | "jpeg" => "JPEG Image",

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -556,8 +556,7 @@ async fn get_health(
     // 永続トークン由来 (external principal) で deck.read が無い場合、streams
     // 詳細 (接続先 host 等のローカルデータ) は応答から間引く (#712 §5.3)。
     // self-diagnosis の summary 部 (backendReady / frontendReady 等) は返す
-    let may_read_streams = external.is_none()
-        || crate::permissions_gate::external_may_read_deck();
+    let may_read_streams = external.is_none() || crate::permissions_gate::external_may_read_deck();
 
     if let Value::Object(map) = &mut body {
         match query_bridge::query_frontend(app, "health/streams", json!({})).await {
@@ -565,7 +564,11 @@ async fn get_health(
                 map.insert("frontendReady".into(), Value::Bool(true));
                 map.insert(
                     "streams".into(),
-                    if may_read_streams { streams } else { Value::Null },
+                    if may_read_streams {
+                        streams
+                    } else {
+                        Value::Null
+                    },
                 );
             }
             Err(e) => {

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -99,7 +99,11 @@ impl ImageCache {
         Self::with_client(app_dir, reqwest::Client::default(), perf)
     }
 
-    pub fn with_client(app_dir: &Path, http_client: reqwest::Client, perf: SharedPerfConfig) -> Self {
+    pub fn with_client(
+        app_dir: &Path,
+        http_client: reqwest::Client,
+        perf: SharedPerfConfig,
+    ) -> Self {
         let cache_dir = app_dir.join("image_cache");
         std::fs::create_dir_all(&cache_dir).ok();
         let max_total = DEFAULT_MEMORY_CACHE_MAX_TOTAL;
@@ -279,7 +283,9 @@ impl ImageCache {
 
     /// Extract host from a URL for circuit breaker keying.
     fn extract_host(url: &str) -> Option<String> {
-        url::Url::parse(url).ok().and_then(|u| u.host_str().map(|h| h.to_string()))
+        url::Url::parse(url)
+            .ok()
+            .and_then(|u| u.host_str().map(|h| h.to_string()))
     }
 
     /// Check if a host's circuit breaker is tripped.
@@ -465,10 +471,12 @@ impl ImageCache {
                 // Update host circuit breaker on stream failure
                 if !url_host.is_empty() {
                     let mut circuits = host_circuits.write().await;
-                    let state = circuits.entry(url_host.clone()).or_insert(HostCircuitState {
-                        consecutive_failures: 0,
-                        tripped_at: None,
-                    });
+                    let state = circuits
+                        .entry(url_host.clone())
+                        .or_insert(HostCircuitState {
+                            consecutive_failures: 0,
+                            tripped_at: None,
+                        });
                     state.consecutive_failures += 1;
                     let threshold = perf.read().await.circuit_breaker_threshold;
                     if state.consecutive_failures >= threshold {
@@ -770,14 +778,20 @@ mod tests {
     async fn check_cache_only_returns_none_for_http() {
         let dir = tempfile::tempdir().unwrap();
         let cache = ImageCache::new(dir.path());
-        assert!(cache.check_cache_only("http://insecure.com/img.png").await.is_none());
+        assert!(cache
+            .check_cache_only("http://insecure.com/img.png")
+            .await
+            .is_none());
     }
 
     #[tokio::test]
     async fn check_cache_only_miss() {
         let dir = tempfile::tempdir().unwrap();
         let cache = ImageCache::new(dir.path());
-        assert!(cache.check_cache_only("https://example.com/missing.png").await.is_none());
+        assert!(cache
+            .check_cache_only("https://example.com/missing.png")
+            .await
+            .is_none());
     }
 
     #[tokio::test]
@@ -785,7 +799,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cache = ImageCache::new(dir.path());
         let data = Arc::new(vec![1u8, 2, 3]);
-        cache.insert_mem_cache("test-hash", &data, "image/png").await;
+        cache
+            .insert_mem_cache("test-hash", &data, "image/png")
+            .await;
 
         let mut mem = cache.mem_cache.write().await;
         let entry = mem.entries.get("test-hash").unwrap();
@@ -807,7 +823,10 @@ mod tests {
         cache.insert_mem_cache("c", &big, "image/png").await;
 
         let mem = cache.mem_cache.read().await;
-        assert!(mem.entries.peek("a").is_none(), "LRU entry 'a' should be evicted");
+        assert!(
+            mem.entries.peek("a").is_none(),
+            "LRU entry 'a' should be evicted"
+        );
         assert!(mem.entries.peek("b").is_some() || mem.entries.peek("c").is_some());
     }
 
@@ -854,7 +873,10 @@ mod tests {
         // TTL 切れは negative 扱いしない (自然回復)
         cache.negative_cache.write().await.insert(
             hex_hash(url),
-            (Instant::now() - Duration::from_secs(10), Duration::from_secs(5)),
+            (
+                Instant::now() - Duration::from_secs(10),
+                Duration::from_secs(5),
+            ),
         );
         assert!(!cache.is_negative_cached(url).await);
     }
@@ -911,7 +933,10 @@ mod tests {
         assert!(cache.begin_ensure("k").await);
         assert!(!cache.begin_ensure("k").await, "must not start twice");
         cache.finish_ensure("k").await;
-        assert!(cache.begin_ensure("k").await, "finished key can start again");
+        assert!(
+            cache.begin_ensure("k").await,
+            "finished key can start again"
+        );
     }
 
     /// `<stem>.dat` + `.meta` の対を作り、mtime を指定秒だけ過去にずらす
@@ -969,11 +994,14 @@ mod tests {
 
         let stats = sweep_dir(dir, 7, 10_000);
 
-        assert_eq!(stats, SweepStats {
-            expired_removed: 0,
-            evicted_removed: 0,
-            bytes_after: 200,
-        });
+        assert_eq!(
+            stats,
+            SweepStats {
+                expired_removed: 0,
+                evicted_removed: 0,
+                bytes_after: 200,
+            }
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 #[cfg(not(mobile))]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(mobile))]
 use std::sync::Arc;
 use tauri::Manager;
-#[cfg(not(mobile))]
-use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(not(mobile))]
 use tauri::{
     menu::{Menu, MenuItem},
@@ -20,12 +20,12 @@ mod api_tokens;
 mod app_dir;
 mod auth_service;
 mod commands;
-#[cfg(target_os = "windows")]
-mod hwheel_hook;
+mod crash_report;
 /// Public so the `gen-openapi` binary and the OpenAPI snapshot test can call
 /// [`http_server::build_openapi`].
 pub mod http_server;
-mod crash_report;
+#[cfg(target_os = "windows")]
+mod hwheel_hook;
 mod image_cache;
 mod media_proxy;
 mod migrations;
@@ -36,8 +36,8 @@ mod perf_config;
 mod permissions_gate;
 mod query_bridge;
 mod query_runtime;
-mod settings_store;
 mod rate_limit;
+mod settings_store;
 mod streaming;
 mod vault;
 mod win_chrome;
@@ -58,8 +58,11 @@ pub fn run() {
 fn init_logging(app: &tauri::App) {
     use tracing_subscriber::prelude::*;
 
-    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| "notedeck=info,notecli=info,warn".parse().expect("default tracing filter must parse"));
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        "notedeck=info,notecli=info,warn"
+            .parse()
+            .expect("default tracing filter must parse")
+    });
 
     // File layer is optional: skipped if the log dir can't be created.
     let file_layer = app
@@ -73,7 +76,9 @@ fn init_logging(app: &tauri::App) {
             // Keep the writer thread alive for the whole process (flushes on drop),
             // mirroring how the tokio runtime handle is leaked above.
             Box::leak(Box::new(guard));
-            tracing_subscriber::fmt::layer().with_ansi(false).with_writer(non_blocking)
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(non_blocking)
         });
 
     tracing_subscriber::registry()
@@ -169,15 +174,13 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
     // 直接叩けない。custom protocol は WebView 自身が intercept するのでその
     // 制限を受けず、リサイズ・ディスクキャッシュ・サーキットブレーカーを全
     // プラットフォームで同じ経路に乗せられる。
-    builder = builder.register_asynchronous_uri_scheme_protocol(
-        "ndmedia",
-        |ctx, request, responder| {
+    builder =
+        builder.register_asynchronous_uri_scheme_protocol("ndmedia", |ctx, request, responder| {
             let app = ctx.app_handle().clone();
             tauri::async_runtime::spawn(async move {
                 responder.respond(media_proxy::handle_uri_request(&app, request).await);
             });
-        },
-    );
+        });
 
     // セーフモード (#794) — `notedeck --safe-mode` で起動したとき、ページ評価前に
     // フラグを注入する。index.html の boot script がこれを localStorage へ畳み込み、

--- a/src-tauri/src/ogp/mod.rs
+++ b/src-tauri/src/ogp/mod.rs
@@ -132,11 +132,17 @@ impl OgpCache {
     /// Create with a default HTTP client (used in tests).
     #[allow(dead_code)]
     pub fn new(db: Arc<notecli::db::Database>) -> Self {
-        let perf = Arc::new(tokio::sync::RwLock::new(crate::perf_config::PerformanceConfig::default()));
+        let perf = Arc::new(tokio::sync::RwLock::new(
+            crate::perf_config::PerformanceConfig::default(),
+        ));
         Self::with_client(db, reqwest::Client::default(), perf)
     }
 
-    pub fn with_client(db: Arc<notecli::db::Database>, http_client: reqwest::Client, perf: SharedPerfConfig) -> Self {
+    pub fn with_client(
+        db: Arc<notecli::db::Database>,
+        http_client: reqwest::Client,
+        perf: SharedPerfConfig,
+    ) -> Self {
         Self {
             cache: Arc::new(Mutex::new(LruCache::new(
                 NonZeroUsize::new(DEFAULT_MAX_ENTRIES).unwrap(),
@@ -407,10 +413,7 @@ impl OgpCache {
         if let Some(ref referer) = referer {
             req = req.header(reqwest::header::REFERER, referer);
         }
-        let resp = req
-            .send()
-            .await
-            .map_err(|e| format!("Fetch failed: {e}"))?;
+        let resp = req.send().await.map_err(|e| format!("Fetch failed: {e}"))?;
 
         if !resp.status().is_success() {
             return Err(format!("HTTP {}", resp.status()));
@@ -500,16 +503,19 @@ fn decode_html_bytes(bytes: &[u8], content_type: &str) -> String {
 }
 
 fn extract_charset_from_content_type(content_type: &str) -> Option<String> {
-    content_type
-        .split(';')
-        .find_map(|part| {
-            let part = part.trim();
-            if part.to_ascii_lowercase().starts_with("charset=") {
-                Some(part["charset=".len()..].trim_matches('"').trim().to_string())
-            } else {
-                None
-            }
-        })
+    content_type.split(';').find_map(|part| {
+        let part = part.trim();
+        if part.to_ascii_lowercase().starts_with("charset=") {
+            Some(
+                part["charset=".len()..]
+                    .trim_matches('"')
+                    .trim()
+                    .to_string(),
+            )
+        } else {
+            None
+        }
+    })
 }
 
 /// Scan the first 1024 bytes for <meta charset="..."> or
@@ -524,8 +530,7 @@ fn detect_charset_from_html(bytes: &[u8]) -> Option<&'static encoding_rs::Encodi
     if let Some(pos) = lower.find("charset=") {
         let rest = &lower[pos + "charset=".len()..];
         let rest = rest.trim_start_matches(['"', '\'', ' ']);
-        let end = rest.find(['"', '\'', ' ', ';', '>'])
-            .unwrap_or(rest.len());
+        let end = rest.find(['"', '\'', ' ', ';', '>']).unwrap_or(rest.len());
         let name = &rest[..end];
         if !name.is_empty() {
             return encoding_rs::Encoding::for_label(name.as_bytes());
@@ -553,7 +558,9 @@ mod tests {
             player_allow: Some(r#"["autoplay","fullscreen"]"#.to_string()),
             final_url: Some("https://example.com/final".to_string()),
             sensitive: false,
-            medias_json: Some(r#"["https://example.com/1.png","https://example.com/2.png"]"#.to_string()),
+            medias_json: Some(
+                r#"["https://example.com/1.png","https://example.com/2.png"]"#.to_string(),
+            ),
         }
     }
 

--- a/src-tauri/src/ogp/plugins/mod.rs
+++ b/src-tauri/src/ogp/plugins/mod.rs
@@ -194,7 +194,10 @@ mod tests {
     #[test]
     fn youtube_plugin_matches() {
         let plugins = all();
-        let yt = plugins.iter().find(|p| p.test(&url("https://www.youtube.com/watch?v=abc"))).unwrap();
+        let yt = plugins
+            .iter()
+            .find(|p| p.test(&url("https://www.youtube.com/watch?v=abc")))
+            .unwrap();
         assert!(yt.test(&url("https://youtube.com/watch?v=abc")));
         assert!(yt.test(&url("https://youtu.be/abc")));
         assert!(yt.test(&url("https://m.youtube.com/watch?v=abc")));
@@ -203,14 +206,20 @@ mod tests {
     #[test]
     fn youtube_does_not_match_other() {
         let plugins = all();
-        let yt = plugins.iter().find(|p| p.test(&url("https://www.youtube.com/watch?v=abc"))).unwrap();
+        let yt = plugins
+            .iter()
+            .find(|p| p.test(&url("https://www.youtube.com/watch?v=abc")))
+            .unwrap();
         assert!(!yt.test(&url("https://example.com")));
     }
 
     #[test]
     fn twitter_plugin_matches() {
         let plugins = all();
-        let tw = plugins.iter().find(|p| p.test(&url("https://x.com/user/status/123"))).unwrap();
+        let tw = plugins
+            .iter()
+            .find(|p| p.test(&url("https://x.com/user/status/123")))
+            .unwrap();
         assert!(tw.test(&url("https://twitter.com/user/status/123")));
         assert!(tw.test(&url("https://x.com/user/status/123")));
         // fxtwitter/vxtwitter are third-party services, not handled by the Twitter plugin
@@ -219,23 +228,31 @@ mod tests {
     #[test]
     fn spotify_plugin_matches() {
         let plugins = all();
-        let sp = plugins.iter().find(|p| p.test(&url("https://open.spotify.com/track/abc")));
+        let sp = plugins
+            .iter()
+            .find(|p| p.test(&url("https://open.spotify.com/track/abc")));
         assert!(sp.is_some());
     }
 
     #[test]
     fn niconico_plugin_matches() {
         let plugins = all();
-        let nico = plugins.iter().find(|p| p.test(&url("https://www.nicovideo.jp/watch/sm123")));
+        let nico = plugins
+            .iter()
+            .find(|p| p.test(&url("https://www.nicovideo.jp/watch/sm123")));
         assert!(nico.is_some());
-        let nico2 = plugins.iter().find(|p| p.test(&url("https://nico.ms/sm123")));
+        let nico2 = plugins
+            .iter()
+            .find(|p| p.test(&url("https://nico.ms/sm123")));
         assert!(nico2.is_some());
     }
 
     #[test]
     fn no_plugin_matches_random_url() {
         let plugins = all();
-        assert!(!plugins.iter().any(|p| p.test(&url("https://example.com/page"))));
+        assert!(!plugins
+            .iter()
+            .any(|p| p.test(&url("https://example.com/page"))));
     }
 
     // --- flexible_u32 deserialization ---

--- a/src-tauri/src/perf_config.rs
+++ b/src-tauri/src/perf_config.rs
@@ -26,7 +26,7 @@ impl Default for PerformanceConfig {
     fn default() -> Self {
         Self {
             memory_cache_max_total: 32 * 1024 * 1024, // 32MB
-            memory_cache_max_item: 256 * 1024,         // 256KB
+            memory_cache_max_item: 256 * 1024,        // 256KB
             max_concurrent_fetches: 30,
             rust_ogp_cache_max: 256,
             max_requests_per_window: 200,

--- a/src-tauri/src/permissions_gate.rs
+++ b/src-tauri/src/permissions_gate.rs
@@ -39,8 +39,7 @@ pub struct ExternalTokenMarker;
 /// フロント側 `EXTERNAL_READ_FLOOR` と同じ意味論的選択 — 「トークンを発行して
 /// 渡す行為そのものが Misskey コンテンツ read への同意」。sync 前でもこの
 /// キーにマップされる GET は許可する。
-const EXTERNAL_READ_FLOOR: [&str; 4] =
-    ["notes.read", "account.read", "drive.read", "clips.read"];
+const EXTERNAL_READ_FLOOR: [&str; 4] = ["notes.read", "account.read", "drive.read", "clips.read"];
 
 /// フロントから同期された external の実効 granted map。
 /// None = 初回 sync 前 (deny-by-default で動く)。
@@ -116,7 +115,9 @@ pub fn route_rule(method: &Method, path: &str) -> RouteRule {
 
     // --- 公開 meta / proxy (認証自体が無いルート) ---
     match (method, path) {
-        (&Method::GET, "/api") | (&Method::GET, "/api/docs") | (&Method::GET, "/api/openapi.json") => {
+        (&Method::GET, "/api")
+        | (&Method::GET, "/api/docs")
+        | (&Method::GET, "/api/openapi.json") => {
             return RouteRule::Exempt;
         }
         _ => {}
@@ -181,9 +182,7 @@ pub fn route_rule(method: &Method, path: &str) -> RouteRule {
                 RouteRule::Keys(&["notes.read"])
             }
             (&Method::POST, ["notes", _, "reactions"])
-            | (&Method::DELETE, ["notes", _, "reactions"]) => {
-                RouteRule::Keys(&["notes.react"])
-            }
+            | (&Method::DELETE, ["notes", _, "reactions"]) => RouteRule::Keys(&["notes.react"]),
             (&Method::GET, ["users", _]) => RouteRule::Keys(&["account.read"]),
             (&Method::GET, ["users", _, "notes"]) => RouteRule::Keys(&["notes.read"]),
             _ => RouteRule::Deny,
@@ -219,11 +218,7 @@ pub async fn external_gate_middleware(req: Request, next: Next) -> Response {
     match route_rule(req.method(), req.uri().path()) {
         RouteRule::Exempt => next.run(req).await,
         RouteRule::Keys(keys) => {
-            let denied: Vec<&str> = keys
-                .iter()
-                .filter(|k| !is_granted(k))
-                .copied()
-                .collect();
+            let denied: Vec<&str> = keys.iter().filter(|k| !is_granted(k)).copied().collect();
             if denied.is_empty() {
                 next.run(req).await
             } else {
@@ -256,10 +251,8 @@ mod tests {
     }
 
     fn sync(pairs: &[(&str, bool)]) {
-        let map: HashMap<String, bool> = pairs
-            .iter()
-            .map(|(k, v)| ((*k).to_string(), *v))
-            .collect();
+        let map: HashMap<String, bool> =
+            pairs.iter().map(|(k, v)| ((*k).to_string(), *v)).collect();
         *EXTERNAL_GRANTED.write().unwrap() = Some(map);
     }
 

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -545,9 +545,7 @@ impl<'a> StreamChange<'a> {
             ),
             StreamEvent::Notification(e) => (
                 e.subscription_id.as_str(),
-                StreamChangeKind::Insert(QueryItem::Notification(Box::new(
-                    e.notification.clone(),
-                ))),
+                StreamChangeKind::Insert(QueryItem::Notification(Box::new(e.notification.clone()))),
             ),
             StreamEvent::ChatMessage(e) => (
                 e.subscription_id.as_str(),
@@ -810,7 +808,9 @@ pub async fn query_subscribe_chat_user(
         return Ok(opened);
     }
 
-    let subscription_id = streaming.subscribe_chat_user(&account_id, &other_id).await?;
+    let subscription_id = streaming
+        .subscribe_chat_user(&account_id, &other_id)
+        .await?;
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
@@ -902,8 +902,8 @@ pub async fn query_set_runtime_state(
                     if snap.runtime_state != QueryRuntimeState::Warm {
                         return;
                     }
-                    let _ = runtime
-                        .set_runtime_state(&query_id_owned, QueryRuntimeState::Suspended);
+                    let _ =
+                        runtime.set_runtime_state(&query_id_owned, QueryRuntimeState::Suspended);
                     if let Ok(Some((account_id, subscription_id))) =
                         runtime.stream_subscription_for(&query_id_owned)
                     {
@@ -1150,7 +1150,11 @@ mod tests {
         assert!(rt.ingest_stream_event(&reaction_event("sub-A", "n1")));
 
         let snap = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();
-        assert_eq!(snap.item_ids.len(), 1, "reaction で recent_ids は変わらない");
+        assert_eq!(
+            snap.item_ids.len(),
+            1,
+            "reaction で recent_ids は変わらない"
+        );
 
         let drained = rt.drain_pending();
         assert_eq!(drained.len(), 1);
@@ -1217,7 +1221,10 @@ mod tests {
             rt.ingest_stream_event(&note_event("sub-A", &id));
         }
 
-        let limited = rt.read_model_snapshot(&s.query_id, Some(10)).unwrap().unwrap();
+        let limited = rt
+            .read_model_snapshot(&s.query_id, Some(10))
+            .unwrap()
+            .unwrap();
         assert_eq!(limited.item_ids.len(), 10);
 
         let unlimited = rt.read_model_snapshot(&s.query_id, None).unwrap().unwrap();

--- a/src-tauri/src/rate_limit.rs
+++ b/src-tauri/src/rate_limit.rs
@@ -45,7 +45,10 @@ impl RateLimiter {
         let window = windows.entry(host.to_string()).or_default();
 
         // Evict expired entries
-        while window.front().is_some_and(|&t| now.duration_since(t) > WINDOW_DURATION) {
+        while window
+            .front()
+            .is_some_and(|&t| now.duration_since(t) > WINDOW_DURATION)
+        {
             window.pop_front();
         }
 
@@ -61,7 +64,10 @@ impl RateLimiter {
     pub async fn cleanup(&self) {
         let now = Instant::now();
         let mut windows = self.windows.write().await;
-        windows.retain(|_, w| w.back().is_some_and(|&t| now.duration_since(t) <= WINDOW_DURATION));
+        windows.retain(|_, w| {
+            w.back()
+                .is_some_and(|&t| now.duration_since(t) <= WINDOW_DURATION)
+        });
     }
 }
 
@@ -132,7 +138,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limiter_allows_within_limit() {
-        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(crate::perf_config::PerformanceConfig::default())));
+        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::perf_config::PerformanceConfig::default(),
+        )));
         for _ in 0..DEFAULT_MAX_REQUESTS_PER_WINDOW {
             assert!(limiter.check("test.host").await);
         }
@@ -142,7 +150,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_rate_limiter_independent_hosts() {
-        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(crate::perf_config::PerformanceConfig::default())));
+        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::perf_config::PerformanceConfig::default(),
+        )));
         for _ in 0..DEFAULT_MAX_REQUESTS_PER_WINDOW {
             limiter.check("host-a.example").await;
         }
@@ -152,7 +162,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_removes_stale_entries() {
-        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(crate::perf_config::PerformanceConfig::default())));
+        let limiter = RateLimiter::new(std::sync::Arc::new(tokio::sync::RwLock::new(
+            crate::perf_config::PerformanceConfig::default(),
+        )));
         limiter.check("stale.host").await;
 
         // Manually inject an old timestamp

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -448,7 +448,13 @@ impl<R: tauri::Runtime> TauriEmitter<R> {
             }
             "login" => ("ログイン検知".to_string(), None),
             "pollEnded" => ("投票終了".to_string(), None),
-            "app" => ("通知".to_string(), None),
+            // 外部アプリ (notifications/create) 由来。本家 sw に合わせ header が
+            // あれば title=header / body=body、無ければ body を title に繰り上げる
+            "app" => match (notification.header.as_deref(), notification.body.as_deref()) {
+                (Some(header), body) => (header.to_string(), body.map(str::to_string)),
+                (None, Some(body)) => (body.to_string(), None),
+                (None, None) => ("通知".to_string(), None),
+            },
             "test" => ("テスト通知".to_string(), Some("テスト通知".to_string())),
 
             _ => return OsNotifPlan::Suppress,
@@ -467,10 +473,12 @@ impl<R: tauri::Runtime> TauriEmitter<R> {
         // ":name@host:") はフルカラー画像として添付。Unicode 絵文字は本文に
         // 出るので画像なし。URL の形式は notify_media::emoji_image_url 参照。
         let media = {
+            // app 通知はアクターが居ないので、送信元アプリの icon を代わりに使う
             let icon_url = notification
                 .user
                 .as_ref()
-                .and_then(|u| u.avatar_url.clone());
+                .and_then(|u| u.avatar_url.clone())
+                .or_else(|| notification.icon.clone());
             let image_url = (notif_type == "reaction")
                 .then_some(notification.reaction.as_deref())
                 .flatten()
@@ -1097,6 +1105,62 @@ mod tests {
                 assert_eq!(ctx.user_id.as_deref(), Some("u1"));
             }
             _ => panic!("first notification should be ShowNow"),
+        }
+    }
+
+    fn app_notification(
+        id: &str,
+        header: Option<&str>,
+        icon: Option<&str>,
+    ) -> NormalizedNotification {
+        serde_json::from_value(json!({
+            "id": id,
+            "_accountId": "acct-1",
+            "_serverHost": "misskey.example",
+            "createdAt": "2026-01-01T00:00:00.000Z",
+            "type": "app",
+            "header": header,
+            "body": "Mewkで実績を獲得しました！",
+            "icon": icon,
+        }))
+        .expect("fixture should deserialize")
+    }
+
+    /// 外部アプリの app 通知は header/body/icon を OS 通知に載せる (#900)。
+    /// header が無ければ本家 sw と同じく body を title に繰り上げる。
+    #[test]
+    fn plan_uses_app_notification_header_body_icon() {
+        let app = mock_app();
+        let emitter = TauriEmitter::new(app.handle().clone());
+
+        match emitter.plan_os_notification(&app_notification(
+            "a1",
+            Some("Mewk | 実績解除"),
+            Some("https://mewk.app/icon.png"),
+        )) {
+            OsNotifPlan::ShowNow {
+                title, body, media, ..
+            } => {
+                assert_eq!(title, "Mewk | 実績解除");
+                assert_eq!(body.as_deref(), Some("Mewkで実績を獲得しました！"));
+                assert_eq!(
+                    media
+                        .expect("app icon should be attached")
+                        .icon_url
+                        .as_deref(),
+                    Some("https://mewk.app/icon.png")
+                );
+            }
+            _ => panic!("should be ShowNow"),
+        }
+
+        *emitter.last_os_notif.lock().unwrap() = None;
+        match emitter.plan_os_notification(&app_notification("a2", None, None)) {
+            OsNotifPlan::ShowNow { title, body, .. } => {
+                assert_eq!(title, "Mewkで実績を獲得しました！");
+                assert!(body.is_none());
+            }
+            _ => panic!("should be ShowNow"),
         }
     }
 

--- a/src-tauri/src/vault/mod.rs
+++ b/src-tauri/src/vault/mod.rs
@@ -23,6 +23,4 @@ pub mod ssrf;
 pub use backend::SecretBackend;
 pub use error::{VaultError, VaultResult};
 pub use keychain_backend::KeychainBackend;
-pub use model::{
-    AuthType, Connection, ConnectionKind, ConnectionOrigin, ConnectionProtocol,
-};
+pub use model::{AuthType, Connection, ConnectionKind, ConnectionOrigin, ConnectionProtocol};

--- a/src-tauri/src/vault/ssrf.rs
+++ b/src-tauri/src/vault/ssrf.rs
@@ -70,17 +70,13 @@ impl Resolve for PinningResolver {
         Box::pin(async move {
             // キャッシュ済みならそれを使う (rebinding 防御の要)。
             if let Some(ips) = cache.lock().unwrap().get(&host).cloned() {
-                let addrs: Addrs =
-                    Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)));
+                let addrs: Addrs = Box::new(ips.into_iter().map(|ip| SocketAddr::new(ip, 0)));
                 return Ok(addrs);
             }
 
             let resolved = resolve_and_validate(&host).await?;
 
-            cache
-                .lock()
-                .unwrap()
-                .insert(host.clone(), resolved.clone());
+            cache.lock().unwrap().insert(host.clone(), resolved.clone());
             let addrs: Addrs = Box::new(resolved.into_iter().map(|ip| SocketAddr::new(ip, 0)));
             Ok(addrs)
         })

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.34.0",
+  "version": "1.35.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -396,6 +396,12 @@ export interface NormalizedNotification {
   users?: NormalizedUser[]
   /** Assigned role (for roleAssigned type) */
   role?: UserRole
+  /** App notification header (for app type) */
+  header?: string | null
+  /** App notification body (for app type) */
+  body?: string | null
+  /** App notification icon URL (for app type) */
+  icon?: string | null
 }
 
 export interface CreateNoteParams {

--- a/src/aiscript/codemirror/theme.ts
+++ b/src/aiscript/codemirror/theme.ts
@@ -9,7 +9,7 @@ const editorTheme = EditorView.theme(
       backgroundColor: '#1e1e1e',
       color: '#d4d4d4',
       fontSize: '0.8em',
-      fontFamily: "'Fira Code', 'Cascadia Code', 'Consolas', monospace",
+      fontFamily: 'var(--nd-font-mono)',
     },
     '.cm-content': {
       caretColor: '#aeafad',

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2876,7 +2876,19 @@ users?: NormalizedUser[] | null;
 /**
  * Assigned role (for roleAssigned type)
  */
-role?: UserRole | null }
+role?: UserRole | null; 
+/**
+ * App notification header (for app type; notifications/create の header)
+ */
+header?: string | null; 
+/**
+ * App notification body (for app type; notifications/create の body)
+ */
+body?: string | null; 
+/**
+ * App notification icon URL (for app type; notifications/create の icon)
+ */
+icon?: string | null }
 export type NormalizedPoll = { choices: NormalizedPollChoice[]; multiple?: boolean; expiresAt: string | null }
 export type NormalizedPollChoice = { text: string; votes?: number; isVoted?: boolean }
 export type NormalizedUser = { id: string; username: string; host: string | null; name: string | null; avatarUrl: string | null; isBot?: boolean; isCat?: boolean; avatarDecorations?: AvatarDecoration[]; emojis?: Partial<{ [key in string]: string }>; instance?: UserInstance | null }

--- a/src/components/DevWelcome.vue
+++ b/src/components/DevWelcome.vue
@@ -159,7 +159,7 @@ const appVersion = __APP_VERSION__
   padding: 0.5rem 1rem;
 
   code {
-    font-family: 'SF Mono', Monaco, Consolas, 'Liberation Mono', monospace;
+    font-family: var(--nd-font-mono);
     font-size: 0.9rem;
     color: var(--accent);
     font-weight: 600;

--- a/src/components/common/AppConfirm.vue
+++ b/src/components/common/AppConfirm.vue
@@ -346,14 +346,7 @@ useNativeDialog(dialogRef, visible, {
   }
 
   :global(code) {
-    font-family: var(
-      --nd-mono,
-      ui-monospace,
-      "SF Mono",
-      Menlo,
-      Consolas,
-      monospace
-    );
+    font-family: var(--nd-font-mono);
     white-space: pre;
     word-break: normal;
   }

--- a/src/components/common/CommandPalette.vue
+++ b/src/components/common/CommandPalette.vue
@@ -850,7 +850,7 @@ function primaryShortcut(cmd: Command): string | null {
 
 .cliHint {
   opacity: 0.5;
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
 }
 
 .cliAction strong {

--- a/src/components/common/MkAutocompletePopup.vue
+++ b/src/components/common/MkAutocompletePopup.vue
@@ -194,7 +194,7 @@ function candidateKey(candidate: AutocompleteCandidate): string {
 }
 
 .acMfmName {
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/components/common/MkDraftsPicker.vue
+++ b/src/components/common/MkDraftsPicker.vue
@@ -568,7 +568,7 @@ async function onDeleteAll() {
 }
 
 .metaRef {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   opacity: 0.7;
 }
 

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -328,7 +328,7 @@ function fnStyle(
       break
     case 'font':
       if (args.serif) s.fontFamily = 'serif'
-      else if (args.monospace) s.fontFamily = 'monospace'
+      else if (args.monospace) s.fontFamily = 'var(--nd-font-mono)'
       else if (args.cursive) s.fontFamily = 'cursive'
       else if (args.fantasy) s.fontFamily = 'fantasy'
       break
@@ -511,7 +511,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
 }
 
 .mfmCode {
-  font-family: 'Fira Code', 'Cascadia Code', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.9em;
   padding: 2px 6px;
   border-radius: 4px;
@@ -525,7 +525,7 @@ function unixtimeValue(token: MfmToken & { type: 'fn' }): number | null {
   overflow: hidden;
 
   :deep(pre) {
-    font-family: 'Fira Code', 'Cascadia Code', monospace;
+    font-family: var(--nd-font-mono);
     font-size: 0.85em;
     padding: 12px 16px;
     border-radius: var(--nd-radius-md);

--- a/src/components/common/RawJsonView.vue
+++ b/src/components/common/RawJsonView.vue
@@ -103,7 +103,7 @@ const lang = jsonLang()
   min-width: 0;
 
   :deep(code) {
-    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    font-family: var(--nd-font-mono);
     background: rgba(127, 127, 127, 0.15);
     padding: 1px 5px;
     border-radius: 3px;

--- a/src/components/common/RegexGuide.vue
+++ b/src/components/common/RegexGuide.vue
@@ -229,7 +229,7 @@ function apply() {
   scrollbar-width: none;
 
   code {
-    font-family: monospace;
+    font-family: var(--nd-font-mono);
     font-size: 0.75em;
     color: var(--nd-accent);
     word-break: break-all;

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -1605,7 +1605,7 @@ function onKeydown(e: KeyboardEvent) {
 
 .toolEventName {
   flex-shrink: 0;
-  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-family: var(--nd-font-mono);
   font-size: 0.92em;
   padding: 1px 6px;
   border-radius: var(--nd-radius-sm);
@@ -1620,7 +1620,7 @@ function onKeydown(e: KeyboardEvent) {
   overflow: hidden;
   text-overflow: ellipsis;
   opacity: 0.6;
-  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-family: var(--nd-font-mono);
   font-size: 0.92em;
 }
 
@@ -1642,7 +1642,7 @@ function onKeydown(e: KeyboardEvent) {
   padding: 8px;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
-  font-family: var(--nd-monoFont, 'Fira Code', monospace);
+  font-family: var(--nd-font-mono);
   font-size: 0.9em;
   line-height: 1.45;
   white-space: pre-wrap;
@@ -1686,7 +1686,7 @@ function onKeydown(e: KeyboardEvent) {
     font-size: 0.85em;
   }
   :global(pre code) {
-    font-family: var(--nd-font-mono, monospace);
+    font-family: var(--nd-font-mono);
   }
   :global(pre button[data-md-copy]) {
     position: absolute;
@@ -1710,7 +1710,7 @@ function onKeydown(e: KeyboardEvent) {
     background: var(--nd-buttonHoverBg);
   }
   :global(code) {
-    font-family: var(--nd-font-mono, monospace);
+    font-family: var(--nd-font-mono);
     background: var(--nd-base);
     padding: 1px 4px;
     border-radius: 3px;

--- a/src/components/deck/DeckAiScriptColumn.vue
+++ b/src/components/deck/DeckAiScriptColumn.vue
@@ -620,7 +620,7 @@ onUnmounted(() => {
 
 .inspectorId {
   opacity: 0.5;
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.85em;
 }
 
@@ -632,7 +632,7 @@ onUnmounted(() => {
     padding: 6px 8px;
     border-radius: var(--nd-radius-sm);
     background: color-mix(in srgb, var(--nd-fg) 5%, transparent);
-    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    font-family: var(--nd-font-mono);
     font-size: 0.75em;
     line-height: 1.4;
     white-space: pre-wrap;
@@ -657,7 +657,7 @@ onUnmounted(() => {
 }
 
 .outputLine {
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   line-height: 1.5;
   white-space: pre-wrap;

--- a/src/components/deck/DeckApiConsoleColumn.vue
+++ b/src/components/deck/DeckApiConsoleColumn.vue
@@ -213,7 +213,7 @@ function onKeydown(e: KeyboardEvent) {
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
   color: var(--nd-fg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.85em;
   outline: none;
   transition: border-color var(--nd-duration-base);
@@ -241,7 +241,7 @@ function onKeydown(e: KeyboardEvent) {
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
   color: var(--nd-fg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   line-height: 1.5;
   resize: vertical;
@@ -271,7 +271,7 @@ function onKeydown(e: KeyboardEvent) {
 
 .responseBody pre {
   margin: 0;
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.75em;
   line-height: 1.5;
   white-space: pre-wrap;

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -190,7 +190,6 @@ const isMuted = computed(
 )
 
 function toggleMute() {
-  closeMenu()
   deckStore.updateColumn(props.columnId, { soundMuted: !isMuted.value })
 }
 
@@ -245,6 +244,18 @@ function openAsPip() {
       <template v-if="!isPipMode">
         <slot name="header-meta" />
       </template>
+
+      <!-- Mute toggle (resident: sound settings are used far more often than the other menu items) -->
+      <button
+        v-if="soundEnabled && !isPipMode"
+        :class="[$style.headerBtn, isMuted && $style.headerBtnActive]"
+        class="_button"
+        :title="isMuted ? 'ミュート解除' : 'ミュート'"
+        @pointerdown.stop
+        @click.stop="toggleMute"
+      >
+        <i :class="isMuted ? 'ti ti-volume-off' : 'ti ti-volume'" />
+      </button>
 
       <!-- Grabber (Misskey 6-dot pattern, hidden in PiP, mobile, and compact layout) -->
       <i v-if="!isPipMode && !isMobilePlatform && !isCompact" :class="$style.grabber" class="column-grabber ti ti-grip-vertical" />
@@ -322,10 +333,6 @@ function openAsPip() {
         <button v-if="canRecall" class="_popupItem" @click="recallToMain">
           <i class="ti ti-arrow-back-up" />
           <span>メインウィンドウに戻す</span>
-        </button>
-        <button v-if="soundEnabled" class="_popupItem" @click="toggleMute">
-          <i :class="isMuted ? 'ti ti-volume' : 'ti ti-volume-off'" />
-          <span>{{ isMuted ? 'ミュート解除' : 'ミュート' }}</span>
         </button>
         <slot name="menu-items" :close-menu="closeMenu" />
         <div :class="$style.columnMenuDivider" />
@@ -436,6 +443,12 @@ function openAsPip() {
     background: var(--nd-buttonHoverBg);
     opacity: 0.8;
   }
+}
+
+/* Muted state must stay readable at a glance (same specificity as .headerBtn) */
+.columnHeader .headerBtnActive {
+  opacity: 1;
+  color: var(--nd-accent);
 }
 
 /* Column action menu — nested for specificity 0,2,0 to beat

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -484,7 +484,7 @@ function closeMenu() {
 }
 
 .metaRef {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   opacity: 0.7;
 }
 

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -495,6 +495,7 @@ const NOTIFICATION_ICONS: Record<string, string> = {
   pollEnded: 'chart-arrows',
   achievementEarned: 'medal',
   roleAssigned: 'badges',
+  app: 'apps',
   login: 'login-2',
   createToken: 'key',
 }
@@ -589,6 +590,13 @@ function notificationColor(type: string): string {
 
 function notificationLabel(type: string): string {
   return NOTIFICATION_LABELS[baseType(type)] || type
+}
+
+// 外部アプリが notifications/create で飛ばす app 通知は user を持たず、
+// header / body / icon で内容を伝える (#900)。header はアプリ名を含むので
+// ユーザー名の位置に出し、汎用ラベル「通知」は抑える。
+function appHeader(notif: NormalizedNotification): string | null {
+  return notif.type === 'app' ? (notif.header ?? null) : null
 }
 
 function cacheAccountKey() {
@@ -1207,7 +1215,8 @@ onUnmounted(() => {
                     @mouseleave="onNotifAvatarMouseLeave"
                   />
                   <template v-else>
-                    <img v-if="resolveNotifAccount(notif)?.avatarUrl" :src="resolveNotifAccount(notif)!.avatarUrl!" :class="$style.notifFallbackAvatar" />
+                    <img v-if="notif.type === 'app' && notif.icon" :src="notif.icon" :class="[$style.notifFallbackAvatar, $style.notifAppIcon]" alt="" />
+                    <img v-else-if="resolveNotifAccount(notif)?.avatarUrl" :src="resolveNotifAccount(notif)!.avatarUrl!" :class="$style.notifFallbackAvatar" />
                   </template>
                   <img
                     v-if="shouldShowServerBadge(notif) && resolveNotifServerIcon(notif)"
@@ -1232,7 +1241,8 @@ onUnmounted(() => {
                         <MkMfm v-if="notif.user.name" :text="notif.user.name" :emojis="notif.user.emojis" :server-host="notif._serverHost" plain />
                         <template v-else>{{ notif.user.username }}</template>
                       </span>
-                      <span :class="$style.notifLabel">{{ notificationLabel(notif.type) }}</span>
+                      <span v-if="appHeader(notif)" :class="$style.notifUserName">{{ appHeader(notif) }}</span>
+                      <span v-else :class="$style.notifLabel">{{ notificationLabel(notif.type) }}</span>
                       <span v-if="notif.type === 'reaction' && notif.reaction" :class="$style.notifReaction">
                         <span v-if="isEmojiMuted(notif.reaction)" class="_emojiMuted" :class="$style.notifReactionEmoji" role="img" :aria-label="notif.reaction" :title="`${notif.reaction} (ミュート中)`" />
                         <img v-else-if="getCachedReactionUrl(notif.reaction, notif)" :src="getCachedReactionUrl(notif.reaction, notif)!" :alt="notif.reaction" :title="notif.reaction" :class="$style.notifReactionEmoji" decoding="async" loading="lazy" @error="onReactionImgError" />
@@ -1245,6 +1255,11 @@ onUnmounted(() => {
                   <!-- Achievement name -->
                   <div v-if="notif.type === 'achievementEarned' && notif.achievement" :class="$style.notifAchievement">
                     {{ ACHIEVEMENT_LABELS[notif.achievement] ?? notif.achievement }}
+                  </div>
+
+                  <!-- App notification body (外部アプリの notifications/create) -->
+                  <div v-if="notif.type === 'app' && notif.body" :class="$style.notifAppBody">
+                    <MkMfm :text="notif.body" :server-host="notif._serverHost" />
                   </div>
 
                   <!-- Assigned role -->
@@ -1412,6 +1427,12 @@ onUnmounted(() => {
   -webkit-user-select: none;
 }
 
+/* アプリのロゴは円形トリミングだと欠けるので角丸 + contain で収める */
+.notifAppIcon {
+  border-radius: 8px;
+  object-fit: contain;
+}
+
 .notifServerBadge {
   position: absolute;
   top: -2px;
@@ -1521,6 +1542,13 @@ onUnmounted(() => {
   color: var(--nd-fg);
   opacity: 0.7;
   margin-top: 2px;
+}
+
+.notifAppBody {
+  margin-top: 2px;
+  font-size: 0.9em;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 .notifRole {

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -911,7 +911,7 @@ onUnmounted(() => {
 }
 
 .regexIconText {
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   font-weight: 700;
 }
@@ -939,7 +939,7 @@ onUnmounted(() => {
 }
 
 .regexInput {
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
 }
 
 .regexInvalid {

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -603,7 +603,7 @@ function onDetailWheel(e: WheelEvent) {
   gap: 8px;
   padding: 3px 8px;
   font-size: 0.72em;
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   cursor: pointer;
   border-bottom: 1px solid transparent;
   white-space: nowrap;

--- a/src/components/deck/DeckTaskRunnerColumn.vue
+++ b/src/components/deck/DeckTaskRunnerColumn.vue
@@ -609,7 +609,7 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
 .defaultBarShortcut {
   flex-shrink: 0;
   font-size: 0.7em;
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   padding: 1px 6px;
   border-radius: 4px;
   background: var(--nd-bg);
@@ -916,7 +916,7 @@ const { value: detailHeight, start: onDividerPointerDown } = useVerticalResize({
 }
 
 .method {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   font-size: 0.95em;
 }
 

--- a/src/components/deck/widgets/AiScriptEditor.vue
+++ b/src/components/deck/widgets/AiScriptEditor.vue
@@ -165,7 +165,7 @@ onUnmounted(() => {
   }
 
   :deep(.cm-scroller) {
-    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    font-family: var(--nd-font-mono);
     overflow: auto;
   }
 

--- a/src/components/deck/widgets/CodeEditor.vue
+++ b/src/components/deck/widgets/CodeEditor.vue
@@ -129,7 +129,7 @@ onUnmounted(() => {
   }
 
   :deep(.cm-scroller) {
-    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    font-family: var(--nd-font-mono);
     overflow: auto;
   }
 

--- a/src/components/deck/widgets/WidgetAiScript.vue
+++ b/src/components/deck/widgets/WidgetAiScript.vue
@@ -488,7 +488,7 @@ onMounted(() => {
   padding: 6px 10px;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   line-height: 1.6;
   max-height: 200px;

--- a/src/components/dev/DevFrameOverlay.vue
+++ b/src/components/dev/DevFrameOverlay.vue
@@ -82,7 +82,7 @@ onUnmounted(() => {
   border-radius: 6px;
   background: rgba(0, 0, 0, 0.8);
   color: #0f0;
-  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 11px;
   line-height: 1.4;
   pointer-events: none;

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -742,7 +742,7 @@ function reportBug() {
   gap: 4px;
   padding: 0 16px 12px;
   font-size: 0.85em;
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
 }
 
 .aboutRow {
@@ -827,7 +827,7 @@ function reportBug() {
   }
 
   :global(code) {
-    font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+    font-family: var(--nd-font-mono);
     white-space: pre-wrap;
     word-break: break-word;
     user-select: all;

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -290,7 +290,7 @@ watch(tab, (t) => {
             font-preview
           />
           <div v-if="presets.customFont" :class="$style.preview" :style="{ fontFamily: `'${presets.customFont}', sans-serif` }">
-            あいうえお ABCabc 123
+            あいうえお 漢字 ABCabc 123 Il1 O0
           </div>
         </template>
       </div>
@@ -310,7 +310,7 @@ watch(tab, (t) => {
             font-preview
             font-fallback="monospace"
           />
-          <div v-if="presets.monoFont" :class="[$style.preview, $style.monoPreview]" :style="{ fontFamily: `'${presets.monoFont}', monospace` }">
+          <div v-if="presets.monoFont" :class="$style.preview" :style="{ fontFamily: `'${presets.monoFont}', monospace` }">
             const 変数 = 0; // Il1 O0
           </div>
           <div :class="$style.hideCountNote">
@@ -580,18 +580,14 @@ watch(tab, (t) => {
 
 /* ドロップダウンの見た目は CssPresetDropdown (#778) が持つ */
 
-.monoPreview {
-  text-align: left;
-  white-space: nowrap;
-  overflow-x: auto;
-}
-
+/* 本文 / 等幅で同じ見た目。字形の差 (Il1 O0) が読めるよう左揃え + 横スクロール */
 .preview {
   padding: 8px 10px;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
   font-size: 0.9em;
-  text-align: center;
+  white-space: nowrap;
+  overflow-x: auto;
 }
 
 .visibilityBgPreview {

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -10,6 +10,21 @@ import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
+import {
+  buildPresetCss,
+  type CssPresets,
+  EMPTY_PRESETS,
+  extractUserCss,
+  FONT_OPTIONS,
+  FONT_SIZE_BASE,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  HIDE_COUNT_OPTIONS,
+  MONO_FONT_OPTIONS,
+  parsePresetsFromCss,
+  VISIBILITY_BG_COLORS,
+  VISIBILITY_BG_OPTIONS,
+} from '@/services/cssPresets'
 import { useThemeStore } from '@/stores/theme'
 
 const cssLang = css()
@@ -62,29 +77,8 @@ useWindowExternalFile(() =>
 // Local CSS mirror (synced from store on mount)
 const cssCode = ref(themeStore.customCss)
 
-// Preset toggles
-const presets = ref({
-  customFont: '',
-  fontSize: 0,
-  visibilityBg: '',
-  hideNoteCounts: '',
-  hideUserStats: '',
-})
-
-// Parse existing CSS to restore preset states
-function parsePresetsFromCss(cssStr: string) {
-  const fontMatch = cssStr.match(/\/\* nd-font: (.+?) \*\//)
-  presets.value.customFont = fontMatch?.[1] ?? ''
-  const sizeMatch = cssStr.match(/\/\* nd-fontsize: (.+?) \*\//)
-  presets.value.fontSize = sizeMatch ? Number(sizeMatch[1]) : 0
-  const visibilityBgMatch = cssStr.match(/\/\* nd-visibility-bg: (.+?) \*\//)
-  presets.value.visibilityBg = visibilityBgMatch?.[1] ?? ''
-  const noteCountsMatch = cssStr.match(/\/\* nd-hide-note-counts: (.+?) \*\//)
-  presets.value.hideNoteCounts = noteCountsMatch?.[1] ?? ''
-  const userStatsMatch = cssStr.match(/\/\* nd-hide-user-stats: (.+?) \*\//)
-  presets.value.hideUserStats = userStatsMatch?.[1] ?? ''
-}
-parsePresetsFromCss(cssCode.value)
+// Preset toggles (定義・CSS 変換は src/services/cssPresets.ts)
+const presets = ref<CssPresets>(parsePresetsFromCss(cssCode.value))
 
 const expandedSections = reactive<Record<string, boolean>>({ font: true })
 
@@ -92,99 +86,9 @@ function toggleSection(key: string) {
   expandedSections[key] = !expandedSections[key]
 }
 
-interface FontOption {
-  value: string
-  label: string
-  importUrl?: string
-  customCss?: string
-}
-
-const FONT_OPTIONS: FontOption[] = [
-  { value: '', label: 'デフォルト' },
-  { value: 'Noto Sans JP', label: 'Noto Sans JP' },
-  { value: 'Noto Serif JP', label: 'Noto Serif JP' },
-  { value: 'Sawarabi Gothic', label: 'Sawarabi Gothic' },
-  { value: 'Sawarabi Mincho', label: 'Sawarabi Mincho' },
-  { value: 'M PLUS 1p', label: 'M PLUS' },
-  { value: 'M PLUS Rounded 1c', label: 'M PLUS Rounded' },
-  { value: 'M PLUS 2', label: 'M PLUS 2' },
-  { value: 'Murecho', label: 'Murecho' },
-  { value: 'RocknRoll One', label: 'RocknRoll One' },
-  { value: 'Klee One', label: 'Klee One' },
-  { value: 'Zen Maru Gothic', label: 'Zen Maru Gothic' },
-  { value: 'Kaisei Decol', label: 'Kaisei Decol' },
-  { value: 'Yomogi', label: 'Yomogi' },
-  { value: 'Kosugi', label: 'Kosugi' },
-  { value: 'Kosugi Maru', label: 'Kosugi Maru' },
-  {
-    value: 'Kiwi Maru',
-    label: 'Kiwi Maru',
-    importUrl:
-      'https://fonts.googleapis.com/css2?family=Kiwi+Maru:wght@300&display=swap',
-  },
-  { value: 'Hachi Maru Pop', label: 'Hachi Maru Pop' },
-  { value: 'Mochiy Pop One', label: 'Mochiy Pop One' },
-  { value: 'Mochiy Pop P One', label: 'Mochiy Pop P One' },
-  { value: 'Yusei Magic', label: 'Yusei Magic' },
-  { value: 'DotGothic16', label: 'Dot Gothic 16' },
-  {
-    value: '手書き雑フォント',
-    label: '手書き雑フォント',
-    customCss: `@font-face { font-family: '手書き雑フォント'; src: url('https://cdn.leafscape.be/tegaki_zatsu/851tegaki_zatsu_web.woff2') format("woff2"); font-display: swap; }`,
-  },
-  {
-    value: '瀬戸フォント',
-    label: '瀬戸フォント',
-    customCss: `@font-face { font-family: '瀬戸フォント'; src: url('https://cdn.leafscape.be/setofont/setofont_web.woff2') format("woff2"); font-display: swap; }`,
-  },
-]
-
-const FONT_SIZE_BASE = 15
-const FONT_SIZE_MIN = -3
-const FONT_SIZE_MAX = 5
-
 // スライダーの塗りつぶし率 (OS のボリュームバー式に左側をアクセント色で塗る)
 function sliderFill(value: number, min: number, max: number): string {
   return `${((value - min) / (max - min)) * 100}%`
-}
-
-// 公開範囲ごとのノート背景色 (public はデフォルトのまま)
-const VISIBILITY_BG_COLORS: Record<string, { label: string; color: string }> = {
-  home: { label: 'ホーム', color: 'rgba(51, 127, 255, 0.08)' },
-  followers: { label: 'フォロワー', color: 'rgba(0, 170, 100, 0.08)' },
-  specified: { label: 'ダイレクト', color: 'rgba(255, 90, 120, 0.1)' },
-}
-
-interface VisibilityBgOption {
-  key: string
-  label: string
-}
-
-const VISIBILITY_BG_OPTIONS: VisibilityBgOption[] = [
-  { key: '', label: 'デフォルト' },
-  { key: 'tint', label: '背景色で色分け' },
-]
-
-// 数字の非表示 (#593/#594)。yamisskey の hideReactionCount / hide*Count と
-// 同じ self/others/all の 3 段階。導線 (クリックで一覧を開く等) は残し数字だけ消す。
-// ノート側はリアクション数 + リノート数 (評価シグナル)。返信数は会話の量なので対象外
-interface HideCountOption {
-  key: string
-  label: string
-}
-
-const HIDE_COUNT_OPTIONS: HideCountOption[] = [
-  { key: '', label: 'デフォルト' },
-  { key: 'self', label: '自分のみ隠す' },
-  { key: 'others', label: '他人のみ隠す' },
-  { key: 'all', label: 'すべて隠す' },
-]
-
-function hideCountTargets(key: string): string[] {
-  if (key === 'self') return ['true']
-  if (key === 'others') return ['false']
-  if (key === 'all') return ['true', 'false']
-  return []
 }
 
 const fontSizeLabel = computed(() => {
@@ -210,92 +114,6 @@ function validateCss(cssStr: string): string | null {
   }
 }
 
-function buildPresetCss(): string {
-  const parts: string[] = []
-
-  if (presets.value.customFont) {
-    const font = presets.value.customFont
-    const opt = FONT_OPTIONS.find((o) => o.value === font)
-    parts.push(`/* nd-font: ${font} */`)
-    if (opt?.customCss) {
-      parts.push(opt.customCss)
-    } else {
-      const url =
-        opt?.importUrl ??
-        `https://fonts.googleapis.com/css2?family=${encodeURIComponent(font)}&display=swap`
-      parts.push(`@import url('${url}');`)
-    }
-    parts.push(`html { font-family: '${font}', sans-serif; }`)
-  }
-
-  if (presets.value.fontSize !== 0) {
-    const px = FONT_SIZE_BASE + presets.value.fontSize
-    parts.push(`/* nd-fontsize: ${presets.value.fontSize} */`)
-    parts.push(`html { font-size: ${px}px; }`)
-  }
-
-  if (presets.value.visibilityBg === 'tint') {
-    parts.push('/* nd-visibility-bg: tint */')
-    for (const [visibility, { color }] of Object.entries(
-      VISIBILITY_BG_COLORS,
-    )) {
-      parts.push(
-        `.note-root[data-visibility="${visibility}"] { background-color: ${color}; }`,
-      )
-    }
-  }
-
-  const noteCountTargets = hideCountTargets(presets.value.hideNoteCounts)
-  if (noteCountTargets.length > 0) {
-    parts.push(`/* nd-hide-note-counts: ${presets.value.hideNoteCounts} */`)
-    for (const own of noteCountTargets) {
-      parts.push(
-        `.note-root[data-own="${own}"] :is(.note-reaction-count, .note-renote-count) { display: none; }`,
-      )
-    }
-  }
-
-  const statsTargets = hideCountTargets(presets.value.hideUserStats)
-  if (statsTargets.length > 0) {
-    parts.push(`/* nd-hide-user-stats: ${presets.value.hideUserStats} */`)
-    for (const own of statsTargets) {
-      parts.push(
-        `.user-stats[data-own="${own}"] .user-stat-count { font-size: 0; }`,
-      )
-      parts.push(
-        `.user-stats[data-own="${own}"] .user-stat-count::before { content: '-'; font-size: 1rem; }`,
-      )
-    }
-  }
-
-  return parts.join('\n')
-}
-
-function extractUserCss(fullCss: string): string {
-  return fullCss
-    .split('\n')
-    .filter((line) => {
-      const t = line.trim()
-      if (!t) return false
-      if (t.startsWith('/* nd-font:')) return false
-      if (t.startsWith('/* nd-fontsize:')) return false
-      if (t.startsWith('/* nd-visibility-bg:')) return false
-      if (t.startsWith('/* nd-hide-note-counts:')) return false
-      if (t.startsWith('/* nd-hide-user-stats:')) return false
-      // 生成行 (1 行完結) のみ除去。ユーザーが複数行で書いた同セレクタは残す
-      if (t.match(/^\.note-root\[data-visibility=.+\{.*\}$/)) return false
-      if (t.match(/^\.note-root\[data-own=.+\{.*\}$/)) return false
-      if (t.match(/^\.user-stats\[data-own=.+\{.*\}$/)) return false
-      if (t.startsWith('@import url(')) return false
-      if (t.startsWith('@font-face')) return false
-      if (t.match(/^html\s*\{\s*font-family:/)) return false
-      if (t.match(/^html\s*\{\s*font-size:/)) return false
-      return true
-    })
-    .join('\n')
-    .trim()
-}
-
 const userFreeformCss = ref(extractUserCss(cssCode.value))
 const cssError = ref<string | null>(null)
 
@@ -308,7 +126,7 @@ watch(userFreeformCss, (cssStr) => {
 })
 
 const fullCss = computed(() => {
-  const preset = buildPresetCss()
+  const preset = buildPresetCss(presets.value)
   const user = cssError.value ? '' : userFreeformCss.value.trim()
   if (preset && user) return `${preset}\n\n${user}`
   return preset || user
@@ -326,6 +144,7 @@ watch(fullCss, (cssStr) => {
 watch(
   () => [
     presets.value.customFont,
+    presets.value.monoFont,
     presets.value.fontSize,
     presets.value.visibilityBg,
     presets.value.hideNoteCounts,
@@ -362,7 +181,7 @@ function applyFromCode() {
     return
   }
   codeError.value = null
-  parsePresetsFromCss(cssStr)
+  presets.value = parsePresetsFromCss(cssStr)
   userFreeformCss.value = extractUserCss(cssStr)
   cssError.value = null
   themeStore.setCustomCss(cssStr)
@@ -391,7 +210,7 @@ async function importCss() {
       return
     }
     cssCode.value = text
-    parsePresetsFromCss(text)
+    presets.value = parsePresetsFromCss(text)
     userFreeformCss.value = extractUserCss(text)
     themeStore.setCustomCss(text)
     showImported()
@@ -405,13 +224,7 @@ const { confirming: confirmingClear, trigger: triggerClear } =
 
 function handleClear() {
   triggerClear(() => {
-    presets.value = {
-      customFont: '',
-      fontSize: 0,
-      visibilityBg: '',
-      hideNoteCounts: '',
-      hideUserStats: '',
-    }
+    presets.value = { ...EMPTY_PRESETS }
     userFreeformCss.value = ''
     cssCode.value = ''
     cssError.value = null
@@ -422,32 +235,28 @@ function handleClear() {
 
 // プリセット用ドロップダウンは CssPresetDropdown (#778) に共通化。
 // セクションヘッダの選択中ラベル表示にだけ label 解決を残す
-const selectedVisibilityBgLabel = computed(() => {
-  const opt = VISIBILITY_BG_OPTIONS.find(
-    (o) => o.key === presets.value.visibilityBg,
-  )
-  return opt?.label ?? 'デフォルト'
-})
+const selectedVisibilityBgLabel = computed(
+  () =>
+    VISIBILITY_BG_OPTIONS.find((o) => o.value === presets.value.visibilityBg)
+      ?.label ?? 'デフォルト',
+)
+
+const selectedMonoFontLabel = computed(
+  () =>
+    MONO_FONT_OPTIONS.find((o) => o.value === presets.value.monoFont)?.label ??
+    'デフォルト',
+)
 
 function hideCountLabel(key: string): string {
-  return HIDE_COUNT_OPTIONS.find((o) => o.key === key)?.label ?? 'デフォルト'
+  return HIDE_COUNT_OPTIONS.find((o) => o.value === key)?.label ?? 'デフォルト'
 }
-
-const VISIBILITY_BG_DD_OPTIONS = VISIBILITY_BG_OPTIONS.map((o) => ({
-  value: o.key,
-  label: o.label,
-}))
-const HIDE_COUNT_DD_OPTIONS = HIDE_COUNT_OPTIONS.map((o) => ({
-  value: o.key,
-  label: o.label,
-}))
 
 watch(tab, (t) => {
   if (t === 'code') {
     cssCode.value = fullCss.value
     codeError.value = null
   } else {
-    parsePresetsFromCss(cssCode.value)
+    presets.value = parsePresetsFromCss(cssCode.value)
     userFreeformCss.value = extractUserCss(cssCode.value)
   }
 })
@@ -482,6 +291,30 @@ watch(tab, (t) => {
           />
           <div v-if="presets.customFont" :class="$style.preview" :style="{ fontFamily: `'${presets.customFont}', sans-serif` }">
             あいうえお ABCabc 123
+          </div>
+        </template>
+      </div>
+
+      <!-- Mono font (#901) -->
+      <div :class="$style.section">
+        <button class="_button" :class="$style.sectionLabel" @click="toggleSection('monoFont')">
+          <i class="ti ti-code" />
+          等幅フォント
+          <span :class="$style.sectionValue">{{ selectedMonoFontLabel }}</span>
+          <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedSections.monoFont }]" />
+        </button>
+        <template v-if="expandedSections.monoFont">
+          <CssPresetDropdown
+            v-model="presets.monoFont"
+            :options="MONO_FONT_OPTIONS"
+            font-preview
+            font-fallback="monospace"
+          />
+          <div v-if="presets.monoFont" :class="[$style.preview, $style.monoPreview]" :style="{ fontFamily: `'${presets.monoFont}', monospace` }">
+            const 変数 = 0; // Il1 O0
+          </div>
+          <div :class="$style.hideCountNote">
+            コードブロック・JSON ビューア・エディタ系に反映されます
           </div>
         </template>
       </div>
@@ -530,7 +363,7 @@ watch(tab, (t) => {
         <template v-if="expandedSections.visibilityBg">
           <CssPresetDropdown
             v-model="presets.visibilityBg"
-            :options="VISIBILITY_BG_DD_OPTIONS"
+            :options="VISIBILITY_BG_OPTIONS"
           />
           <div v-if="presets.visibilityBg === 'tint'" :class="$style.visibilityBgPreview">
             <div
@@ -556,7 +389,7 @@ watch(tab, (t) => {
         <template v-if="expandedSections.noteCounts">
           <CssPresetDropdown
             v-model="presets.hideNoteCounts"
-            :options="HIDE_COUNT_DD_OPTIONS"
+            :options="HIDE_COUNT_OPTIONS"
           />
           <div :class="$style.hideCountNote">
             リアクション数とリノート数が消えます (返信数は会話の量なので残ります)
@@ -575,7 +408,7 @@ watch(tab, (t) => {
         <template v-if="expandedSections.userStats">
           <CssPresetDropdown
             v-model="presets.hideUserStats"
-            :options="HIDE_COUNT_DD_OPTIONS"
+            :options="HIDE_COUNT_OPTIONS"
           />
           <div :class="$style.hideCountNote">
             ノート数・フォロー数・フォロワー数が「-」になります (クリック導線は残ります)
@@ -746,6 +579,12 @@ watch(tab, (t) => {
 }
 
 /* ドロップダウンの見た目は CssPresetDropdown (#778) が持つ */
+
+.monoPreview {
+  text-align: left;
+  white-space: nowrap;
+  overflow-x: auto;
+}
 
 .preview {
   padding: 8px 10px;

--- a/src/components/window/CssPresetDropdown.vue
+++ b/src/components/window/CssPresetDropdown.vue
@@ -17,8 +17,10 @@ const props = withDefaults(
     options: PresetDropdownOption[]
     /** ラベルと選択肢をその value のフォントで描画する (フォントプリセット用) */
     fontPreview?: boolean
+    /** fontPreview 時のフォールバック総称ファミリ (等幅なら monospace) */
+    fontFallback?: string
   }>(),
-  { fontPreview: false },
+  { fontPreview: false, fontFallback: 'sans-serif' },
 )
 
 const model = defineModel<string>({ required: true })
@@ -33,7 +35,7 @@ const selectedLabel = computed(
 
 function fontStyle(value: string) {
   if (!props.fontPreview || !value) return undefined
-  return { fontFamily: `'${value}', sans-serif` }
+  return { fontFamily: `'${value}', ${props.fontFallback}` }
 }
 
 function select(value: string) {

--- a/src/components/window/InstanceProfileContent.vue
+++ b/src/components/window/InstanceProfileContent.vue
@@ -540,7 +540,7 @@ const statusBadges = computed(() => {
 
 .bannerUsername {
   font-weight: bold;
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   font-size: 0.95em;
 }
 
@@ -729,7 +729,7 @@ const statusBadges = computed(() => {
 }
 
 .linkPath {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
 }
 
 .rawPane {

--- a/src/components/window/KeybindsContent.vue
+++ b/src/components/window/KeybindsContent.vue
@@ -605,7 +605,7 @@ function handleReset() {
   border: 1px solid var(--nd-divider);
   border-radius: 4px;
   font-size: 0.75em;
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
   color: var(--nd-fg);
   cursor: pointer;
   transition: border-color var(--nd-duration-base), background var(--nd-duration-base);

--- a/src/components/window/MemoEditorContent.vue
+++ b/src/components/window/MemoEditorContent.vue
@@ -291,7 +291,7 @@ async function onDelete() {
   width: 64px;
   flex-shrink: 0;
   opacity: 0.55;
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
 }
 
 .metaValue {
@@ -300,7 +300,7 @@ async function onDelete() {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
 }
 
 .visualPanel {

--- a/src/components/window/PageDetailContent.vue
+++ b/src/components/window/PageDetailContent.vue
@@ -410,7 +410,7 @@ onMounted(loadPage)
   margin: 0 12px;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   line-height: 1.6;
 }

--- a/src/components/window/PlayDetailContent.vue
+++ b/src/components/window/PlayDetailContent.vue
@@ -483,7 +483,7 @@ onMounted(loadFlash)
   margin: 0 12px 12px;
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   line-height: 1.6;
 }

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -761,7 +761,7 @@ async function importPlugin() {
 
 .logsList {
   background: var(--nd-codeEditorBg, #1e1e1e);
-  font-family: monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.8em;
   min-height: 100%;
 }

--- a/src/components/window/SkillEditContent.vue
+++ b/src/components/window/SkillEditContent.vue
@@ -364,7 +364,7 @@ const statusText = computed(() => {
   height: auto;
   min-height: 60px;
   padding: 6px 8px;
-  font-family: var(--nd-monoFont, monospace);
+  font-family: var(--nd-font-mono);
   line-height: 1.4;
   resize: vertical;
 }

--- a/src/components/window/TasksEditorContent.vue
+++ b/src/components/window/TasksEditorContent.vue
@@ -938,7 +938,7 @@ function handleReset() {
 }
 
 .method {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
 }
 
 .inputsBadge {
@@ -1038,7 +1038,7 @@ function handleReset() {
 }
 
 .mono {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
 }
 
 .fieldset {
@@ -1189,7 +1189,7 @@ function handleReset() {
   opacity: 0.5;
 
   code {
-    font-family: var(--nd-font-mono, monospace);
+    font-family: var(--nd-font-mono);
     background: var(--nd-buttonBg);
     padding: 1px 4px;
     margin: 0 2px;

--- a/src/components/window/ThemeEditorContent.vue
+++ b/src/components/window/ThemeEditorContent.vue
@@ -1091,7 +1091,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 }
 
 .propKey {
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.7em;
   opacity: 0.4;
 }
@@ -1145,7 +1145,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
   border-radius: var(--nd-radius-sm);
   background: var(--nd-bg);
   color: var(--nd-fg);
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.75em;
   outline: none;
   transition: border-color var(--nd-duration-base);
@@ -1160,7 +1160,7 @@ onUnmounted(() => document.removeEventListener('click', handleOutsideClick))
 }
 
 .resolvedHex {
-  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  font-family: var(--nd-font-mono);
   font-size: 0.65em;
   opacity: 0.4;
   flex-shrink: 0;

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -607,7 +607,7 @@ function toggleAutoRun() {
 }
 
 .outputLine {
-  font-family: var(--nd-font-mono, monospace);
+  font-family: var(--nd-font-mono);
   white-space: pre-wrap;
   padding: 2px 4px;
 }

--- a/src/services/cssPresets.test.ts
+++ b/src/services/cssPresets.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPresetCss,
+  EMPTY_PRESETS,
+  extractUserCss,
+  parsePresetsFromCss,
+} from '@/services/cssPresets'
+
+describe('buildPresetCss', () => {
+  it('等幅フォントを選ぶと --nd-font-mono を :root で上書きする (#901)', () => {
+    const css = buildPresetCss({ ...EMPTY_PRESETS, monoFont: 'M PLUS 1 Code' })
+    expect(css).toContain('/* nd-mono-font: M PLUS 1 Code */')
+    expect(css).toContain(
+      "@import url('https://fonts.googleapis.com/css2?family=M%20PLUS%201%20Code&display=swap');",
+    )
+    expect(css).toContain(
+      ":root { --nd-font-mono: 'M PLUS 1 Code', monospace; }",
+    )
+  })
+
+  it('システムフォントは @import せずに変数だけ差し替える', () => {
+    const css = buildPresetCss({ ...EMPTY_PRESETS, monoFont: 'Consolas' })
+    expect(css).not.toContain('@import')
+    expect(css).toContain(":root { --nd-font-mono: 'Consolas', monospace; }")
+  })
+
+  it('@import は @font-face や通常ルールより前に出す', () => {
+    const css = buildPresetCss({
+      ...EMPTY_PRESETS,
+      customFont: '瀬戸フォント', // @font-face 方式
+      monoFont: 'Cascadia Code', // @import 方式
+    })
+    const importIndex = css.indexOf('@import')
+    const fontFaceIndex = css.indexOf('@font-face')
+    const ruleIndex = css.indexOf('html { font-family:')
+    expect(importIndex).toBeGreaterThanOrEqual(0)
+    expect(importIndex).toBeLessThan(fontFaceIndex)
+    expect(importIndex).toBeLessThan(ruleIndex)
+  })
+
+  it('プリセット未選択なら空文字を返す', () => {
+    expect(buildPresetCss(EMPTY_PRESETS)).toBe('')
+  })
+})
+
+describe('parsePresetsFromCss', () => {
+  it('生成した CSS から選択状態を復元できる', () => {
+    const presets = {
+      ...EMPTY_PRESETS,
+      customFont: 'Noto Sans JP',
+      monoFont: 'Cascadia Mono',
+      fontSize: 2,
+      visibilityBg: 'tint',
+      hideNoteCounts: 'self',
+      hideUserStats: 'all',
+    }
+    expect(parsePresetsFromCss(buildPresetCss(presets))).toEqual(presets)
+  })
+
+  it('マーカーが無い CSS では既定値になる', () => {
+    expect(parsePresetsFromCss('body { color: red; }')).toEqual(EMPTY_PRESETS)
+  })
+})
+
+describe('extractUserCss', () => {
+  it('プリセット生成行を取り除きユーザー記述だけ残す', () => {
+    const preset = buildPresetCss({
+      ...EMPTY_PRESETS,
+      monoFont: 'Cascadia Code',
+      fontSize: -1,
+    })
+    const full = `${preset}\n\n.my-rule { color: red; }`
+    expect(extractUserCss(full)).toBe('.my-rule { color: red; }')
+  })
+})

--- a/src/services/cssPresets.ts
+++ b/src/services/cssPresets.ts
@@ -1,0 +1,251 @@
+/**
+ * カスタム CSS エディタ (CssEditorContent) のプリセット定義と、
+ * プリセット ⇄ CSS テキストの相互変換。
+ *
+ * CSS 側にはマーカーコメント (`/* nd-font: X *\/` 等) を埋め、コードタブで
+ * 直接編集された CSS からも選択状態を復元できるようにしている。
+ */
+
+export interface FontOption {
+  value: string
+  label: string
+  /** Google Fonts の既定 URL 以外から取る場合 */
+  importUrl?: string
+  /** @font-face を直接書く場合 (webfont CDN 配信のフォント) */
+  customCss?: string
+  /** OS プリインストール前提でダウンロード不要なもの */
+  system?: boolean
+}
+
+export const FONT_OPTIONS: FontOption[] = [
+  { value: '', label: 'デフォルト' },
+  { value: 'Noto Sans JP', label: 'Noto Sans JP' },
+  { value: 'Noto Serif JP', label: 'Noto Serif JP' },
+  { value: 'Sawarabi Gothic', label: 'Sawarabi Gothic' },
+  { value: 'Sawarabi Mincho', label: 'Sawarabi Mincho' },
+  { value: 'M PLUS 1p', label: 'M PLUS' },
+  { value: 'M PLUS Rounded 1c', label: 'M PLUS Rounded' },
+  { value: 'M PLUS 2', label: 'M PLUS 2' },
+  { value: 'Murecho', label: 'Murecho' },
+  { value: 'RocknRoll One', label: 'RocknRoll One' },
+  { value: 'Klee One', label: 'Klee One' },
+  { value: 'Zen Maru Gothic', label: 'Zen Maru Gothic' },
+  { value: 'Kaisei Decol', label: 'Kaisei Decol' },
+  { value: 'Yomogi', label: 'Yomogi' },
+  { value: 'Kosugi', label: 'Kosugi' },
+  { value: 'Kosugi Maru', label: 'Kosugi Maru' },
+  {
+    value: 'Kiwi Maru',
+    label: 'Kiwi Maru',
+    importUrl:
+      'https://fonts.googleapis.com/css2?family=Kiwi+Maru:wght@300&display=swap',
+  },
+  { value: 'Hachi Maru Pop', label: 'Hachi Maru Pop' },
+  { value: 'Mochiy Pop One', label: 'Mochiy Pop One' },
+  { value: 'Mochiy Pop P One', label: 'Mochiy Pop P One' },
+  { value: 'Yusei Magic', label: 'Yusei Magic' },
+  { value: 'DotGothic16', label: 'Dot Gothic 16' },
+  {
+    value: '手書き雑フォント',
+    label: '手書き雑フォント',
+    customCss: `@font-face { font-family: '手書き雑フォント'; src: url('https://cdn.leafscape.be/tegaki_zatsu/851tegaki_zatsu_web.woff2') format("woff2"); font-display: swap; }`,
+  },
+  {
+    value: '瀬戸フォント',
+    label: '瀬戸フォント',
+    customCss: `@font-face { font-family: '瀬戸フォント'; src: url('https://cdn.leafscape.be/setofont/setofont_web.woff2') format("woff2"); font-display: swap; }`,
+  },
+]
+
+/**
+ * 等幅フォント (#901)。コード/JSON/エディタ系が参照する --nd-font-mono を差し替える。
+ * 候補は「Web からそのまま取れる (Google Fonts)」か「OS プリインストール」の
+ * どちらかに絞ってある。GitHub の release zip でしか配布されていないもの
+ * (PlemolJP, HackGen, Cica 等) は @import で取れないので入れていない。
+ */
+export const MONO_FONT_OPTIONS: FontOption[] = [
+  { value: '', label: 'デフォルト' },
+  { value: 'M PLUS 1 Code', label: 'M PLUS 1 Code (日本語)' },
+  { value: 'Cascadia Code', label: 'Cascadia Code' },
+  { value: 'Cascadia Mono', label: 'Cascadia Mono' },
+  { value: 'MS Gothic', label: 'MS ゴシック (システム)', system: true },
+  { value: 'Consolas', label: 'Consolas (システム)', system: true },
+  { value: 'Lucida Console', label: 'Lucida Console (システム)', system: true },
+  { value: 'Courier New', label: 'Courier New (システム)', system: true },
+]
+
+export const FONT_SIZE_BASE = 15
+export const FONT_SIZE_MIN = -3
+export const FONT_SIZE_MAX = 5
+
+/** 公開範囲ごとのノート背景色 (public はデフォルトのまま) */
+export const VISIBILITY_BG_COLORS: Record<
+  string,
+  { label: string; color: string }
+> = {
+  home: { label: 'ホーム', color: 'rgba(51, 127, 255, 0.08)' },
+  followers: { label: 'フォロワー', color: 'rgba(0, 170, 100, 0.08)' },
+  specified: { label: 'ダイレクト', color: 'rgba(255, 90, 120, 0.1)' },
+}
+
+export const VISIBILITY_BG_OPTIONS = [
+  { value: '', label: 'デフォルト' },
+  { value: 'tint', label: '背景色で色分け' },
+]
+
+// 数字の非表示 (#593/#594)。yamisskey の hideReactionCount / hide*Count と
+// 同じ self/others/all の 3 段階。導線 (クリックで一覧を開く等) は残し数字だけ消す。
+// ノート側はリアクション数 + リノート数 (評価シグナル)。返信数は会話の量なので対象外
+export const HIDE_COUNT_OPTIONS = [
+  { value: '', label: 'デフォルト' },
+  { value: 'self', label: '自分のみ隠す' },
+  { value: 'others', label: '他人のみ隠す' },
+  { value: 'all', label: 'すべて隠す' },
+]
+
+export interface CssPresets {
+  customFont: string
+  monoFont: string
+  fontSize: number
+  visibilityBg: string
+  hideNoteCounts: string
+  hideUserStats: string
+}
+
+export const EMPTY_PRESETS: CssPresets = {
+  customFont: '',
+  monoFont: '',
+  fontSize: 0,
+  visibilityBg: '',
+  hideNoteCounts: '',
+  hideUserStats: '',
+}
+
+function hideCountTargets(key: string): string[] {
+  if (key === 'self') return ['true']
+  if (key === 'others') return ['false']
+  if (key === 'all') return ['true', 'false']
+  return []
+}
+
+function fontImport(font: string, opt: FontOption | undefined): string {
+  const url =
+    opt?.importUrl ??
+    `https://fonts.googleapis.com/css2?family=${encodeURIComponent(font)}&display=swap`
+  return `@import url('${url}');`
+}
+
+export function parsePresetsFromCss(css: string): CssPresets {
+  const fontSize = css.match(/\/\* nd-fontsize: (.+?) \*\//)
+  return {
+    customFont: css.match(/\/\* nd-font: (.+?) \*\//)?.[1] ?? '',
+    monoFont: css.match(/\/\* nd-mono-font: (.+?) \*\//)?.[1] ?? '',
+    fontSize: fontSize ? Number(fontSize[1]) : 0,
+    visibilityBg: css.match(/\/\* nd-visibility-bg: (.+?) \*\//)?.[1] ?? '',
+    hideNoteCounts:
+      css.match(/\/\* nd-hide-note-counts: (.+?) \*\//)?.[1] ?? '',
+    hideUserStats: css.match(/\/\* nd-hide-user-stats: (.+?) \*\//)?.[1] ?? '',
+  }
+}
+
+export function buildPresetCss(presets: CssPresets): string {
+  // @import は他のルール (@font-face 含む) より前に無いとブラウザに無視される。
+  // フォント 2 系統 (本文 / 等幅) を同時に選べるので、生成順ではなく
+  // バケツで分けて必ず先頭に寄せる
+  const imports: string[] = []
+  const parts: string[] = []
+
+  if (presets.customFont) {
+    const font = presets.customFont
+    const opt = FONT_OPTIONS.find((o) => o.value === font)
+    parts.push(`/* nd-font: ${font} */`)
+    if (opt?.customCss) {
+      parts.push(opt.customCss)
+    } else {
+      imports.push(fontImport(font, opt))
+    }
+    parts.push(`html { font-family: '${font}', sans-serif; }`)
+  }
+
+  if (presets.monoFont) {
+    const font = presets.monoFont
+    const opt = MONO_FONT_OPTIONS.find((o) => o.value === font)
+    parts.push(`/* nd-mono-font: ${font} */`)
+    if (opt?.customCss) {
+      parts.push(opt.customCss)
+    } else if (!opt?.system) {
+      imports.push(fontImport(font, opt))
+    }
+    // :root で上書きする (global.css の :root と同特異度 + 後勝ち)
+    parts.push(`:root { --nd-font-mono: '${font}', monospace; }`)
+  }
+
+  if (presets.fontSize !== 0) {
+    const px = FONT_SIZE_BASE + presets.fontSize
+    parts.push(`/* nd-fontsize: ${presets.fontSize} */`)
+    parts.push(`html { font-size: ${px}px; }`)
+  }
+
+  if (presets.visibilityBg === 'tint') {
+    parts.push('/* nd-visibility-bg: tint */')
+    for (const [visibility, { color }] of Object.entries(
+      VISIBILITY_BG_COLORS,
+    )) {
+      parts.push(
+        `.note-root[data-visibility="${visibility}"] { background-color: ${color}; }`,
+      )
+    }
+  }
+
+  const noteCountTargets = hideCountTargets(presets.hideNoteCounts)
+  if (noteCountTargets.length > 0) {
+    parts.push(`/* nd-hide-note-counts: ${presets.hideNoteCounts} */`)
+    for (const own of noteCountTargets) {
+      parts.push(
+        `.note-root[data-own="${own}"] :is(.note-reaction-count, .note-renote-count) { display: none; }`,
+      )
+    }
+  }
+
+  const statsTargets = hideCountTargets(presets.hideUserStats)
+  if (statsTargets.length > 0) {
+    parts.push(`/* nd-hide-user-stats: ${presets.hideUserStats} */`)
+    for (const own of statsTargets) {
+      parts.push(
+        `.user-stats[data-own="${own}"] .user-stat-count { font-size: 0; }`,
+      )
+      parts.push(
+        `.user-stats[data-own="${own}"] .user-stat-count::before { content: '-'; font-size: 1rem; }`,
+      )
+    }
+  }
+
+  return [...imports, ...parts].join('\n')
+}
+
+export function extractUserCss(fullCss: string): string {
+  return fullCss
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim()
+      if (!t) return false
+      if (t.startsWith('/* nd-font:')) return false
+      if (t.startsWith('/* nd-mono-font:')) return false
+      if (t.startsWith('/* nd-fontsize:')) return false
+      if (t.startsWith('/* nd-visibility-bg:')) return false
+      if (t.startsWith('/* nd-hide-note-counts:')) return false
+      if (t.startsWith('/* nd-hide-user-stats:')) return false
+      // 生成行 (1 行完結) のみ除去。ユーザーが複数行で書いた同セレクタは残す
+      if (t.match(/^\.note-root\[data-visibility=.+\{.*\}$/)) return false
+      if (t.match(/^\.note-root\[data-own=.+\{.*\}$/)) return false
+      if (t.match(/^\.user-stats\[data-own=.+\{.*\}$/)) return false
+      if (t.startsWith('@import url(')) return false
+      if (t.startsWith('@font-face')) return false
+      if (t.match(/^html\s*\{\s*font-family:/)) return false
+      if (t.match(/^html\s*\{\s*font-size:/)) return false
+      if (t.match(/^:root\s*\{\s*--nd-font-mono:/)) return false
+      return true
+    })
+    .join('\n')
+    .trim()
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,6 +111,10 @@
   --nd-shadow-l:
     0 4px 8px var(--nd-shadow-contact),
     0 12px 28px color-mix(in srgb, var(--nd-shadow-ambient) 120%, transparent);
+  /* 等幅フォント (#872) — コード/JSON/エディタ系はすべてこの 1 変数を参照する。
+     カスタム CSS の「等幅フォント」プリセットが :root ごと上書きする */
+  --nd-font-mono: 'Fira Code', 'Cascadia Code', Consolas, ui-monospace,
+    'SF Mono', Menlo, monospace;
   /* Non-theme layout constants */
   --nd-radius: 12px;
   --nd-radius-sm: 6px;


### PR DESCRIPTION
## 変更一覧 (v1.34.0..develop)

- feat(deck): カラムのミュートをヘッダー常駐ボタンに出す
- feat(css): 等幅フォントをカスタム CSS プリセットから選べるようにする
- fix(style): 等幅フォントの変数を --nd-font-mono に統一して定義する
- refactor(css): 本文フォントのプレビューを等幅と同じ見せ方に揃える
- fix(notification): 外部アプリの app 通知を header / body / icon で描画する

notecli の pin をリリースタグ v0.7.0 (e235701) に更新した。

Closes #900
Closes #901
Closes #902
Closes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)