### PR TITLE
Release v1.38.0

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,9 +39,10 @@ graph TB
     end
 
     FE -->|"IPC (型安全)"| CMD
-    FE -->|"loopback HTTP (画像プロキシ)"| HTTP
+    FE -->|"loopback HTTP"| HTTP
     EXT -->|"localhost only"| HTTP
-    HTTP --> AUTH
+    HTTP -->|"画像プロキシ (認証なし)"| IC
+    HTTP -->|"外部 principal API"| AUTH
     AUTH -->|"401 if invalid"| EXT
     AUTH --> IC
     AUTH --> OGP
@@ -64,7 +65,7 @@ graph TB
 
 1. **Tauri のプロセス分離**: WebView (フロントエンド) と Rust コアは別プロセス。IPC ブリッジ経由でのみ通信し、フロントエンドから直接ネットワークやファイルシステムにアクセスできない
 2. **Rust による境界防御**: ネットワーク通信・トークン管理・ホスト検証はすべて Rust 側で実行。メモリ安全性が保証された言語で機密処理を行う
-3. **メディア取得の単一経路**: 画像・効果音は WebView・外部ツールとも localhost 限定 HTTP サーバー (`127.0.0.1:19820`) の画像プロキシ経由 (画像プロキシは認証なし、外部 principal 向け API は Bearer Token 保護)。すべて同じ Rust 側キャッシュ層に入り、HTTPS 強制・ホスト検証・サーキットブレーカーを迂回できない
+3. **メディア取得の単一経路**: 画像・効果音は WebView・外部ツールとも loopback に bind した内蔵 HTTP サーバー (bind 先とポートの正本は `src-tauri/src/http_server.rs`) の画像プロキシ経由。認証はルート単位で、画像プロキシは認証なし・外部 principal 向け API は Bearer Token 保護。すべて同じ Rust 側キャッシュ層に入り、HTTPS 強制・ホスト検証・サーキットブレーカーを迂回できない
 
 ---
 
@@ -324,7 +325,7 @@ flowchart TB
 
 ### メディアプロキシ (画像・効果音)
 
-WebView 内・外部ツールとも HTTP API `/proxy/image` の一経路 (`src-tauri/src/media_proxy.rs` が共通ロジック)。すべて `image_cache.rs` を通るため、以下の制御を迂回できない。localhost への接続制限は Android は networkSecurityConfig (`src-tauri/android/`、cleartext は 127.0.0.1 のみ)、macOS/iOS は ATS の `NSAllowsLocalNetworking` (`src-tauri/Info.plist`) で loopback に限って許可している。
+WebView 内・外部ツールとも HTTP API `/proxy/image` の一経路 (`src-tauri/src/media_proxy.rs` が共通ロジック)。すべて `image_cache.rs` を通るため、以下の制御を迂回できない。WebView から loopback へ繋ぐための OS 側の許可は、Android が networkSecurityConfig、macOS/iOS が ATS の例外 (`src-tauri/Info.plist`)。**cleartext を loopback だけに絞るのは release ビルドのみ**で、debug ビルドは dev サーバー (LAN 上の http) に繋ぐため全面的に許可する — 許可範囲の正本は `src-tauri/android/` の各 networkSecurityConfig。
 
 | 制御 | 内容 | ファイル |
 |------|-----|----------|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,6 @@ graph TB
 
             subgraph "Rust コア"
                 CMD[Tauri Commands<br/>IPC ブリッジ]
-                NDM["custom protocol<br/>ndmedia:"]
                 HTTP[HTTP Server<br/>127.0.0.1:19820]
                 AUTH[Bearer Auth<br/>Middleware]
                 HV[Host 検証<br/>validate_host]
@@ -40,8 +39,7 @@ graph TB
     end
 
     FE -->|"IPC (型安全)"| CMD
-    FE -->|"WebView が intercept"| NDM
-    NDM --> IC
+    FE -->|"loopback HTTP (画像プロキシ)"| HTTP
     EXT -->|"localhost only"| HTTP
     HTTP --> AUTH
     AUTH -->|"401 if invalid"| EXT
@@ -66,7 +64,7 @@ graph TB
 
 1. **Tauri のプロセス分離**: WebView (フロントエンド) と Rust コアは別プロセス。IPC ブリッジ経由でのみ通信し、フロントエンドから直接ネットワークやファイルシステムにアクセスできない
 2. **Rust による境界防御**: ネットワーク通信・トークン管理・ホスト検証はすべて Rust 側で実行。メモリ安全性が保証された言語で機密処理を行う
-3. **メディア取得の単一経路**: 画像・効果音は WebView からは custom protocol `ndmedia:`、外部ツールからは localhost 限定 HTTP サーバー (`127.0.0.1:19820`、Bearer Token 保護) 経由。どちらも同じ Rust 側キャッシュ層に入り、HTTPS 強制・ホスト検証・サーキットブレーカーを迂回できない
+3. **メディア取得の単一経路**: 画像・効果音は WebView・外部ツールとも localhost 限定 HTTP サーバー (`127.0.0.1:19820`) の画像プロキシ経由 (画像プロキシは認証なし、外部 principal 向け API は Bearer Token 保護)。すべて同じ Rust 側キャッシュ層に入り、HTTPS 強制・ホスト検証・サーキットブレーカーを迂回できない
 
 ---
 
@@ -326,7 +324,7 @@ flowchart TB
 
 ### メディアプロキシ (画像・効果音)
 
-WebView 内からは custom protocol `ndmedia:` (`src-tauri/src/media_proxy.rs`)、外部ツールからは HTTP API `/proxy/image` の 2 経路。どちらも同じ `image_cache.rs` を通るため、以下の制御を迂回できない。モバイルの WebView は `http://127.0.0.1` への接続が制限される (Android の cleartext policy / iOS の ATS) が、custom protocol は WebView 自身が intercept するためこの制限を受けない。
+WebView 内・外部ツールとも HTTP API `/proxy/image` の一経路 (`src-tauri/src/media_proxy.rs` が共通ロジック)。すべて `image_cache.rs` を通るため、以下の制御を迂回できない。localhost への接続制限は Android は networkSecurityConfig (`src-tauri/android/`、cleartext は 127.0.0.1 のみ)、macOS/iOS は ATS の `NSAllowsLocalNetworking` (`src-tauri/Info.plist`) で loopback に限って許可している。
 
 | 制御 | 内容 | ファイル |
 |------|-----|----------|

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.37.0",
+  "version": "1.38.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/public/server-icon-error.svg
+++ b/public/server-icon-error.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff8844"/>
+      <stop offset="100%" stop-color="#e03060"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="20" fill="url(#bg)"/>
+  <!-- server racks -->
+  <rect x="28" y="36" width="72" height="24" rx="7" fill="#fff"/>
+  <rect x="28" y="68" width="72" height="24" rx="7" fill="#fff"/>
+  <!-- status lights (unlit = unreachable) -->
+  <circle cx="41" cy="48" r="5" fill="#00000038"/>
+  <circle cx="41" cy="80" r="5" fill="#00000038"/>
+</svg>

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.37.0"
+version = "1.38.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.37.0"
+version = "1.38.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Tauri が生成する Info.plist にマージされる (macOS / iOS 共通)。
+     メディア配信は内蔵 HTTP サーバー (http://127.0.0.1:19820) に一本化して
+     いるため (#921 Phase 3)、ATS のループバック例外を明示する。
+     リモートへの http は許可しない (NSAllowsArbitraryLoads は付けない)。 -->
+<plist version="1.0">
+<dict>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,15 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!-- Tauri が生成する Info.plist にマージされる (macOS / iOS 共通)。
-     メディア配信は内蔵 HTTP サーバー (http://127.0.0.1:19820) に一本化して
-     いるため (#921 Phase 3)、ATS のループバック例外を明示する。
-     リモートへの http は許可しない (NSAllowsArbitraryLoads は付けない)。 -->
+<!-- Tauri が生成する Info.plist にマージされる。メディア配信は内蔵 HTTP
+     サーバー (ループバック) に一本化しているため (#921)、ATS の例外を
+     ループバック宛だけに絞って開ける。リモートへの http は許可しない
+     (NSAllowsArbitraryLoads は付けない)。
+
+     例外を 2 つ書くのは OS 世代で IP 宛の扱いが違うため:
+       - macOS 14 / iOS 17 より前: NSAllowsLocalNetworking が IP 宛を許可する
+       - macOS 14 / iOS 17 以降: IP 宛は既定で不許可になり、
+         NSExceptionDomains に明示した宛先だけが通る。ドメイン名の例外は
+         IP 宛の接続には効かない (逆も同じ) ため、IP を直接書く -->
 <plist version="1.0">
 <dict>
     <key>NSAppTransportSecurity</key>
     <dict>
         <key>NSAllowsLocalNetworking</key>
         <true/>
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>127.0.0.1</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
 </dict>
 </plist>

--- a/src-tauri/android/AndroidManifest.xml
+++ b/src-tauri/android/AndroidManifest.xml
@@ -6,10 +6,16 @@
     <!-- AndroidTV support -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
 
+    <!-- networkSecurityConfig (#921): 127.0.0.1 への cleartext を許可し、
+         メディア配信をループバック HTTP (内蔵サーバー) に載せる。
+         NSC がある場合 usesCleartextTraffic は無視されるため、dev サーバー
+         (LAN IP への http) 用の緩い設定は debug ビルド側の同名リソースで
+         上書きする (sync.sh 参照)。 -->
     <application
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.notedeck"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="${usesCleartextTraffic}">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"

--- a/src-tauri/android/network_security_config.xml
+++ b/src-tauri/android/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- release 用 (#921): cleartext はループバック (内蔵メディアプロキシ
+     127.0.0.1:19820) のみ許可。リモートは https 強制のまま。 -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false" />
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/src-tauri/android/network_security_config_debug.xml
+++ b/src-tauri/android/network_security_config_debug.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- debug 用 (#921): tauri android dev は LAN IP の vite dev サーバーへ
+     http で繋ぐため、debug ビルドでは cleartext を全面許可する。
+     sync.sh が app/src/debug/res/xml/network_security_config.xml として
+     配置し、release 側の同名リソースを buildType で上書きする。 -->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true" />
+</network-security-config>

--- a/src-tauri/android/sync.sh
+++ b/src-tauri/android/sync.sh
@@ -14,6 +14,12 @@ cp "$SCRIPT_DIR/MainActivity.kt" "$JAVA_DIR/MainActivity.kt"
 cp "$SCRIPT_DIR/NotificationWorker.kt" "$JAVA_DIR/NotificationWorker.kt"
 cp "$SCRIPT_DIR/AndroidManifest.xml" "$GEN_DIR/AndroidManifest.xml"
 
+# networkSecurityConfig (#921): release はループバック (127.0.0.1) のみ
+# cleartext 許可、debug は dev サーバー (LAN IP) 用に全面許可で上書き
+mkdir -p "$GEN_DIR/res/xml" "$GEN_DIR/../debug/res/xml"
+cp "$SCRIPT_DIR/network_security_config.xml" "$GEN_DIR/res/xml/network_security_config.xml"
+cp "$SCRIPT_DIR/network_security_config_debug.xml" "$GEN_DIR/../debug/res/xml/network_security_config.xml"
+
 # Add WorkManager dependency to build.gradle.kts if not already present
 BUILD_GRADLE="$SCRIPT_DIR/../gen/android/app/build.gradle.kts"
 WORK_DEP='implementation("androidx.work:work-runtime-ktx:2.10.1")'

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.37.0"
+    "version": "1.38.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -1389,6 +1389,20 @@
             }
           },
           {
+            "name": "h",
+            "in": "query",
+            "description": "Optional max height (aspect-preserving fit; emoji-style sizing)",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
             "name": "format",
             "in": "query",
             "description": "Optional output format (\"webp\" to convert)",

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -701,6 +701,8 @@ struct ProxyImageParams {
     url: String,
     /// Optional max width for thumbnail generation (e.g. 300)
     w: Option<u32>,
+    /// Optional max height (aspect-preserving fit; emoji-style sizing)
+    h: Option<u32>,
     /// Optional output format ("webp" to convert)
     format: Option<String>,
 }
@@ -725,6 +727,7 @@ async fn proxy_image(
     let req = MediaRequest {
         url: params.url.clone(),
         w: params.w,
+        h: params.h,
         format: params.format.clone(),
     };
     let etag = req.etag();
@@ -741,14 +744,14 @@ async fn proxy_image(
         }
     }
 
-    let wants_transform = params.w.is_some() || params.format.is_some();
+    let wants_transform = params.w.is_some() || params.h.is_some() || params.format.is_some();
 
     // Helper: build a cached-image response, applying transform if requested.
     // Accepts &[u8] to avoid cloning Arc<Vec<u8>> when no transform is needed.
     let make_response = |data: &[u8], ct: &str, etag: &str| -> Response {
         if wants_transform {
             if let Some((transformed, new_ct)) =
-                transform_image(data, params.w, params.format.as_deref())
+                transform_image(data, params.w, params.h, params.format.as_deref())
             {
                 return Response::builder()
                     .status(StatusCode::OK)

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -721,7 +721,7 @@ async fn proxy_image(
     Query(params): Query<ProxyImageParams>,
 ) -> Response {
     use crate::image_cache::StreamingFetchResult;
-    use crate::media_proxy::{transform_image, MediaRequest};
+    use crate::media_proxy::MediaRequest;
 
     // 変換パラメータ込みのキー / ETag は custom protocol 側と同じ規則を使う
     let req = MediaRequest {
@@ -744,30 +744,14 @@ async fn proxy_image(
         }
     }
 
-    let wants_transform = params.w.is_some() || params.h.is_some() || params.format.is_some();
-
-    // Helper: build a cached-image response, applying transform if requested.
-    // Accepts &[u8] to avoid cloning Arc<Vec<u8>> when no transform is needed.
-    let make_response = |data: &[u8], ct: &str, etag: &str| -> Response {
-        if wants_transform {
-            if let Some((transformed, new_ct)) =
-                transform_image(data, params.w, params.h, params.format.as_deref())
-            {
-                return Response::builder()
-                    .status(StatusCode::OK)
-                    .header("Content-Type", new_ct)
-                    .header("Cache-Control", "public, max-age=86400, immutable")
-                    .header("ETag", etag)
-                    .body(Body::from(transformed))
-                    .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
-            }
-        }
+    // Helper: build a plain 200 response from ready bytes
+    let ok_response = |data: Vec<u8>, ct: &str, etag: &str| -> Response {
         Response::builder()
             .status(StatusCode::OK)
             .header("Content-Type", ct)
             .header("Cache-Control", "public, max-age=86400, immutable")
             .header("ETag", etag)
-            .body(Body::from(data.to_vec()))
+            .body(Body::from(data))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
     };
 
@@ -776,51 +760,55 @@ async fn proxy_image(
         ($entry:expr, $etag:expr) => {{
             let entry = $entry;
             if let Some(ref mem) = entry.mem_bytes {
-                make_response(mem, &entry.content_type, $etag)
+                ok_response(mem.as_ref().clone(), &entry.content_type, $etag)
             } else {
                 match tokio::fs::read(&entry.path).await {
-                    Ok(b) => make_response(&b, &entry.content_type, $etag),
+                    Ok(b) => ok_response(b, &entry.content_type, $etag),
                     Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
                 }
             }
         }};
     }
 
+    // 変換要求 (絵文字・アバターのサムネイル): ndmedia と同じ variant
+    // キャッシュ経路に載せる。この route は Android の WebView の主経路
+    // (#921) なので、リクエスト毎に再変換すると初回表示のたびに decode +
+    // WebP エンコードの CPU を払い続けることになる。ensure_media_inner が
+    // cache_key で variant を永続化し、2 回目以降はヒットで返る。
+    if req.wants_transform() {
+        if let Some(entry) = state.image_cache.check_cache_only(&req.cache_key()).await {
+            return respond_from_cache!(entry, &etag);
+        }
+        return match crate::media_proxy::ensure_media_inner(&state.image_cache, &req).await {
+            Ok((bytes, content_type)) => ok_response(bytes, &content_type, &etag),
+            Err(msg) => {
+                tracing::warn!(url = %params.url, error = %msg, "proxy_image: fetch failed");
+                (StatusCode::BAD_GATEWAY, msg).into_response()
+            }
+        };
+    }
+
+    // 無変換 (効果音・原寸画像): オリジナルをそのまま配信
     // Phase 1: Check cache (instant response)
     if let Some(entry) = state.image_cache.check_cache_only(&params.url).await {
         return respond_from_cache!(entry, &etag);
     }
 
-    // Phase 2: Fetch from upstream
+    // Phase 2: Fetch from upstream — stream directly for low TTFB
     match state.image_cache.fetch_streaming(&params.url).await {
         Ok(StreamingFetchResult::Cached(entry)) => respond_from_cache!(entry, &etag),
         Ok(StreamingFetchResult::Streaming {
             byte_stream,
             content_type,
         }) => {
-            if wants_transform {
-                // Need full bytes for transform — collect stream first
-                use futures_util::StreamExt;
-                let mut all_bytes = Vec::with_capacity(65_536);
-                let mut stream = byte_stream;
-                while let Some(chunk) = stream.next().await {
-                    match chunk {
-                        Ok(b) => all_bytes.extend_from_slice(&b),
-                        Err(_) => return StatusCode::BAD_GATEWAY.into_response(),
-                    }
-                }
-                make_response(&all_bytes, &content_type, &etag)
-            } else {
-                // No transform needed — stream directly for low TTFB
-                let body = Body::from_stream(byte_stream);
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header("Content-Type", &content_type)
-                    .header("Cache-Control", "public, max-age=86400, immutable")
-                    .header("ETag", &etag)
-                    .body(body)
-                    .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
-            }
+            let body = Body::from_stream(byte_stream);
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", &content_type)
+                .header("Cache-Control", "public, max-age=86400, immutable")
+                .header("ETag", &etag)
+                .body(body)
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         }
         Err(msg) => {
             tracing::warn!(url = %params.url, error = %msg, "proxy_image: upstream fetch failed");

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -770,8 +770,8 @@ async fn proxy_image(
         }};
     }
 
-    // 変換要求 (絵文字・アバターのサムネイル): ndmedia と同じ variant
-    // キャッシュ経路に載せる。この route は Android の WebView の主経路
+    // 変換要求 (絵文字・アバターのサムネイル): variant キャッシュ経路に
+    // 載せる。この route は WebView 全プラットフォームのメディア主経路
     // (#921) なので、リクエスト毎に再変換すると初回表示のたびに decode +
     // WebP エンコードの CPU を払い続けることになる。ensure_media_inner が
     // cache_key で variant を永続化し、2 回目以降はヒットで返る。

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -94,8 +94,6 @@ pub struct ImageCache {
     negative_cache: Arc<RwLock<HashMap<String, (Instant, Duration)>>>,
     mem_cache: Arc<RwLock<MemCacheState>>,
     host_circuits: Arc<RwLock<HashMap<String, HostCircuitState>>>,
-    /// 二段階配信の背景 ensure (取得+変換) の重複防止 (cache_key 単位)
-    ensure_pending: Arc<Mutex<std::collections::HashSet<String>>>,
     perf: SharedPerfConfig,
 }
 
@@ -132,7 +130,6 @@ impl ImageCache {
                 total_size: 0,
             })),
             host_circuits: Arc::new(RwLock::new(HashMap::new())),
-            ensure_pending: Arc::new(Mutex::new(std::collections::HashSet::new())),
             perf,
         }
     }
@@ -183,38 +180,14 @@ impl ImageCache {
         }
     }
 
-    /// URL (または cache_key) が negative cache 中か。二段階配信のフェーズ 1 が
-    /// これを見ずに ensure を再発行すると、失敗イベント → img 再試行 → 失敗
-    /// イベントの無限ループになる。
+    /// URL (または cache_key) が negative cache 中か (テストの観測口。
+    /// 本番経路では fetch_streaming が内部で同じ表を照会する)。
     pub async fn is_negative_cached(&self, url: &str) -> bool {
         let neg = self.negative_cache.read().await;
         match neg.get(&hex_hash(url)) {
             Some((failed_at, ttl)) => failed_at.elapsed() < *ttl,
             None => false,
         }
-    }
-
-    /// 直近失敗 (negative cache) か既知のダウンホスト (circuit breaker) か。
-    /// 二段階配信のフェーズ 1 はこれが真なら ensure を発行せず即エラーを返す。
-    pub async fn is_fast_fail(&self, url: &str) -> bool {
-        if self.is_negative_cached(url).await {
-            return true;
-        }
-        if let Some(host) = Self::extract_host(url) {
-            if self.is_host_blocked(&host).await {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// ensure (背景取得+変換) の開始を予約する。既に進行中なら false。
-    pub async fn begin_ensure(&self, key: &str) -> bool {
-        self.ensure_pending.lock().await.insert(key.to_string())
-    }
-
-    pub async fn finish_ensure(&self, key: &str) {
-        self.ensure_pending.lock().await.remove(key);
     }
 
     async fn check_cache(
@@ -975,15 +948,14 @@ mod tests {
         }
     }
 
-    /// circuit breaker で塞がれたホストもフェーズ 1 の即時失敗対象になること。
-    /// (negative cache に入らない失敗経路なので、これを見落とすと ensure が
-    /// 高速に空振りし続ける)
+    /// circuit breaker で塞がれたホストは fetch_streaming が上流アクセス前に
+    /// 即エラーで弾くこと
     #[tokio::test]
-    async fn fast_fail_covers_circuit_breaker() {
+    async fn circuit_breaker_blocks_fetch_before_network() {
         let dir = tempfile::tempdir().unwrap();
         let cache = ImageCache::new(dir.path());
         let url = "https://down.example/a.png";
-        assert!(!cache.is_fast_fail(url).await);
+        assert!(!cache.is_host_blocked("down.example").await);
 
         cache.host_circuits.write().await.insert(
             "down.example".to_string(),
@@ -992,21 +964,8 @@ mod tests {
                 tripped_at: Some(Instant::now()),
             },
         );
-        assert!(cache.is_fast_fail(url).await);
-    }
-
-    /// 同じ variant への ensure が並走しないこと (変換 CPU の二重払い防止)
-    #[tokio::test]
-    async fn ensure_dedup_via_begin_finish() {
-        let dir = tempfile::tempdir().unwrap();
-        let cache = ImageCache::new(dir.path());
-        assert!(cache.begin_ensure("k").await);
-        assert!(!cache.begin_ensure("k").await, "must not start twice");
-        cache.finish_ensure("k").await;
-        assert!(
-            cache.begin_ensure("k").await,
-            "finished key can start again"
-        );
+        let err = cache.fetch_streaming(url).await.err().expect("must fail");
+        assert!(err.contains("circuit breaker"), "got: {err}");
     }
 
     /// `<stem>.dat` + `.meta` の対を作り、mtime を指定秒だけ過去にずらす

--- a/src-tauri/src/image_cache.rs
+++ b/src-tauri/src/image_cache.rs
@@ -49,6 +49,14 @@ struct HostCircuitState {
     tripped_at: Option<Instant>,
 }
 
+/// 取得並列度の制限。perf_config.max_concurrent_fetches に追従するため、
+/// 固定サイズの Semaphore ではなく「現在の上限 + 差し替え可能なセマフォ」で
+/// 持つ (Semaphore は後からサイズを縮められない)。
+struct FetchLimiter {
+    limit: usize,
+    semaphore: Arc<Semaphore>,
+}
+
 type InflightMap = HashMap<String, watch::Receiver<Option<Result<CacheEntry, String>>>>;
 
 #[derive(Clone)]
@@ -82,7 +90,7 @@ pub struct ImageCache {
     cache_dir: PathBuf,
     inflight: Arc<Mutex<InflightMap>>,
     http_client: reqwest::Client,
-    fetch_semaphore: Arc<Semaphore>,
+    fetch_limiter: Arc<Mutex<FetchLimiter>>,
     negative_cache: Arc<RwLock<HashMap<String, (Instant, Duration)>>>,
     mem_cache: Arc<RwLock<MemCacheState>>,
     host_circuits: Arc<RwLock<HashMap<String, HostCircuitState>>>,
@@ -114,7 +122,10 @@ impl ImageCache {
             cache_dir,
             inflight: Arc::new(Mutex::new(HashMap::new())),
             http_client,
-            fetch_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_FETCHES)),
+            fetch_limiter: Arc::new(Mutex::new(FetchLimiter {
+                limit: DEFAULT_MAX_CONCURRENT_FETCHES,
+                semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_FETCHES)),
+            })),
             negative_cache: Arc::new(RwLock::new(HashMap::new())),
             mem_cache: Arc::new(RwLock::new(MemCacheState {
                 entries: LruCache::new(NonZeroUsize::new(capacity).unwrap()),
@@ -124,6 +135,29 @@ impl ImageCache {
             ensure_pending: Arc::new(Mutex::new(std::collections::HashSet::new())),
             perf,
         }
+    }
+
+    /// 上流取得の permit を取る。perf_config.max_concurrent_fetches を毎回
+    /// 読み、値が変わっていればセマフォごと差し替える (#921 — 以前は生成時の
+    /// 定数 30 で固定され、perf config は起動後にフロントから push されるため
+    /// 設定が一生効かない死にノブだった)。差し替え時、旧セマフォの permit を
+    /// 持つ取得が残る間だけ一時的に旧上限ぶん超過しうるが、取得は
+    /// MEDIA_FETCH_TIMEOUT (6s) 以内に収束する。
+    async fn acquire_fetch_permit(&self) -> Result<tokio::sync::OwnedSemaphorePermit, String> {
+        // 0 は「取得不能」ではなく最低 1 に丸める (設定ミスで全画像が詰まる)
+        let desired = self.perf.read().await.max_concurrent_fetches.max(1);
+        let semaphore = {
+            let mut limiter = self.fetch_limiter.lock().await;
+            if limiter.limit != desired {
+                limiter.limit = desired;
+                limiter.semaphore = Arc::new(Semaphore::new(desired));
+            }
+            limiter.semaphore.clone()
+        };
+        semaphore
+            .acquire_owned()
+            .await
+            .map_err(|_| "Semaphore closed".to_string())
     }
 
     /// 変換結果 (variant) を cache_key 単位で保存する。オリジナルと同じ
@@ -357,12 +391,7 @@ impl ImageCache {
         drop(inflight);
 
         // Acquire semaphore
-        let _permit = self
-            .fetch_semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|_| "Semaphore closed".to_string())?;
+        let _permit = self.acquire_fetch_permit().await?;
 
         // Start HTTP request (headers only, don't consume body yet)
         // Some hosts (e.g. i.pximg.net) require a valid Referer header.
@@ -772,6 +801,47 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _cache = ImageCache::new(dir.path());
         assert!(dir.path().join("image_cache").exists());
+    }
+
+    /// 取得並列度は perf_config.max_concurrent_fetches に追従する (#921)。
+    /// 以前は生成時の定数 30 で固定され、performance.json5 の値が一生
+    /// 効かない死にノブだった (perf config は起動後にフロントから push
+    /// されるため、生成時に読むだけでも足りない)
+    #[tokio::test]
+    async fn fetch_limit_follows_perf_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+
+        // 既定 (30) では複数同時に取れる
+        let p1 = cache.acquire_fetch_permit().await.unwrap();
+        let p2 = cache.acquire_fetch_permit().await.unwrap();
+        drop(p2);
+
+        // 実行中に 1 へ下げると、以降の取得は同時 1 に絞られる
+        cache.perf.write().await.max_concurrent_fetches = 1;
+        let p3 = cache.acquire_fetch_permit().await.unwrap();
+        let blocked =
+            tokio::time::timeout(Duration::from_millis(50), cache.acquire_fetch_permit()).await;
+        assert!(blocked.is_err(), "limit=1 なので 2 本目は待たされる");
+
+        // permit を返せば次が通る
+        drop(p3);
+        let p4 =
+            tokio::time::timeout(Duration::from_millis(50), cache.acquire_fetch_permit()).await;
+        assert!(p4.is_ok(), "枠が空いたら取得できる");
+        drop(p1);
+    }
+
+    /// 0 は「取得不能」ではなく最低 1 に丸める (設定ミスで全画像が
+    /// 永久に詰まるのを防ぐ)
+    #[tokio::test]
+    async fn fetch_limit_zero_is_clamped_to_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = ImageCache::new(dir.path());
+        cache.perf.write().await.max_concurrent_fetches = 0;
+        let permit =
+            tokio::time::timeout(Duration::from_millis(50), cache.acquire_fetch_permit()).await;
+        assert!(permit.is_ok(), "0 指定でも 1 本は通る");
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -278,6 +278,10 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             let sweeper = image_cache.clone();
             tauri::async_runtime::spawn(async move {
                 let interval = std::time::Duration::from_secs(6 * 60 * 60);
+                // 初回だけ遅らせる: 起動直後はフロントがカラムを mount して
+                // 同じディレクトリから絵文字・アバターを読むため、全走査を
+                // 被せると本来支えるはずの読み出しと I/O を奪い合う
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
                 loop {
                     let stats = sweeper.sweep_disk().await;
                     if stats.expired_removed > 0 || stats.evicted_removed > 0 {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,40 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             .build()?;
         app.manage(shared_http.clone());
 
+        // Image cache — 必ず Phase 1 で manage する (#921)。フロントは
+        // nd:accounts-early を受けた瞬間にカラムを mount して絵文字を要求する
+        // ため、Phase 2 (背景スレッド) に置くと起動直後の要求が 503
+        // (media cache not ready) になり、onerror の unknown アイコンが
+        // カラム再 mount まで DOM に焼き付く。依存はディレクトリと
+        // perf/http client だけなので前倒しできる。
+        let image_cache = std::sync::Arc::new(image_cache::ImageCache::with_client(
+            &app_dir,
+            shared_http.clone(),
+            shared_perf_bg.clone(),
+        ));
+        app.manage(image_cache.clone());
+
+        // ディスク画像キャッシュの掃除 (#815)。TTL 超過分と上限超過分は
+        // read 側では消えないため、起動時と定期実行でここだけが削除口になる
+        {
+            let sweeper = image_cache.clone();
+            tauri::async_runtime::spawn(async move {
+                let interval = std::time::Duration::from_secs(6 * 60 * 60);
+                loop {
+                    let stats = sweeper.sweep_disk().await;
+                    if stats.expired_removed > 0 || stats.evicted_removed > 0 {
+                        tracing::info!(
+                            expired = stats.expired_removed,
+                            evicted = stats.evicted_removed,
+                            bytes_after = stats.bytes_after,
+                            "image cache swept"
+                        );
+                    }
+                    tokio::time::sleep(interval).await;
+                }
+            });
+        }
+
         // HEARTBEAT scheduler (#411): per-AI-column tokio interval task。
         // フロントの useHeartbeatScheduler から configure / trigger される。
         app.manage(std::sync::Arc::new(commands::HeartbeatScheduler::new()));
@@ -322,6 +356,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
         let app_handle = app.app_handle().clone();
         let app_dir_bg = app_dir.clone();
+        let image_cache_bg = image_cache.clone();
         std::thread::spawn(move || {
             // Parallel: DB open + MisskeyClient init + HTTP bind (all independent)
             let db_path = app_dir_bg.join("notecli.db");
@@ -377,34 +412,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             app_state.initialize(db.clone(), client.clone());
 
             // OGP cache (lazy-loaded on first access via ensure_loaded())
-            app_handle.manage(ogp::OgpCache::with_client(db.clone(), shared_http.clone(), shared_perf_bg.clone()));
-
-            // Image cache
-            let image_cache = std::sync::Arc::new(
-                image_cache::ImageCache::with_client(&app_dir_bg, shared_http, shared_perf_bg.clone()),
-            );
-            app_handle.manage(image_cache.clone());
-
-            // ディスク画像キャッシュの掃除 (#815)。TTL 超過分と上限超過分は
-            // read 側では消えないため、起動時と定期実行でここだけが削除口になる
-            {
-                let sweeper = image_cache.clone();
-                tauri::async_runtime::spawn(async move {
-                    let interval = std::time::Duration::from_secs(6 * 60 * 60);
-                    loop {
-                        let stats = sweeper.sweep_disk().await;
-                        if stats.expired_removed > 0 || stats.evicted_removed > 0 {
-                            tracing::info!(
-                                expired = stats.expired_removed,
-                                evicted = stats.evicted_removed,
-                                bytes_after = stats.bytes_after,
-                                "image cache swept"
-                            );
-                        }
-                        tokio::time::sleep(interval).await;
-                    }
-                });
-            }
+            app_handle.manage(ogp::OgpCache::with_client(db.clone(), shared_http, shared_perf_bg.clone()));
 
             // Start HTTP API server (attach routes to pre-bound listener)
             // Wait for the server to be ready before signalling the frontend,
@@ -422,7 +430,7 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
                         api_token,
                         api_token_store,
                         token_path: token_path_str,
-                        image_cache,
+                        image_cache: image_cache_bg,
                         perf: shared_perf_bg,
                     }, ready_tx)
                     .await;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,18 +170,10 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
 
     builder = builder.invoke_handler(specta_builder.invoke_handler());
 
-    // 画像プロキシの WebView 側の口。モバイルの WebView は http://127.0.0.1 への
-    // 接続が制限される (Android: cleartext policy / iOS: ATS) ため、HTTP API を
-    // 直接叩けない。custom protocol は WebView 自身が intercept するのでその
-    // 制限を受けず、リサイズ・ディスクキャッシュ・サーキットブレーカーを全
-    // プラットフォームで同じ経路に乗せられる。
-    builder =
-        builder.register_asynchronous_uri_scheme_protocol("ndmedia", |ctx, request, responder| {
-            let app = ctx.app_handle().clone();
-            tauri::async_runtime::spawn(async move {
-                responder.respond(media_proxy::handle_uri_request(&app, request).await);
-            });
-        });
+    // メディア配信は custom protocol を持たない (#921 Phase 3)。全プラット
+    // フォームでループバック HTTP (http_server の /proxy/image) に一本化した。
+    // cleartext/ATS の localhost 例外は src-tauri/android/ の
+    // networkSecurityConfig と src-tauri/Info.plist で許可する。
 
     // セーフモード (#794) — `notedeck --safe-mode` で起動したとき、ページ評価前に
     // フラグを注入する。index.html の boot script がこれを localStorage へ畳み込み、
@@ -979,7 +971,6 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             streaming::StreamEmojiChanged,
             os_notify::NotificationClicked,
             commands::ExportProgress,
-            media_proxy::MediaFetched,
         ])
 }
 

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -1,16 +1,17 @@
 //! リモートメディア (画像・効果音) を取り込むプロキシの共通ロジック。
 //!
 //! 経路が 2 つある:
-//!   - HTTP API `/proxy/image` (port 19820) — 外部 principal にも開いている口
-//!   - custom protocol `ndmedia:` — WebView 内から使う口
+//!   - HTTP API `/proxy/image` (port 19820) — 外部 principal に加え、
+//!     **Android の WebView の主経路** (#921)。wry Android の custom protocol
+//!     は全リクエストが単一ロックで直列化されるため、メディアはループバック
+//!     HTTP に載せて WebView の並列スタックとブラウザキャッシュを使う。
+//!     cleartext-to-localhost は networkSecurityConfig で許可 (src-tauri/android/)
+//!   - custom protocol `ndmedia:` — デスクトップ / iOS の WebView が使う口。
+//!     WebView 自身が intercept するのでネットワークスタックを通らず、
+//!     iOS の ATS 制限も受けない
 //!
-//! モバイルの WebView は `http://127.0.0.1` への接続が制限される
-//! (Android: cleartext policy / iOS: ATS) ため、以前はモバイルだけ
-//! プロキシをバイパスして元 URL を直読みしていた。その結果リサイズ・
-//! ディスクキャッシュ・サーキットブレーカーがモバイルでだけ効かず、
-//! アバターは `proxyThumbUrl(url, 56)` を指定しても原寸が読まれていた。
-//! custom protocol は WebView 自身が intercept するのでネットワーク
-//! スタックを通らず、この制限を受けない。
+//! どちらもバックエンドは同じ ImageCache なので、リサイズ・ディスク
+//! キャッシュ・サーキットブレーカー・オフライン動作は共通。
 
 use std::sync::Arc;
 

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -1,46 +1,19 @@
 //! リモートメディア (画像・効果音) を取り込むプロキシの共通ロジック。
 //!
-//! 経路が 2 つある:
-//!   - HTTP API `/proxy/image` (port 19820) — 外部 principal に加え、
-//!     **Android の WebView の主経路** (#921)。wry Android の custom protocol
-//!     は全リクエストが単一ロックで直列化されるため、メディアはループバック
-//!     HTTP に載せて WebView の並列スタックとブラウザキャッシュを使う。
-//!     cleartext-to-localhost は networkSecurityConfig で許可 (src-tauri/android/)
-//!   - custom protocol `ndmedia:` — デスクトップ / iOS の WebView が使う口。
-//!     WebView 自身が intercept するのでネットワークスタックを通らず、
-//!     iOS の ATS 制限も受けない
+//! 配信の口は HTTP API `/proxy/image` (port 19820) の一本 (#921 Phase 3)。
+//! WebView は全プラットフォームでループバック HTTP を読む — cleartext/ATS の
+//! localhost 例外は src-tauri/android/ の networkSecurityConfig と
+//! src-tauri/Info.plist で許可する。以前あった custom protocol `ndmedia:` は、
+//! wry Android の直列ロック ([[project_wry_android_pipe_fuse]] 相当の制約) を
+//! 補う二段階配信とフロント側の自己修復機構を必要とし続けたため廃止した。
 //!
-//! どちらもバックエンドは同じ ImageCache なので、リサイズ・ディスク
-//! キャッシュ・サーキットブレーカー・オフライン動作は共通。
-
-use std::sync::Arc;
+//! バックエンドは ImageCache (リサイズ・ディスクキャッシュ・サーキット
+//! ブレーカー・オフライン配信)。OS 通知の画像取得 (notify_media) も
+//! [`ensure_media_inner`] の同じ口を使う。
 
 use futures_util::StreamExt;
-use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
 
 use crate::image_cache::{hex_hash, CacheEntry, ImageCache, StreamingFetchResult};
-
-/// 二段階配信 (フェーズ 2) の背景取得が終わったことをフロントへ知らせる。
-/// mediaProxy.ts がこれを受けて該当 URL の `<img>` に再要求させる
-/// (成否によらず emit する。失敗時の再要求は negative cache が 502 で
-/// 受け止め、`onerror` フォールバックに繋がる)。
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type, tauri_specta::Event)]
-#[serde(rename_all = "camelCase")]
-pub struct MediaFetched {
-    pub url: String,
-    pub ok: bool,
-}
-
-/// 1×1 透明 GIF。キャッシュミス時の仮応答 (フェーズ 1)。
-/// 404 を返すと `<img>` の onerror が発火して MkAvatar などのフォールバック
-/// (プロキシ迂回で原寸直読み) を誤爆させるため、成功扱いの透明画像で場を
-/// 持たせ、取得完了イベントで差し替えさせる。
-const PLACEHOLDER_GIF: &[u8] = &[
-    0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0xFF, 0xFF, 0xFF, 0x21, 0xF9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2C, 0x00, 0x00, 0x00, 0x00,
-    0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x44, 0x00, 0x3B,
-];
 
 /// 変換パラメータ込みのメディアリクエスト。
 /// 変換は画像にしか効かないが、効果音は変換なしで同じ経路を通る。
@@ -58,30 +31,6 @@ pub struct MediaRequest {
 }
 
 impl MediaRequest {
-    /// `url=...&w=...&format=...` 形式のクエリ文字列から組み立てる。
-    /// `url` が無い / https 以外なら None。
-    pub fn from_query(query: &str) -> Option<Self> {
-        let mut url = None;
-        let mut w = None;
-        let mut h = None;
-        let mut format = None;
-        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
-            match key.as_ref() {
-                "url" => url = Some(value.into_owned()),
-                "w" => w = value.parse::<u32>().ok(),
-                "h" => h = value.parse::<u32>().ok(),
-                "format" => format = Some(value.into_owned()),
-                _ => {}
-            }
-        }
-        let url = url?;
-        // 上流フェッチの宛先になるので scheme を絞る (ローカル資源への横取りを防ぐ)
-        if !url.starts_with("https://") {
-            return None;
-        }
-        Some(Self { url, w, h, format })
-    }
-
     /// 変換パラメータもキーに含める (サイズ違いを別エントリとして扱う)。
     /// `h` は指定時のみ付ける — h 導入前からある variant (アバター等の w 指定)
     /// のキーを変えると、更新直後に全端末で再変換とディスクの二重保存が走る
@@ -240,8 +189,7 @@ pub fn transform_image(
 /// 要求されていれば変換を適用する。変換不要・失敗時 (効果音など) は元のまま返す。
 ///
 /// decode + WebP エンコードは端末によって CPU を数秒占有するため blocking pool
-/// へ逃がす。async ワーカー上で回すと他の応答 (IPC の channel-fetch を含む) まで
-/// 詰まり、Android では応答締切 (RESPONSE_DEADLINE) の超過に直結する。
+/// へ逃がす。async ワーカー上で回すと他の応答まで詰まる。
 async fn apply_transform(
     data: Vec<u8>,
     content_type: String,
@@ -275,227 +223,6 @@ async fn entry_bytes(entry: &CacheEntry) -> Result<Vec<u8>, String> {
             .await
             .map_err(|e| e.to_string()),
     }
-}
-
-/// custom protocol の応答締切。
-///
-/// wry の Android 実装は全 custom protocol を単一の Mutex で直列処理し、
-/// 各リクエストの応答を 10 秒で打ち切って `unwrap()` で panic する
-/// (wry-0.54.4 src/android/mod.rs:247 の `rx.recv_timeout(MAIN_PIPE_TIMEOUT)`)。
-/// `panic = "abort"` のためそのままプロセス即死になる。応答さえ返れば panic
-/// しないので、どの経路でもこの締切までに必ず何かを応答する。
-const RESPONSE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(7);
-
-/// custom protocol (`ndmedia:`) のハンドラ。
-///
-/// URL 形式はプラットフォームで割れる (macOS/iOS/Linux は
-/// `ndmedia://localhost/m?...`、Windows/Android は
-/// `http://ndmedia.localhost/m?...`) が、クエリの読み方は同じ。
-/// フロントは `convertFileSrc('m', 'ndmedia')` で組み立てる。
-///
-/// 実作業は detach したタスクに任せて RESPONSE_DEADLINE で応答だけ打ち切る。
-/// 途中キャンセルすると inflight 登録が宙に浮くため、作業自体は完走させる
-/// (キャッシュも温まるので、フロントの再要求はヒットで返せる)。
-pub async fn handle_uri_request(
-    app: &AppHandle,
-    request: tauri::http::Request<Vec<u8>>,
-) -> tauri::http::Response<Vec<u8>> {
-    let query_for_log = request.uri().query().unwrap_or_default().to_string();
-    let app = app.clone();
-    let work = tokio::spawn(async move { handle_uri_request_inner(app, request).await });
-    match tokio::time::timeout(RESPONSE_DEADLINE, work).await {
-        Ok(Ok(response)) => response,
-        // JoinError: 実作業タスクの panic (release では panic = "abort" が先に効く)
-        Ok(Err(_)) => error_response(
-            tauri::http::StatusCode::INTERNAL_SERVER_ERROR,
-            "media task failed",
-        ),
-        Err(_) => {
-            tracing::warn!(query = %query_for_log, "ndmedia: response deadline exceeded");
-            error_response(
-                tauri::http::StatusCode::GATEWAY_TIMEOUT,
-                "media fetch deadline exceeded",
-            )
-        }
-    }
-}
-
-async fn handle_uri_request_inner(
-    app: AppHandle,
-    request: tauri::http::Request<Vec<u8>>,
-) -> tauri::http::Response<Vec<u8>> {
-    let query = request.uri().query().unwrap_or_default();
-    let Some(req) = MediaRequest::from_query(query) else {
-        return error_response(tauri::http::StatusCode::BAD_REQUEST, "invalid url param");
-    };
-    // wait=1: 上流取得を待つブロッキング応答 (上限は RESPONSE_DEADLINE)。
-    // fetch()/Audio 要素のようにプレースホルダを飲み込めない消費者 (効果音) 用。
-    // soft=1 (wait と併用): 待ちはソフト予算までで、超過したらプレースホルダ +
-    // MediaFetched の二段階配信へ降格してよい (非 Android の画像用)。
-    let wait = url::form_urlencoded::parse(query.as_bytes()).any(|(k, v)| k == "wait" && v == "1");
-    let soft = url::form_urlencoded::parse(query.as_bytes()).any(|(k, v)| k == "soft" && v == "1");
-
-    let etag = req.etag();
-    // 条件付きリクエスト: 同じ ETag を持っているなら本文を送らない
-    if let Some(if_none_match) = request
-        .headers()
-        .get("if-none-match")
-        .and_then(|v| v.to_str().ok())
-    {
-        if if_none_match == etag {
-            return tauri::http::Response::builder()
-                .status(tauri::http::StatusCode::NOT_MODIFIED)
-                .header("ETag", &etag)
-                .header("Cache-Control", CACHE_CONTROL)
-                .header("Access-Control-Allow-Origin", "*")
-                .body(Vec::new())
-                .unwrap_or_else(|_| internal_error());
-        }
-    }
-
-    // ImageCache は Phase 1 (ウィンドウ表示前) で manage されるため通常は
-    // 必ず居るが、setup 失敗系の防御として残す (#921 で Phase 2 から前倒し —
-    // 以前は起動直後の絵文字要求がここで 503 になり、unknown アイコンが
-    // カラム再 mount まで焼き付いていた)
-    let Some(cache) = app.try_state::<Arc<ImageCache>>() else {
-        return error_response(
-            tauri::http::StatusCode::SERVICE_UNAVAILABLE,
-            "media cache not ready",
-        );
-    };
-    let cache = cache.inner().clone();
-
-    // ── フェーズ 1: ローカル (メモリ/ディスク) だけで応答する ──
-    // variant (変換結果) は cache_key で保存済みなので、ヒットすれば
-    // 変換なしの読み出しだけで返せる。ここが応答時間の実質上限になる。
-    let key = req.cache_key();
-    if let Some(entry) = cache.check_cache_only(&key).await {
-        return match entry_bytes(&entry).await {
-            Ok(bytes) => ok_response(bytes, &entry.content_type, &etag),
-            Err(msg) => {
-                tracing::warn!(url = %req.url, error = %msg, "ndmedia: cache read failed");
-                error_response(tauri::http::StatusCode::INTERNAL_SERVER_ERROR, &msg)
-            }
-        };
-    }
-
-    if wait && soft {
-        return soft_wait_response(app, cache, req, &etag).await;
-    }
-
-    if wait {
-        // ブロッキング経路: プレースホルダを飲み込めない消費者 (効果音の
-        // fetch/Audio 要素) 用。ensure と同じ経路なので変換結果 (variant) も
-        // 永続化される
-        return match ensure_media_inner(&cache, &req).await {
-            Ok((bytes, content_type)) => ok_response(bytes, &content_type, &etag),
-            Err(msg) => {
-                tracing::warn!(url = %req.url, error = %msg, "ndmedia: upstream fetch failed");
-                error_response(tauri::http::StatusCode::BAD_GATEWAY, &msg)
-            }
-        };
-    }
-
-    // 失敗直後 (negative cache) / 既知のダウンホスト (circuit breaker) は
-    // ensure を発行せず即エラー。ここで遮断しないと「失敗イベント → img
-    // 再要求 → ensure → 失敗イベント」が空回りし続ける
-    if cache.is_fast_fail(&req.url).await {
-        return error_response(
-            tauri::http::StatusCode::BAD_GATEWAY,
-            "upstream recently failed",
-        );
-    }
-
-    // ── フェーズ 2: 取得+変換は背景で行い、即プレースホルダを返す ──
-    // wry Android は custom protocol を単一 Mutex で直列処理するため、
-    // ここで上流を待つと他の全メディア + 8KB 超の IPC 応答まで道連れになる。
-    // 完了は MediaFetched イベントで通知し、フロントが再要求してくる。
-    if cache.begin_ensure(&key).await {
-        tokio::spawn(ensure_media(app, cache, req));
-    }
-    placeholder_response()
-}
-
-/// ソフト予算付きブロッキング (非 Android の画像) の待ち時間上限。
-///
-/// キャッシュ済み・軽い取得はこの予算内に収まり単一トリップで返る。
-/// セマフォ枯渇 (大量絵文字バースト・プリフェッチ競合) や遅い上流では
-/// 予算超過でプレースホルダに降格し、二段階配信 (MediaFetched → 再要求)
-/// が引き継ぐ。以前はここが RESPONSE_DEADLINE (7s) までのフルブロッキング
-/// だったため、バースト時に `<img>` が 7 秒空白のまま → 504 → onerror の
-/// unknown 固定化、という経路になっていた。
-const SOFT_WAIT_BUDGET: std::time::Duration = std::time::Duration::from_millis(1500);
-
-/// wait=1&soft=1 の応答。予算内に取得できれば本物を返し、超過したら
-/// プレースホルダへ降格する。取得タスクは応答後も完走し、降格した場合
-/// (受信側 drop) のみ MediaFetched を emit して `<img>` に再要求させる
-/// (予算内に返せた場合の emit は余計な世代 bump = 再読込になるので送らない)。
-///
-/// begin_ensure の重複排除は使わない: 同一 key の同時要求は fetch_streaming
-/// の inflight dedup が上流アクセスを 1 本にまとめるので、重複するのは
-/// 軽い変換だけ。ここで dedup すると「後着がプレースホルダを受け取ったのに
-/// 完了イベントが来ない」競合を生む。
-async fn soft_wait_response(
-    app: AppHandle,
-    cache: Arc<ImageCache>,
-    req: MediaRequest,
-    etag: &str,
-) -> tauri::http::Response<Vec<u8>> {
-    // 失敗直後 (negative cache) / 既知のダウンホストは即エラー。hard wait と
-    // 違い、ここで遮断しないと「プレースホルダ → 失敗イベント → 再要求」の
-    // 空回りに合流する
-    if cache.is_fast_fail(&req.url).await {
-        return error_response(
-            tauri::http::StatusCode::BAD_GATEWAY,
-            "upstream recently failed",
-        );
-    }
-    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Result<(Vec<u8>, String), String>>();
-    tokio::spawn(async move {
-        let result = ensure_media_inner(&cache, &req).await;
-        if let Err(ref msg) = result {
-            tracing::warn!(url = %req.url, error = %msg, "ndmedia: soft-wait fetch failed");
-        }
-        if let Err(result) = done_tx.send(result) {
-            // 受信側が予算超過でプレースホルダに降格済み → 完了イベントで
-            // 再要求させる (成否によらず emit — 失敗は negative cache が
-            // 502 で受け止め、onerror → バックオフ再試行に繋がる)
-            use tauri_specta::Event;
-            MediaFetched {
-                url: req.url.clone(),
-                ok: result.is_ok(),
-            }
-            .emit(&app)
-            .ok();
-        }
-    });
-    match tokio::time::timeout(SOFT_WAIT_BUDGET, done_rx).await {
-        Ok(Ok(Ok((bytes, content_type)))) => ok_response(bytes, &content_type, etag),
-        Ok(Ok(Err(msg))) => error_response(tauri::http::StatusCode::BAD_GATEWAY, &msg),
-        // 予算超過 (or 取得タスクの panic — release では abort が先に効く)
-        _ => placeholder_response(),
-    }
-}
-
-/// 背景取得: オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して
-/// cache_key で保存し、完了イベントを emit する。
-///
-/// 変換が不要・不能でも必ず cache_key で保存する。保存しないとフェーズ 1 が
-/// 永遠にミスして ensure と完了イベントを打ち続ける。
-async fn ensure_media(app: AppHandle, cache: Arc<ImageCache>, req: MediaRequest) {
-    let key = req.cache_key();
-    let result = ensure_media_inner(&cache, &req).await;
-    cache.finish_ensure(&key).await;
-    if let Err(ref msg) = result {
-        tracing::warn!(url = %req.url, error = %msg, "ndmedia: background fetch failed");
-    }
-    use tauri_specta::Event;
-    MediaFetched {
-        url: req.url.clone(),
-        ok: result.is_ok(),
-    }
-    .emit(&app)
-    .ok();
 }
 
 /// オリジナルを (キャッシュ or 上流から) 用意し、変換を適用して cache_key で
@@ -532,111 +259,48 @@ pub(crate) async fn ensure_media_inner(
     };
 
     let (bytes, content_type) = apply_transform(data, content_type, req).await?;
-    // fetch_streaming の背景タスクもオリジナルを書くが、それを待たずに emit
-    // すると再要求がミスする競合があるため、ここで確実に書き切ってから返す
+    // fetch_streaming の背景タスクもオリジナルを書くが、それを待たずに返すと
+    // 直後の再表示・lookup が variant をミスする競合があるため、ここで確実に
+    // 書き切ってから返す
     cache
         .store_variant(&req.cache_key(), bytes.clone(), &content_type)
         .await;
     Ok((bytes, content_type))
 }
 
-fn ok_response(bytes: Vec<u8>, content_type: &str, etag: &str) -> tauri::http::Response<Vec<u8>> {
-    tauri::http::Response::builder()
-        .status(tauri::http::StatusCode::OK)
-        .header("Content-Type", content_type)
-        .header("Cache-Control", CACHE_CONTROL)
-        .header("ETag", etag)
-        // 効果音は fetch() + decodeAudioData で読むため CORS が要る。
-        // img と違い ACAO が無いと access control で弾かれる。
-        // custom protocol は WebView 内からしか到達できないので * で安全
-        .header("Access-Control-Allow-Origin", "*")
-        .body(bytes)
-        .unwrap_or_else(|_| internal_error())
-}
-
-fn placeholder_response() -> tauri::http::Response<Vec<u8>> {
-    tauri::http::Response::builder()
-        .status(tauri::http::StatusCode::OK)
-        .header("Content-Type", "image/gif")
-        // 仮応答をどの層にもキャッシュさせない (本物はイベント後の再要求で返す)
-        .header("Cache-Control", "no-store")
-        .header("Access-Control-Allow-Origin", "*")
-        .header("X-ND-Pending", "1")
-        .body(PLACEHOLDER_GIF.to_vec())
-        .unwrap_or_else(|_| internal_error())
-}
-
-const CACHE_CONTROL: &str = "public, max-age=86400, immutable";
-
-fn error_response(
-    status: tauri::http::StatusCode,
-    message: &str,
-) -> tauri::http::Response<Vec<u8>> {
-    tauri::http::Response::builder()
-        .status(status)
-        // 失敗も fetch 側で読めるようにする (CORS で潰れると原因が見えない)
-        .header("Access-Control-Allow-Origin", "*")
-        .header("Content-Type", "text/plain; charset=utf-8")
-        .body(message.as_bytes().to_vec())
-        .unwrap_or_else(|_| internal_error())
-}
-
-fn internal_error() -> tauri::http::Response<Vec<u8>> {
-    tauri::http::Response::new(Vec::new())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn parses_url_with_transform_params() {
-        let req =
-            MediaRequest::from_query("url=https%3A%2F%2Fexample.com%2Fa.png&w=56&format=webp")
-                .expect("should parse");
-        assert_eq!(req.url, "https://example.com/a.png");
-        assert_eq!(req.w, Some(56));
-        assert_eq!(req.h, None);
-        assert_eq!(req.format.as_deref(), Some("webp"));
-        assert!(req.wants_transform());
-    }
-
-    /// 絵文字経路は h (最大高さ) だけを指定する (#921)
-    #[test]
-    fn parses_height_param() {
-        let req = MediaRequest::from_query("url=https%3A%2F%2Fexample.com%2Fa.png&h=128")
-            .expect("should parse");
-        assert_eq!(req.w, None);
-        assert_eq!(req.h, Some(128));
-        assert!(req.wants_transform());
-    }
-
-    #[test]
-    fn rejects_non_https_url() {
-        assert!(MediaRequest::from_query("url=http%3A%2F%2Fexample.com%2Fa.png").is_none());
-        assert!(MediaRequest::from_query("url=file%3A%2F%2F%2Fetc%2Fpasswd").is_none());
-        assert!(MediaRequest::from_query("w=56").is_none());
+    fn req(url: &str, w: Option<u32>, h: Option<u32>, format: Option<&str>) -> MediaRequest {
+        MediaRequest {
+            url: url.to_string(),
+            w,
+            h,
+            format: format.map(str::to_string),
+        }
     }
 
     #[test]
     fn cache_key_separates_sizes() {
-        let plain = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png").unwrap();
-        let sized = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").unwrap();
-        let bigger = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=112").unwrap();
-        let tall = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&h=128").unwrap();
+        let plain = req("https://e.com/a.png", None, None, None);
+        let sized = req("https://e.com/a.png", Some(56), None, None);
+        let bigger = req("https://e.com/a.png", Some(112), None, None);
+        let tall = req("https://e.com/a.png", None, Some(128), None);
         assert_ne!(plain.cache_key(), sized.cache_key());
         assert_ne!(sized.cache_key(), bigger.cache_key());
         assert_ne!(sized.etag(), bigger.etag());
         assert_ne!(tall.cache_key(), plain.cache_key());
         assert_ne!(tall.cache_key(), sized.cache_key());
         assert!(!plain.wants_transform());
+        assert!(tall.wants_transform());
     }
 
     /// h 導入前からある variant (アバター等の w 指定) のキーは変えない。
     /// 変わると更新直後に全端末で再変換 + ディスクの二重保存が走る
     #[test]
     fn cache_key_is_stable_for_width_only_requests() {
-        let sized = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").unwrap();
+        let sized = req("https://e.com/a.png", Some(56), None, None);
         assert_eq!(sized.cache_key(), "https://e.com/a.png|w=56|f=");
     }
 
@@ -710,14 +374,6 @@ mod tests {
             .expect("explicit format must be honored");
         let img = image::load_from_memory(&out).expect("must decode");
         assert_eq!((img.width(), img.height()), (40, 10));
-    }
-
-    /// フェーズ 1 の仮応答が本物の画像としてデコードできること
-    /// (壊れたバイト列だと WebView が broken image を描いてしまう)
-    #[test]
-    fn placeholder_gif_is_valid_1x1() {
-        let img = image::load_from_memory(PLACEHOLDER_GIF).expect("must decode");
-        assert_eq!((img.width(), img.height()), (1, 1));
     }
 
     /// 寸法が大きすぎる画像はデコードを拒否して原本のまま返す (None)。
@@ -797,8 +453,7 @@ mod tests {
             .store_variant(url, png_bytes(200, 200), "image/png")
             .await;
 
-        let req =
-            MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").expect("should parse");
+        let req = req("https://e.com/a.png", Some(56), None, None);
         let (bytes, content_type) = ensure_media_inner(&cache, &req)
             .await
             .expect("cached original should transform without network");
@@ -811,10 +466,12 @@ mod tests {
     /// 効果音は変換パラメータを持たないので素通しになる
     #[test]
     fn sound_url_passes_through_without_transform() {
-        let req = MediaRequest::from_query(
-            "url=https%3A%2F%2Fmisskey.example%2Fclient-assets%2Fsounds%2Fn-aec.mp3",
-        )
-        .expect("should parse");
+        let req = req(
+            "https://misskey.example/client-assets/sounds/n-aec.mp3",
+            None,
+            None,
+            None,
+        );
         assert!(!req.wants_transform());
         assert_eq!(req.cache_key(), req.url);
     }

--- a/src-tauri/src/media_proxy.rs
+++ b/src-tauri/src/media_proxy.rs
@@ -47,6 +47,11 @@ pub struct MediaRequest {
     pub url: String,
     /// サムネイル生成時の最大幅
     pub w: Option<u32>,
+    /// サムネイル生成時の最大高さ。絵文字は横長が普通に存在する資産なので、
+    /// 絵文字経路は幅ではなく高さで丸める (本家 media-proxy の `emoji=1` =
+    /// 最大高さ 128px と同じ意味論、#921)。幅基準だと横長絵文字の高さが
+    /// 潰れ、表示側の引き伸ばしで荒れる
+    pub h: Option<u32>,
     /// 出力形式 ("webp" で変換)
     pub format: Option<String>,
 }
@@ -57,11 +62,13 @@ impl MediaRequest {
     pub fn from_query(query: &str) -> Option<Self> {
         let mut url = None;
         let mut w = None;
+        let mut h = None;
         let mut format = None;
         for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
             match key.as_ref() {
                 "url" => url = Some(value.into_owned()),
                 "w" => w = value.parse::<u32>().ok(),
+                "h" => h = value.parse::<u32>().ok(),
                 "format" => format = Some(value.into_owned()),
                 _ => {}
             }
@@ -71,19 +78,27 @@ impl MediaRequest {
         if !url.starts_with("https://") {
             return None;
         }
-        Some(Self { url, w, format })
+        Some(Self { url, w, h, format })
     }
 
-    /// 変換パラメータもキーに含める (サイズ違いを別エントリとして扱う)
+    /// 変換パラメータもキーに含める (サイズ違いを別エントリとして扱う)。
+    /// `h` は指定時のみ付ける — h 導入前からある variant (アバター等の w 指定)
+    /// のキーを変えると、更新直後に全端末で再変換とディスクの二重保存が走る
     pub fn cache_key(&self) -> String {
-        match (&self.w, &self.format) {
-            (None, None) => self.url.clone(),
-            _ => format!(
-                "{}|w={}|f={}",
-                self.url,
-                self.w.unwrap_or(0),
-                self.format.as_deref().unwrap_or("")
-            ),
+        match (&self.w, &self.h, &self.format) {
+            (None, None, None) => self.url.clone(),
+            _ => {
+                let mut key = format!(
+                    "{}|w={}|f={}",
+                    self.url,
+                    self.w.unwrap_or(0),
+                    self.format.as_deref().unwrap_or("")
+                );
+                if let Some(h) = self.h {
+                    key.push_str(&format!("|h={h}"));
+                }
+                key
+            }
         }
     }
 
@@ -92,7 +107,7 @@ impl MediaRequest {
     }
 
     pub fn wants_transform(&self) -> bool {
-        self.w.is_some() || self.format.is_some()
+        self.w.is_some() || self.h.is_some() || self.format.is_some()
     }
 }
 
@@ -152,12 +167,17 @@ fn image_dimensions(data: &[u8]) -> Option<(u32, u32)> {
 
 /// Apply resize and/or format conversion to raw image bytes.
 /// Returns (transformed_bytes, content_type) or None if no transform needed / failed.
+///
+/// `max_width` / `max_height` は「収まる箱」の指定 (アスペクト維持・拡大しない)。
+/// 片方だけなら他方は無制限 — 絵文字は `max_height` のみ指定し、横長でも
+/// 高さが潰れないようにする (本家 media-proxy と同じ意味論、#921)。
 pub fn transform_image(
     data: &[u8],
     max_width: Option<u32>,
+    max_height: Option<u32>,
     target_format: Option<&str>,
 ) -> Option<(Vec<u8>, String)> {
-    let needs_resize = max_width.is_some();
+    let needs_resize = max_width.is_some() || max_height.is_some();
     let needs_webp = target_format == Some("webp");
     if !needs_resize && !needs_webp {
         return None;
@@ -177,11 +197,11 @@ pub fn transform_image(
     // format が明示されている場合はスキップしない。HTTP API (`/proxy/image`) は
     // 外部 principal にも開いており、webp を要求されたのに元形式を返すと契約違反。
     if target_format.is_none() {
-        if let Some(w) = max_width {
-            if let Some((width, _)) = image_dimensions(data) {
-                if width <= w {
-                    return None;
-                }
+        if let Some((width, height)) = image_dimensions(data) {
+            let fits_w = max_width.is_none_or(|w| width <= w);
+            let fits_h = max_height.is_none_or(|h| height <= h);
+            if fits_w && fits_h {
+                return None;
             }
         }
     }
@@ -195,9 +215,11 @@ pub fn transform_image(
     reader.limits(limits);
     let img = reader.decode().ok()?;
 
-    let img = if let Some(w) = max_width {
-        if img.width() > w {
-            img.resize(w, u32::MAX, image::imageops::FilterType::Triangle)
+    let img = if needs_resize {
+        let box_w = max_width.unwrap_or(u32::MAX);
+        let box_h = max_height.unwrap_or(u32::MAX);
+        if img.width() > box_w || img.height() > box_h {
+            img.resize(box_w, box_h, image::imageops::FilterType::Triangle)
         } else {
             img
         }
@@ -228,11 +250,14 @@ async fn apply_transform(
         return Ok((data, content_type));
     }
     let w = req.w;
+    let h = req.h;
     let format = req.format.clone();
-    tokio::task::spawn_blocking(move || match transform_image(&data, w, format.as_deref()) {
-        Some(transformed) => transformed,
-        None => (data, content_type),
-    })
+    tokio::task::spawn_blocking(
+        move || match transform_image(&data, w, h, format.as_deref()) {
+            Some(transformed) => transformed,
+            None => (data, content_type),
+        },
+    )
     .await
     // JoinError は closure の panic のみ (release は panic = "abort" が先に
     // 効く)。空バイト列を成功として返すと variant に永続化されて TTL の間
@@ -327,7 +352,10 @@ async fn handle_uri_request_inner(
         }
     }
 
-    // ImageCache は setup で manage されるため、起動直後は未登録でありうる
+    // ImageCache は Phase 1 (ウィンドウ表示前) で manage されるため通常は
+    // 必ず居るが、setup 失敗系の防御として残す (#921 で Phase 2 から前倒し —
+    // 以前は起動直後の絵文字要求がここで 503 になり、unknown アイコンが
+    // カラム再 mount まで焼き付いていた)
     let Some(cache) = app.try_state::<Arc<ImageCache>>() else {
         return error_response(
             tauri::http::StatusCode::SERVICE_UNAVAILABLE,
@@ -567,7 +595,18 @@ mod tests {
                 .expect("should parse");
         assert_eq!(req.url, "https://example.com/a.png");
         assert_eq!(req.w, Some(56));
+        assert_eq!(req.h, None);
         assert_eq!(req.format.as_deref(), Some("webp"));
+        assert!(req.wants_transform());
+    }
+
+    /// 絵文字経路は h (最大高さ) だけを指定する (#921)
+    #[test]
+    fn parses_height_param() {
+        let req = MediaRequest::from_query("url=https%3A%2F%2Fexample.com%2Fa.png&h=128")
+            .expect("should parse");
+        assert_eq!(req.w, None);
+        assert_eq!(req.h, Some(128));
         assert!(req.wants_transform());
     }
 
@@ -583,10 +622,21 @@ mod tests {
         let plain = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png").unwrap();
         let sized = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").unwrap();
         let bigger = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=112").unwrap();
+        let tall = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&h=128").unwrap();
         assert_ne!(plain.cache_key(), sized.cache_key());
         assert_ne!(sized.cache_key(), bigger.cache_key());
         assert_ne!(sized.etag(), bigger.etag());
+        assert_ne!(tall.cache_key(), plain.cache_key());
+        assert_ne!(tall.cache_key(), sized.cache_key());
         assert!(!plain.wants_transform());
+    }
+
+    /// h 導入前からある variant (アバター等の w 指定) のキーは変えない。
+    /// 変わると更新直後に全端末で再変換 + ディスクの二重保存が走る
+    #[test]
+    fn cache_key_is_stable_for_width_only_requests() {
+        let sized = MediaRequest::from_query("url=https%3A%2F%2Fe.com%2Fa.png&w=56").unwrap();
+        assert_eq!(sized.cache_key(), "https://e.com/a.png|w=56|f=");
     }
 
     fn png_bytes(w: u32, h: u32) -> Vec<u8> {
@@ -602,26 +652,63 @@ mod tests {
     /// Misskey のアバターはサーバー側で縮小済みなので、この経路が大半を占める。
     #[test]
     fn skips_transform_when_already_within_limit() {
-        assert!(transform_image(&png_bytes(32, 32), Some(56), None).is_none());
+        assert!(transform_image(&png_bytes(32, 32), Some(56), None, None).is_none());
         // ちょうど上限も変換しない
-        assert!(transform_image(&png_bytes(56, 56), Some(56), None).is_none());
+        assert!(transform_image(&png_bytes(56, 56), Some(56), None, None).is_none());
     }
 
     /// format を明示されたら縮まなくても変換する。HTTP API は外部にも開いて
     /// いるので、webp を要求されたのに元形式を返すのは契約違反。
     #[test]
     fn honors_explicit_format_even_when_small() {
-        let (_, ct) = transform_image(&png_bytes(32, 32), Some(56), Some("webp"))
+        let (_, ct) = transform_image(&png_bytes(32, 32), Some(56), None, Some("webp"))
             .expect("explicit format must be honored");
         assert_eq!(ct, "image/webp");
     }
 
     #[test]
     fn transforms_when_wider_than_limit() {
-        let (out, ct) = transform_image(&png_bytes(200, 200), Some(56), Some("webp"))
+        let (out, ct) = transform_image(&png_bytes(200, 200), Some(56), None, Some("webp"))
             .expect("should transform");
         assert_eq!(ct, "image/webp");
         assert!(!out.is_empty());
+    }
+
+    /// 横長絵文字の核心 (#921): h だけ指定すると幅は制限されず、アスペクト
+    /// 維持で高さが h に丸まる。旧実装 (w=64 固定) は 512×128 を 64×16 に
+    /// 潰していた
+    #[test]
+    fn height_only_resize_preserves_wide_aspect() {
+        let (out, ct) =
+            transform_image(&png_bytes(400, 100), None, Some(50), None).expect("should transform");
+        assert_eq!(ct, "image/webp");
+        let img = image::load_from_memory(&out).expect("must decode");
+        assert_eq!((img.width(), img.height()), (200, 50));
+    }
+
+    /// 高さが収まっている横長画像は、幅がどれだけ大きくても素通し
+    /// (h 基準では幅を理由に再エンコードしない)
+    #[test]
+    fn skips_wide_image_when_height_within_limit() {
+        assert!(transform_image(&png_bytes(400, 100), None, Some(128), None).is_none());
+    }
+
+    /// w と h の両指定は「収まる箱」: きつい方の辺が効く
+    #[test]
+    fn width_and_height_fit_within_box() {
+        let (out, _) = transform_image(&png_bytes(400, 100), Some(100), Some(50), None)
+            .expect("should transform");
+        let img = image::load_from_memory(&out).expect("must decode");
+        assert_eq!((img.width(), img.height()), (100, 25));
+    }
+
+    /// format 明示で変換は走っても拡大はしない (小さい原本はそのままの寸法)
+    #[test]
+    fn never_upscales_small_images() {
+        let (out, _) = transform_image(&png_bytes(40, 10), None, Some(50), Some("webp"))
+            .expect("explicit format must be honored");
+        let img = image::load_from_memory(&out).expect("must decode");
+        assert_eq!((img.width(), img.height()), (40, 10));
     }
 
     /// フェーズ 1 の仮応答が本物の画像としてデコードできること
@@ -639,7 +726,7 @@ mod tests {
     fn refuses_decode_of_oversized_dimensions() {
         // 高さ 2px なのでテスト自体のメモリは軽い
         let wide = png_bytes(MAX_DECODE_DIMENSION + 1, 2);
-        assert!(transform_image(&wide, Some(56), Some("webp")).is_none());
+        assert!(transform_image(&wide, Some(56), None, Some("webp")).is_none());
     }
 
     /// アニメーションの可能性がある形式は変換で 1 フレーム目に潰れるため、
@@ -656,7 +743,7 @@ mod tests {
             drop(enc);
             buf.into_inner()
         };
-        assert!(transform_image(&gif, Some(56), Some("webp")).is_none());
+        assert!(transform_image(&gif, Some(56), None, Some("webp")).is_none());
 
         // APNG: IDAT より前の acTL チャンクで判定 (CRC は見ない)
         let mut apng = png_bytes(100, 100);
@@ -666,7 +753,7 @@ mod tests {
         actl.extend_from_slice(&[0u8; 12]); // frames(4) + plays(4) + crc(4)
         apng.splice(33..33, actl); // IHDR 直後 (8 sig + 25 IHDR chunk)
         assert!(may_be_animated(&apng));
-        assert!(transform_image(&apng, Some(56), Some("webp")).is_none());
+        assert!(transform_image(&apng, Some(56), None, Some("webp")).is_none());
 
         // Animated WebP: ヘッダ近傍の ANIM チャンク
         let mut awebp = Vec::new();

--- a/src-tauri/src/notify_media.rs
+++ b/src-tauri/src/notify_media.rs
@@ -39,6 +39,7 @@ pub async fn ensure_local_file(cache: &ImageCache, url: &str, w: Option<u32>) ->
     let req = MediaRequest {
         url: url.to_string(),
         w,
+        h: None,
         format: None,
     };
     let key = req.cache_key();
@@ -60,6 +61,7 @@ pub async fn ensure_bytes(cache: &ImageCache, url: &str) -> Option<Vec<u8>> {
     let req = MediaRequest {
         url: url.to_string(),
         w: None,
+        h: None,
         format: None,
     };
     crate::media_proxy::ensure_media_inner(cache, &req)

--- a/src-tauri/src/notify_media.rs
+++ b/src-tauri/src/notify_media.rs
@@ -1,7 +1,7 @@
 //! OS 通知に添付するメディアの取得口。
 //!
 //! 通知画像 (アバター・リアクション絵文字) は WebView の外 (OS の通知
-//! システム) で描画されるため custom protocol (`ndmedia`) を通せない。
+//! システム) で描画されるため WebView の画像プロキシを通せない。
 //! かつては各プラットフォームが独自に fetch していた (Android は Kotlin の
 //! HttpURLConnection で原寸 DL、デスクトップは os_notify 専用の reqwest) が、
 //! ImageCache の防御 (ディスク/メモリキャッシュ・in-flight dedup・negative

--- a/src-tauri/src/os_notify.rs
+++ b/src-tauri/src/os_notify.rs
@@ -205,7 +205,7 @@ mod desktop {
         }
         let bytes = tauri::async_runtime::block_on(crate::notify_media::ensure_bytes(cache, url))?;
         // 寸法上限なしの decode は巨大 PNG の RGBA 展開でメモリを食い潰す。
-        // ndmedia の変換 (media_proxy::transform_image) と同じ上限を掛ける
+        // 画像プロキシの変換 (media_proxy::transform_image) と同じ上限を掛ける
         let mut reader = image::ImageReader::new(std::io::Cursor::new(&bytes))
             .with_guessed_format()
             .ok()?;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.37.0",
+  "version": "1.38.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
     "enableGTKAppId": false,
     "macOSPrivateApi": false,
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; worker-src 'self' blob: data:; style-src 'self' 'unsafe-inline' https://*; img-src 'self' asset: http://asset.localhost ndmedia: http://ndmedia.localhost data: blob: https://* http://127.0.0.1:19820; media-src 'self' ndmedia: http://ndmedia.localhost https://*; font-src 'self' data: https://*; connect-src ipc: http://ipc.localhost http://tauri.localhost ndmedia: http://ndmedia.localhost http://127.0.0.1:19820 http://localhost:* https://* data: blob:; frame-src http://127.0.0.1:19820 https://*",
+      "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; worker-src 'self' blob: data:; style-src 'self' 'unsafe-inline' https://*; img-src 'self' asset: http://asset.localhost data: blob: https://* http://127.0.0.1:19820; media-src 'self' http://127.0.0.1:19820 https://*; font-src 'self' data: https://*; connect-src ipc: http://ipc.localhost http://tauri.localhost http://127.0.0.1:19820 http://localhost:* https://* data: blob:; frame-src http://127.0.0.1:19820 https://*",
       "dangerousDisableAssetCspModification": true
     }
   },

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -2801,7 +2801,6 @@ async permissionsLockdown() : Promise<Result<null, string>> {
 
 export const events = __makeEvents__<{
 exportProgress: ExportProgress,
-mediaFetched: MediaFetched,
 noteCaptureBatch: NoteCaptureBatch,
 notificationClicked: NotificationClicked,
 queryDelta: QueryDelta,
@@ -2812,7 +2811,6 @@ streamEnvelope: StreamEnvelope,
 streamStatus: StreamStatus
 }>({
 exportProgress: "export-progress",
-mediaFetched: "media-fetched",
 noteCaptureBatch: "note-capture-batch",
 notificationClicked: "notification-clicked",
 queryDelta: "query-delta",
@@ -3187,13 +3185,6 @@ export type HttpFetchResponse = { status: number; headers: Partial<{ [key in str
  */
 export type ImageCacheStats = { bytes: number; files: number }
 export type JsonValue = null | boolean | number | string | JsonValue[] | Partial<{ [key in string]: JsonValue }>
-/**
- * 二段階配信 (フェーズ 2) の背景取得が終わったことをフロントへ知らせる。
- * mediaProxy.ts がこれを受けて該当 URL の `<img>` に再要求させる
- * (成否によらず emit する。失敗時の再要求は negative cache が 502 で
- * 受け止め、`onerror` フォールバックに繋がる)。
- */
-export type MediaFetched = { url: string; ok: boolean }
 /**
  * Misskey の `mutedWords` / `hardMutedWords` の 1 要素。
  * 文字列配列なら AND 語群（全語含むとマッチ）、文字列なら `/regex/flags` 形式の正規表現。

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, reactive, ref, watch, watchEffect } from 'vue'
 import {
   ACCOUNT_INDEPENDENT_TYPES,
   ACCOUNT_OPTIONAL_TYPES,
@@ -61,6 +61,19 @@ const expandedCategories = reactive<Record<string, boolean>>({})
 function toggleCategory(key: string) {
   expandedCategories[key] = !expandedCategories[key]
 }
+
+// spotlight (チュートリアル) が特定のカラム種別を指しているときは、その種別を
+// 含むカテゴリを開いておく。閉じたままだと種別ボタンが DOM に存在せず、
+// 光らせる対象が無いまま手順が進まなくなる。開くだけで閉じないので、
+// spotlight が無いときの既定 (全て閉じる) は変わらない
+watchEffect(() => {
+  for (const g of COLUMN_TYPE_GROUPS) {
+    const spotlighted = g.types.some((t) =>
+      spotlightStore.spotlights.has(commandItemTargetId(`col-${t}`)),
+    )
+    if (spotlighted) expandedCategories[g.group] = true
+  }
+})
 
 const addColumnType = ref<ColumnType | null>(null)
 

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -56,9 +56,18 @@ function finalizeColumn(config: Omit<DeckColumn, 'id'>) {
   }
 }
 
-const expandedCategories = reactive<Record<string, boolean>>({
-  account: true,
-})
+const expandedCategories = reactive<Record<string, boolean>>({})
+
+/**
+ * 型を選ぶ前に対象アカウントを決めておくチップ行。
+ * 1 件以下では selectColumnType 側の自動選択が働くので出さない。
+ */
+const showAccountChips = computed(() => accountsStore.accounts.length >= 2)
+const pickedAccountId = ref<string | null>(accountsStore.activeAccountId)
+const pickedAccount = computed(
+  () =>
+    accountsStore.accounts.find((a) => a.id === pickedAccountId.value) ?? null,
+)
 
 function toggleCategory(key: string) {
   expandedCategories[key] = !expandedCategories[key]
@@ -84,6 +93,26 @@ function selectColumnType(type: ColumnType) {
   // Account-optional types: always show selection screen so user can choose "no account"
   if (ACCOUNT_OPTIONAL_TYPES.has(type)) return
   const authRequired = !GUEST_ALLOWED_TYPES.has(type)
+  // チップで対象を決めてある場合は選択画面を挟まず確定する
+  if (showAccountChips.value) {
+    const picked = pickedAccount.value
+    if (!picked) {
+      // 「全アカウント」— per-account 専用型は対象を選べないので選択画面へ
+      if (CROSS_ACCOUNT_TYPES.has(type)) addColumnForAccount(null)
+      return
+    }
+    if (isGuestAccount(picked) && authRequired) {
+      addColumnType.value = null
+      useToast().show('ゲストアカウントではこのカラムを使えません', 'info')
+      return
+    }
+    if (!picked.hasToken && authRequired) {
+      showLoginPrompt()
+      return
+    }
+    addColumnForAccount(picked.id)
+    return
+  }
   const accounts = accountsStore.accounts.filter(
     (a) => !(authRequired && isGuestAccount(a)),
   )
@@ -319,6 +348,31 @@ function close() {
 
       <!-- Step 1: Column type selection -->
       <template v-if="!addColumnType">
+        <div v-if="showAccountChips" :class="$style.chipBar">
+          <div :class="$style.chipRow">
+            <button
+              v-for="account in accountsStore.accounts"
+              :key="account.id"
+              class="_button"
+              :class="[$style.chip, { [$style.chipActive]: pickedAccountId === account.id }]"
+              :title="getAccountLabel(account)"
+              @click="pickedAccountId = account.id"
+            >
+              <img :src="getAccountAvatarUrl(account)" :class="$style.chipAvatar" />
+            </button>
+            <button
+              class="_button"
+              :class="[$style.chip, { [$style.chipActive]: pickedAccountId === null }]"
+              title="全アカウント"
+              @click="pickedAccountId = null"
+            >
+              <AvatarStack :size="28" />
+            </button>
+          </div>
+          <div :class="$style.chipLabel">
+            {{ pickedAccount ? getAccountLabel(pickedAccount) : '全アカウント' }}
+          </div>
+        </div>
         <div
           v-for="g in COLUMN_TYPE_GROUPS"
           :key="g.group"
@@ -521,6 +575,62 @@ function close() {
   align-items: center;
   justify-content: center;
   padding: 2rem;
+}
+
+.chipBar {
+  padding: 12px 24px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.chipRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.chip {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 2px;
+  border: 2px solid transparent;
+  // 「全アカウント」は AvatarStack が横長になるため pill 型で受ける
+  border-radius: 999px;
+  opacity: 0.5;
+  transition:
+    opacity var(--nd-duration-base),
+    border-color var(--nd-duration-base);
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.chipActive {
+  border-color: var(--nd-accent);
+  opacity: 1;
+}
+
+.chipAvatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+}
+
+.chipLabel {
+  margin-top: 8px;
+  font-size: 0.8em;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .addAccountBtn {

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -79,9 +79,6 @@ function resolveAccountServerIcon(host: string): string {
   return proxyThumbUrl(url, 28) ?? url
 }
 
-/** favicon を持たないサーバーは壊れた画像を出さずバッジごと省く。 */
-const badgeFailedHosts = reactive(new Set<string>())
-
 function toggleCategory(key: string) {
   expandedCategories[key] = !expandedCategories[key]
 }
@@ -374,10 +371,9 @@ function close() {
               <span :class="$style.chipAvatarWrap">
                 <img :src="getAccountAvatarUrl(account)" :class="$style.chipAvatar" />
                 <img
-                  v-if="!badgeFailedHosts.has(account.host)"
                   :src="resolveAccountServerIcon(account.host)"
                   :class="$style.chipServerBadge"
-                  @error="badgeFailedHosts.add(account.host)"
+                  @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
                 />
               </span>
             </button>

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -30,10 +30,8 @@ import {
 } from '@/stores/accounts'
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
-import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { logWarn } from '@/utils/logger'
-import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const props = defineProps<{
@@ -47,7 +45,6 @@ const emit = defineEmits<{
 
 const deckStore = useDeckStore()
 const accountsStore = useAccountsStore()
-const serversStore = useServersStore()
 const spotlightStore = useSpotlightStore()
 
 function finalizeColumn(config: Omit<DeckColumn, 'id'>) {
@@ -60,24 +57,6 @@ function finalizeColumn(config: Omit<DeckColumn, 'id'>) {
 }
 
 const expandedCategories = reactive<Record<string, boolean>>({})
-
-/**
- * 型を選ぶ前に対象アカウントを決めておくチップ行。
- * 1 件以下では selectColumnType 側の自動選択が働くので出さない。
- */
-const showAccountChips = computed(() => accountsStore.accounts.length >= 2)
-const pickedAccountId = ref<string | null>(accountsStore.activeAccountId)
-const pickedAccount = computed(
-  () =>
-    accountsStore.accounts.find((a) => a.id === pickedAccountId.value) ?? null,
-)
-
-/** チップのアバターに重ねるサーバー favicon URL を解決する。 */
-function resolveAccountServerIcon(host: string): string {
-  const url =
-    serversStore.servers.get(host)?.iconUrl || `https://${host}/favicon.ico`
-  return proxyThumbUrl(url, 28) ?? url
-}
 
 function toggleCategory(key: string) {
   expandedCategories[key] = !expandedCategories[key]
@@ -103,26 +82,6 @@ function selectColumnType(type: ColumnType) {
   // Account-optional types: always show selection screen so user can choose "no account"
   if (ACCOUNT_OPTIONAL_TYPES.has(type)) return
   const authRequired = !GUEST_ALLOWED_TYPES.has(type)
-  // チップで対象を決めてある場合は選択画面を挟まず確定する
-  if (showAccountChips.value) {
-    const picked = pickedAccount.value
-    if (!picked) {
-      // 「全アカウント」— per-account 専用型は対象を選べないので選択画面へ
-      if (CROSS_ACCOUNT_TYPES.has(type)) addColumnForAccount(null)
-      return
-    }
-    if (isGuestAccount(picked) && authRequired) {
-      addColumnType.value = null
-      useToast().show('ゲストアカウントではこのカラムを使えません', 'info')
-      return
-    }
-    if (!picked.hasToken && authRequired) {
-      showLoginPrompt()
-      return
-    }
-    addColumnForAccount(picked.id)
-    return
-  }
   const accounts = accountsStore.accounts.filter(
     (a) => !(authRequired && isGuestAccount(a)),
   )
@@ -358,38 +317,6 @@ function close() {
 
       <!-- Step 1: Column type selection -->
       <template v-if="!addColumnType">
-        <div v-if="showAccountChips" :class="$style.chipBar">
-          <div :class="$style.chipRow">
-            <button
-              v-for="account in accountsStore.accounts"
-              :key="account.id"
-              class="_button"
-              :class="[$style.chip, { [$style.chipActive]: pickedAccountId === account.id }]"
-              :title="getAccountLabel(account)"
-              @click="pickedAccountId = account.id"
-            >
-              <span :class="$style.chipAvatarWrap">
-                <img :src="getAccountAvatarUrl(account)" :class="$style.chipAvatar" />
-                <img
-                  :src="resolveAccountServerIcon(account.host)"
-                  :class="$style.chipServerBadge"
-                  @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'"
-                />
-              </span>
-            </button>
-            <button
-              class="_button"
-              :class="[$style.chip, { [$style.chipActive]: pickedAccountId === null }]"
-              title="全アカウント"
-              @click="pickedAccountId = null"
-            >
-              <AvatarStack :size="28" />
-            </button>
-          </div>
-          <div :class="$style.chipLabel">
-            {{ pickedAccount ? getAccountLabel(pickedAccount) : '全アカウント' }}
-          </div>
-        </div>
         <div
           v-for="g in COLUMN_TYPE_GROUPS"
           :key="g.group"
@@ -485,7 +412,9 @@ function close() {
           :class="$style.addAccountBtn"
           @click="addColumnForAccount(null)"
         >
-          <AvatarStack :size="28" />
+          <!-- 「全アカウント」は文字どおり全件重ねる (既定の 3 件打ち切りだと
+               4 件目以降が含まれないように見える) -->
+          <AvatarStack :size="28" :max="accountsStore.accounts.length" />
           <span>全アカウント</span>
         </button>
         <button
@@ -592,85 +521,6 @@ function close() {
   align-items: center;
   justify-content: center;
   padding: 2rem;
-}
-
-.chipBar {
-  padding: 12px 24px;
-  border-bottom: 1px solid var(--nd-divider);
-}
-
-.chipRow {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  // overflow-x: auto は overflow-y も auto にするため、バッジの影が
-  // 切れないよう上下に余白を確保する
-  padding: 2px 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-
-  &::-webkit-scrollbar {
-    display: none;
-  }
-}
-
-.chip {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  padding: 2px;
-  border: 2px solid transparent;
-  // 「全アカウント」は AvatarStack が横長になるため pill 型で受ける
-  border-radius: 999px;
-  opacity: 0.5;
-  transition:
-    opacity var(--nd-duration-base),
-    border-color var(--nd-duration-base);
-
-  &:hover {
-    opacity: 0.8;
-  }
-}
-
-.chipActive {
-  border-color: var(--nd-accent);
-  opacity: 1;
-}
-
-.chipAvatarWrap {
-  position: relative;
-  display: flex;
-}
-
-.chipAvatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  object-fit: cover;
-}
-
-.chipServerBadge {
-  position: absolute;
-  top: -3px;
-  right: -4px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  object-fit: contain;
-  background: var(--nd-panel);
-  box-shadow: 0 0 0 2px var(--nd-panel);
-  user-select: none;
-  -webkit-user-select: none;
-}
-
-.chipLabel {
-  margin-top: 8px;
-  font-size: 0.8em;
-  color: var(--nd-fg);
-  opacity: 0.7;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .addAccountBtn {

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -30,8 +30,10 @@ import {
 } from '@/stores/accounts'
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { logWarn } from '@/utils/logger'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const props = defineProps<{
@@ -45,6 +47,7 @@ const emit = defineEmits<{
 
 const deckStore = useDeckStore()
 const accountsStore = useAccountsStore()
+const serversStore = useServersStore()
 const spotlightStore = useSpotlightStore()
 
 function finalizeColumn(config: Omit<DeckColumn, 'id'>) {
@@ -68,6 +71,16 @@ const pickedAccount = computed(
   () =>
     accountsStore.accounts.find((a) => a.id === pickedAccountId.value) ?? null,
 )
+
+/** チップのアバターに重ねるサーバー favicon URL を解決する。 */
+function resolveAccountServerIcon(host: string): string {
+  const url =
+    serversStore.servers.get(host)?.iconUrl || `https://${host}/favicon.ico`
+  return proxyThumbUrl(url, 28) ?? url
+}
+
+/** favicon を持たないサーバーは壊れた画像を出さずバッジごと省く。 */
+const badgeFailedHosts = reactive(new Set<string>())
 
 function toggleCategory(key: string) {
   expandedCategories[key] = !expandedCategories[key]
@@ -358,7 +371,15 @@ function close() {
               :title="getAccountLabel(account)"
               @click="pickedAccountId = account.id"
             >
-              <img :src="getAccountAvatarUrl(account)" :class="$style.chipAvatar" />
+              <span :class="$style.chipAvatarWrap">
+                <img :src="getAccountAvatarUrl(account)" :class="$style.chipAvatar" />
+                <img
+                  v-if="!badgeFailedHosts.has(account.host)"
+                  :src="resolveAccountServerIcon(account.host)"
+                  :class="$style.chipServerBadge"
+                  @error="badgeFailedHosts.add(account.host)"
+                />
+              </span>
             </button>
             <button
               class="_button"
@@ -586,6 +607,9 @@ function close() {
   display: flex;
   align-items: center;
   gap: 10px;
+  // overflow-x: auto は overflow-y も auto にするため、バッジの影が
+  // 切れないよう上下に余白を確保する
+  padding: 2px 0;
   overflow-x: auto;
   scrollbar-width: none;
 
@@ -617,10 +641,30 @@ function close() {
   opacity: 1;
 }
 
+.chipAvatarWrap {
+  position: relative;
+  display: flex;
+}
+
 .chipAvatar {
   width: 28px;
   height: 28px;
   border-radius: 50%;
+  object-fit: cover;
+}
+
+.chipServerBadge {
+  position: absolute;
+  top: -3px;
+  right: -4px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  object-fit: contain;
+  background: var(--nd-panel);
+  box-shadow: 0 0 0 2px var(--nd-panel);
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .chipLabel {

--- a/src/components/window/CssEditorContent.vue
+++ b/src/components/window/CssEditorContent.vue
@@ -80,7 +80,7 @@ const cssCode = ref(themeStore.customCss)
 // Preset toggles (定義・CSS 変換は src/services/cssPresets.ts)
 const presets = ref<CssPresets>(parsePresetsFromCss(cssCode.value))
 
-const expandedSections = reactive<Record<string, boolean>>({ font: true })
+const expandedSections = reactive<Record<string, boolean>>({})
 
 function toggleSection(key: string) {
   expandedSections[key] = !expandedSections[key]

--- a/src/components/window/KeybindsContent.vue
+++ b/src/components/window/KeybindsContent.vue
@@ -154,7 +154,7 @@ const CATEGORY_LABELS: Record<string, { label: string; icon: string }> = {
   profile: { label: 'プロファイル', icon: 'ti-id-badge-2' },
 }
 
-const expandedSections = reactive<Record<string, boolean>>({ general: true })
+const expandedSections = reactive<Record<string, boolean>>({})
 
 function toggleSection(key: string) {
   expandedSections[key] = !expandedSections[key]

--- a/src/components/window/ProfileEditorContent.vue
+++ b/src/components/window/ProfileEditorContent.vue
@@ -41,7 +41,7 @@ const deckStore = useDeckStore()
 const profileStore = useDeckProfileStore()
 const isCompact = useIsCompactLayout()
 
-const expandedSections = reactive<Record<string, boolean>>({ name: true })
+const expandedSections = reactive<Record<string, boolean>>({})
 
 function toggleSection(key: string) {
   expandedSections[key] = !expandedSections[key]

--- a/src/components/window/ThemeEditorContent.vue
+++ b/src/components/window/ThemeEditorContent.vue
@@ -366,7 +366,7 @@ function deleteInstalledTheme(theme: MisskeyTheme, e: Event) {
 }
 
 // Section expand states (default: all collapsed)
-const expandedSections = reactive<Record<string, boolean>>({ info: true })
+const expandedSections = reactive<Record<string, boolean>>({})
 
 function toggleSection(section: string) {
   expandedSections[section] = !expandedSections[section]

--- a/src/components/window/ai-settings/AiConnectionSection.vue
+++ b/src/components/window/ai-settings/AiConnectionSection.vue
@@ -66,7 +66,6 @@ function openConnectionsWindow(): void {
     :badge="currentConnection ? currentConnection.name : '未選択'"
     :badge-icon="currentConnection ? 'ti-shield-check' : 'ti-shield-off'"
     :badge-ok="!!currentConnection"
-    default-expanded
   >
     <div :class="$style.keyHint">
       <i class="ti ti-info-circle" />

--- a/src/components/window/ai-settings/AiSettingsSection.vue
+++ b/src/components/window/ai-settings/AiSettingsSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 
-const props = withDefaults(
+withDefaults(
   defineProps<{
     icon: string
     title: string
@@ -9,17 +9,15 @@ const props = withDefaults(
     badge?: string
     badgeIcon?: string
     badgeOk?: boolean
-    defaultExpanded?: boolean
   }>(),
   {
     badge: undefined,
     badgeIcon: 'ti-info-circle',
     badgeOk: false,
-    defaultExpanded: false,
   },
 )
 
-const expanded = ref(props.defaultExpanded)
+const expanded = ref(false)
 </script>
 
 <template>

--- a/src/composables/useNoteList.dom.test.ts
+++ b/src/composables/useNoteList.dom.test.ts
@@ -70,3 +70,44 @@ describe('useNoteList: 保持上限の切り捨て方向 (#834)', () => {
     expect(list.rawNotes.value).toHaveLength(4)
   })
 })
+
+describe('useNoteList: noteCapture 同期の通知経路 (#939)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  function setup(maxNotes: number) {
+    return useNoteList({
+      getMyUserId: () => 'me',
+      getAdapter: () => null,
+      deleteHandler: async () => false,
+      closePostForm: () => {},
+      maxNotes,
+    })
+  }
+
+  // ストリーミングの新着 flush (useStreamingBatch) は setNotes を通らず
+  // rawNotes setter へ直接書く。通知が setNotes だけにあると、WS で流れ込んだ
+  // ノートが一度も subNote されず、他者リアクションの noteUpdated が届かない
+  it('setter 直書き (ストリーミング flush 相当) でも onNotesChanged が呼ばれる', () => {
+    const list = setup(10)
+    const seen: string[][] = []
+    list.setOnNotesChanged((notes) => seen.push(notes.map((n) => n.id)))
+    list.setNotes(descNotes(2))
+    expect(seen.at(-1)).toEqual(['n0', 'n1'])
+
+    const fresh = makeNote('fresh', new Date(2026, 0, 2).toISOString())
+    list.rawNotes.value = [fresh, ...list.rawNotes.value]
+    expect(seen.at(-1)).toEqual(['fresh', 'n0', 'n1'])
+  })
+
+  it('setNotes の通知は 1 回だけ (setter 経由と二重にならない)', () => {
+    const list = setup(10)
+    let calls = 0
+    list.setOnNotesChanged(() => {
+      calls++
+    })
+    list.setNotes(descNotes(2))
+    expect(calls).toBe(1)
+  })
+})

--- a/src/composables/useNoteList.dom.test.ts
+++ b/src/composables/useNoteList.dom.test.ts
@@ -132,9 +132,12 @@ describe('useNoteList: noteCapture 同期の通知経路 (#939)', () => {
     if (!target) throw new Error('fixture broken')
     await list.removeNote(target)
 
-    // 楽観削除の通知 → 巻き戻しの通知、の順で来る
-    expect(seen.at(-2)).toEqual(['n0', 'n2'])
-    expect(seen.at(-1)).toEqual(['n0', 'n1', 'n2'])
+    // 楽観削除の通知 → 巻き戻しの通知の 2 回ちょうど。全体を突き合わせる
+    // ことで、余分な通知 (購読の無駄な張り直し) の再発も検出する
+    expect(seen).toEqual([
+      ['n0', 'n2'],
+      ['n0', 'n1', 'n2'],
+    ])
     expect(list.rawNotes.value.map((n) => n.id)).toEqual(['n0', 'n1', 'n2'])
   })
 })

--- a/src/composables/useNoteList.dom.test.ts
+++ b/src/composables/useNoteList.dom.test.ts
@@ -110,4 +110,31 @@ describe('useNoteList: noteCapture 同期の通知経路 (#939)', () => {
     list.setNotes(descNotes(2))
     expect(calls).toBe(1)
   })
+
+  // 削除に失敗したら楽観削除を巻き戻すが、そこで購読同期を呼ばないと
+  // 「表示は戻っているのに subNote は外れたまま」になり、そのノートへの
+  // 他者リアクションが以後届かなくなる
+  it('削除失敗で巻き戻したとき、購読同期にノートが戻って通知される', async () => {
+    const pinia = createPinia()
+    setActivePinia(pinia)
+    const list = useNoteList({
+      getMyUserId: () => 'me',
+      getAdapter: () => null,
+      deleteHandler: async () => false, // 削除失敗
+      closePostForm: () => {},
+      maxNotes: 10,
+    })
+    const seen: string[][] = []
+    list.setNotes(descNotes(3))
+    list.setOnNotesChanged((notes) => seen.push(notes.map((n) => n.id)))
+
+    const target = list.rawNotes.value[1]
+    if (!target) throw new Error('fixture broken')
+    await list.removeNote(target)
+
+    // 楽観削除の通知 → 巻き戻しの通知、の順で来る
+    expect(seen.at(-2)).toEqual(['n0', 'n2'])
+    expect(seen.at(-1)).toEqual(['n0', 'n1', 'n2'])
+    expect(list.rawNotes.value.map((n) => n.id)).toEqual(['n0', 'n1', 'n2'])
+  })
 })

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -186,9 +186,10 @@ export function useNoteList(options: UseNoteListOptions) {
           console.debug('[delete-cached-note] ignored:', e)
       })
     } else {
-      orderedIds.value = prevIds
-      noteIds.clear()
-      for (const nid of prevIds) noteIds.add(nid)
+      // 楽観削除の巻き戻し。orderedIds を直接書かずに setter を通す — 直接
+      // 書くと noteCapture の購読同期が走らず、ノートは表示に戻るのに購読は
+      // 外れたままになり、そのノートへの他者リアクションが以後届かなくなる
+      rawNotes.value = noteStore.resolve(prevIds)
     }
   }
 

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -78,6 +78,12 @@ export function useNoteList(options: UseNoteListOptions) {
       for (const id of ids) noteIds.add(id)
       orderedIds.value = ids
       if (inserted.length > 0) suspensionsStore.probeNotes(inserted)
+      // noteCapture の購読同期 (#939)。ストリーミングの新着 flush
+      // (useStreamingBatch) は setNotes を通らず setter へ直接書くため、
+      // setNotes 側で通知すると WS 由来の新着が一度も subNote されず、
+      // 他者リアクションの noteUpdated が届かない。書込経路の合流点である
+      // ここで、可視ノートのみ (= capture の購読対象) を通知する
+      onNotesChangedFn?.(notes.value)
     },
   })
 
@@ -110,8 +116,6 @@ export function useNoteList(options: UseNoteListOptions) {
       trim === 'newest' && newNotes.length > maxNotes
         ? newNotes.slice(newNotes.length - maxNotes)
         : newNotes
-    // 可視ノートのみを通知する（noteCapture の購読対象は表示中ノート）
-    onNotesChangedFn?.(notes.value)
   }
 
   /**

--- a/src/composables/useNoteSound.ts
+++ b/src/composables/useNoteSound.ts
@@ -37,9 +37,9 @@ if (IS_MOBILE && !IS_ANDROID) {
 
 function getSoundUrl(host: string, soundType: string): string {
   const remoteUrl = `https://${host}/client-assets/sounds/${soundType}.mp3`
-  // 画像と同じプロキシに寄せる (モバイルのバイパスも同じ理由で不要になった)。
-  // fetch/Audio 要素は二段階配信のプレースホルダを飲み込めないので wait 指定
-  return proxyUrl(remoteUrl, { wait: true }) ?? remoteUrl
+  // 画像と同じプロキシ (ループバック HTTP) に寄せる。常にブロッキングで
+  // 本物が返るので fetch/Audio 要素でもそのまま使える
+  return proxyUrl(remoteUrl) ?? remoteUrl
 }
 
 async function ensureBuffer(

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -119,10 +119,26 @@ describe('wait オプション (効果音などブロッキング消費者用)',
 })
 
 describe('proxyEmojiUrl (カスタム絵文字の共通サムネイル口)', () => {
-  it('全文脈で同じ幅バケット (64px) に丸めてキャッシュを共有する', async () => {
-    const { proxyEmojiUrl, proxyThumbUrl } = await loadModule()
-    expect(proxyEmojiUrl(REMOTE)).toBe(proxyThumbUrl(REMOTE, 64))
-    expect(proxyEmojiUrl(REMOTE)).toContain('w=64')
+  // 本家 media-proxy の emoji=1 と同じ「最大高さ 128px」基準 (#921)。
+  // 幅基準 (旧 w=64) だと横長絵文字の高さが潰れ、表示 (2em × DPR) の
+  // 引き伸ばしで荒れていた
+  it('全文脈で同じ高さバケット (128px) に丸めてキャッシュを共有する', async () => {
+    const { proxyEmojiUrl } = await loadModule()
+    expect(proxyEmojiUrl(REMOTE)).toBe(
+      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&h=128&wait=1&soft=1`,
+    )
+  })
+
+  it('幅は制限しない (横長絵文字の解像度を潰さない)', async () => {
+    const { proxyEmojiUrl } = await loadModule()
+    expect(proxyEmojiUrl(REMOTE)).not.toContain('w=')
+  })
+
+  it('世代番号は絵文字 URL にも波及する', async () => {
+    const { proxyEmojiUrl, handleMediaFetched } = await loadModule()
+    const base = proxyEmojiUrl(REMOTE) ?? ''
+    handleMediaFetched(REMOTE)
+    expect(proxyEmojiUrl(REMOTE)).toBe(`${base}&r=1`)
   })
 
   it('https 以外は素通し (同梱 twemoji のローカルパス等)', async () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -65,20 +65,27 @@ describe('proxyUrl', () => {
     )
   })
 
-  it('Android は二段階配信 (wait を付けない)', async () => {
+  // Android は wry custom protocol の直列ロックを避け、ループバック HTTP
+  // (#921) に載せる。HTTP ルートは常にブロッキングで本物を返すため
+  // wait/soft パラメータも二段階配信も不要
+  it('Android はループバック HTTP に載せる (直列 custom protocol を通らない)', async () => {
     stubUserAgent(ANDROID_UA)
     const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toContain('ndmedia')
-    expect(proxyUrl(REMOTE)).not.toContain('wait=1')
+    expect(proxyUrl(REMOTE)).toBe(
+      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}`,
+    )
   })
 
-  it.each([
-    ['Android', ANDROID_UA],
-    ['iOS', IOS_UA],
-  ])('%s でもプロキシをバイパスしない', async (_name, ua) => {
-    stubUserAgent(ua)
+  it('iOS は ndmedia のままバイパスしない (ATS で 127.0.0.1 に繋げない)', async () => {
+    stubUserAgent(IOS_UA)
     const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).toContain('ndmedia')
+    expect(proxyUrl(REMOTE)).not.toBe(REMOTE)
+  })
+
+  it('Android でもプロキシをバイパスしない (元 URL 直読みに戻さない)', async () => {
+    stubUserAgent(ANDROID_UA)
+    const { proxyUrl } = await loadModule()
     expect(proxyUrl(REMOTE)).not.toBe(REMOTE)
   })
 
@@ -101,14 +108,14 @@ describe('proxyUrl', () => {
 })
 
 describe('wait オプション (効果音などブロッキング消費者用)', () => {
-  // 二段階配信の Android でも、fetch/Audio 要素はプレースホルダを飲み込め
-  // ないので明示 wait で従来のブロッキングに乗せる
-  it('Android でも明示 wait は wait=1 を付ける', async () => {
+  // Android の HTTP ルートは常にブロッキングで本物を返すため、効果音の
+  // 明示 wait でもパラメータは不要 (プレースホルダがそもそも存在しない)
+  it('Android は明示 wait でもパラメータなしの HTTP URL になる', async () => {
     stubUserAgent(ANDROID_UA)
     const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE, { wait: true })).toContain('wait=1')
-    const normal = proxyUrl(REMOTE)
-    expect(normal).not.toContain('wait=1')
+    expect(proxyUrl(REMOTE, { wait: true })).toBe(
+      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}`,
+    )
   })
 
   it('明示 wait (効果音) には soft を付けない — プレースホルダを飲み込めない', async () => {

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -1,17 +1,22 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 /**
- * 画像プロキシの URL 組み立て。
+ * 画像・効果音プロキシの URL 組み立て (#921 Phase 3)。
  *
- * モバイルだけプロキシをバイパスしていた頃はリサイズ・ディスクキャッシュ・
- * サーキットブレーカーが Android/iOS で効かなかった。custom protocol に
- * 一本化してその分岐を無くしたので、UA によらず同じ経路に乗ることを守る。
+ * 全プラットフォームでループバック HTTP (127.0.0.1:19820) に一本化した。
+ * custom protocol (ndmedia) 時代のプラットフォーム分岐・二段階配信・
+ * 自己修復機構は存在しないこと自体が仕様。ここでは「どの UA でも同じ
+ * プロキシ URL になり、元 URL 直読みに戻らない」ことを守る。
  */
 
-/** Tauri の内部 API を差し込む。protocol ごとの URL 形式は Tauri が決める */
-function stubTauri(format: (path: string, protocol: string) => string) {
-  vi.stubGlobal('__TAURI_INTERNALS__', { convertFileSrc: format })
-}
+const BASE = 'http://127.0.0.1:19820/proxy/image'
+const REMOTE = 'https://example.com/emoji/petthex.png'
+
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36'
+const IOS_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148'
 
 function stubUserAgent(ua: string) {
   Object.defineProperty(navigator, 'userAgent', {
@@ -25,76 +30,26 @@ async function loadModule() {
   return await import('@/utils/mediaProxy')
 }
 
-const ANDROID_UA =
-  'Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36'
-const IOS_UA =
-  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148'
-const REMOTE = 'https://example.com/emoji/petthex.png'
-
-beforeEach(() => {
-  // Windows/Android 形式を既定にする
-  stubTauri((path, protocol) => `http://${protocol}.localhost/${path}`)
-})
-
-// defineProperty で書き換えた UA は unstubAllGlobals では戻らないため明示復元
 const ORIGINAL_UA = navigator.userAgent
 
-afterEach(() => {
+beforeEach(() => {
+  setActivePinia(createPinia())
   stubUserAgent(ORIGINAL_UA)
-  vi.unstubAllGlobals()
 })
 
 describe('proxyUrl', () => {
-  // 非 Android の wait=1: Android の custom protocol だけが直列 + 10 秒フューズ
-  // (wry) なので二段階配信が必須。それ以外はブロッキングが安全なので、初回
-  // 表示から往復 1 回で本物を返す
-  // soft=1: 画像の wait は最適化にすぎないので、プロキシ側は予算超過時に
-  // プレースホルダへ降格してよい (効果音の hard wait と区別する)
-  it('custom protocol の口に載せる (非 Android は単一トリップ + soft 降格可)', async () => {
+  it('ループバック HTTP の口に載せる', async () => {
     const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
-    )
+    expect(proxyUrl(REMOTE)).toBe(`${BASE}?url=${encodeURIComponent(REMOTE)}`)
   })
 
-  it('macOS/iOS/Linux 形式でも Tauri の解決結果に従う', async () => {
-    stubTauri((path, protocol) => `${protocol}://localhost/${path}`)
+  it.each([
+    ['Android', ANDROID_UA],
+    ['iOS', IOS_UA],
+  ])('%s でも同じ経路 (プロキシをバイパスしない)', async (_name, ua) => {
+    stubUserAgent(ua)
     const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toBe(
-      `ndmedia://localhost/m?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
-    )
-  })
-
-  // Android は wry custom protocol の直列ロックを避け、ループバック HTTP
-  // (#921) に載せる。HTTP ルートは常にブロッキングで本物を返すため
-  // wait/soft パラメータも二段階配信も不要
-  it('Android はループバック HTTP に載せる (直列 custom protocol を通らない)', async () => {
-    stubUserAgent(ANDROID_UA)
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toBe(
-      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}`,
-    )
-  })
-
-  it('iOS は ndmedia のままバイパスしない (ATS で 127.0.0.1 に繋げない)', async () => {
-    stubUserAgent(IOS_UA)
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toContain('ndmedia')
-    expect(proxyUrl(REMOTE)).not.toBe(REMOTE)
-  })
-
-  it('Android でもプロキシをバイパスしない (元 URL 直読みに戻さない)', async () => {
-    stubUserAgent(ANDROID_UA)
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).not.toBe(REMOTE)
-  })
-
-  it('Tauri 外 (ブラウザ確認) では HTTP の口にフォールバックする', async () => {
-    vi.stubGlobal('__TAURI_INTERNALS__', undefined)
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE)).toBe(
-      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}&wait=1&soft=1`,
-    )
+    expect(proxyUrl(REMOTE)).toBe(`${BASE}?url=${encodeURIComponent(REMOTE)}`)
   })
 
   it('https 以外はそのまま返す', async () => {
@@ -107,21 +62,18 @@ describe('proxyUrl', () => {
   })
 })
 
-describe('wait オプション (効果音などブロッキング消費者用)', () => {
-  // Android の HTTP ルートは常にブロッキングで本物を返すため、効果音の
-  // 明示 wait でもパラメータは不要 (プレースホルダがそもそも存在しない)
-  it('Android は明示 wait でもパラメータなしの HTTP URL になる', async () => {
-    stubUserAgent(ANDROID_UA)
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE, { wait: true })).toBe(
-      `http://127.0.0.1:19820/proxy/image?url=${encodeURIComponent(REMOTE)}`,
+describe('proxyThumbUrl', () => {
+  // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
+  it('幅だけを付ける', async () => {
+    const { proxyThumbUrl } = await loadModule()
+    expect(proxyThumbUrl(REMOTE, 56)).toBe(
+      `${BASE}?url=${encodeURIComponent(REMOTE)}&w=56`,
     )
   })
 
-  it('明示 wait (効果音) には soft を付けない — プレースホルダを飲み込めない', async () => {
-    const { proxyUrl } = await loadModule()
-    expect(proxyUrl(REMOTE, { wait: true })).not.toContain('soft=1')
-    expect(proxyUrl(REMOTE, { wait: true })).toContain('wait=1')
+  it('幅違いは別 URL になる (srcset の 1x/2x が潰れない)', async () => {
+    const { proxyThumbUrl } = await loadModule()
+    expect(proxyThumbUrl(REMOTE, 56)).not.toBe(proxyThumbUrl(REMOTE, 112))
   })
 })
 
@@ -132,20 +84,13 @@ describe('proxyEmojiUrl (カスタム絵文字の共通サムネイル口)', () 
   it('全文脈で同じ高さバケット (128px) に丸めてキャッシュを共有する', async () => {
     const { proxyEmojiUrl } = await loadModule()
     expect(proxyEmojiUrl(REMOTE)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&h=128&wait=1&soft=1`,
+      `${BASE}?url=${encodeURIComponent(REMOTE)}&h=128`,
     )
   })
 
   it('幅は制限しない (横長絵文字の解像度を潰さない)', async () => {
     const { proxyEmojiUrl } = await loadModule()
     expect(proxyEmojiUrl(REMOTE)).not.toContain('w=')
-  })
-
-  it('世代番号は絵文字 URL にも波及する', async () => {
-    const { proxyEmojiUrl, handleMediaFetched } = await loadModule()
-    const base = proxyEmojiUrl(REMOTE) ?? ''
-    handleMediaFetched(REMOTE)
-    expect(proxyEmojiUrl(REMOTE)).toBe(`${base}&r=1`)
   })
 
   it('https 以外は素通し (同梱 twemoji のローカルパス等)', async () => {
@@ -155,397 +100,14 @@ describe('proxyEmojiUrl (カスタム絵文字の共通サムネイル口)', () 
   })
 })
 
-describe('背景取得完了による再読込 (二段階配信)', () => {
-  // フェーズ 1 はキャッシュミス時に透明プレースホルダを返す。取得完了イベント
-  // で URL の世代を進め、テンプレート再評価 → <img> 再要求で本物に差し替える
-  it('media-fetched で世代番号が付き、再度の完了でさらに進む', async () => {
-    const { proxyUrl, handleMediaFetched } = await loadModule()
-    const base = proxyUrl(REMOTE) ?? ''
-    expect(base).not.toBe('')
-    expect(base).not.toContain('&r=')
-
-    handleMediaFetched(REMOTE)
-    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
-
-    handleMediaFetched(REMOTE)
-    expect(proxyUrl(REMOTE)).toBe(`${base}&r=2`)
-  })
-
-  it('世代はサムネイル URL (幅違い) にも波及する', async () => {
-    const { proxyThumbUrl, handleMediaFetched } = await loadModule()
-    const base = proxyThumbUrl(REMOTE, 56) ?? ''
-    expect(base).not.toBe('')
-    handleMediaFetched(REMOTE)
-    expect(proxyThumbUrl(REMOTE, 56)).toBe(`${base}&r=1`)
-    expect(proxyThumbUrl(REMOTE, 112)).toContain('&r=1')
-  })
-
-  it('無関係の URL には影響しない', async () => {
-    const { proxyUrl, handleMediaFetched } = await loadModule()
-    const other = 'https://example.com/other.png'
-    handleMediaFetched(REMOTE)
-    expect(proxyUrl(other)).not.toContain('&r=')
-  })
-
-  it('世代マップは上限で古い順に捨てる (無限成長しない)', async () => {
-    const { proxyUrl, handleMediaFetched } = await loadModule()
-    // 上限 (テスト環境の既定 256) を超えて完了イベントを流す
-    handleMediaFetched(REMOTE)
+describe('URL 文字列キャッシュの追い出し (#893)', () => {
+  it('上限を超えたら古い順に捨てるが、組み立て結果は変わらない', async () => {
+    const { proxyUrl } = await loadModule()
+    const first = proxyUrl(REMOTE)
     for (let i = 0; i < 300; i++) {
-      handleMediaFetched(`https://example.com/e${i}.png`)
+      proxyUrl(`https://example.com/e${i}.png`)
     }
-    // 最古の REMOTE は追い出され、素の URL に戻る (キャッシュ済みなので実害なし)
-    expect(proxyUrl(REMOTE)).not.toContain('&r=')
-    // 直近のものは世代付きのまま
-    expect(proxyUrl('https://example.com/e299.png')).toContain('&r=1')
-  })
-})
-
-describe('失敗申告によるバックオフ再試行 (markMediaFailed)', () => {
-  // @error の DOM 書き換え (unknown アイコンへの差し替え) は :src バインドが
-  // 変わらない限り戻らず、一過性の 502/504 がセッション中固定化していた。
-  // 失敗を申告するとバックオフ後に世代番号が進み、バインド再評価で自然復帰する
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('バックオフ後に世代番号を進めて <img> に再要求させる', async () => {
-    const { proxyUrl, markMediaFailed } = await loadModule()
-    const base = proxyUrl(REMOTE)
-    markMediaFailed(REMOTE)
-    // バックオフ前は変わらない (失敗直後の連打再要求を避ける)
-    expect(proxyUrl(REMOTE)).toBe(base)
-    vi.advanceTimersByTime(8_000)
-    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
-  })
-
-  it('タイマー待ち中の重複申告は 1 回の再試行にまとまる', async () => {
-    const { proxyUrl, markMediaFailed } = await loadModule()
-    markMediaFailed(REMOTE)
-    markMediaFailed(REMOTE)
-    markMediaFailed(REMOTE)
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-
-  it('再試行は上限で打ち切る (無限リトライしない)', async () => {
-    const { proxyUrl, markMediaFailed } = await loadModule()
-    for (let i = 0; i < 10; i++) {
-      markMediaFailed(REMOTE)
-      vi.advanceTimersByTime(10 * 60_000)
-    }
-    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
-    expect(r).toBe(3)
-  })
-
-  it('取得成功で失敗カウントがリセットされ、次の失敗からまた再試行できる', async () => {
-    const { proxyUrl, markMediaFailed, handleMediaFetched } = await loadModule()
-    for (let i = 0; i < 10; i++) {
-      markMediaFailed(REMOTE)
-      vi.advanceTimersByTime(10 * 60_000)
-    }
-    // 成功イベント → リセット (世代も 1 進む: 3 + 1 = 4)
-    handleMediaFetched(REMOTE, true)
-    markMediaFailed(REMOTE)
-    vi.advanceTimersByTime(10 * 60_000)
-    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
-    expect(r).toBe(5)
-  })
-
-  it('失敗の完了イベント (ok=false) ではリセットしない', async () => {
-    const { proxyUrl, markMediaFailed, handleMediaFetched } = await loadModule()
-    for (let i = 0; i < 10; i++) {
-      markMediaFailed(REMOTE)
-      vi.advanceTimersByTime(10 * 60_000)
-    }
-    handleMediaFetched(REMOTE, false)
-    markMediaFailed(REMOTE)
-    vi.advanceTimersByTime(10 * 60_000)
-    // ok=false の世代 bump (+1) だけで、リトライは復活しない
-    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
-    expect(r).toBe(4)
-  })
-})
-
-describe('プレースホルダ滞留の自己修復 (ensurePlaceholderRecovery)', () => {
-  // 二段階配信は「透明プレースホルダ → MediaFetched → 再要求」で完結するが、
-  // イベントを取りこぼすと透明 GIF のまま固まり、onerror も発火しないため
-  // 再試行機構 (markMediaFailed) の対象外になる。<img> の @load で
-  // プレースホルダ (1×1) を掴んだことを申告し、一定時間内に世代が進まなければ
-  // 自力で再要求させる
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('世代が進まないまま滞留したら自力で世代を進める', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    const base = proxyUrl(REMOTE)
-    ensurePlaceholderRecovery(REMOTE)
-    expect(proxyUrl(REMOTE)).toBe(base)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toBe(`${base}&r=1`)
-  })
-
-  it('MediaFetched で世代が進んでいれば何もしない (正常経路に譲る)', async () => {
-    const { proxyUrl, handleMediaFetched, ensurePlaceholderRecovery } =
-      await loadModule()
-    ensurePlaceholderRecovery(REMOTE)
-    handleMediaFetched(REMOTE)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-    vi.advanceTimersByTime(10 * 60_000)
-    // watchdog による余計な bump (&r=2) は起きない
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-
-  it('タイマー待ち中の重複申告は 1 本にまとまる', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    ensurePlaceholderRecovery(REMOTE)
-    ensurePlaceholderRecovery(REMOTE)
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-
-  it('再要求でまたプレースホルダを掴んだら再申告できる (取得完了まで収束)', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-    // 再要求後もまだ取得中 → @load が再度申告 → もう一周
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=2')
-  })
-
-  it('自己修復は上限で打ち切る (本当に 1×1 の画像で無限ループしない)', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    // 本物が 1×1 の画像は再要求してもずっと 1×1 → 毎回 @load から申告される
-    for (let i = 0; i < 10; i++) {
-      ensurePlaceholderRecovery(REMOTE)
-      vi.advanceTimersByTime(4_000)
-    }
-    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
-    expect(r).toBe(3)
-  })
-
-  it('取得成功 (MediaFetched ok) で自己修復の試行回数がリセットされる', async () => {
-    const { proxyUrl, handleMediaFetched, ensurePlaceholderRecovery } =
-      await loadModule()
-    for (let i = 0; i < 10; i++) {
-      ensurePlaceholderRecovery(REMOTE)
-      vi.advanceTimersByTime(4_000)
-    }
-    handleMediaFetched(REMOTE, true) // r=4
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    const r = Number(/&r=(\d+)/.exec(proxyUrl(REMOTE) ?? '')?.[1])
-    expect(r).toBe(5)
-  })
-})
-
-describe('プレースホルダ滞留の全画像監視 (installPlaceholderWatchdog) #892', () => {
-  // 自己修復の関数を直接呼ぶのではなく、document capture の load 監視の
-  // 判断そのものを検証する: 全画像の読み込みを通る位置にあるため、ここが
-  // 壊れると「一部の画像がまれに空白のまま」という気づきにくい形で出る
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-    document.body.innerHTML = ''
-  })
-
-  /** 寸法を差し替えた要素を document に繋ぎ、load を capture へ流す */
-  function dispatchLoad(
-    tag: string,
-    src: string | undefined,
-    width?: number,
-    height?: number,
-  ) {
-    const el = document.createElement(tag)
-    if (width !== undefined) {
-      Object.defineProperty(el, 'naturalWidth', { value: width })
-      Object.defineProperty(el, 'naturalHeight', { value: height })
-    }
-    if (src !== undefined) (el as HTMLImageElement).src = src
-    document.body.appendChild(el)
-    el.dispatchEvent(new Event('load'))
-    return el
-  }
-
-  it('1×1 (プレースホルダ) を掴んだ IMG は自己修復に乗る', async () => {
-    const { proxyUrl } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    dispatchLoad('img', proxied, 1, 1)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-
-  it('実画像 (非 1×1) を掴んだら自己修復に乗せない', async () => {
-    const { proxyUrl } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    dispatchLoad('img', proxied, 200, 100)
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(REMOTE)).not.toContain('&r=')
-  })
-
-  it('プロキシ経由でない画像は 1×1 でも対象外', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    proxyUrl(REMOTE) // 監視を起動させる
-    const direct = 'https://example.com/tracker.png'
-    dispatchLoad('img', direct, 1, 1)
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(direct)).not.toContain('&r=')
-    // ensurePlaceholderRecovery が生きていることの対照 (テスト自体の空振り防止)
-    ensurePlaceholderRecovery(direct)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(direct)).toContain('&r=1')
-  })
-
-  it('実画像が載ったら試行回数をリセットし、再度の滞留から修復できる', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    // 上限まで自己修復を使い切る (count=3 で打ち切り状態)
-    for (let i = 0; i < 10; i++) {
-      ensurePlaceholderRecovery(REMOTE)
-      vi.advanceTimersByTime(4_000)
-    }
-    expect(proxyUrl(REMOTE)).toContain('&r=3')
-    // 実画像の load が届いたら試行回数がリセットされる
-    dispatchLoad('img', proxied, 200, 100)
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=4')
-  })
-
-  it('プロキシ経由の IMG の error は失敗申告され、バックオフ後に再試行する', async () => {
-    // 以前は絵文字の onerror (onCustomEmojiImgError) だけが失敗を申告して
-    // いた。アバター・添付・OGP も同じ二段階配信を通るので、error も load と
-    // 同じ document capture で一括して拾う
-    const { proxyUrl } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    const img = document.createElement('img')
-    img.src = proxied
-    document.body.appendChild(img)
-    img.dispatchEvent(new Event('error'))
-    vi.advanceTimersByTime(8_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-
-  it('プロキシ経由でない IMG の error は申告しない', async () => {
-    const { proxyUrl } = await loadModule()
-    proxyUrl(REMOTE) // 監視を起動させる
-    const direct = 'https://example.com/broken.png'
-    const img = document.createElement('img')
-    img.src = direct
-    document.body.appendChild(img)
-    img.dispatchEvent(new Event('error'))
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(direct)).not.toContain('&r=')
-  })
-
-  it('IMG 以外の要素の error は申告しない', async () => {
-    const { proxyUrl } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    const video = document.createElement('video')
-    ;(video as unknown as { src: string }).src = proxied
-    document.body.appendChild(video)
-    video.dispatchEvent(new Event('error'))
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(REMOTE)).not.toContain('&r=')
-  })
-
-  it('IMG 以外の要素の load では試行回数をリセットしない', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    const proxied = proxyUrl(REMOTE) ?? ''
-    for (let i = 0; i < 10; i++) {
-      ensurePlaceholderRecovery(REMOTE)
-      vi.advanceTimersByTime(4_000)
-    }
-    expect(proxyUrl(REMOTE)).toContain('&r=3')
-    // video 要素は src と寸法を持つが、監視の対象は IMG だけ
-    dispatchLoad('video', proxied, 200, 100)
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    // リセットされていないので打ち切り状態のまま (世代は進まない)
-    expect(proxyUrl(REMOTE)).toContain('&r=3')
-  })
-})
-
-describe('URL 単位の状態の追い出し (#893)', () => {
-  // 失敗回数と自己修復の試行回数は「取得成功」でしか消えないため、恒久的に
-  // 壊れた URL・本当に 1×1 の画像が長時間セッションで無限に積もっていた。
-  // 世代番号の表 (mediaVersions) と同じ「上限で古い順に捨てる」規則を適用する
-  beforeEach(() => {
-    vi.useFakeTimers()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
-  it('失敗記録は上限で古い順に捨てられ、追い出された URL は再試行できる', async () => {
-    const { proxyUrl, markMediaFailed } = await loadModule()
-    // リトライ上限まで失敗を積む (retries=3 で打ち切り状態)
-    for (let i = 0; i < 10; i++) {
-      markMediaFailed(REMOTE)
-      vi.advanceTimersByTime(10 * 60_000)
-    }
-    // 上限 (テスト環境の既定 256) を超える数の別 URL が失敗を申告する
-    for (let i = 0; i < 300; i++) {
-      markMediaFailed(`https://example.com/f${i}.png`)
-    }
-    // 最古の REMOTE は追い出されているので、打ち切り状態が解けて再試行できる
-    markMediaFailed(REMOTE)
-    vi.advanceTimersByTime(10 * 60_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=4')
-  })
-
-  it('自己修復の試行回数は上限で古い順に捨てられる', async () => {
-    const { proxyUrl, ensurePlaceholderRecovery } = await loadModule()
-    // 自己修復上限まで積む (count=3 で打ち切り状態)
-    for (let i = 0; i < 10; i++) {
-      ensurePlaceholderRecovery(REMOTE)
-      vi.advanceTimersByTime(4_000)
-    }
-    // 上限を超える数の別 URL が自己修復に乗る
-    for (let i = 0; i < 300; i++) {
-      ensurePlaceholderRecovery(`https://example.com/p${i}.png`)
-    }
-    vi.advanceTimersByTime(4_000)
-    // 最古の REMOTE は追い出されているので、打ち切り状態が解けて再修復できる
-    ensurePlaceholderRecovery(REMOTE)
-    vi.advanceTimersByTime(4_000)
-    expect(proxyUrl(REMOTE)).toContain('&r=1')
-  })
-})
-
-describe('proxyThumbUrl', () => {
-  // format は付けない: 明示すると「上限以下なら変換不要」の素通しが効かなくなる
-  it('幅だけを付ける (非 Android は wait + soft も付く)', async () => {
-    const { proxyThumbUrl } = await loadModule()
-    expect(proxyThumbUrl(REMOTE, 56)).toBe(
-      `http://ndmedia.localhost/m?url=${encodeURIComponent(REMOTE)}&w=56&wait=1&soft=1`,
-    )
-  })
-
-  it('モバイルでもリサイズ指定が落ちない', async () => {
-    stubUserAgent(ANDROID_UA)
-    const { proxyThumbUrl } = await loadModule()
-    expect(proxyThumbUrl(REMOTE, 56)).toContain('w=56')
-  })
-
-  it('幅違いは別 URL になる (srcset の 1x/2x が潰れない)', async () => {
-    const { proxyThumbUrl } = await loadModule()
-    expect(proxyThumbUrl(REMOTE, 56)).not.toBe(proxyThumbUrl(REMOTE, 112))
+    // 追い出されても再構築されるだけで同じ URL になる
+    expect(proxyUrl(REMOTE)).toBe(first)
   })
 })

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -1,262 +1,28 @@
-import { convertFileSrc } from '@tauri-apps/api/core'
-import { reactive } from 'vue'
-import { events } from '@/bindings'
 import { usePerformanceStore } from '@/stores/performance'
 
 /**
- * 画像プロキシの WebView 側の口。プラットフォームで配信経路が割れる:
+ * 画像・効果音プロキシの WebView 側の口 (#921 Phase 3)。
  *
- * - **Android**: ループバック HTTP (`127.0.0.1:19820/proxy/image`) を使う
- *   (#921)。wry Android の custom protocol は全リクエスト (アセット・大きい
- *   IPC 応答・メディア) が単一ロックで直列化されるため、メディアを載せると
- *   構造的に遅い。HTTP なら WebView の並列ネットワークスタックとブラウザ
- *   キャッシュが使え、プロキシ側は本物が用意できるまでブロックして返せる
- *   (二段階配信もプレースホルダも不要)。cleartext-to-localhost は
- *   networkSecurityConfig で許可済み (src-tauri/android/)。
- * - **それ以外 (デスクトップ / iOS)**: custom protocol `ndmedia:`。WebView が
- *   intercept するのでネットワークスタックを通らず、iOS の ATS 制限も受け
- *   ない。URL 形式のプラットフォーム差 (macOS/iOS/Linux は
- *   `ndmedia://localhost/m`、Windows は `http://ndmedia.localhost/m`) は
- *   convertFileSrc が吸収する。
+ * 全プラットフォームで内蔵 HTTP サーバー (`127.0.0.1:19820/proxy/image`) に
+ * 一本化している。以前は custom protocol `ndmedia:` を使っていたが、
+ * wry Android は全 custom protocol リクエストが単一ロックで直列化されるため
+ * 構造的に遅く、それを補う二段階配信 (プレースホルダ + 完了イベント +
+ * 再要求) とフロント側の自己修復機構 (世代番号・バックオフ・1×1 検知・
+ * 全画像監視) が 4 層積み重なっていた。ループバック HTTP なら WebView の
+ * 並列ネットワークスタックとブラウザキャッシュが使え、プロキシは本物が
+ * 用意できるまでブロックして返せるので、その全部が不要になる。
  *
- * どちらもバックエンドは同じ ImageCache なので、リサイズ・ディスク
- * キャッシュ・サーキットブレーカー・オフライン動作は共通。
+ * - Android の cleartext-to-localhost は networkSecurityConfig で許可
+ *   (src-tauri/android/)
+ * - macOS/iOS の ATS は NSAllowsLocalNetworking で許可 (src-tauri/Info.plist)
+ * - バックエンドは ImageCache (リサイズ・ディスクキャッシュ・サーキット
+ *   ブレーカー・オフライン配信) — 経路によらず共通
+ * - 失敗時の見た目のフォールバック (unknown アイコン等) は各コンポーネントの
+ *   @error に残る。再試行はブラウザの通常のナビゲーション・再描画に任せる
  */
 const HTTP_MEDIA_BASE = 'http://127.0.0.1:19820/proxy/image'
 
-/**
- * Android はループバック HTTP に載せるため wait/soft パラメータ自体が不要
- * (HTTP ルートは常にブロッキングで本物を返す)。ndmedia を使う残りの
- * プラットフォームはブロッキングが安全なので wait=1 を既定にし、初回表示
- * から往復 1 回で本物を返す (単一トリップ)。
- */
-const IS_ANDROID = /Android/i.test(navigator.userAgent)
-
-let proxyBase: string | null = null
 const proxyUrlCache = new Map<string, string>()
-
-/**
- * 二段階配信 (プロキシ側) の再読込機構。
- *
- * キャッシュミス時、プロキシは上流を待たず透明プレースホルダを即返し、
- * 取得完了を media-fetched イベントで知らせてくる。ここで URL の世代番号を
- * 進めると、テンプレート内の proxyUrl 呼び出しが再評価されて `&r=N` 付きの
- * 新 URL になり、`<img>` が自然に再要求する (呼び出し箇所の変更は不要)。
- */
-const mediaVersions = reactive(new Map<string, number>())
-
-/**
- * URL 単位の状態表の共通追い出し規則: 新規キーの挿入前に、上限に達していたら
- * 最古の 1 件を捨てる (#893)。取得成功でしか消えない表 (失敗回数・自己修復の
- * 試行回数) も、この規則で長時間セッションの無限成長を防ぐ。
- */
-function evictOldestIfFull(
-  map: Map<string, unknown>,
-  key: string,
-  onEvict?: (evicted: string) => void,
-) {
-  if (map.has(key) || map.size < getProxyCacheMax()) return
-  const oldest = map.keys().next().value
-  if (oldest === undefined) return
-  onEvict?.(oldest)
-  map.delete(oldest)
-}
-
-function bumpMediaVersion(url: string) {
-  // 追い出された URL は素の URL に戻るだけで、実体はキャッシュ済みなので
-  // 表示は壊れない
-  evictOldestIfFull(mediaVersions, url)
-  mediaVersions.set(url, (mediaVersions.get(url) ?? 0) + 1)
-}
-
-export function handleMediaFetched(url: string, ok = true) {
-  if (ok) {
-    // 取得成功 → 失敗カウント・自己修復の試行回数をリセット
-    const entry = mediaFailures.get(url)
-    if (entry?.timer != null) clearTimeout(entry.timer)
-    mediaFailures.delete(url)
-    placeholderRecoveryCounts.delete(url)
-  }
-  bumpMediaVersion(url)
-}
-
-/**
- * `<img>` の onerror 側からの失敗申告。
- *
- * @error ハンドラは src を unknown アイコンへ DOM 書き換えするが、それだけ
- * だと :src バインドが変わる契機がなく、一過性の 502/504 がセッション中
- * 固定化する。ここでバックオフ後に世代番号を進めるとバインドが再評価され、
- * `<img>` が再要求して自然復帰する。負のキャッシュが生きている間の再試行は
- * プロキシが即 502 で受けるので安価に失敗し、次のバックオフに進む。
- * 上限に達したら諦める (回復は取得成功イベントのリセット任せ)。
- */
-const MEDIA_RETRY_BACKOFF_MS = [8_000, 40_000, 180_000] as const
-
-const mediaFailures = new Map<
-  string,
-  { retries: number; timer: ReturnType<typeof setTimeout> | null }
->()
-
-export function markMediaFailed(url: string): void {
-  const entry = mediaFailures.get(url) ?? { retries: 0, timer: null }
-  if (entry.timer !== null || entry.retries >= MEDIA_RETRY_BACKOFF_MS.length) {
-    return
-  }
-  const delay = MEDIA_RETRY_BACKOFF_MS[entry.retries] ?? 0
-  entry.timer = setTimeout(() => {
-    entry.timer = null
-    entry.retries += 1
-    bumpMediaVersion(url)
-  }, delay)
-  // リトライ上限に達した URL は取得成功が来ない限り残り続けるため、
-  // 上限で追い出す。待機中のタイマーごと破棄する
-  evictOldestIfFull(mediaFailures, url, (evicted) => {
-    const old = mediaFailures.get(evicted)
-    if (old?.timer != null) clearTimeout(old.timer)
-  })
-  mediaFailures.set(url, entry)
-}
-
-/**
- * プレースホルダ滞留の自己修復 (`<img>` の @load からの申告)。
- *
- * 二段階配信は「透明プレースホルダ → MediaFetched → 再要求」で完結するが、
- * イベントを取りこぼす (Android の WebView フリーズ復帰等) と透明 GIF の
- * まま固まる。プレースホルダは正常な 200 応答なので onerror が発火せず、
- * markMediaFailed の再試行にも乗らない。@load で 1×1 を掴んだことを申告し、
- * 一定時間内に世代が進まなければ自力で進めて再要求させる。再要求がまた
- * プレースホルダなら @load が再申告するので、取得完了まで自然に収束する
- * (取得失敗は 502 → onerror → markMediaFailed 側が引き継ぐ)。
- */
-const PLACEHOLDER_RECHECK_MS = 4_000
-
-/** 自力再要求の上限。本当に 1×1 の画像 (再要求しても 1×1 のまま) で
- * 無限ループしないための打ち切り。取得成功でリセットされる */
-const PLACEHOLDER_RECOVERY_MAX = 3
-
-const placeholderTimers = new Map<string, ReturnType<typeof setTimeout>>()
-const placeholderRecoveryCounts = new Map<string, number>()
-
-export function ensurePlaceholderRecovery(url: string): void {
-  if ((placeholderRecoveryCounts.get(url) ?? 0) >= PLACEHOLDER_RECOVERY_MAX) {
-    return
-  }
-  if (placeholderTimers.has(url)) return
-  const versionAtSchedule = mediaVersions.get(url) ?? 0
-  placeholderTimers.set(
-    url,
-    setTimeout(() => {
-      placeholderTimers.delete(url)
-      // MediaFetched が正常に届いて世代が進んでいれば何もしない
-      if ((mediaVersions.get(url) ?? 0) === versionAtSchedule) {
-        // 本当に 1×1 の画像は取得成功でリセットされないため、上限で追い出す
-        evictOldestIfFull(placeholderRecoveryCounts, url)
-        placeholderRecoveryCounts.set(
-          url,
-          (placeholderRecoveryCounts.get(url) ?? 0) + 1,
-        )
-        bumpMediaVersion(url)
-      }
-    }, PLACEHOLDER_RECHECK_MS),
-  )
-}
-
-/**
- * プロキシ URL (`...?url=<encoded>`) から元 URL を取り出す。
- * プロキシ経由でない (ローカルアセット等) は null。
- */
-export function proxiedRawUrl(src: string): string | null {
-  try {
-    return new URL(src).searchParams.get('url')
-  } catch {
-    return null
-  }
-}
-
-/**
- * 全画像の読み込み結果の一括監視。
- *
- * 二段階配信 (Android 全画像 / デスクトップの soft 降格) はアバター・添付・
- * ピッカーなどあらゆる `<img>` を通るため、個別コンポーネントに @load /
- * @error を配線するのではなく document の capture で一括して拾う (load /
- * error イベントはバブルしないが capture では捕捉できる)。
- *
- * - load: 1×1 = プレースホルダを掴んだ `<img>` を自己修復に乗せ、実画像が
- *   載ったら試行回数をリセットする
- * - error: 失敗を申告してバックオフ再試行に乗せる (一過性の 502/504 の
- *   セッション中固定化を防ぐ)。unknown アイコン等への DOM フォールバックは
- *   各コンポーネントの @error に残る
- */
-function installMediaWatchdog() {
-  try {
-    document.addEventListener(
-      'load',
-      (e) => {
-        const img = e.target as HTMLImageElement | null
-        if (img?.tagName !== 'IMG') return
-        const raw = proxiedRawUrl(img.currentSrc || img.src)
-        if (!raw) return
-        if (img.naturalWidth === 1 && img.naturalHeight === 1) {
-          ensurePlaceholderRecovery(raw)
-        } else {
-          placeholderRecoveryCounts.delete(raw)
-        }
-      },
-      true,
-    )
-    document.addEventListener(
-      'error',
-      (e) => {
-        const img = e.target as HTMLImageElement | null
-        if (img?.tagName !== 'IMG') return
-        const raw = proxiedRawUrl(img.currentSrc || img.src)
-        if (raw) markMediaFailed(raw)
-      },
-      true,
-    )
-  } catch {
-    // document の無い環境 (ユニットテストの node 側等) では何もしない
-  }
-}
-
-let listenerStarted = false
-function ensureFetchedListener() {
-  if (listenerStarted) return
-  listenerStarted = true
-  installMediaWatchdog()
-  try {
-    events.mediaFetched
-      .listen(({ payload }) => handleMediaFetched(payload.url, payload.ok))
-      .catch(() => {
-        // Tauri 外 (pnpm dev のブラウザ確認) ではイベント購読できない
-      })
-  } catch {
-    // 同上
-  }
-}
-
-/** 世代番号が進んでいれば `&r=N` を付けて別 URL 化する */
-function withVersion(base: string, url: string): string {
-  // 未登録キーの get も reactive の依存として追跡される (後の set で再評価)
-  const v = mediaVersions.get(url)
-  return v ? `${base}&r=${v}` : base
-}
-
-function getProxyBase(): string {
-  if (proxyBase !== null) return proxyBase
-  if (IS_ANDROID) {
-    // 直列 custom protocol を避けてループバック HTTP に載せる (#921)
-    proxyBase = HTTP_MEDIA_BASE
-    return proxyBase
-  }
-  try {
-    proxyBase = convertFileSrc('m', 'ndmedia')
-  } catch {
-    // Tauri 外 (pnpm dev のブラウザ確認) では custom protocol を解決できない
-    proxyBase = HTTP_MEDIA_BASE
-  }
-  return proxyBase
-}
 
 function getProxyCacheMax(): number {
   try {
@@ -266,33 +32,31 @@ function getProxyCacheMax(): number {
   }
 }
 
-export function proxyUrl(
+/** URL 文字列キャッシュの上限追い出し (最古 1 件、#893) */
+function evictOldestIfFull(map: Map<string, unknown>, key: string) {
+  if (map.has(key) || map.size < getProxyCacheMax()) return
+  const oldest = map.keys().next().value
+  if (oldest !== undefined) map.delete(oldest)
+}
+
+function buildProxyUrl(
   url: string | null | undefined,
-  opts?: {
-    /**
-     * 上流取得をブロッキングで待つ (プレースホルダを返さない)。
-     * fetch() や Audio 要素のように透明 GIF を飲み込めない消費者 (効果音) 用。
-     */
-    wait?: boolean
-  },
+  sizeQuery?: string,
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
-  ensureFetchedListener()
-  // Android はループバック HTTP (常にブロッキングで本物を返す) なので
-  // wait/soft パラメータ自体が不要
-  const wait = !IS_ANDROID
-  // 画像の wait は最適化にすぎないので soft を付け、プロキシ側が予算超過時に
-  // プレースホルダ + MediaFetched の二段階配信へ降格できるようにする。
-  // 明示 wait (効果音の fetch/Audio) はプレースホルダを飲み込めないので hard
-  const soft = wait && !opts?.wait
-  const cacheKey = soft ? `${url}|soft` : wait ? `${url}|wait` : url
-  let cached = proxyUrlCache.get(cacheKey)
+  const key = sizeQuery ? `${url}|${sizeQuery}` : url
+  let cached = proxyUrlCache.get(key)
   if (!cached) {
-    evictOldestIfFull(proxyUrlCache, cacheKey)
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}${wait ? '&wait=1' : ''}${soft ? '&soft=1' : ''}`
-    proxyUrlCache.set(cacheKey, cached)
+    evictOldestIfFull(proxyUrlCache, key)
+    cached = `${HTTP_MEDIA_BASE}?url=${encodeURIComponent(url)}${sizeQuery ? `&${sizeQuery}` : ''}`
+    proxyUrlCache.set(key, cached)
   }
-  return withVersion(cached, url)
+  return cached
+}
+
+/** 変換なしのプロキシ URL (効果音・原寸画像)。https 以外は素通し */
+export function proxyUrl(url: string | null | undefined): string | undefined {
+  return buildProxyUrl(url)
 }
 
 /**
@@ -308,7 +72,7 @@ export function proxyThumbUrl(
   url: string | null | undefined,
   width: number,
 ): string | undefined {
-  return proxySizedUrl(url, `w=${width}`)
+  return buildProxyUrl(url, `w=${width}`)
 }
 
 /**
@@ -324,23 +88,5 @@ export function proxyThumbUrl(
 export function proxyEmojiUrl(
   url: string | null | undefined,
 ): string | undefined {
-  return proxySizedUrl(url, 'h=128')
-}
-
-function proxySizedUrl(
-  url: string | null | undefined,
-  sizeQuery: string,
-): string | undefined {
-  if (!url?.startsWith('https://')) return url ?? undefined
-  ensureFetchedListener()
-  // 画像は常に soft (予算超過でプレースホルダ降格可 — proxyUrl 参照)
-  const wait = !IS_ANDROID
-  const key = `${url}|${sizeQuery}`
-  let cached = proxyUrlCache.get(key)
-  if (!cached) {
-    evictOldestIfFull(proxyUrlCache, key)
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&${sizeQuery}${wait ? '&wait=1&soft=1' : ''}`
-    proxyUrlCache.set(key, cached)
-  }
-  return withVersion(cached, url)
+  return buildProxyUrl(url, 'h=128')
 }

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -4,26 +4,31 @@ import { events } from '@/bindings'
 import { usePerformanceStore } from '@/stores/performance'
 
 /**
- * 画像プロキシの WebView 側の口。
+ * 画像プロキシの WebView 側の口。プラットフォームで配信経路が割れる:
  *
- * 以前はローカル HTTP サーバー (127.0.0.1:19820) を直接叩き、そこへ繋げない
- * モバイルだけプロキシをバイパスして元 URL を直読みしていた
- * (Android: cleartext policy / iOS: ATS)。その結果、リサイズ・ディスク
- * キャッシュ・サーキットブレーカーがモバイルでだけ効かず、アバターは
- * `proxyThumbUrl(url, 56)` を指定しても原寸が読まれていた。
+ * - **Android**: ループバック HTTP (`127.0.0.1:19820/proxy/image`) を使う
+ *   (#921)。wry Android の custom protocol は全リクエスト (アセット・大きい
+ *   IPC 応答・メディア) が単一ロックで直列化されるため、メディアを載せると
+ *   構造的に遅い。HTTP なら WebView の並列ネットワークスタックとブラウザ
+ *   キャッシュが使え、プロキシ側は本物が用意できるまでブロックして返せる
+ *   (二段階配信もプレースホルダも不要)。cleartext-to-localhost は
+ *   networkSecurityConfig で許可済み (src-tauri/android/)。
+ * - **それ以外 (デスクトップ / iOS)**: custom protocol `ndmedia:`。WebView が
+ *   intercept するのでネットワークスタックを通らず、iOS の ATS 制限も受け
+ *   ない。URL 形式のプラットフォーム差 (macOS/iOS/Linux は
+ *   `ndmedia://localhost/m`、Windows は `http://ndmedia.localhost/m`) は
+ *   convertFileSrc が吸収する。
  *
- * custom protocol は WebView 自身が intercept するのでネットワークスタックを
- * 通らず、この制限を受けない。URL 形式のプラットフォーム差
- * (macOS/iOS/Linux は `ndmedia://localhost/m`、Windows/Android は
- * `http://ndmedia.localhost/m`) は convertFileSrc が吸収する。
+ * どちらもバックエンドは同じ ImageCache なので、リサイズ・ディスク
+ * キャッシュ・サーキットブレーカー・オフライン動作は共通。
  */
-const HTTP_FALLBACK_BASE = 'http://127.0.0.1:19820/proxy/image'
+const HTTP_MEDIA_BASE = 'http://127.0.0.1:19820/proxy/image'
 
 /**
- * Android の custom protocol だけは直列 + 10 秒フューズ (wry) のため、ミス時
- * に上流を待てない → 二段階配信 (プレースホルダ + media-fetched 再要求)。
- * それ以外のプラットフォームはブロッキングでも安全なので wait=1 を既定にし、
- * 初回表示から往復 1 回で本物を返す (単一トリップ)。
+ * Android はループバック HTTP に載せるため wait/soft パラメータ自体が不要
+ * (HTTP ルートは常にブロッキングで本物を返す)。ndmedia を使う残りの
+ * プラットフォームはブロッキングが安全なので wait=1 を既定にし、初回表示
+ * から往復 1 回で本物を返す (単一トリップ)。
  */
 const IS_ANDROID = /Android/i.test(navigator.userAgent)
 
@@ -239,11 +244,16 @@ function withVersion(base: string, url: string): string {
 
 function getProxyBase(): string {
   if (proxyBase !== null) return proxyBase
+  if (IS_ANDROID) {
+    // 直列 custom protocol を避けてループバック HTTP に載せる (#921)
+    proxyBase = HTTP_MEDIA_BASE
+    return proxyBase
+  }
   try {
     proxyBase = convertFileSrc('m', 'ndmedia')
   } catch {
     // Tauri 外 (pnpm dev のブラウザ確認) では custom protocol を解決できない
-    proxyBase = HTTP_FALLBACK_BASE
+    proxyBase = HTTP_MEDIA_BASE
   }
   return proxyBase
 }
@@ -268,7 +278,9 @@ export function proxyUrl(
 ): string | undefined {
   if (!url?.startsWith('https://')) return url ?? undefined
   ensureFetchedListener()
-  const wait = opts?.wait || !IS_ANDROID
+  // Android はループバック HTTP (常にブロッキングで本物を返す) なので
+  // wait/soft パラメータ自体が不要
+  const wait = !IS_ANDROID
   // 画像の wait は最適化にすぎないので soft を付け、プロキシ側が予算超過時に
   // プレースホルダ + MediaFetched の二段階配信へ降格できるようにする。
   // 明示 wait (効果音の fetch/Audio) はプレースホルダを飲み込めないので hard

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -296,29 +296,39 @@ export function proxyThumbUrl(
   url: string | null | undefined,
   width: number,
 ): string | undefined {
-  if (!url?.startsWith('https://')) return url ?? undefined
-  ensureFetchedListener()
-  // 画像は常に soft (予算超過でプレースホルダ降格可 — proxyUrl 参照)
-  const wait = !IS_ANDROID
-  const key = `${url}|w=${width}`
-  let cached = proxyUrlCache.get(key)
-  if (!cached) {
-    evictOldestIfFull(proxyUrlCache, key)
-    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&w=${width}${wait ? '&wait=1&soft=1' : ''}`
-    proxyUrlCache.set(key, cached)
-  }
-  return withVersion(cached, url)
+  return proxySizedUrl(url, `w=${width}`)
 }
 
 /**
  * カスタム絵文字の共通サムネイル口。
  *
- * 表示は ~20px なので retina 込みで 64px に丸め、全文脈 (ノート本文/
- * ピッカー/リアクション面) で同じ variant キャッシュを共有する。
+ * 本家 media-proxy の `emoji=1` と同じ「最大高さ 128px」基準 (#921)。
+ * 絵文字は横長が普通に存在する資産なので、幅で丸めると高さが潰れて
+ * 表示 (2em × DPR、MFM の $[x2] 等) の引き伸ばしで荒れる。128px は
+ * 2em × DPR3 を賄い、全文脈 (ノート本文/ピッカー/リアクション面) で
+ * 同じ variant キャッシュを共有する。
  * アニメ絵文字はプロキシ側が変換を素通しするので壊れない。
  */
 export function proxyEmojiUrl(
   url: string | null | undefined,
 ): string | undefined {
-  return proxyThumbUrl(url, 64)
+  return proxySizedUrl(url, 'h=128')
+}
+
+function proxySizedUrl(
+  url: string | null | undefined,
+  sizeQuery: string,
+): string | undefined {
+  if (!url?.startsWith('https://')) return url ?? undefined
+  ensureFetchedListener()
+  // 画像は常に soft (予算超過でプレースホルダ降格可 — proxyUrl 参照)
+  const wait = !IS_ANDROID
+  const key = `${url}|${sizeQuery}`
+  let cached = proxyUrlCache.get(key)
+  if (!cached) {
+    evictOldestIfFull(proxyUrlCache, key)
+    cached = `${getProxyBase()}?url=${encodeURIComponent(url)}&${sizeQuery}${wait ? '&wait=1&soft=1' : ''}`
+    proxyUrlCache.set(key, cached)
+  }
+  return withVersion(cached, url)
 }


### PR DESCRIPTION
## 概要

カスタム絵文字の描画品質とメディア配信経路を作り直したリリース (#921)。あわせてリアクションのライブ反映のバグ (#939) を修正した。

## メディア配信の作り直し (#921)

症状 3 つ (横長絵文字が荒い / Android で遅い / タブ切替まで反映されない) を独立した 3 根因に分解し、場当たり的な対症療法の層を減らす方向で作り直した。設計の正本は #921 のコメント。

- **絵文字を高さ基準 (h=128) に** — 縮小指定が「最大幅」だったため、横長絵文字は高さが潰れてから表示側で引き伸ばされていた。本家 media-proxy の `emoji=1` と同じ「最大高さ 128px」に揃える
- **メディア配信をループバック HTTP に一本化** — custom protocol (`ndmedia`) を廃止し、全プラットフォームで内蔵 HTTP サーバー経由にする。custom protocol は wry Android の直列ロックを避けられず、それを補う二段階配信とフロント側の自己修復機構 4 層 (世代番号・バックオフ再試行・プレースホルダ検知・全画像 watchdog) が積み上がっていた。経路を一本化してまとめて削除 (差し引き約 1200 行減)
- **起動直後の画像読み込み失敗を解消** — 画像キャッシュの初期化がカラム表示より後だったため、起動直後の要求が失敗し、代替アイコンがカラム再 mount (= タブ切替) まで残っていた
- **取得並列度の設定が効いていなかった問題を修正** — `performance.json5` の `max_concurrent_fetches` が生成時の定数で固定されていた

localhost への接続許可は Android が networkSecurityConfig (release は 127.0.0.1 のみ、debug は dev サーバー用に全面許可)、macOS/iOS が ATS の `NSAllowsLocalNetworking`。

## リアクションのライブ反映 (#939)

note capture の購読同期が「初回取得・loadMore・復帰」の書込経路にしか紐づいておらず、ストリーミングで流れ込んだ新着ノートが一度も購読されていなかった。そのため他者のリアクションが届かず、タブ切替 (再 mount → 再取得) で初めて反映されるように見えていた。通知を全書込経路の合流点へ移して修正。

## その他

- カラム追加ダイアログのアカウント事前選択チップを取りやめ (型 → アカウントの 2 段に戻す)
- 設定ウィンドウのアコーディオンを全て閉じた状態で開く
- 参照だけあって存在しなかったサーバーアイコンのエラー画像を追加

## 検証

CI (lint / typecheck / test / openapi_snapshot / bindings_snapshot) に加えてローカルで Rust 269 + スナップショット、vitest 2451、biome、docs-lint が通っている。

実機確認は未実施 (#865 iOS / #866 Mac / #867 Linux / #870 Android / #871 Windows に集約)。特に見てほしい点:

- 横長のカスタム絵文字がくっきり表示されるか (全 OS)
- TL に流れてきたノートへのリアクションがタブ切替なしで付くか
- Android で絵文字・アバター・添付・効果音の読み込みが速くなっているか、オフライン時にキャッシュから出るか
- 各デスクトップ WebView (WebKitGTK / WebView2 / WKWebView) で画像・効果音が出るか

最後の点はループバック HTTP 一本化に伴うもの。v1.32.0 以前 (2026-03〜07) にデスクトップが同じ構成で本番稼働しており、CSP にもその許可が残っていたため実績のある構成への回帰にあたるが、custom protocol からの切り戻しなので念のため。

Refs #921, #939, #940


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media is now delivered through a unified local HTTP proxy across platforms.
  * Image requests support optional maximum-height resizing while preserving aspect ratio.
  * Emoji thumbnails use improved height-based sizing.

* **Bug Fixes**
  * Improved note-change notifications for streamed and directly updated notes.
  * Media caching and fetch limits now adapt to performance settings.

* **UI Improvements**
  * Settings and editor sections now start collapsed for a more compact experience.
  * Category expansion highlights relevant sections, and account lists display all accounts.

* **Release**
  * Updated the application to version 1.38.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->