### PR TITLE
Release v1.37.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/fork_support.yml
+++ b/.github/ISSUE_TEMPLATE/fork_support.yml
@@ -1,0 +1,92 @@
+name: Misskey フォーク対応
+description: フォーク固有の機能を NoteDeck で使えるようにする
+labels: ["✨Feature", "🍴Fork"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        対応範囲は **Misskey 本家および「Misskey を名乗り続けるフォーク」** です。
+        Misskey から名前が別物になったフォーク (Sharkey, CherryPick, Firefish, Iceshrimp 等) は対応していません。
+
+        カスタムタイムライン・モードフラグ・タイムラインフィルターは **コード変更なしで動的に検出** されます。
+        まずそのまま試して、動かないものだけをここに書いてください。
+        背景と手順: [CONTRIBUTING — フォーク対応の追加](https://github.com/notedeck-dev/notedeck/blob/main/CONTRIBUTING.md#フォーク対応の追加)
+
+  - type: input
+    id: host
+    attributes:
+      label: サーバーのホスト名
+      placeholder: "例: misskey.flowers"
+    validations:
+      required: true
+
+  - type: input
+    id: repository
+    attributes:
+      label: フォークのリポジトリ URL
+      placeholder: "例: https://github.com/hanamisskey/misskey"
+    validations:
+      required: true
+
+  - type: textarea
+    id: what
+    attributes:
+      label: 動かない / 対応してほしいこと
+      description: NoteDeck 上でどうなるか (エラーメッセージ、何も出ない、等) も書いてください
+    validations:
+      required: true
+
+  - type: dropdown
+    id: kind
+    attributes:
+      label: 本家との差分の種類
+      description: 分かる範囲で。複数選択できます
+      multiple: true
+      options:
+        - 独自エンドポイントがある
+        - 本家エンドポイントがロールポリシーで無効化されている
+        - パラメータやレスポンスの形が違う
+        - 分からない
+    validations:
+      required: true
+
+  - type: textarea
+    id: nodeinfo
+    attributes:
+      label: nodeinfo の software
+      description: |
+        フォークの識別に使います。`curl -s https://<ホスト名>/nodeinfo/2.1 | jq .software` の出力を貼ってください。
+        `repository` が空だと本家と区別できません
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: policies
+    attributes:
+      label: /api/meta の policies (該当部分)
+      description: |
+        ロールポリシーで機能が出し分けられている場合に必要です。
+        `curl -s https://<ホスト名>/api/meta -X POST -H 'Content-Type: application/json' -d '{"detail":true}' | jq .policies`
+      render: json
+    validations:
+      required: false
+
+  - type: textarea
+    id: endpoint
+    attributes:
+      label: 該当エンドポイントの定義
+      description: フォークのソースコードへのリンク、または受け付けるパラメータ一覧。本家との差分が分かる形だと助かります
+    validations:
+      required: false
+
+  - type: dropdown
+    id: pr
+    attributes:
+      label: PR を出せますか
+      options:
+        - 出せる
+        - 相談しながらなら出せる
+        - 情報提供のみ
+    validations:
+      required: true

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1428,7 +1428,7 @@ DB::open_with_eviction(path, notes_cfg, chat_cfg)
 
 ### 課題 3: Adapter Layer の抽象軸のずれ
 
-`src/adapters/types.ts` の `ServerSoftware` は `'misskey-dev/misskey' | 'yamisskey-dev/yamisskey' | 'lqvp/misskey-tempura' | 'unknown'` で owner/repo 形式のフォーク単位に再定義済み。`registry.ts` の `resolveSoftware()` で nodeinfo から検出し、未知のフォークは `'misskey-dev/misskey'` にフォールバックする。
+`src/adapters/types.ts` の `ServerSoftware` は owner/repo 形式のフォーク単位に再定義済み（対応フォークの正本は `registry.ts` の `FORKS` テーブル）。`registry.ts` の `resolveSoftware()` で nodeinfo から検出し、未知のフォークは `'misskey-dev/misskey'` にフォールバックする。
 
 **現状の評価**: フォーク単位の分類は既に実装されている。残る課題は各フォーク adapter が capability フラグ（`hasAntenna`, `hasClip` 等）で機能差分を宣言する仕組みの拡充。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,28 @@ Misskey から名前が別物になったフォーク（Sharkey, CherryPick, Fir
 多くのフォーク固有機能（カスタム TL、モードフラグ等）はコード変更なしで動的に検出されます。
 静的な capability 宣言が必要な場合の具体的な手順は [DEVELOPMENT.md — Fork support](DEVELOPMENT.md#fork-support) を参照してください。
 
+#### フォーク開発者へのお願い
+
+NoteDeck 側にコードを書かなくても、フォーク側の設定次第で自動的に対応できる範囲が広がります。
+
+- **nodeinfo 2.1 の `software.repository` に自分のリポジトリ URL を入れてください。** NoteDeck はこれでフォークを識別します。`software.name` を `misskey` のままにしているフォークが多く、名前だけでは本家と区別できません。repository を返さないサーバーは本家扱いにフォールバックします
+- **独自エンドポイントは `/api/endpoints` に載せてください。** カスタムタイムラインはこのスキャンで自動検出します
+- **機能の有効/無効はロールポリシー (`/api/meta` の `policies`) に出してください。** クライアント側はこれを見て UI を出し分けられます。ポリシーに出ていない機能は「叩いてエラー」でしか判定できず、静的宣言をコードに焼き込むことになります
+
+#### フォーク対応の 3 パターン
+
+| パターン | 必要な作業 | 例 |
+|---|---|---|
+| 動的検出で動く | なし | カスタム TL、モードフラグ、タイムラインフィルター |
+| 静的な capability 宣言が要る | `src/adapters/<fork>/` で宣言 | リモート絵文字リアクション (misskey-tempura) |
+| 叩くエンドポイント自体が違う | notecli にメソッド追加 → Tauri コマンド → アダプターで差し替え | はなみすきーのノート検索 (`notes/hanamisearch-v1`) |
+
+API クライアントの実体は別リポジトリ [notecli](https://github.com/notedeck-dev/notecli) にあるため、
+3 番目のパターンは 2 リポジトリにまたがります。手順は [DEVELOPMENT.md — Fork support](DEVELOPMENT.md#fork-support) にあります。
+
+**PR に書いてほしいこと:** 対象サーバーのホスト名、`/api/meta` と nodeinfo の実測値（該当部分の抜粋）、
+なぜ動的検出では足りないか。実測値があると再現・検証がすぐできます。
+
 ### コードの貢献
 
 1. リポジトリをフォーク

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1092,13 +1092,15 @@ export type ServerSoftware =
 }
 ```
 
-3. `src/core/server.ts` — `detectFeatures()` にフォーク固有の capability を設定
+3. `src/adapters/<fork>/index.ts` — フォーク固有の capability を宣言し、`registerAdapter()` の第 3 引数で渡す
 
 ```typescript
-if (software === 'your-org/your-fork') {
-  features.yourFeature = true
-}
+export const YOUR_FORK_FEATURES: Partial<ServerFeatures> = { yourFeature: true }
 ```
+
+`src/core/server.ts` の `detectFeatures()` が `forkFeatures()` 経由でこれを重ねます
+（フォークの知識をフォークのディレクトリから外に漏らさないため、`server.ts` 側に
+`if (software === ...)` を足さないこと）。
 
 4. 叩くエンドポイント自体が違う場合は、フォーク固有アダプターを作って `registerAdapter()` で登録する
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1100,7 +1100,24 @@ if (software === 'your-org/your-fork') {
 }
 ```
 
-4. カスタムタイムラインのアイコンを追加する場合は `src/utils/customTimelines.ts` の `CUSTOM_TL_ICONS` に SVG パスを追加
+4. 叩くエンドポイント自体が違う場合は、フォーク固有アダプターを作って `registerAdapter()` で登録する
+
+```typescript
+// src/adapters/<fork>/index.ts — 本家アダプターを土台に差分だけ上書きする
+const base = createMisskeyAdapter(serverInfo, accountId, hasToken)
+return { ...base, api: { ...base.api, searchNotes } }
+```
+
+API の実体は notecli 側にあるため、**エンドポイントの差し替えは TS だけでは完結しません**。
+`notecli` に typed メソッドを足す → `#[specta::specta]` な Tauri コマンドとして出す →
+アダプターがそれを呼ぶ、という経路になります（`src/adapters/hanamisskey/` が実例。
+はなみすきーはロールポリシーで `notes/search` が無効なため `notes/hanamisearch-v1` に差し替えている）。
+
+どちらを呼ぶかの判定に DB の `accounts.software` 列を使わないこと。ログイン時の値のまま固定されるため、
+フォーク定義を後から追加しても既存アカウントが本家扱いのままになります。判定は nodeinfo 由来の
+`ServerInfo.software`（= アダプター選択）に一本化します。
+
+5. カスタムタイムラインのアイコンを追加する場合は `src/utils/customTimelines.ts` の `CUSTOM_TL_ICONS` に SVG パスを追加
 
 **PR を出す前に:**
 - `pnpm lint && pnpm typecheck && pnpm test` を通す

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.36.2",
+  "version": "1.37.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/site/index.html
+++ b/site/index.html
@@ -220,7 +220,7 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
           </div>
           <h4>フォークにも対応</h4>
-          <p>Misskey 本家だけでなく、Misskey 系フォークのサーバーでも使えます。サーバー種別は自動判別、独自タイムラインなどフォーク固有の機能もそのまま。未対応の独自機能はリクエストできます。</p>
+          <p>Misskey 本家と、Misskey を名乗り続けるフォーク（yamisskey・misskey-tempura・はなみすきーなど）に対応。サーバー種別は自動判別し、独自タイムラインなどフォーク固有の機能もそのまま使えます。未対応の独自機能はリクエスト可。Sharkey のように名前が別物になったフォークは対象外です。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">

--- a/site/index.html
+++ b/site/index.html
@@ -220,7 +220,7 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
           </div>
           <h4>フォークにも対応</h4>
-          <p>Misskey 本家だけでなく、Misskey 系フォークのサーバーでも使えます。サーバー種別は自動判別、細かな違いはアプリが吸収。</p>
+          <p>Misskey 本家だけでなく、Misskey 系フォークのサーバーでも使えます。サーバー種別は自動判別、独自タイムラインなどフォーク固有の機能もそのまま。未対応の独自機能はリクエストできます。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
@@ -348,6 +348,17 @@
           </div>
         </div>
       </div>
+      <h3 class="pillars-subtitle fade-in" data-direction="up">あなたの鯖の独自機能を、NoteDeck に</h3>
+      <p class="pillars-sublead fade-in" data-direction="up">
+        フォークごとの違いは<strong>アダプター</strong>という層が引き受けます。独自タイムラインやモードフラグの多くはサーバーに聞いて自動で認識するのでコードは要らず、
+        叩くエンドポイントごと違う機能でも、フォーク 1 つ分をディレクトリ 1 つに閉じ込めて足せる形にしてあります。<br />
+        「この機能が NoteDeck で使えない」があれば、サーバーの実測値を添えて投げてください。フォーク開発者からの情報提供も歓迎します。
+      </p>
+      <div class="arch-tags fade-in" data-direction="up">
+        <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml">独自機能の対応を依頼する</a>
+        <a href="https://github.com/notedeck-dev/notedeck/blob/main/CONTRIBUTING.md#フォーク対応の追加">自分で対応を書く</a>
+      </div>
+
       <div class="arch-tags arch-doc-links fade-in" data-direction="up">
         <a href="https://github.com/notedeck-dev/notedeck/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/notedeck-dev/notedeck/blob/main/DEVELOPMENT.md">Development</a>

--- a/site/index.html
+++ b/site/index.html
@@ -348,15 +348,15 @@
           </div>
         </div>
       </div>
-      <h3 class="pillars-subtitle fade-in" data-direction="up">あなたの鯖の独自機能を、NoteDeck に</h3>
-      <p class="pillars-sublead fade-in" data-direction="up">
-        フォークごとの違いは<strong>アダプター</strong>という層が引き受けます。独自タイムラインやモードフラグの多くはサーバーに聞いて自動で認識するのでコードは要らず、
-        叩くエンドポイントごと違う機能でも、フォーク 1 つ分をディレクトリ 1 つに閉じ込めて足せる形にしてあります。<br />
-        「この機能が NoteDeck で使えない」があれば、サーバーの実測値を添えて投げてください。フォーク開発者からの情報提供も歓迎します。
-      </p>
-      <div class="arch-tags fade-in" data-direction="up">
-        <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml">独自機能の対応を依頼する</a>
-        <a href="https://github.com/notedeck-dev/notedeck/blob/main/CONTRIBUTING.md#フォーク対応の追加">自分で対応を書く</a>
+      <div class="guest-cta glass fork-cta fade-in" data-direction="up">
+        <div class="guest-cta-icon">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 01-9 9"/></svg>
+        </div>
+        <div class="guest-cta-text">
+          <h3>あなたの鯖の独自機能を、NoteDeck に</h3>
+          <p>フォークごとの違いは<strong>アダプター</strong>が引き受けます。独自タイムラインやモードフラグの多くは自動で認識し、叩くエンドポイントごと違う機能もフォーク 1 つ分をまとめて足せる形に。使えない独自機能があれば教えてください。</p>
+        </div>
+        <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml" class="btn btn-primary">対応を依頼する</a>
       </div>
 
       <div class="arch-tags arch-doc-links fade-in" data-direction="up">

--- a/site/index.html
+++ b/site/index.html
@@ -220,7 +220,7 @@
             <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
           </div>
           <h4>フォークにも対応</h4>
-          <p>Misskey 本家と、Misskey を名乗り続けるフォーク（yamisskey・misskey-tempura・はなみすきーなど）に対応。サーバー種別は自動判別し、独自タイムラインなどフォーク固有の機能もそのまま使えます。未対応の独自機能はリクエスト可。Sharkey のように名前が別物になったフォークは対象外です。</p>
+          <p>Misskey 本家と、Misskey を名乗り続けるフォークに対応。サーバー種別は自動判別、独自タイムラインもそのまま使えます。</p>
         </div>
         <div class="feature-card glass fade-in" data-direction="up">
           <div class="feature-card-icon">
@@ -354,7 +354,7 @@
         </div>
         <div class="guest-cta-text">
           <h3>あなたの鯖の独自機能を、NoteDeck に</h3>
-          <p>フォークごとの違いは<strong>アダプター</strong>が引き受けます。独自タイムラインやモードフラグの多くは自動で認識し、叩くエンドポイントごと違う機能もフォーク 1 つ分をまとめて足せる形に。使えない独自機能があれば教えてください。</p>
+          <p>フォークごとの違いは<strong>アダプター</strong>が引き受けます。使えない独自機能があれば教えてください（対象は Misskey を名乗り続けるフォーク）。</p>
         </div>
         <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml" class="btn btn-primary">対応を依頼する</a>
       </div>

--- a/site/style.css
+++ b/site/style.css
@@ -241,7 +241,7 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .arch-tags span{font-size:.7rem;font-weight:700;color:var(--text-muted);background:var(--surface);border:1px solid var(--border);padding:.15em .6em;border-radius:var(--radius-pill)}
 .arch-tags a{font-size:.8rem;font-weight:700;color:var(--accent);background:var(--surface);background-image:none;border:1px solid var(--border);padding:.25em .9em;border-radius:var(--radius-pill);transition:all .2s var(--ease)}
 .arch-tags a:hover{border-color:var(--accent);background:var(--accent-soft)}
-.arch-doc-links{margin-top:1.25rem}
+.arch-doc-links{margin-top:2.5rem}
 .arch-arrow{display:flex;justify-content:center;padding:.25rem 0}
 
 /* ===== Download ===== */

--- a/site/style.css
+++ b/site/style.css
@@ -191,6 +191,7 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .guest-cta-text h3{font-size:1rem;font-weight:800;margin:0 0 .25rem}
 .guest-cta-text p{color:var(--text-muted);font-size:.9rem;line-height:1.6;margin:0}
 .guest-cta .btn{flex-shrink:0;white-space:nowrap}
+.fork-cta{margin-top:3rem}
 @media(max-width:640px){.guest-cta{flex-direction:column;text-align:center}.guest-cta .btn{align-self:center}}
 
 /* ===== Store CTA (mobile distribution) ===== */
@@ -241,7 +242,7 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .arch-tags span{font-size:.7rem;font-weight:700;color:var(--text-muted);background:var(--surface);border:1px solid var(--border);padding:.15em .6em;border-radius:var(--radius-pill)}
 .arch-tags a{font-size:.8rem;font-weight:700;color:var(--accent);background:var(--surface);background-image:none;border:1px solid var(--border);padding:.25em .9em;border-radius:var(--radius-pill);transition:all .2s var(--ease)}
 .arch-tags a:hover{border-color:var(--accent);background:var(--accent-soft)}
-.arch-doc-links{margin-top:2.5rem}
+.arch-doc-links{margin-top:1.25rem}
 .arch-arrow{display:flex;justify-content:center;padding:.25rem 0}
 
 /* ===== Download ===== */

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.7.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=b791d84128542e3865c24035e23a871a628226e9#b791d84128542e3865c24035e23a871a628226e9"
+source = "git+https://github.com/notedeck-dev/notecli?rev=a85c34c2ec3bc6b4129e476e69afc6aa4c29a021#a85c34c2ec3bc6b4129e476e69afc6aa4c29a021"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.7.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=664ceee2c6067ec341c0b29be8f1f88354690812#664ceee2c6067ec341c0b29be8f1f88354690812"
+source = "git+https://github.com/notedeck-dev/notecli?rev=b791d84128542e3865c24035e23a871a628226e9#b791d84128542e3865c24035e23a871a628226e9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.36.2"
+version = "1.37.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "664ceee2c6067ec341c0b29be8f1f88354690812", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "b791d84128542e3865c24035e23a871a628226e9", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.36.2"
+version = "1.37.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "b791d84128542e3865c24035e23a871a628226e9", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "a85c34c2ec3bc6b4129e476e69afc6aa4c29a021", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.36.2"
+    "version": "1.37.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -727,6 +727,36 @@ pub async fn api_search_notes(
         .await
 }
 
+/// はなみすきー専用のノート検索 (`notes/hanamisearch-v1`)。
+///
+/// 本家 `notes/search` はロールポリシーで無効化されているため、フォーク別
+/// アダプター (`src/adapters/hanamisskey/`) がこちらを呼ぶ。エンドポイントは
+/// 匿名アクセスでサーバー側が 500 になるので、認証必須として扱う。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_search_notes_hanami(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    query: String,
+    options: Option<SearchOptions>,
+) -> Result<Vec<NormalizedNote>> {
+    if query.len() > 1000 {
+        return Err(NoteDeckError::InvalidInput(
+            "Search query too long".to_string(),
+        ));
+    }
+    let (client, host, token) = app_state.authed(&account_id).await?;
+    client
+        .search_notes_hanami(
+            &host,
+            &token,
+            &account_id,
+            &query,
+            options.unwrap_or_default(),
+        )
+        .await
+}
+
 // --- Upload ---
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -743,6 +743,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_get_notifications,
             commands::api_get_notifications_grouped,
             commands::api_search_notes,
+            commands::api_search_notes_hanami,
             commands::api_get_note_children,
             commands::api_get_note_renotes,
             commands::api_get_note_conversation,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.36.2",
+  "version": "1.37.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/adapters/hanamisskey/index.ts
+++ b/src/adapters/hanamisskey/index.ts
@@ -1,0 +1,50 @@
+import { commands } from '@/utils/tauriInvoke'
+import { createMisskeyAdapter } from '../misskey'
+import { createContext, unwrapAny } from '../misskey/api/context'
+import type {
+  NormalizedNote,
+  SearchOptions,
+  ServerAdapter,
+  ServerInfo,
+} from '../types'
+
+/**
+ * はなみすきー (hanamisskey/misskey) 用アダプター。
+ *
+ * 本家との差分はノート検索のみ。ロールポリシー `canSearchNotes` が false で
+ * `notes/search` が常に UNAVAILABLE を返すため、独自エンドポイント
+ * `notes/hanamisearch-v1` に差し替える (#917)。
+ */
+export function createHanamisskeyAdapter(
+  serverInfo: ServerInfo,
+  accountId: string,
+  hasToken = true,
+): ServerAdapter {
+  const base = createMisskeyAdapter(serverInfo, accountId, hasToken)
+  const ctx = createContext(accountId, hasToken)
+
+  return {
+    ...base,
+    api: {
+      ...base.api,
+      async searchNotes(
+        query: string,
+        options: SearchOptions = {},
+      ): Promise<NormalizedNote[]> {
+        // notes/hanamisearch-v1 は requireCredential: false だが、トークンなしだと
+        // サーバー側が user.id を触って 500 になるためゲストは手前で弾く
+        ctx.requireAuth()
+        return unwrapAny(
+          await commands.apiSearchNotesHanami(accountId, query, {
+            limit: options.limit ?? 20,
+            sinceId: options.sinceId ?? null,
+            untilId: options.untilId ?? null,
+            sinceDate: options.sinceDate ?? null,
+            untilDate: options.untilDate ?? null,
+            userId: options.userId ?? null,
+          }),
+        )
+      },
+    },
+  }
+}

--- a/src/adapters/misskey-tempura/index.ts
+++ b/src/adapters/misskey-tempura/index.ts
@@ -1,0 +1,22 @@
+import { createMisskeyAdapter } from '../misskey'
+import type { ServerAdapter, ServerFeatures, ServerInfo } from '../types'
+
+/**
+ * Misskey tempura (lqvp/misskey-tempura) 用アダプター。
+ *
+ * 叩くエンドポイントは本家と同じで、差分は静的に宣言する capability のみ。
+ */
+export const MISSKEY_TEMPURA_FEATURES: Partial<ServerFeatures> = {
+  // リモート絵文字でのリアクション (#630)。本家は `@ホスト名` 付きを ❤ に
+  // フォールバックするため、連合キャッシュまで絵文字を探索するフォークのみ。
+  // API から判定する手段はないので静的宣言 — 漏れても「押せない」側に落ちる
+  remoteEmojiReactions: true,
+}
+
+export function createMisskeyTempuraAdapter(
+  serverInfo: ServerInfo,
+  accountId: string,
+  hasToken = true,
+): ServerAdapter {
+  return createMisskeyAdapter(serverInfo, accountId, hasToken)
+}

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,3 +1,4 @@
+import { createHanamisskeyAdapter } from './hanamisskey'
 import { createMisskeyAdapter } from './misskey'
 import type { ServerAdapter, ServerInfo, ServerSoftware } from './types'
 
@@ -62,6 +63,12 @@ const FORKS: ForkDefinition[] = [
     displayName: 'Misskey tempura',
     supported: true,
     names: ['misskey-tempura', 'tempura'],
+  },
+  {
+    id: 'hanamisskey/misskey',
+    displayName: 'はなみすきー',
+    supported: true,
+    names: [],
   },
   {
     id: 'iceshrimp/iceshrimp',
@@ -147,3 +154,4 @@ export function getRegisteredSoftware(): ServerSoftware[] {
 // Misskey 本家アダプターをデフォルトとして登録。
 // フォーク固有アダプターが必要な場合、ここに追加登録する。
 registerAdapter('misskey-dev/misskey', createMisskeyAdapter)
+registerAdapter('hanamisskey/misskey', createHanamisskeyAdapter)

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,6 +1,16 @@
 import { createHanamisskeyAdapter } from './hanamisskey'
 import { createMisskeyAdapter } from './misskey'
-import type { ServerAdapter, ServerInfo, ServerSoftware } from './types'
+import {
+  createMisskeyTempuraAdapter,
+  MISSKEY_TEMPURA_FEATURES,
+} from './misskey-tempura'
+import type {
+  ServerAdapter,
+  ServerFeatures,
+  ServerInfo,
+  ServerSoftware,
+} from './types'
+import { createYamisskeyAdapter } from './yamisskey'
 
 type AdapterFactory = (
   info: ServerInfo,
@@ -8,13 +18,27 @@ type AdapterFactory = (
   hasToken?: boolean,
 ) => ServerAdapter
 
-const registry = new Map<ServerSoftware, AdapterFactory>()
+interface AdapterRegistration {
+  factory: AdapterFactory
+  /** そのフォークが静的に宣言する capability (動的検出できないものだけ) */
+  features: Partial<ServerFeatures>
+}
+
+const registry = new Map<ServerSoftware, AdapterRegistration>()
 
 export function registerAdapter(
   software: ServerSoftware,
   factory: AdapterFactory,
+  features: Partial<ServerFeatures> = {},
 ): void {
-  registry.set(software, factory)
+  registry.set(software, { factory, features })
+}
+
+/** 登録済みアダプターが宣言するフォーク固有 capability。未登録なら空。 */
+export function forkFeatures(
+  software: ServerSoftware,
+): Partial<ServerFeatures> {
+  return registry.get(software)?.features ?? {}
 }
 
 /** GitHub URL から owner/repo を抽出 */
@@ -137,14 +161,14 @@ export function createAdapter(
   accountId: string,
   hasToken = true,
 ): ServerAdapter {
-  const factory =
+  const registration =
     registry.get(info.software) ?? registry.get('misskey-dev/misskey')
-  if (!factory) {
+  if (!registration) {
     throw new Error(
       `No adapter registered for "${info.software}" and no fallback adapter found`,
     )
   }
-  return factory(info, accountId, hasToken)
+  return registration.factory(info, accountId, hasToken)
 }
 
 export function getRegisteredSoftware(): ServerSoftware[] {
@@ -152,6 +176,13 @@ export function getRegisteredSoftware(): ServerSoftware[] {
 }
 
 // Misskey 本家アダプターをデフォルトとして登録。
-// フォーク固有アダプターが必要な場合、ここに追加登録する。
+// フォーク固有アダプターは src/adapters/<fork>/ に置いてここで登録する。
+// 未登録のフォーク (misskey.io 等) は本家アダプターにフォールバックする。
 registerAdapter('misskey-dev/misskey', createMisskeyAdapter)
 registerAdapter('hanamisskey/misskey', createHanamisskeyAdapter)
+registerAdapter('yamisskey-dev/yamisskey', createYamisskeyAdapter)
+registerAdapter(
+  'lqvp/misskey-tempura',
+  createMisskeyTempuraAdapter,
+  MISSKEY_TEMPURA_FEATURES,
+)

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -18,6 +18,7 @@ export type ServerSoftware =
   | 'misskeyio/misskey'
   | 'yamisskey-dev/yamisskey'
   | 'lqvp/misskey-tempura'
+  | 'hanamisskey/misskey'
   // 名前が Misskey から乖離したフォーク。識別のみで未対応 (STRATEGY.md)
   | 'iceshrimp/iceshrimp'
   | 'kokonect-link/cherrypick'

--- a/src/adapters/yamisskey/index.ts
+++ b/src/adapters/yamisskey/index.ts
@@ -1,0 +1,18 @@
+import { createMisskeyAdapter } from '../misskey'
+import type { ServerAdapter, ServerInfo } from '../types'
+
+/**
+ * yamisskey (yamisskey-dev/yamisskey) 用アダプター。
+ *
+ * 現状 API・capability ともに本家との差分はない。yami モードやカスタム TL は
+ * ポリシー API と `/api/endpoints` スキャンで動的に検出しており (`customTimelines.ts`)、
+ * 数字の非表示は CSS プリセット側で扱う (#593/#594)。
+ * 静的な差分が出たときにここへ足す。
+ */
+export function createYamisskeyAdapter(
+  serverInfo: ServerInfo,
+  accountId: string,
+  hasToken = true,
+): ServerAdapter {
+  return createMisskeyAdapter(serverInfo, accountId, hasToken)
+}

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -664,6 +664,23 @@ async apiSearchNotes(accountId: string, query: string, options: SearchOptions | 
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * はなみすきー専用のノート検索 (`notes/hanamisearch-v1`)。
+ * 
+ * 本家 `notes/search` はロールポリシーで無効化されているため、フォーク別
+ * アダプター (`src/adapters/hanamisskey/`) がこちらを呼ぶ。エンドポイントは
+ * 匿名アクセスでサーバー側が 500 になるので、認証必須として扱う。
+ *
+ * @see src-tauri/src/commands/timeline.rs
+ */
+async apiSearchNotesHanami(accountId: string, query: string, options: SearchOptions | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_search_notes_hanami", { accountId, query, options }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /** @see src-tauri/src/commands/timeline.rs */
 async apiGetNoteChildren(accountId: string, noteId: string, limit: number | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
     try {

--- a/src/core/server.ts
+++ b/src/core/server.ts
@@ -1,4 +1,8 @@
-import { isSupportedSoftware, resolveSoftware } from '@/adapters/registry'
+import {
+  forkFeatures,
+  isSupportedSoftware,
+  resolveSoftware,
+} from '@/adapters/registry'
 import type {
   ServerFeatures,
   ServerInfo,
@@ -70,9 +74,10 @@ export async function detectServer(host: string): Promise<ServerInfo> {
  * Misskey 互換と判定したすべてで capability を有効化する。未対応サーバーでは
  * 実際の API 呼び出しがエラーで返るので fail-fast する。
  *
- * フォーク固有の capability はここに追加。カスタム TL や modeFlags は
+ * フォーク固有の capability はここではなく `src/adapters/<fork>/` が宣言し、
+ * registry の `forkFeatures()` 経由で重ねる。カスタム TL や modeFlags は
  * customTimelines.ts のポリシー検出で動的に対応済み。静的に宣言が必要な
- * capability のみここで設定する。手順: DEVELOPMENT.md の "Fork support" を参照。
+ * capability のみ扱う。手順: DEVELOPMENT.md の "Fork support" を参照。
  */
 function detectFeatures(software: ServerSoftware): ServerFeatures {
   const features = defaultFeatures()
@@ -84,14 +89,8 @@ function detectFeatures(software: ServerSoftware): ServerFeatures {
     features.notesShowPartialBulk = true
   }
 
-  // リモート絵文字でのリアクション (#630)。本家は `@ホスト名` 付きを ❤ に
-  // フォールバックするため、連合キャッシュまで絵文字を探索するフォークのみ。
-  // API から判定する手段はないので静的宣言 — 漏れても「押せない」側に落ちる
-  if (software === 'lqvp/misskey-tempura') {
-    features.remoteEmojiReactions = true
-  }
-
-  return features
+  // ServerFeatures は index signature を持つため spread だと optional が混ざる
+  return Object.assign(features, forkFeatures(software))
 }
 
 function defaultFeatures(): ServerFeatures {

--- a/tests/adapters/hanamisskey.test.ts
+++ b/tests/adapters/hanamisskey.test.ts
@@ -1,0 +1,65 @@
+import { clearMocks, mockIPC } from '@tauri-apps/api/mocks'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createHanamisskeyAdapter } from '@/adapters/hanamisskey'
+import type { ServerInfo } from '@/adapters/types'
+import { AppError } from '@/utils/errors'
+
+const serverInfo: ServerInfo = {
+  host: 'misskey.flowers',
+  software: 'hanamisskey/misskey',
+  version: '2025.11.1-hanami',
+  features: {
+    mastodonApi: false,
+    reactions: true,
+    customEmoji: true,
+    drive: true,
+    channels: true,
+    antennas: true,
+    quotes: true,
+  },
+}
+
+describe('createHanamisskeyAdapter', () => {
+  afterEach(() => {
+    clearMocks()
+  })
+
+  it('searchNotes は notes/search ではなく HanamiSearch V1 のコマンドを叩く (#917)', async () => {
+    const calls: { cmd: string; args: Record<string, unknown> }[] = []
+    mockIPC((cmd, args) => {
+      calls.push({ cmd, args: args as Record<string, unknown> })
+      return []
+    })
+
+    const adapter = createHanamisskeyAdapter(serverInfo, 'acc-1')
+    await adapter.api.searchNotes('rust', { untilId: 'n42', limit: 30 })
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].cmd).toBe('api_search_notes_hanami')
+    expect(calls[0].args).toMatchObject({
+      accountId: 'acc-1',
+      query: 'rust',
+      options: { untilId: 'n42', limit: 30 },
+    })
+  })
+
+  it('ゲスト (トークンなし) の検索はサーバーに投げる前に弾く', async () => {
+    const adapter = createHanamisskeyAdapter(serverInfo, 'acc-1', false)
+    await expect(adapter.api.searchNotes('rust')).rejects.toBeInstanceOf(
+      AppError,
+    )
+  })
+
+  it('検索以外は本家アダプターの実装をそのまま使う', async () => {
+    const calls: string[] = []
+    mockIPC((cmd) => {
+      calls.push(cmd)
+      return []
+    })
+
+    const adapter = createHanamisskeyAdapter(serverInfo, 'acc-1')
+    await adapter.api.getTimeline('home', { limit: 20 })
+
+    expect(calls).toEqual(['api_get_timeline'])
+  })
+})

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -74,6 +74,13 @@ describe('resolveSoftware', () => {
     ).toBe('misskeyio/misskey')
   })
 
+  it('identifies はなみすきー by repository URL (#916)', () => {
+    // nodeinfo 2.1 の software.name は "misskey" のままで repository だけが違う
+    expect(
+      resolveSoftware('misskey', 'https://github.com/hanamisskey/misskey'),
+    ).toBe('hanamisskey/misskey')
+  })
+
   it('identifies known but unsupported forks by software name (#853)', () => {
     expect(resolveSoftware('sharkey')).toBe('sharkey/sharkey')
     expect(resolveSoftware('cherrypick')).toBe('kokonect-link/cherrypick')
@@ -97,6 +104,7 @@ describe('isSupportedSoftware', () => {
     expect(isSupportedSoftware('yamisskey-dev/yamisskey')).toBe(true)
     expect(isSupportedSoftware('lqvp/misskey-tempura')).toBe(true)
     expect(isSupportedSoftware('misskeyio/misskey')).toBe(true)
+    expect(isSupportedSoftware('hanamisskey/misskey')).toBe(true)
   })
 
   it('rejects identified but unsupported forks and unknown software', () => {

--- a/tests/adapters/registry.test.ts
+++ b/tests/adapters/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   createAdapter,
+  forkFeatures,
   getRegisteredSoftware,
   isSupportedSoftware,
   resolveSoftware,
@@ -42,6 +43,29 @@ describe('adapter registry', () => {
   it('lists registered software', () => {
     const registered = getRegisteredSoftware()
     expect(registered).toContain('misskey-dev/misskey')
+  })
+
+  it('registers fork-specific adapters', () => {
+    expect(getRegisteredSoftware()).toEqual(
+      expect.arrayContaining([
+        'hanamisskey/misskey',
+        'yamisskey-dev/yamisskey',
+        'lqvp/misskey-tempura',
+      ]),
+    )
+  })
+})
+
+describe('forkFeatures', () => {
+  it('returns the capabilities declared by the fork adapter (#630)', () => {
+    expect(forkFeatures('lqvp/misskey-tempura')).toEqual({
+      remoteEmojiReactions: true,
+    })
+  })
+
+  it('returns an empty patch for forks without static capabilities', () => {
+    expect(forkFeatures('misskey-dev/misskey')).toEqual({})
+    expect(forkFeatures('sharkey/sharkey')).toEqual({})
   })
 })
 

--- a/tests/core/server.test.ts
+++ b/tests/core/server.test.ts
@@ -64,6 +64,16 @@ describe('server detection', () => {
     expect(info.software).toBe('lqvp/misskey-tempura')
   })
 
+  it('applies fork-specific capabilities declared by the adapter (#630)', async () => {
+    mockDetect('misskey-tempura')
+    const tempura = await detectServer('misskey.vip')
+    expect(tempura.features.remoteEmojiReactions).toBe(true)
+
+    mockDetect('misskey')
+    const upstream = await detectServer('example.com')
+    expect(upstream.features.remoteEmojiReactions).toBe(false)
+  })
+
   it('returns unknown for non-misskey software', async () => {
     mockDetect('mastodon')
     const info = await detectServer('masto.example.com')


### PR DESCRIPTION
## Misskey フォーク対応まわりだけのリリース

### ✨ Features

- **はなみすきー (hanamisskey/misskey) に対応** — nodeinfo の `software.repository` でフォークを識別し、フォーク別アダプターを登録
- **はなみすきーのノート検索が使えるようになった** — ロールポリシー `canSearchNotes` が false で本家 `notes/search` が常に失敗していたため、`notes/hanamisearch-v1` に差し替え。日付フィルタは Misskey ID の時刻部に変換して補う

### 💚 Refactor

- yamisskey / misskey-tempura もフォークアダプターとして切り出し、フォーク固有 capability の宣言を各フォークのディレクトリへ移動（`core/server.ts` の `if (software === ...)` を廃止）

### 📖 Docs

- フォーク開発者向けの案内を CONTRIBUTING に追加（nodeinfo に `software.repository` を入れる / 独自エンドポイントを `/api/endpoints` に載せる / 機能の可否をロールポリシーに出す）
- Misskey フォーク対応の issue テンプレートを追加
- ランディングページに対応状況とリクエスト導線を追加

### 🔧 Chore

- notecli を [notedeck-dev/notecli#50](https://github.com/notedeck-dev/notecli/pull/50) 込みの rev に更新

Closes #916, #917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic support for Hanamisskey, Yamisskey, and Misskey Tempura.
  * Added authenticated Hanamisskey note search with filtering, pagination, and date options.
  * Added fork-specific capability detection, including remote emoji reactions where supported.
  * Added guidance and an issue template for reporting unsupported fork functionality.

* **Documentation**
  * Updated developer and architecture guidance for Misskey fork support.

* **Chores**
  * Updated the application version to 1.37.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->