### PR TITLE
chore: 開発ビルドのディスク使用量を削減

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ Misskey 統合デッキ環境 (IDE: Integrated Deck Environment)。対外ブラ�
 
 ## 環境セットアップ
 
-開発環境は Nix flake で管理。`nix develop`（または direnv）で Node.js, pnpm, Rust 等が揃う。
+開発環境は Nix flake で管理。`nix develop`（または direnv）で Node.js, pnpm, Rust 等が揃う。Android SDK/NDK は容量が大きいため別シェル（`nix develop .#android`）に分離している。
 
 ## 開発コマンド
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,10 +33,10 @@ pnpm install       # パッケージインストール
 
 [direnv](https://direnv.net/) を使うと `cd` するだけで自動的に環境が有効になります（`.envrc` 同梱）。
 
-Android SDK / NDK は既定のシェルには入っていません（nix store に 2.7GB 積むため）。Android をビルドするときだけ専用シェルに入ってください:
+Android SDK / NDK は nix store を数 GB 占めるため、既定のシェルには入っていません。Android をビルドするときだけ専用シェルに入ってください:
 
 ```bash
-nix develop .#android    # 上記に加えて JDK 17 + Android SDK/NDK が揃う
+nix develop .#android    # 上記に加えて JDK + Android SDK/NDK が揃う（内訳は flake.nix）
 ```
 
 ### 手動セットアップ
@@ -756,7 +756,7 @@ du -sh /nix/store ~/.rustup ~/.cargo src-tauri/target node_modules
 ```
 
 - **`/nix/store`** — flake の入力が更新されるたび旧世代が残る。`nix-collect-garbage -d` で、どの GC root からも参照されていない分が消える。**direnv 利用時は `.direnv/flake-profile-*` が旧 devShell を GC root として掴んだままなので、flake.nix を変えたら先に `direnv reload` すること**（これを忘れると GC しても何も減らない）。Android SDK/NDK は既定シェルから外してあるので、`nix develop .#android` に入らない限り GC 後に戻ってこない
-- **`~/.rustup`** — ツールチェーンは 1 つで 1GB 超。`rustup toolchain list` に `rust-toolchain.toml` が指す版以外が並んでいたら `rustup toolchain uninstall <name>`。`rust-docs` は 700MB あるうえ `rust-toolchain.toml` の components に無いので、オフラインで `rustup doc` を引かないなら `rustup component remove rust-docs`。`rustup set profile minimal` にしておくと以後のインストールに docs が付いてこない
+- **`~/.rustup`** — ツールチェーンは 1 つで数百 MB〜GB 規模。`rustup toolchain list` に `rust-toolchain.toml` が指す版以外が並んでいたら `rustup toolchain uninstall <name>`。`rust-docs` は単体で大きく、かつ `rust-toolchain.toml` の components に無いので、オフラインで `rustup doc` を引かないなら `rustup component remove rust-docs`。`rustup set profile minimal` にしておくと以後のインストールに docs が付いてこない
 - **`~/.cargo/registry`** — 依存のソースと `.crate` アーカイブ。消しても次のビルドで再取得されるだけなので、オフラインでないなら消してよい
 
 WSL2 では、以上を削除しても Windows 側の `.vhdx` は自動では縮まない（一度膨らんだサイズを保持する）。Windows のディスクを空けたい場合は PowerShell で `wsl --manage <distro> --set-sparse true` を実行する。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,6 +33,12 @@ pnpm install       # パッケージインストール
 
 [direnv](https://direnv.net/) を使うと `cd` するだけで自動的に環境が有効になります（`.envrc` 同梱）。
 
+Android SDK / NDK は既定のシェルには入っていません（nix store に 2.7GB 積むため）。Android をビルドするときだけ専用シェルに入ってください:
+
+```bash
+nix develop .#android    # 上記に加えて JDK 17 + Android SDK/NDK が揃う
+```
+
 ### 手動セットアップ
 
 | ツール | インストール |
@@ -721,6 +727,39 @@ Vite 8 (Rolldown + OXC ベース) を使用。`vite.config.ts` で以下のカ�
 
 - **stripUnusedFonts** — 未使用フォント形式（woff, ttf）をビルドから除外
 - **subsetTablerIcons** — ソースコードから使用中のアイコンを検出し、CSS ルールとフォントをサブセット化
+
+#### Rust ビルド成果物の肥大
+
+`src-tauri/target` は放置すると際限なく膨らむ。cargo は古い成果物を自動 GC しないため、開発期間に比例して単調増加する。要因は 3 つ:
+
+- `[lib] crate-type` — モバイル対応のため同じコードを複数形態で出力する（`staticlib`/`cdylib` は依存ツリー全体を抱え込む）
+- 重量級の依存ツリー（tauri, axum, reqwest, image, specta, utoipa 等）にデバッグ情報が付き、上記の形態数と掛け算になる
+- `debug/incremental` はビルドのたびにセッションが積まれ、cargo が消さない
+
+2 つ目が支配的で、`src-tauri/Cargo.toml` の `[profile.dev]` でデバッグ情報を削っている（自分のコードは `line-tables-only`、依存クレートと build script / proc-macro は `false`）。デバッグ情報を full にしたフルビルドと比べると 5 倍以上の差が出る。依存クレート内部をデバッガでステップ実行したいときだけ一時的に外すこと。自分のコードのブレークポイントとバックトレースはこの設定のままで効く。
+
+1 つ目は `staticlib`（iOS 専用）を外して 2 形態に減らしてある。iOS プロジェクト（`src-tauri/gen/apple`）を生成するときに戻す。
+
+3 つ目は定期的な手動削除で対処する:
+
+```bash
+pnpm clean:incremental   # incremental のみ削除（再ビルドは差分から）
+pnpm clean               # dist と target を全消し（フルビルドになる）
+```
+
+#### 開発環境全体のディスク使用量
+
+`src-tauri/target` 以外にも、開発を続けると単調増加する置き場がある。容量が逼迫したらこの順で確認する:
+
+```bash
+du -sh /nix/store ~/.rustup ~/.cargo src-tauri/target node_modules
+```
+
+- **`/nix/store`** — flake の入力が更新されるたび旧世代が残る。`nix-collect-garbage -d` で、どの GC root からも参照されていない分が消える。**direnv 利用時は `.direnv/flake-profile-*` が旧 devShell を GC root として掴んだままなので、flake.nix を変えたら先に `direnv reload` すること**（これを忘れると GC しても何も減らない）。Android SDK/NDK は既定シェルから外してあるので、`nix develop .#android` に入らない限り GC 後に戻ってこない
+- **`~/.rustup`** — ツールチェーンは 1 つで 1GB 超。`rustup toolchain list` に `rust-toolchain.toml` が指す版以外が並んでいたら `rustup toolchain uninstall <name>`。`rust-docs` は 700MB あるうえ `rust-toolchain.toml` の components に無いので、オフラインで `rustup doc` を引かないなら `rustup component remove rust-docs`。`rustup set profile minimal` にしておくと以後のインストールに docs が付いてこない
+- **`~/.cargo/registry`** — 依存のソースと `.crate` アーカイブ。消しても次のビルドで再取得されるだけなので、オフラインでないなら消してよい
+
+WSL2 では、以上を削除しても Windows 側の `.vhdx` は自動では縮まない（一度膨らんだサイズを保持する）。Windows のディスクを空けたい場合は PowerShell で `wsl --manage <distro> --set-sparse true` を実行する。
 
 ### Guest Mode & Logout Fallback
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,66 +33,81 @@
           librsvg
           glib-networking
         ];
-      in
-      {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            # Node.js
-            nodejs_24
-            pnpm_11
 
-            # Java (Android)
-            jdk17
+        commonPackages = with pkgs; [
+          # Node.js
+          nodejs_24
+          pnpm_11
 
-            # Rust
-            # (rust-analyzer / rust-src は rust-toolchain.toml の components で入る)
-            rustup
+          # Rust
+          # (rust-analyzer / rust-src は rust-toolchain.toml の components で入る)
+          rustup
 
-            # Language servers — devShell に入った時点で
-            # どのエディタでも補完・定義ジャンプが動く状態にする (#896)
-            taplo # TOML (Cargo.toml, rust-toolchain.toml)
-            nil # Nix (flake.nix)
-            vue-language-server # Vue SFC (TypeScript は node_modules の版を使う)
+          # Language servers — devShell に入った時点で
+          # どのエディタでも補完・定義ジャンプが動く状態にする (#896)
+          taplo # TOML (Cargo.toml, rust-toolchain.toml)
+          nil # Nix (flake.nix)
+          vue-language-server # Vue SFC (TypeScript は node_modules の版を使う)
 
-            # Tauri desktop dependencies (Linux)
-            pkg-config
-          ] ++ desktopDeps;
+          # Tauri desktop dependencies (Linux)
+          pkg-config
+        ] ++ desktopDeps;
 
-          JAVA_HOME = "${pkgs.jdk17}";
-          ANDROID_HOME = androidHome;
-          ANDROID_SDK_ROOT = androidHome;
-          NDK_HOME = "${androidHome}/ndk/27.0.12077973";
-          GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidHome}/build-tools/36.0.0/aapt2";
-
+        commonEnv = {
           # WSL2: WebKitGTK EGL workaround (software rendering fallback)
           WEBKIT_DISABLE_DMABUF_RENDERER = "1";
           LIBGL_ALWAYS_SOFTWARE = "1";
+        };
 
-          shellHook = ''
-            export PATH="${androidHome}/platform-tools:$PATH"
-            export LANG="C.UTF-8"
-            export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"
-            export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0"
-            export __EGL_VENDOR_LIBRARY_FILENAMES="${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json"
-            export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (desktopDeps ++ (with pkgs; [
-              gdk-pixbuf
-              pango
-              cairo
-              glib
-              atk
-              harfbuzz
-              libsoup_3
-              libx11
-              libxcb
-              libxext
-              libxrender
-              libGL
-              dbus
-              gst_all_1.gstreamer
-              gst_all_1.gst-plugins-base
-              gst_all_1.gst-plugins-good
-            ]))}:$LD_LIBRARY_PATH"
-          '';
+        commonShellHook = ''
+          export LANG="C.UTF-8"
+          export GIO_EXTRA_MODULES="${pkgs.glib-networking}/lib/gio/modules"
+          export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.gst_all_1.gstreamer}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-base}/lib/gstreamer-1.0:${pkgs.gst_all_1.gst-plugins-good}/lib/gstreamer-1.0"
+          export __EGL_VENDOR_LIBRARY_FILENAMES="${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json"
+          export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath (desktopDeps ++ (with pkgs; [
+            gdk-pixbuf
+            pango
+            cairo
+            glib
+            atk
+            harfbuzz
+            libsoup_3
+            libx11
+            libxcb
+            libxext
+            libxrender
+            libGL
+            dbus
+            gst_all_1.gstreamer
+            gst_all_1.gst-plugins-base
+            gst_all_1.gst-plugins-good
+          ]))}:$LD_LIBRARY_PATH"
+        '';
+      in
+      {
+        devShells = {
+          # デスクトップ開発用（direnv / `nix develop` はこれ）。
+          # Android SDK/NDK は store に 2.7GB 積むため入れない。
+          default = pkgs.mkShell (commonEnv // {
+            buildInputs = commonPackages;
+            shellHook = commonShellHook;
+          });
+
+          # Android ビルド用: `nix develop .#android`
+          # (`pnpm tauri android dev` / `build` を叩くときだけ入る)
+          android = pkgs.mkShell (commonEnv // {
+            buildInputs = commonPackages ++ (with pkgs; [ jdk17 androidSdk ]);
+
+            JAVA_HOME = "${pkgs.jdk17}";
+            ANDROID_HOME = androidHome;
+            ANDROID_SDK_ROOT = androidHome;
+            NDK_HOME = "${androidHome}/ndk/27.0.12077973";
+            GRADLE_OPTS = "-Dorg.gradle.project.android.aapt2FromMavenOverride=${androidHome}/build-tools/36.0.0/aapt2";
+
+            shellHook = commonShellHook + ''
+              export PATH="${androidHome}/platform-tools:$PATH"
+            '';
+          });
         };
       }
     );

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "lint:fix": "biome check --write .",
     "changelog": "git log $(git describe --tags --abbrev=0 2>/dev/null || echo '')..HEAD --pretty=format:'- %s' --no-merges",
     "icons": "tauri icon src-tauri/icons/icon.svg -o src-tauri/icons && node scripts/gen-android-foreground.mjs",
-    "clean": "rm -rf dist src-tauri/target"
+    "clean": "rm -rf dist src-tauri/target",
+    "clean:incremental": "rm -rf src-tauri/target/debug/incremental"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -138,15 +138,15 @@ if [ -n "${ANDROID_HOME:-}" ] && [ -d "${ANDROID_HOME}" ]; then
   if [ -n "${NDK_HOME:-}" ] && [ -d "${NDK_HOME}" ]; then
     ok "NDK_HOME: ${NDK_HOME}"
   else
-    warn "NDK_HOME が無効 (${NDK_HOME:-未設定})" "nix develop に入ると設定される"
+    warn "NDK_HOME が無効 (${NDK_HOME:-未設定})" "nix develop .#android に入ると設定される"
   fi
   if command -v java >/dev/null 2>&1; then
     ok "Java $(java -version 2>&1 | head -1 | sed 's/.*"\(.*\)".*/\1/')"
   else
-    warn "java が見つからない" "nix develop に入ると JDK 17 が入る"
+    warn "java が見つからない" "nix develop .#android に入ると JDK 17 が入る"
   fi
 else
-  warn "ANDROID_HOME が未設定 (Android ビルドはできない)" "nix develop に入ると SDK/NDK ごと揃う"
+  warn "ANDROID_HOME が未設定 (Android ビルドはできない)" "nix develop .#android に入ると SDK/NDK ごと揃う"
 fi
 
 # ---------------------------------------------------------------- サマリ

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -89,11 +89,21 @@ tauri = { version = "2", features = ["test"] }
 tauri-build = { version = "2", features = [] }
 
 # dev: 自分のコードは最速コンパイル、依存クレートだけ軽く最適化（実行速度とコンパイル速度のバランス）
+# debug 情報は target/ 肥大の主因（[lib] の 3 crate-type × 重量級依存ツリーで掛け算になる）。
+# 自分のコードは行番号のみ（パニック時のバックトレースは読める）、依存クレートは捨てる。
+# 依存クレート内部をデバッガでステップ実行したいときだけ一時的にこの 2 行を外す。
 [profile.dev]
 opt-level = 0
+debug = "line-tables-only"
 
 [profile.dev.package."*"]
 opt-level = 1
+debug = false
+
+# build script / proc-macro（デバッグ対象ではない）は debug 情報だけ落とす。
+# opt-level は cargo のデフォルト（0）のままにして、コンパイル時間は変えない。
+[profile.dev.build-override]
+debug = false
 
 [profile.release]
 lto = "fat"
@@ -103,4 +113,7 @@ panic = "abort"
 
 [lib]
 name = "notedeck_lib"
-crate-type = ["lib", "cdylib", "staticlib"]
+# staticlib は iOS 専用。iOS プロジェクト (gen/apple) を生成するまでは
+# どのビルドでも使われず、debug ビルドごとに .a を 300MB 超積むだけなので外している。
+# iOS に着手する (#865) ときに "staticlib" を戻すこと。
+crate-type = ["lib", "cdylib"]


### PR DESCRIPTION
## なぜ

`src-tauri/target` と nix store が開発期間に比例して単調増加し、ローカルのディスクを圧迫していた。開発体験を落とさない範囲で発生源を削る。

## 変更

- **flake.nix** — Android SDK/NDK（nix store 2.7GB）を `nix develop .#android` に分離。日常の direnv / `nix develop` はデスクトップ依存のみになる
- **Cargo.toml** — iOS 専用の `staticlib` を `crate-type` から除外。`gen/apple` は未生成で現状どのビルドでも使われず、debug ビルドごとに `.a` を 355MB 積んでいた（iOS 着手 #865 時に戻す）
- **Cargo.toml** — build script / proc-macro の debug 情報も落とす
- **DEVELOPMENT.md** — 開発環境全体のディスク使用量の節を追加。nix GC が direnv の gcroot で空振りする件、`rust-docs` 700MB、WSL2 の `.vhdx` が自動では縮まない件
- **doctor.sh / CLAUDE.md** — Android シェル分離に追随

## 実測

- debug 情報を full にしたフルビルドは中断時点で **14.3GiB**、現行設定は完成形で **2.7GB**。既存の `[profile.dev]` の debug 設定は 5 倍以上効いている
- `staticlib` 除外でビルドごとに **355MB**
- 検証: `nix derivation show` で default devShell に android 参照 0 件、`.#android` にのみ含まれることを確認済み。`cargo build` はデスクトップで通ることを確認済み

## 影響

Android をビルドするときだけ `nix develop .#android` に入る必要がある。CI は nix を使っていないため影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Android development environment with JDK 17, Android SDK, NDK, and platform tools.
  * Added a command to clean incremental build artifacts.

* **Documentation**
  * Expanded guidance for Android setup, build artifact management, disk usage diagnosis, and WSL2 storage maintenance.
  * Updated troubleshooting instructions to use the dedicated Android environment.

* **Performance**
  * Reduced debug information in development builds to limit artifact size.
  * Removed an unnecessary iOS-specific build output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->