### PR TITLE
docs(site): フォーク CTA の上に区切りを入れる

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -348,15 +348,17 @@
           </div>
         </div>
       </div>
-      <div class="guest-cta glass fork-cta fade-in" data-direction="up">
-        <div class="guest-cta-icon">
-          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 01-9 9"/></svg>
+      <div class="fork-cta-block">
+        <div class="guest-cta glass fade-in" data-direction="up">
+          <div class="guest-cta-icon">
+            <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 01-9 9"/></svg>
+          </div>
+          <div class="guest-cta-text">
+            <h3>あなたの鯖の独自機能を、NoteDeck に</h3>
+            <p>フォークごとの違いは<strong>アダプター</strong>が引き受けます。使えない独自機能があれば教えてください（対象は Misskey を名乗り続けるフォーク）。</p>
+          </div>
+          <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml" class="btn btn-primary">対応を依頼する</a>
         </div>
-        <div class="guest-cta-text">
-          <h3>あなたの鯖の独自機能を、NoteDeck に</h3>
-          <p>フォークごとの違いは<strong>アダプター</strong>が引き受けます。使えない独自機能があれば教えてください（対象は Misskey を名乗り続けるフォーク）。</p>
-        </div>
-        <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=fork_support.yml" class="btn btn-primary">対応を依頼する</a>
       </div>
 
       <div class="arch-tags arch-doc-links fade-in" data-direction="up">

--- a/site/style.css
+++ b/site/style.css
@@ -191,7 +191,7 @@ html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0
 .guest-cta-text h3{font-size:1rem;font-weight:800;margin:0 0 .25rem}
 .guest-cta-text p{color:var(--text-muted);font-size:.9rem;line-height:1.6;margin:0}
 .guest-cta .btn{flex-shrink:0;white-space:nowrap}
-.fork-cta{margin-top:3rem}
+.fork-cta-block{margin-top:3rem;padding-top:2.5rem;border-top:1px dashed var(--border)}
 @media(max-width:640px){.guest-cta{flex-direction:column;text-align:center}.guest-cta .btn{align-self:center}}
 
 /* ===== Store CTA (mobile distribution) ===== */


### PR DESCRIPTION
LP のフォーク対応 CTA カードが、真上のアーキテクチャ図と地続きに見えていた（図側が `gap:0` の密着スタックなので `margin-top: 3rem` では区切りとして読めない）。

ダウンロード節の「ストア配布」ブロックと同じ、点線 + 余白の区切りイディオムに揃えた。

リリースは伴わない（バージョン据え置き）。マージすると Cloudflare Pages が https://notedeck.io/ を更新する。