### PR TITLE
Release v1.36.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.36.0",
+  "version": "1.36.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3194,7 +3194,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.36.0"
+version = "1.36.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.36.0"
+version = "1.36.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 [dependencies]

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.36.0"
+    "version": "1.36.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkReactionUsersPopup.vue
+++ b/src/components/common/MkReactionUsersPopup.vue
@@ -157,23 +157,7 @@ onUnmounted(() => {
     <template v-if="!isLoading || reactions.length > 0">
       <!-- Left: reaction icon -->
       <div :class="$style.reaction">
-        <span
-          v-if="isEmojiMuted(reaction)"
-          class="_emojiMuted"
-          :class="$style.reactionIcon"
-          role="img"
-          :aria-label="reaction"
-          :title="`${reaction} (ミュート中)`"
-        />
-        <img
-          v-else-if="reactionUrl"
-          :src="proxyEmojiUrl(reactionUrl)"
-          :alt="reaction"
-          :class="$style.reactionIcon"
-          decoding="async"
-          loading="lazy"
-        />
-        <MkEmoji v-else :emoji="reaction" :class="$style.reactionIcon" />
+        <!-- バッジ側から入ったマウスの導線を短くするため絵文字より左に置く -->
         <div :class="$style.reactionActions">
           <button
             class="_button"
@@ -194,6 +178,23 @@ onUnmounted(() => {
             <i :class="isEmojiMuted(reaction) ? 'ti ti-mood-smile' : 'ti ti-mood-off'" />
           </button>
         </div>
+        <span
+          v-if="isEmojiMuted(reaction)"
+          class="_emojiMuted"
+          :class="$style.reactionIcon"
+          role="img"
+          :aria-label="reaction"
+          :title="`${reaction} (ミュート中)`"
+        />
+        <img
+          v-else-if="reactionUrl"
+          :src="proxyEmojiUrl(reactionUrl)"
+          :alt="reaction"
+          :class="$style.reactionIcon"
+          decoding="async"
+          loading="lazy"
+        />
+        <MkEmoji v-else :emoji="reaction" :class="$style.reactionIcon" />
       </div>
 
       <!-- Right: user list (original style) -->
@@ -254,6 +255,10 @@ onUnmounted(() => {
   padding: 8px 0 8px 12px;
   pointer-events: auto;
   animation: reactionPopupIn 0.2s var(--nd-ease-spring);
+  /* _popup の contain: paint は要素境界外の paint と pointer hit を切るため、
+     アクションボタンのツールチップが popup 内で途切れ、下の ::before ブリッジも
+     効かなくなる。DeckWindow と同じく layout のみに留める (#914) */
+  contain: layout style;
 
   /* Bridge to catch the mouse in the gap between badge and tooltip */
   &::before {
@@ -268,7 +273,6 @@ onUnmounted(() => {
 
 .reaction {
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 6px;
@@ -280,6 +284,7 @@ onUnmounted(() => {
 
 .reactionActions {
   display: flex;
+  flex-direction: column;
   gap: 2px;
 }
 
@@ -296,13 +301,15 @@ onUnmounted(() => {
     background: var(--nd-buttonHoverBg);
   }
 
-  /* ネイティブ title は popover の top-layer に潜るため、popup 内で描く */
+  /* ネイティブ title は popover の top-layer に潜るため、popup 内で描く。
+     中央揃えだと最左カラムで画面外にはみ出すのでボタン左端に寄せ、
+     右隣のユーザー一覧の上に重ねる */
   &::after {
     content: attr(data-tooltip);
     position: absolute;
+    z-index: 1;
     bottom: calc(100% + 6px);
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
     padding: 3px 8px;
     border-radius: 6px;
     background: var(--nd-bg);

--- a/src/composables/useHoverPopup.dom.test.ts
+++ b/src/composables/useHoverPopup.dom.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { type App, createApp, defineComponent, h } from 'vue'
+import type { useHoverPopup as UseHoverPopup } from './useHoverPopup'
+
+type Popup = ReturnType<typeof UseHoverPopup>
+
+let app: App | null = null
+
+/** ポインタ環境を差し替える。coarse = 主ポインタがタッチ */
+function stubPointerEnv(coarse: boolean, maxTouchPoints: number) {
+  Object.defineProperty(navigator, 'maxTouchPoints', {
+    value: maxTouchPoints,
+    configurable: true,
+  })
+  window.matchMedia = ((query: string) =>
+    ({
+      matches: query.includes('coarse') ? coarse : !coarse,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: () => false,
+    }) as MediaQueryList) as typeof window.matchMedia
+}
+
+// グローバルシングルトンを持つので、テストごとにモジュールを読み直す
+async function mountHoverPopup(): Promise<Popup> {
+  vi.resetModules()
+  const { useHoverPopup } = await import('./useHoverPopup')
+  let popup!: Popup
+  app = createApp(
+    defineComponent({
+      setup() {
+        popup = useHoverPopup({ showDelay: 0 })
+        return () => h('div')
+      },
+    }),
+  )
+  app.mount(document.createElement('div'))
+  return popup
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 5))
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+})
+
+describe('useHoverPopup', () => {
+  it('マウス環境ではポップアップを表示する', async () => {
+    stubPointerEnv(false, 0)
+    const popup = await mountHoverPopup()
+    popup.show({ x: 10, y: 20 })
+    await tick()
+    expect(popup.isVisible.value).toBe(true)
+    expect(popup.position.value).toEqual({ x: 10, y: 20 })
+  })
+
+  it('タッチスクリーン付き PC でもマウス操作ならポップアップを表示する (#914)', async () => {
+    stubPointerEnv(false, 10)
+    const popup = await mountHoverPopup()
+    popup.show({ x: 10, y: 20 })
+    await tick()
+    expect(popup.isVisible.value).toBe(true)
+  })
+
+  it('主ポインタがタッチの端末ではポップアップを出さない', async () => {
+    stubPointerEnv(true, 10)
+    const popup = await mountHoverPopup()
+    popup.show({ x: 10, y: 20 })
+    await tick()
+    expect(popup.isVisible.value).toBe(false)
+  })
+})

--- a/src/composables/useHoverPopup.ts
+++ b/src/composables/useHoverPopup.ts
@@ -1,6 +1,9 @@
 import { computed, onUnmounted, shallowRef } from 'vue'
 
-const IS_TOUCH = navigator.maxTouchPoints > 0
+// maxTouchPoints はタッチスクリーン付き PC でも > 0 になり、マウス操作なのに
+// ホバーポップアップが一切出なくなる (#914)。AppTooltip と同じく主ポインタが
+// coarse かどうかで判定し、後からマウスを挿しても効くよう参照時に評価する
+const coarsePointer = window.matchMedia('(pointer: coarse)')
 
 // Global singleton state — only one hover popup is active at a time
 let activeSlotId: number | null = null
@@ -66,7 +69,7 @@ export function useHoverPopup(options?: {
   )
 
   function show(pos: { x: number; y: number }) {
-    if (IS_TOUCH || Date.now() < scrollingUntil) return
+    if (coarsePointer.matches || Date.now() < scrollingUntil) return
     // Preempt any pending hide/show from a different slot
     if (activeSlotId !== slotId) {
       clearShowTimer()


### PR DESCRIPTION
タッチスクリーン付き PC でホバーポップアップが出ない不具合の修正リリース。

## 修正

- **fix(ui)**: タッチ対応 PC でホバーポップアップが出ない問題を修正 (6352f2d9)
  タッチ入力への対応有無だけで判定していたため、タッチスクリーン付き Windows PC ではマウス操作でもリアクション絵文字やユーザーのホバーポップアップが一切出なかった。主ポインタが coarse のときだけ抑止するよう変更し、後からマウスを接続した場合もリロード不要にした
- **fix(reaction)**: リアクションポップアップ内のツールチップが途切れる問題を修正 (f42b097f)
  コピー / ミュートボタンのツールチップがポップアップの縁で途切れる・最左カラムで画面外にはみ出す問題を解消。あわせてボタンを絵文字の左に縦一列で配置し、リアクションバッジからの導線を短くした

## その他

- chore: bump version to 1.36.1
- chore: regenerate openapi.json for 1.36.1

Closes #914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reaction popups so tooltips display in the correct position and remain visible above the user list.
  - Enhanced hover popup behavior across mouse, touch-capable, and touch-primary devices.
  - Prevented hover popups from appearing during touch interactions and inertial scrolling.

- **Tests**
  - Added coverage for hover popup visibility and positioning across pointer types.

- **Chores**
  - Updated the application version to 1.36.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->