### PR TITLE
Release v1.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.35.0",
+  "version": "1.36.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.35.0"
+version = "1.36.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.35.0"
+version = "1.36.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.35.0"
+    "version": "1.36.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkMfm.dom.test.ts
+++ b/src/components/common/MkMfm.dom.test.ts
@@ -1,0 +1,58 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { type App, createApp, nextTick } from 'vue'
+import MkMfm from './MkMfm.vue'
+
+let app: App | null = null
+let container: HTMLElement | null = null
+let pinia: ReturnType<typeof createPinia>
+
+function mountMfm(text: string) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(MkMfm, { text })
+  app.use(pinia)
+  app.mount(container)
+}
+
+beforeEach(() => {
+  pinia = createPinia()
+  setActivePinia(pinia)
+})
+
+afterEach(() => {
+  app?.unmount()
+  container?.remove()
+  app = null
+  container = null
+})
+
+/**
+ * KaTeX は動的 import なので、読み込み完了で再レンダリングされるまで待つ。
+ * 再レンダリングされなければタイムアウトして未描画のままになる。
+ */
+async function waitFor(selector: string) {
+  for (let i = 0; i < 50; i++) {
+    await nextTick()
+    if (container?.querySelector(selector)) return
+    await new Promise((r) => setTimeout(r, 20))
+  }
+}
+
+describe('MkMfm math', () => {
+  it('インライン数式は KaTeX 読み込み後に描画される', async () => {
+    mountMfm('\\(x^2\\)')
+    await waitFor('math')
+    const math = container?.querySelector('math')
+    expect(math).toBeTruthy()
+    expect(math?.getAttribute('display')).toBeNull()
+  })
+
+  it('ブロック数式は KaTeX 読み込み後に display=block で描画される', async () => {
+    mountMfm('\\[x^2\\]')
+    await waitFor('math')
+    expect(container?.querySelector('math')?.getAttribute('display')).toBe(
+      'block',
+    )
+  })
+})

--- a/src/components/common/MkMfm.vue
+++ b/src/components/common/MkMfm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, useCssModule } from 'vue'
+import { computed, shallowRef, useCssModule } from 'vue'
 import { useEmojiMute } from '@/composables/useEmojiMute'
 import { useEmojiResolver } from '@/composables/useEmojiResolver'
 import { useNavigation } from '@/composables/useNavigation'
@@ -99,6 +99,8 @@ function escapeHtml(text: string): string {
 let katexModule: typeof import('katex') | null = null
 let domPurifyModule: typeof import('dompurify') | null = null
 let mathLoadPromise: Promise<void> | null = null
+/** 読み込み完了で数式ノードを再レンダリングさせるための reactive flag (shiki と同じ方式) */
+const mathLoaded = shallowRef(false)
 
 function ensureMathLoaded(): Promise<void> {
   if (katexModule && domPurifyModule) return Promise.resolve()
@@ -107,6 +109,7 @@ function ensureMathLoaded(): Promise<void> {
       ([k, d]) => {
         katexModule = k
         domPurifyModule = d
+        mathLoaded.value = true
       },
     )
   }
@@ -163,8 +166,8 @@ const KATEX_ALLOWED_ATTR = [
 ]
 
 function renderKatex(formula: string, displayMode: boolean): string {
-  if (!katexModule || !domPurifyModule) {
-    // Trigger load (will re-render on next update)
+  // mathLoaded を render 中に読むことで、読み込み完了時の再レンダリングを購読する
+  if (!mathLoaded.value || !katexModule || !domPurifyModule) {
     ensureMathLoaded()
     return escapeHtml(formula)
   }

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -1009,6 +1009,7 @@ onBeforeUnmount(() => {
     :column-id="column.id"
     :title="viewMode === 'conversation' ? conversationTitle : (column.name || 'チャット')"
     :theme-vars="columnThemeVars"
+    sound-enabled
     require-account
     @header-click="scrollToTop(true)"
   >

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -6,6 +6,7 @@ import {
   requestMoveColumn,
 } from '@/composables/useDeckWindow'
 import { useNativePopover } from '@/composables/useNativePopover'
+import { usePipAlwaysOnTop } from '@/composables/usePipAlwaysOnTop'
 import { usePullToRefresh } from '@/composables/usePullToRefresh'
 import { useServerImages } from '@/composables/useServerImages'
 import { useVaporTransition } from '@/composables/useVaporTransition'
@@ -152,6 +153,9 @@ async function close() {
     })
   }
 }
+
+const { alwaysOnTop: pipAlwaysOnTop, toggle: togglePipAlwaysOnTop } =
+  usePipAlwaysOnTop()
 
 /** Return this PiP column back to the main deck window */
 async function returnToDeck() {
@@ -316,6 +320,10 @@ function openAsPip() {
     <div v-if="menuVisible" ref="menuEl" popover="manual" :class="[$style.columnMenu, menuLeaving ? $style.menuLeave : $style.menuEnter]" class="_popupMenu" :style="{ ...themeVars, position: 'fixed', top: menuPos.top, right: menuPos.right }" @pointerdown.stop>
       <!-- PiP menu -->
       <template v-if="isPipMode">
+        <button class="_popupItem" @click="togglePipAlwaysOnTop">
+          <i :class="pipAlwaysOnTop ? 'ti ti-pinned-off' : 'ti ti-pin'" />
+          <span>{{ pipAlwaysOnTop ? '最前面固定を解除' : '最前面に固定' }}</span>
+        </button>
         <button class="_popupItem" @click="returnToDeck">
           <i class="ti ti-arrow-back-up" />
           <span>デッキに戻す</span>

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -185,12 +185,22 @@ watch(
   },
 )
 
+// PiP ではデッキストアを読み込まないため、PiP ローカルのカラム設定を直接読み書きする。
+// この設定は「デッキに戻す」でそのままメインウィンドウへ引き継がれる。
 const isMuted = computed(
-  () => deckStore.getColumn(props.columnId)?.soundMuted ?? false,
+  () =>
+    (isPipMode ? pipColumnConfig?.() : deckStore.getColumn(props.columnId))
+      ?.soundMuted ?? false,
 )
 
 function toggleMute() {
-  deckStore.updateColumn(props.columnId, { soundMuted: !isMuted.value })
+  const soundMuted = !isMuted.value
+  if (isPipMode) {
+    const config = pipColumnConfig?.()
+    if (config) config.soundMuted = soundMuted
+    return
+  }
+  deckStore.updateColumn(props.columnId, { soundMuted })
 }
 
 function onOpenWebUi() {
@@ -247,7 +257,7 @@ function openAsPip() {
 
       <!-- Mute toggle (resident: sound settings are used far more often than the other menu items) -->
       <button
-        v-if="soundEnabled && !isPipMode"
+        v-if="soundEnabled"
         :class="[$style.headerBtn, isMuted && $style.headerBtnActive]"
         class="_button"
         :title="isMuted ? 'ミュート解除' : 'ミュート'"

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -62,7 +62,8 @@ const {
   // 照会結果は noteStore ではなくローカルの deep ref (result / ancestors /
   // children) に保持しているため、差分は対象オブジェクトへ直接代入して
   // 反映する (cross-account 側の handleReactionCrossAccount と同じ規則)
-  applyNotePatch: (note, patch) => Object.assign(note, patch),
+  // note を直接 mutate しているので、note 自身が常に最新 (#904)
+  applyNotePatch: (note, compute) => Object.assign(note, compute(note)),
 })
 
 const accountsStore = useAccountsStore()
@@ -434,8 +435,8 @@ async function handleReactionCrossAccount(
   const { toggleReaction } = await import('@/utils/toggleReaction')
   try {
     // スレッドは deep reactive (ref) なので、差分の代入で反映される
-    await toggleReaction(adapter.api, target, reaction, (patch) => {
-      Object.assign(target, patch)
+    await toggleReaction(adapter.api, target, reaction, (compute) => {
+      Object.assign(target, compute(target))
     })
   } catch {
     // ignore
@@ -448,8 +449,8 @@ async function handleVoteCrossAccount(choice: number, target: NormalizedNote) {
   const { votePoll } = await import('@/utils/votePoll')
   try {
     // スレッドは deep reactive (ref) なので、差分の代入で反映される
-    await votePoll(adapter.api, target, choice, (patch) => {
-      Object.assign(target, patch)
+    await votePoll(adapter.api, target, choice, (compute) => {
+      Object.assign(target, compute(target))
     })
   } catch {
     // ignore

--- a/src/components/window/ClipDetailContent.vue
+++ b/src/components/window/ClipDetailContent.vue
@@ -64,16 +64,19 @@ const visibleNotes = computed(() =>
   filterVisible(notes.value, { ignoreSuspension: isOwnClip.value }),
 )
 
-/** 楽観的更新の差分を反映する。shallowRef 保持なので新オブジェクトへ差し替える */
+/**
+ * 楽観的更新の差分を反映する。shallowRef 保持なので新オブジェクトへ差し替える。
+ * 差分は手元の最新のノートから計算する (#904)
+ */
 function applyNotePatch(
   target: NormalizedNote,
-  patch: Partial<NormalizedNote>,
+  compute: (current: NormalizedNote) => Partial<NormalizedNote>,
 ) {
   notes.value = notes.value.map((n) =>
     n.id === target.id
-      ? { ...n, ...patch }
+      ? { ...n, ...compute(n) }
       : n.renote?.id === target.id
-        ? { ...n, renote: { ...n.renote, ...patch } }
+        ? { ...n, renote: { ...n.renote, ...compute(n.renote) } }
         : n,
   )
 }
@@ -81,8 +84,8 @@ function applyNotePatch(
 async function handleReaction(reaction: string, target: NormalizedNote) {
   if (!adapter) return
   try {
-    await toggleReaction(adapter.api, target, reaction, (patch) =>
-      applyNotePatch(target, patch),
+    await toggleReaction(adapter.api, target, reaction, (compute) =>
+      applyNotePatch(target, compute),
     )
   } catch (e) {
     const err = AppError.from(e)
@@ -94,8 +97,8 @@ async function handleVote(choice: number, target: NormalizedNote) {
   if (!adapter) return
   const { votePoll } = await import('@/utils/votePoll')
   try {
-    await votePoll(adapter.api, target, choice, (patch) =>
-      applyNotePatch(target, patch),
+    await votePoll(adapter.api, target, choice, (compute) =>
+      applyNotePatch(target, compute),
     )
   } catch (e) {
     const err = AppError.from(e)

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -240,8 +240,8 @@ async function handleReaction(reaction: string, target: NormalizedNote) {
   if (!adapter) return
   try {
     // note は deep reactive (ref) なので、差分の代入で反映される
-    await toggleReaction(adapter.api, target, reaction, (patch) => {
-      Object.assign(target, patch)
+    await toggleReaction(adapter.api, target, reaction, (compute) => {
+      Object.assign(target, compute(target))
     })
   } catch (e) {
     error.value = AppError.from(e)
@@ -253,8 +253,8 @@ async function handleVote(choice: number, target: NormalizedNote) {
   const { votePoll } = await import('@/utils/votePoll')
   try {
     // note は deep reactive (ref) なので、差分の代入で反映される
-    await votePoll(adapter.api, target, choice, (patch) => {
-      Object.assign(target, patch)
+    await votePoll(adapter.api, target, choice, (compute) => {
+      Object.assign(target, compute(target))
     })
   } catch (e) {
     error.value = AppError.from(e)

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -521,29 +521,35 @@ function handleComposeToUser(acct: string) {
  * 楽観的更新の差分を全タブへ反映する。各面とも shallowRef 保持
  * (非 reactive オブジェクト) なので、新オブジェクトへの差し替えで反映する。
  * note がどの面から来たかは追わず、全面を id で差し替える
- * (リノートに包まれた表示も含む)
+ * (リノートに包まれた表示も含む)。差分は各面が持つ最新のノートから計算する
+ * — 開始時の note で丸ごと置き換えると、API を待つ間に届いた更新が巻き戻る
+ * (#904)
  */
-function applyNotePatch(note: NormalizedNote, patch: Partial<NormalizedNote>) {
-  const updated = { ...note, ...patch }
+function applyNotePatch(
+  note: NormalizedNote,
+  compute: (current: NormalizedNote) => Partial<NormalizedNote>,
+) {
   const swap = (n: NormalizedNote) =>
     n.id === note.id
-      ? updated
+      ? { ...n, ...compute(n) }
       : n.renote?.id === note.id
-        ? { ...n, renote: updated }
+        ? { ...n, renote: { ...n.renote, ...compute(n.renote) } }
         : n
   pinnedNotes.value = pinnedNotes.value.map(swap)
   filesNotes.value = filesNotes.value.map(swap)
   reactionEntries.value = reactionEntries.value.map((e) =>
-    e.note.id === note.id ? { ...e, note: updated } : e,
+    e.note.id === note.id
+      ? { ...e, note: { ...e.note, ...compute(e.note) } }
+      : e,
   )
-  notesListRef.value?.replaceNote(note.id, updated)
+  notesListRef.value?.patchNote(note.id, compute)
 }
 
 async function handleReaction(reaction: string, note: NormalizedNote) {
   if (!adapter.value) return
   try {
-    await toggleReaction(adapter.value.api, note, reaction, (patch) =>
-      applyNotePatch(note, patch),
+    await toggleReaction(adapter.value.api, note, reaction, (compute) =>
+      applyNotePatch(note, compute),
     )
   } catch (e) {
     error.value = AppError.from(e)
@@ -554,8 +560,8 @@ async function handleVote(choice: number, target: NormalizedNote) {
   if (!adapter.value) return
   const { votePoll } = await import('@/utils/votePoll')
   try {
-    await votePoll(adapter.value.api, target, choice, (patch) =>
-      applyNotePatch(target, patch),
+    await votePoll(adapter.value.api, target, choice, (compute) =>
+      applyNotePatch(target, compute),
     )
   } catch (e) {
     error.value = AppError.from(e)

--- a/src/components/window/ai-settings/AiConnectionSection.vue
+++ b/src/components/window/ai-settings/AiConnectionSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { resolveAiConnection, useAiConfig } from '@/composables/useAiConfig'
 import { useVault } from '@/composables/useVault'
 import { BUILTIN_TEMPLATES, faviconUrl } from '@/data/connectionTemplates'
@@ -13,6 +13,9 @@ const windowsStore = useWindowsStore()
 onMounted(() => {
   void vault.refresh()
 })
+
+// favicon の取得に失敗した接続 id。tabler icon に fallback する。
+const failedIcons = ref(new Set<string>())
 
 // AI プロバイダーとして使える接続 = protocol が設定済みの接続。
 const aiConnections = computed(() =>
@@ -69,36 +72,38 @@ function openConnectionsWindow(): void {
       <i class="ti ti-info-circle" />
       API キーは Secret Vault (OS キーチェーン) に保管され、フロントエンドや AI には渡りません。接続の追加・編集は「接続」ウィンドウで行います。
     </div>
-    <div :class="$style.connList">
-      <label
+    <div v-if="aiConnections.length > 0" :class="$style.grid">
+      <button
         v-for="conn in aiConnections"
         :key="conn.id"
-        :class="[$style.connOption, { [$style.connOptionActive]: config.activeConnectionId === conn.id }]"
+        class="_button"
+        :class="[$style.card, { [$style.cardActive]: config.activeConnectionId === conn.id }]"
+        :aria-pressed="config.activeConnectionId === conn.id"
+        :title="conn.baseUrl"
+        @click="selectConnection(conn.id)"
       >
-        <input
-          type="radio"
-          :checked="config.activeConnectionId === conn.id"
-          @change="selectConnection(conn.id)"
-        />
-        <img
-          v-if="faviconUrl(conn.baseUrl)"
-          :src="faviconUrl(conn.baseUrl) ?? ''"
-          :class="$style.connOptionAvatar"
-          alt=""
-          aria-hidden="true"
-        />
-        <i v-else class="ti ti-plug" :class="$style.connOptionIcon" />
-        <div :class="$style.connOptionMain">
-          <div :class="$style.connOptionName">{{ conn.name }}</div>
-          <div :class="$style.connOptionDesc">{{ conn.baseUrl }}</div>
-        </div>
-      </label>
-      <div v-if="aiConnections.length === 0" :class="$style.connEmpty">
-        <i class="ti ti-info-circle" />
-        <span>
-          AI プロバイダー接続がありません。「接続」ウィンドウで OpenAI / Anthropic / OpenRouter のテンプレートから接続を追加してください。
+        <span
+          v-if="config.activeConnectionId === conn.id"
+          :class="$style.activeBadge"
+        >
+          <i class="ti ti-circle-check-filled" />
         </span>
-      </div>
+        <img
+          v-if="faviconUrl(conn.baseUrl) && !failedIcons.has(conn.id)"
+          :src="faviconUrl(conn.baseUrl)!"
+          :class="$style.logo"
+          alt=""
+          @error="failedIcons.add(conn.id)"
+        />
+        <i v-else class="ti ti-plug-connected" :class="$style.logoFallback" />
+        <span>{{ conn.name }}</span>
+      </button>
+    </div>
+    <div v-else :class="$style.connEmpty">
+      <i class="ti ti-info-circle" />
+      <span>
+        AI プロバイダー接続がありません。「接続」ウィンドウで OpenAI / Anthropic / OpenRouter のテンプレートから接続を追加してください。
+      </span>
     </div>
     <button
       class="_button"
@@ -157,82 +162,65 @@ function openConnectionsWindow(): void {
   }
 }
 
-// AiPersonaSection の personaOption と同型の radio 選択リスト
-.connList {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.connOption {
-  display: flex;
-  align-items: center;
+// 「接続」ウィンドウ (ConnectionsContent) のカードグリッドと同じ見た目に揃える
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: 8px;
-  padding: 8px 10px;
-  border-radius: var(--nd-radius-sm);
-  cursor: pointer;
-  transition: background var(--nd-duration-base);
-
-  &:hover {
-    background: var(--nd-buttonHoverBg);
-  }
-
-  input[type='radio'] {
-    flex-shrink: 0;
-    margin: 0;
-  }
 }
 
-.connOptionActive {
-  background: color-mix(in srgb, var(--nd-accent) 10%, transparent);
-
-  &:hover {
-    background: color-mix(in srgb, var(--nd-accent) 14%, transparent);
-  }
-}
-
-.connOptionIcon {
-  width: 24px;
-  height: 24px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 18px;
-  color: var(--nd-fg);
-  opacity: 0.6;
-  flex-shrink: 0;
-}
-
-// 接続 favicon (ラスタ画像)。persona icon と違い SVG mask は使わずそのまま表示。
-.connOptionAvatar {
-  width: 24px;
-  height: 24px;
-  flex-shrink: 0;
-  border-radius: var(--nd-radius-sm);
-  object-fit: contain;
-}
-
-.connOptionMain {
-  flex: 1;
-  min-width: 0;
+// `_button` と特異度が同点だと WebView2 で display: inline-block に負けるため (0,2,0) に上げる
+.card.card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 1px;
+  align-items: center;
+  gap: 6px;
+  padding: 14px 8px;
+  border-radius: var(--nd-radius-sm);
+  background: var(--nd-buttonBg);
+  color: var(--nd-fg);
+  font-size: 0.8em;
+  cursor: pointer;
+  text-align: center;
+
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
+  }
 }
 
-.connOptionName {
-  font-size: 0.85em;
-  font-weight: 500;
-  color: var(--nd-fg);
+// 選択中の接続。ConnectionsContent には無い状態なのでアクセントで示す
+.cardActive.cardActive {
+  background: color-mix(in srgb, var(--nd-accent) 12%, var(--nd-buttonBg));
+  box-shadow: inset 0 0 0 1px var(--nd-accent);
 }
 
-.connOptionDesc {
-  font-size: 0.7em;
-  color: var(--nd-fg);
-  opacity: 0.6;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.activeBadge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  color: var(--nd-accent);
+
+  i {
+    font-size: 12px;
+  }
+}
+
+.logo {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+.logoFallback {
+  font-size: 22px;
+  color: var(--nd-fgMuted);
 }
 
 .connEmpty {

--- a/src/components/window/ai-settings/AiPersonaSection.vue
+++ b/src/components/window/ai-settings/AiPersonaSection.vue
@@ -30,51 +30,50 @@ const currentPersonaSkill = computed(() => {
   >
     <div :class="$style.keyHint">
       <i class="ti ti-info-circle" />
-      **新規セッション**のデフォルトペルソナです。新しいチャット / heartbeat / task を開始したときに、ここで選んだペルソナが session に snapshot されます。**過去のセッション**は作成時のペルソナを保持し続けるため (Git commit の Author と同じ immutable semantic)、ここを変更しても遡って書き換わりません。
+      新規セッションのデフォルトです。過去のセッションは作成時のペルソナを保持します。
     </div>
-    <div :class="$style.personaList">
-      <label :class="[$style.personaOption, { [$style.personaOptionActive]: !config.personaSkillId }]">
-        <input
-          type="radio"
-          :checked="!config.personaSkillId"
-          @change="config.personaSkillId = ''"
-        />
-        <i class="ti ti-user-off" :class="$style.personaOptionIcon" />
-        <span :class="$style.personaOptionName">ペルソナなし (汎用 AI)</span>
-      </label>
-      <label
+    <div :class="$style.grid">
+      <button
+        class="_button"
+        :class="[$style.card, { [$style.cardActive]: !config.personaSkillId }]"
+        :aria-pressed="!config.personaSkillId"
+        @click="config.personaSkillId = ''"
+      >
+        <span v-if="!config.personaSkillId" :class="$style.activeBadge">
+          <i class="ti ti-circle-check-filled" />
+        </span>
+        <i class="ti ti-user-off" :class="$style.logoFallback" />
+        <span>なし</span>
+      </button>
+      <button
         v-for="s in personaCandidates"
         :key="s.id"
-        :class="[$style.personaOption, { [$style.personaOptionActive]: config.personaSkillId === s.id }]"
+        class="_button"
+        :class="[$style.card, { [$style.cardActive]: config.personaSkillId === s.id }]"
+        :aria-pressed="config.personaSkillId === s.id"
+        :title="s.description || s.name"
+        @click="config.personaSkillId = s.id"
       >
-        <input
-          type="radio"
-          :checked="config.personaSkillId === s.id"
-          @change="config.personaSkillId = s.id"
-        />
+        <span v-if="config.personaSkillId === s.id" :class="$style.activeBadge">
+          <i class="ti ti-circle-check-filled" />
+        </span>
         <!-- SVG icon を accent 色で render (DeckAiColumn.personaIndicator と同じ
              mask + currentColor パターン) -->
         <span
           v-if="s.iconUrl"
-          :class="$style.personaOptionAvatar"
+          :class="$style.logo"
           :style="{ '--icon-url': `url('${s.iconUrl}')` }"
-          :title="s.name"
           aria-hidden="true"
         />
-        <i v-else class="ti ti-user-circle" :class="$style.personaOptionIcon" />
-        <div :class="$style.personaOptionMain">
-          <div :class="$style.personaOptionName">{{ s.name }}</div>
-          <div v-if="s.description" :class="$style.personaOptionDesc">
-            {{ s.description }}
-          </div>
-        </div>
-      </label>
-      <div v-if="personaCandidates.length === 0" :class="$style.personaEmpty">
-        <i class="ti ti-info-circle" />
-        <span>
-          ペルソナ候補がありません。Skill 編集ウィンドウで「Persona」を ON にしたスキルがここに表示されます。
-        </span>
-      </div>
+        <i v-else class="ti ti-user-circle" :class="$style.logoFallback" />
+        <span>{{ s.name }}</span>
+      </button>
+    </div>
+    <div v-if="personaCandidates.length === 0" :class="$style.personaEmpty">
+      <i class="ti ti-info-circle" />
+      <span>
+        ペルソナ候補がありません。Skill 編集ウィンドウで「Persona」を ON にしたスキルがここに表示されます。
+      </span>
     </div>
   </AiSettingsSection>
 </template>
@@ -89,57 +88,61 @@ const currentPersonaSkill = computed(() => {
 }
 
 // --- Persona selector (#491) ---
+// 「接続」ウィンドウ (ConnectionsContent) のカードグリッドと同じ見た目に揃える
 
-.personaList {
+.grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+// `_button` と特異度が同点だと WebView2 で display: inline-block に負けるため (0,2,0) に上げる
+.card.card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-}
-
-.personaOption {
-  display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 6px;
+  padding: 14px 8px;
   border-radius: var(--nd-radius-sm);
+  background: var(--nd-buttonBg);
+  color: var(--nd-fg);
+  font-size: 0.8em;
   cursor: pointer;
-  transition: background var(--nd-duration-base);
+  text-align: center;
 
-  &:hover {
-    background: var(--nd-buttonHoverBg);
-  }
-
-  input[type='radio'] {
-    flex-shrink: 0;
-    margin: 0;
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 100%;
   }
 }
 
-.personaOptionActive {
-  background: color-mix(in srgb, var(--nd-accent) 10%, transparent);
-
-  &:hover {
-    background: color-mix(in srgb, var(--nd-accent) 14%, transparent);
-  }
+// 選択中のペルソナ。ConnectionsContent には無い状態なのでアクセントで示す
+.cardActive.cardActive {
+  background: color-mix(in srgb, var(--nd-accent) 12%, var(--nd-buttonBg));
+  box-shadow: inset 0 0 0 1px var(--nd-accent);
 }
 
-.personaOptionIcon {
-  width: 24px;
-  height: 24px;
+.activeBadge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 18px;
-  color: var(--nd-fg);
-  opacity: 0.6;
-  flex-shrink: 0;
+  color: var(--nd-accent);
+
+  i {
+    font-size: 12px;
+  }
 }
 
 // SVG mask + currentColor でテーマアクセント色化 (DeckAiColumn.personaIndicator
 // と同じパターン)。ラスタ画像は表示できないが、persona icon は SVG 前提。
-.personaOptionAvatar {
-  width: 24px;
-  height: 24px;
+.logo {
+  width: 22px;
+  height: 22px;
   flex-shrink: 0;
   background-color: currentColor;
   color: var(--nd-accent);
@@ -147,27 +150,9 @@ const currentPersonaSkill = computed(() => {
   mask: var(--icon-url) center / contain no-repeat;
 }
 
-.personaOptionMain {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-
-.personaOptionName {
-  font-size: 0.85em;
-  font-weight: 500;
-  color: var(--nd-fg);
-}
-
-.personaOptionDesc {
-  font-size: 0.7em;
-  color: var(--nd-fg);
-  opacity: 0.6;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+.logoFallback {
+  font-size: 22px;
+  color: var(--nd-fgMuted);
 }
 
 .personaEmpty {

--- a/src/components/window/user-profile/UserProfileNotesList.vue
+++ b/src/components/window/user-profile/UserProfileNotesList.vue
@@ -120,7 +120,24 @@ function replaceNote(id: string, updated: NormalizedNote) {
   )
 }
 
-defineExpose({ loadMore, removeNote, replaceNote })
+/**
+ * 親の楽観的更新 handler から呼ぶ。差分はこのリストが持つ最新のノートから
+ * 計算する (親の持つ参照は API を待つ間に古くなりうる — #904)
+ */
+function patchNote(
+  id: string,
+  compute: (current: NormalizedNote) => Partial<NormalizedNote>,
+) {
+  notes.value = notes.value.map((n) =>
+    n.id === id
+      ? { ...n, ...compute(n) }
+      : n.renote?.id === id
+        ? { ...n, renote: { ...n.renote, ...compute(n.renote) } }
+        : n,
+  )
+}
+
+defineExpose({ loadMore, removeNote, replaceNote, patchNote })
 </script>
 
 <template>

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -30,10 +30,12 @@ export interface ColumnSetupOptions {
    * 楽観的更新の差分 (リアクション・投票) の適用先。既定は noteStore への
    * 差し替えだが、ノートを noteStore に置かない面 (照会カラムのローカル
    * deep ref 等) は自分の保持形態に合わせて差し替える。
+   * `compute` には自分が持つ最新のノートを渡し、返った差分をそこへマージする
+   * (#904)。
    */
   applyNotePatch?: (
     note: NormalizedNote,
-    patch: Partial<NormalizedNote>,
+    compute: (current: NormalizedNote) => Partial<NormalizedNote>,
   ) => void
 }
 
@@ -176,12 +178,18 @@ export function useColumnSetup(
   }
 
   /** 楽観的更新の差分を面の保持形態に反映する (既定は noteStore への差し替え) */
-  function applyPatch(note: NormalizedNote, patch: Partial<NormalizedNote>) {
+  function applyPatch(
+    note: NormalizedNote,
+    compute: (current: NormalizedNote) => Partial<NormalizedNote>,
+  ) {
     if (options?.applyNotePatch) {
-      options.applyNotePatch(note, patch)
+      options.applyNotePatch(note, compute)
     } else {
+      // 手元の note は API を待つ間にストリーミングで差し替わっていることが
+      // あるので、常に store の最新から差分を計算する (#904)
+      const current = noteStore.get(note.id) ?? note
       // 新オブジェクトへの差し替えで store に反映する (reactive に届く)
-      noteStore.update(note.id, { ...note, ...patch })
+      noteStore.update(note.id, { ...current, ...compute(current) })
     }
     customMutatedFn?.()
   }
@@ -189,8 +197,8 @@ export function useColumnSetup(
   async function handleReaction(reaction: string, note: NormalizedNote) {
     if (!adapter || checkOffline()) return
     try {
-      await toggleReaction(adapter.api, note, reaction, (patch) =>
-        applyPatch(note, patch),
+      await toggleReaction(adapter.api, note, reaction, (compute) =>
+        applyPatch(note, compute),
       )
       if (!getColumn().soundMuted) actionSound.play()
     } catch (e) {
@@ -203,8 +211,8 @@ export function useColumnSetup(
   async function handlePollVote(choice: number, note: NormalizedNote) {
     if (!adapter || checkOffline()) return
     try {
-      await votePoll(adapter.api, note, choice, (patch) =>
-        applyPatch(note, patch),
+      await votePoll(adapter.api, note, choice, (compute) =>
+        applyPatch(note, compute),
       )
     } catch (e) {
       const err = AppError.from(e)

--- a/src/composables/usePipAlwaysOnTop.ts
+++ b/src/composables/usePipAlwaysOnTop.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+
+/**
+ * PiP ウィンドウの「最前面に固定」状態。
+ *
+ * PiP は 1 枚ごとに別 WebView = 別 JS realm なので、module 変数がそのまま
+ * このウィンドウ 1 枚分の状態になる（＝ PiP ごとに独立して切り替えられる）。
+ * 生成時は最前面固定で開くため初期値は true（usePipWindow の alwaysOnTop と対）。
+ */
+const alwaysOnTop = ref(true)
+
+export function usePipAlwaysOnTop() {
+  async function toggle(): Promise<void> {
+    const next = !alwaysOnTop.value
+    try {
+      const { getCurrentWindow } = await import('@tauri-apps/api/window')
+      await getCurrentWindow().setAlwaysOnTop(next)
+      alwaysOnTop.value = next
+    } catch {
+      // 適用できなかったときは表示も変えない（実際のウィンドウとずらさない）
+    }
+  }
+
+  return { alwaysOnTop, toggle }
+}

--- a/src/utils/toggleReaction.ts
+++ b/src/utils/toggleReaction.ts
@@ -12,15 +12,29 @@ export interface ReactionPatch {
   myReaction: string | null
 }
 
-/** reactions から 1 減算した新オブジェクト (0 でキーごと削除) */
-function decremented(
+/**
+ * 差分を「呼び出し元が持つ最新のノート」から計算する関数 (#904)。
+ * 呼び出し元は自分の保持形態から現在のノートを取り出して渡し、返った差分を
+ * そこへマージする。await をまたいで届いたストリーミング更新を巻き込まない。
+ */
+export type ReactionPatchFn = (current: NormalizedNote) => ReactionPatch
+
+/** reactions に増減を適用した新オブジェクト (0 以下でキーごと削除) */
+function withDelta(
   reactions: Record<string, number>,
-  key: string,
+  delta: Record<string, number>,
 ): Record<string, number> {
   const next = { ...reactions }
-  if ((next[key] ?? 0) > 1) next[key] = (next[key] ?? 0) - 1
-  else delete next[key]
+  for (const [key, d] of Object.entries(delta)) {
+    const count = (next[key] ?? 0) + d
+    if (count > 0) next[key] = count
+    else delete next[key]
+  }
   return next
+}
+
+function negated(delta: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(delta).map(([k, d]) => [k, -d]))
 }
 
 /**
@@ -34,20 +48,20 @@ function decremented(
  * `patch.reactions` は常に新オブジェクトなので、reactions の参照を watch
  * する購読 (#575 の数え直し等) も確実に発火する。
  *
- * 失敗時は元の状態を apply し直してから throw する。
+ * 適用もロールバックも「自分が動かした絵文字の増減」だけを最新状態へ足し引き
+ * する。開始時のスナップショットで丸ごと置き換えると、API を待つ間に届いた
+ * 他人のリアクションまで巻き戻してしまう (#904)。
  */
 export async function toggleReaction(
   api: ReactionApi,
   note: NormalizedNote,
   reaction: string,
-  apply: (patch: ReactionPatch) => void,
+  apply: (compute: ReactionPatchFn) => void,
 ): Promise<void> {
   hapticLight()
-  const prevReaction = note.myReaction
-  const prevPatch: ReactionPatch = {
-    reactions: { ...note.reactions },
-    myReaction: prevReaction ?? null,
-  }
+  const prevReaction = note.myReaction ?? null
+  /** 楽観的更新で加えた増減。ロールバックはこれを最新状態から引く */
+  const delta: Record<string, number> = {}
 
   // 切替 (取消 → 付与) の途中経過。取消だけ成功して付与に失敗した場合、
   // サーバーは「リアクション無し」なので、元へ巻き戻すと旧絵文字のカウントが
@@ -57,18 +71,20 @@ export async function toggleReaction(
   try {
     if (prevReaction === reaction) {
       // 取消
-      apply({
-        reactions: decremented(note.reactions, reaction),
+      delta[reaction] = -1
+      apply((cur) => ({
+        reactions: withDelta(cur.reactions, delta),
         myReaction: null,
-      })
+      }))
       await api.deleteReaction(note.id)
     } else {
       // 追加 / 切替
-      const next = prevReaction
-        ? decremented(note.reactions, prevReaction)
-        : { ...note.reactions }
-      next[reaction] = (next[reaction] ?? 0) + 1
-      apply({ reactions: next, myReaction: reaction })
+      if (prevReaction) delta[prevReaction] = -1
+      delta[reaction] = (delta[reaction] ?? 0) + 1
+      apply((cur) => ({
+        reactions: withDelta(cur.reactions, delta),
+        myReaction: reaction,
+      }))
 
       if (prevReaction) {
         await api.deleteReaction(note.id)
@@ -77,15 +93,12 @@ export async function toggleReaction(
       await api.createReaction(note.id, reaction)
     }
   } catch (e) {
-    if (removedOnServer && prevReaction) {
-      // サーバーの実状態 (取消のみ成立) に合わせてリアクション無しへ倒す
-      apply({
-        reactions: decremented(note.reactions, prevReaction),
-        myReaction: null,
-      })
-    } else {
-      apply(prevPatch)
-    }
+    // 取消だけ成立しているなら、旧絵文字の減算は戻さず付与分だけ取り消す
+    const undo = removedOnServer ? { [reaction]: -1 } : negated(delta)
+    apply((cur) => ({
+      reactions: withDelta(cur.reactions, undo),
+      myReaction: removedOnServer ? null : prevReaction,
+    }))
     throw e
   }
 }

--- a/src/utils/votePoll.ts
+++ b/src/utils/votePoll.ts
@@ -11,6 +11,24 @@ export interface PollPatch {
 }
 
 /**
+ * 差分を「呼び出し元が持つ最新のノート」から計算する関数 (#904)。
+ * 呼び出し元は自分の保持形態から現在のノートを取り出して渡し、返った差分を
+ * そこへマージする。
+ */
+export type PollPatchFn = (current: NormalizedNote) => PollPatch
+
+function withVoted(
+  poll: NormalizedPoll,
+  choice: number,
+  isVoted: boolean,
+): NormalizedPoll {
+  return {
+    ...poll,
+    choices: poll.choices.map((c, i) => (i === choice ? { ...c, isVoted } : c)),
+  }
+}
+
+/**
  * 投票を楽観的更新つきで行う (toggleReaction と同じ差分適用方式 #888)。
  *
  * note は読み取り専用 — mutate せず、差分を `apply` に渡す。呼び出し元は
@@ -20,13 +38,14 @@ export interface PollPatch {
  * isVoted のみ楽観更新し、votes の +1 はストリーミングの pollVoted
  * イベントに任せる (二重カウントを避けるため)。未接続時は次回取得で整合する。
  *
- * 失敗時は元の状態を apply し直してから throw する。
+ * 失敗時は「押した選択肢の isVoted」だけを最新状態の上で戻す。開始時の poll で
+ * 丸ごと置き換えると、API を待つ間に届いた他人の票まで巻き戻る (#904)。
  */
 export async function votePoll(
   api: PollApi,
   note: NormalizedNote,
   choice: number,
-  apply: (patch: PollPatch) => void,
+  apply: (compute: PollPatchFn) => void,
 ): Promise<void> {
   const poll = note.poll
   if (!poll) return
@@ -37,22 +56,12 @@ export async function votePoll(
   if (!poll.multiple && poll.choices.some((c) => c.isVoted)) return
 
   hapticLight()
-  // note を mutate していないので、ロールバックは元の poll をそのまま返せる
-  const prevPatch: PollPatch = { poll }
-
-  apply({
-    poll: {
-      ...poll,
-      choices: poll.choices.map((c, i) =>
-        i === choice ? { ...c, isVoted: true } : c,
-      ),
-    },
-  })
+  apply((cur) => ({ poll: withVoted(cur.poll ?? poll, choice, true) }))
 
   try {
     await api.votePoll(note.id, choice)
   } catch (e) {
-    apply(prevPatch)
+    apply((cur) => ({ poll: withVoted(cur.poll ?? poll, choice, false) }))
     throw e
   }
 }

--- a/src/views/PipPage.vue
+++ b/src/views/PipPage.vue
@@ -14,6 +14,7 @@ import AppToast from '@/components/common/AppToast.vue'
 import AppTooltip from '@/components/common/AppTooltip.vue'
 import AddColumnDialog from '@/components/deck/AddColumnDialog.vue'
 import ColumnTombstone from '@/components/deck/ColumnTombstone.vue'
+import { usePipAlwaysOnTop } from '@/composables/usePipAlwaysOnTop'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn } from '@/stores/deck'
 import { useThemeStore } from '@/stores/theme'
@@ -171,6 +172,8 @@ function genPipColumnId(): string {
 const selectedColumn = ref<DeckColumn | null>(null)
 const windowPayload = ref<WindowPayload | null>(null)
 
+const { alwaysOnTop, toggle: toggleAlwaysOnTop } = usePipAlwaysOnTop()
+
 const themeVars = computed(() => {
   const accountId =
     selectedColumn.value?.accountId ??
@@ -256,7 +259,14 @@ onMounted(async () => {
     <template v-if="windowPayload">
       <div :class="$style.pipDragBar" data-tauri-drag-region>
         <span :class="$style.pipDragTitle" data-tauri-drag-region>{{ windowTitle }}</span>
-        <button :class="$style.pipDragClose" @click="closeWindow">
+        <button
+          :class="[$style.pipDragBtn, alwaysOnTop && $style.pipDragBtnActive]"
+          :title="alwaysOnTop ? '最前面固定を解除' : '最前面に固定'"
+          @click="toggleAlwaysOnTop"
+        >
+          <i :class="alwaysOnTop ? 'ti ti-pin-filled' : 'ti ti-pin'" />
+        </button>
+        <button :class="$style.pipDragBtn" title="閉じる" @click="closeWindow">
           <i class="ti ti-x" />
         </button>
       </div>
@@ -422,7 +432,14 @@ onMounted(async () => {
       <!-- Drag bar for selector state -->
       <div :class="$style.pipDragBar" data-tauri-drag-region>
         <span :class="$style.pipDragTitle" data-tauri-drag-region>カラムを追加</span>
-        <button :class="$style.pipDragClose" @click="closeWindow">
+        <button
+          :class="[$style.pipDragBtn, alwaysOnTop && $style.pipDragBtnActive]"
+          :title="alwaysOnTop ? '最前面固定を解除' : '最前面に固定'"
+          @click="toggleAlwaysOnTop"
+        >
+          <i :class="alwaysOnTop ? 'ti ti-pin-filled' : 'ti ti-pin'" />
+        </button>
+        <button :class="$style.pipDragBtn" title="閉じる" @click="closeWindow">
           <i class="ti ti-x" />
         </button>
       </div>
@@ -486,7 +503,7 @@ onMounted(async () => {
   font-weight: bold;
 }
 
-.pipDragClose {
+.pipDragBtn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -503,6 +520,11 @@ onMounted(async () => {
     background: var(--nd-buttonHoverBg);
     opacity: 0.8;
   }
+}
+
+.pipDragBtnActive {
+  color: var(--nd-accent);
+  opacity: 1;
 }
 
 .pipSelectorBody {

--- a/tests/utils/toggleReaction.test.ts
+++ b/tests/utils/toggleReaction.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { NormalizedNote } from '@/adapters/types'
-import { type ReactionPatch, toggleReaction } from '@/utils/toggleReaction'
+import {
+  type ReactionPatch,
+  type ReactionPatchFn,
+  toggleReaction,
+} from '@/utils/toggleReaction'
 
 function makeNote(overrides: Partial<NormalizedNote> = {}): NormalizedNote {
   return {
@@ -40,17 +44,22 @@ function makeApi() {
 
 /** apply された差分を状態として追跡する (呼び出し元の反映を模す) */
 function track(note: NormalizedNote) {
-  const state: ReactionPatch = {
-    reactions: note.reactions,
-    myReaction: note.myReaction ?? null,
-  }
+  // 呼び出し元が持つ「最新のノート」。差分はここから計算される
+  const state = { ...note, myReaction: note.myReaction ?? null }
   const patches: ReactionPatch[] = []
-  const apply = (p: ReactionPatch) => {
+  const apply = (compute: ReactionPatchFn) => {
+    const p = compute(state)
     patches.push(p)
-    state.reactions = p.reactions
-    state.myReaction = p.myReaction
+    Object.assign(state, p)
   }
-  return { state, patches, apply }
+  /** API を待つ間にストリーミングで他人のリアクションが届いた状況 */
+  const streamReaction = (reaction: string) => {
+    state.reactions = {
+      ...state.reactions,
+      [reaction]: (state.reactions[reaction] ?? 0) + 1,
+    }
+  }
+  return { state, patches, apply, streamReaction }
 }
 
 describe('toggleReaction', () => {
@@ -181,5 +190,57 @@ describe('toggleReaction', () => {
     expect(state.myReaction).toBeNull()
     expect(state.reactions['👍']).toBe(1)
     expect(state.reactions['❤️']).toBeUndefined()
+  })
+
+  it('付与の巻き戻しは待つ間に届いた他人のリアクションを残す (#904)', async () => {
+    const api = makeApi()
+    const note = makeNote({ reactions: { '👍': 1 } })
+    const t = track(note)
+    api.createReaction.mockImplementation(async () => {
+      t.streamReaction('👍')
+      throw new Error('fail')
+    })
+
+    await expect(toggleReaction(api, note, '❤️', t.apply)).rejects.toThrow(
+      'fail',
+    )
+
+    expect(t.state.reactions).toEqual({ '👍': 2 })
+    expect(t.state.myReaction).toBeNull()
+  })
+
+  it('取消の巻き戻しは待つ間に届いた他人のリアクションを残す (#904)', async () => {
+    const api = makeApi()
+    const note = makeNote({ reactions: { '👍': 2 }, myReaction: '👍' })
+    const t = track(note)
+    api.deleteReaction.mockImplementation(async () => {
+      t.streamReaction('❤️')
+      throw new Error('fail')
+    })
+
+    await expect(toggleReaction(api, note, '👍', t.apply)).rejects.toThrow(
+      'fail',
+    )
+
+    expect(t.state.reactions).toEqual({ '👍': 2, '❤️': 1 })
+    expect(t.state.myReaction).toBe('👍')
+  })
+
+  it('切替の巻き戻しは同じ絵文字への他人のリアクションを残す (#904)', async () => {
+    const api = makeApi()
+    const note = makeNote({ reactions: { '👍': 1 }, myReaction: '👍' })
+    const t = track(note)
+    api.createReaction.mockImplementation(async () => {
+      t.streamReaction('❤️')
+      throw new Error('fail')
+    })
+
+    await expect(toggleReaction(api, note, '❤️', t.apply)).rejects.toThrow(
+      'fail',
+    )
+
+    // 自分が足した ❤️ (+1) だけ取り消し、他人の ❤️ は残る
+    expect(t.state.reactions).toEqual({ '❤️': 1 })
+    expect(t.state.myReaction).toBeNull()
   })
 })

--- a/tests/utils/votePoll.test.ts
+++ b/tests/utils/votePoll.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { NormalizedNote, NormalizedPoll } from '@/adapters/types'
-import { type PollPatch, votePoll } from '@/utils/votePoll'
+import { type PollPatch, type PollPatchFn, votePoll } from '@/utils/votePoll'
 
 function makePoll(overrides: Partial<NormalizedPoll> = {}): NormalizedPoll {
   return {
@@ -29,13 +29,26 @@ function makeApi() {
 
 /** apply された差分を状態として追跡する (呼び出し元の反映を模す) */
 function track(note: NormalizedNote) {
-  const state = { poll: note.poll }
+  // 呼び出し元が持つ「最新のノート」。差分はここから計算される
+  const state = { ...note }
   const patches: PollPatch[] = []
-  const apply = (p: PollPatch) => {
+  const apply = (compute: PollPatchFn) => {
+    const p = compute(state)
     patches.push(p)
-    state.poll = p.poll
+    Object.assign(state, p)
   }
-  return { state, patches, apply }
+  /** API を待つ間にストリーミングで他人の票 (pollVoted) が届いた状況 */
+  const streamVote = (choice: number) => {
+    const poll = state.poll
+    if (!poll) return
+    state.poll = {
+      ...poll,
+      choices: poll.choices.map((c, i) =>
+        i === choice ? { ...c, votes: c.votes + 1 } : c,
+      ),
+    }
+  }
+  return { state, patches, apply, streamVote }
 }
 
 describe('votePoll (差分適用方式 #888)', () => {
@@ -68,17 +81,32 @@ describe('votePoll (差分適用方式 #888)', () => {
     expect(state.poll?.choices[0]?.isVoted).toBe(true)
   })
 
-  it('失敗時は元の poll を apply し直してから throw する', async () => {
+  it('失敗時は押した choice の isVoted を戻してから throw する', async () => {
     const api = makeApi()
     api.votePoll.mockRejectedValue(new Error('fail'))
     const note = makeNote()
-    const originalPoll = note.poll
     const { state, apply } = track(note)
 
     await expect(votePoll(api, note, 0, apply)).rejects.toThrow('fail')
 
-    expect(state.poll).toBe(originalPoll)
-    expect(state.poll?.choices[0]?.isVoted).toBe(false)
+    expect(state.poll?.choices).toEqual(makePoll().choices)
+  })
+
+  it('失敗の巻き戻しは待つ間に届いた他人の票を残す (#904)', async () => {
+    const api = makeApi()
+    const note = makeNote()
+    const t = track(note)
+    api.votePoll.mockImplementation(async () => {
+      t.streamVote(1)
+      throw new Error('fail')
+    })
+
+    await expect(votePoll(api, note, 0, t.apply)).rejects.toThrow('fail')
+
+    expect(t.state.poll?.choices).toEqual([
+      { text: 'A', votes: 3, isVoted: false },
+      { text: 'B', votes: 2, isVoted: false },
+    ])
   })
 
   it.each([


### PR DESCRIPTION
## v1.36.0

### Features

- **PiP ウィンドウの最前面固定を個別に切り替えられるようにする** (347545f2)
  PiP は常に alwaysOnTop で開き解除手段が無かった。カラムモードはカラムメニュー、ウィンドウ / セレクタモードはドラッグバーのピンボタンから、ウィンドウ 1 枚ごとに独立してトグルできる。
- **PiP ウィンドウのカラムでもミュートを切り替えられるようにする** (48659ff6)
  PiP ローカルのカラム設定を直接読み書きし、PiP でもミュートボタンを表示。切り替えた状態は「デッキに戻す」でメインウィンドウへ引き継がれる。
- **エージェント設定の接続・ペルソナを接続ウィンドウと同じカード UI に揃える** (a7a0ef02)
  ラジオ付き縦リストだった AI 接続 / ペルソナの選択肢を、接続ウィンドウと同じカードグリッドに統一。選択状態はアクセント背景 + 右上チェックバッジで表す。

### Fixes

- **楽観的更新のロールバックを自分の操作分だけに絞る** (94ab7657)
  リアクション・投票の巻き戻しがスナップショット置換だったため、API を待つ間にストリーミングで届いた他人のリアクション・票ごと巻き戻っていた。適用もロールバックも自分が動かした分の増減だけを最新状態へ足し引きする方式に統一。
- **チャットカラムのヘッダーにミュートボタンを表示する** (30380245)
  DeckChatColumn が `sound-enabled` を渡しておらず、ミュートボタンが出ていなかった。
- **投稿フォームのプレビューで KaTeX が描画されない問題を修正** (d3ffa7f3)
  on-demand import の完了がリアクティブに通知されておらず、再レンダリングが走らないプレビューでは数式が素のテキストのまま残っていた。Shiki と同じく reactive flag を持たせて再描画させる。

### Chore

- バージョンを 1.36.0 に更新（package.json / Cargo.toml / tauri.conf.json / Cargo.lock / openapi.json）

---

Closes #904
Closes #906
Closes #909
Closes #910
Closes #911

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added always-on-top controls and mute support to picture-in-picture windows.
  * Added sound notifications to chat columns.
  * Redesigned AI connection and persona selection with card-based layouts, active indicators, and favicon fallbacks.

* **Bug Fixes**
  * Improved mathematical formula rendering after asynchronous loading.
  * Made reaction and poll updates more reliable, preserving concurrent changes during optimistic updates.
  * Improved cross-account note interactions and profile note updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->