### PR TITLE
Release v1.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "gen:golden-qir": "UPDATE_GOLDEN_QIR=1 vitest run src/services/columnQuery/goldenVectors.test.ts",
     "typecheck": "vue-tsc -b --noEmit",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.38.0",
+  "version": "1.39.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.38.0"
+version = "1.39.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.7.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=a85c34c2ec3bc6b4129e476e69afc6aa4c29a021#a85c34c2ec3bc6b4129e476e69afc6aa4c29a021"
+source = "git+https://github.com/notedeck-dev/notecli?rev=15f697860561b1a9d53aed3a89ea42cf6fd81d1f#15f697860561b1a9d53aed3a89ea42cf6fd81d1f"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.38.0"
+version = "1.39.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "a85c34c2ec3bc6b4129e476e69afc6aa4c29a021", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "15f697860561b1a9d53aed3a89ea42cf6fd81d1f", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.38.0"
+    "version": "1.39.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/commands/column_query.rs
+++ b/src-tauri/src/commands/column_query.rs
@@ -9,7 +9,10 @@
 //! (src/services/columnQuery/golden/vectors.json) で一致を検証する。
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use specta::Type;
+use std::borrow::Cow;
+use std::collections::HashMap;
 
 /// QIR スキーマ世代。互換性のない構造変更で上げる。
 pub const QIR_SCHEMA_VERSION: u32 = 1;
@@ -293,5 +296,305 @@ mod tests {
         assert_eq!(json["op"], "startsWith");
         assert_eq!(json["target"]["kind"], "field");
         assert_eq!(json["target"]["path"][0], "text");
+    }
+}
+
+// --- QIR 評価器 (Phase 3) ---------------------------------------------------
+
+// 評価器は Phase 3 の結線 (notecli の predicate 注入 API へ述語として渡す) で
+// 初めて呼ばれる。それまでは golden differential test からのみ参照されるため、
+// 非テストビルドでは未使用になる。
+
+/// per-note の判定結果 (V14 の 3 値)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum QirVerdict {
+    Match,
+    Unmatch,
+    /// 型エラー・null レシーバ・非 bool 結果。ノートを除外して診断に計上する
+    Error,
+}
+
+/// 評価中の per-note エラー。呼び出し側では Verdict::Error に畳まれる。
+#[allow(dead_code)]
+struct EvalError;
+
+#[allow(dead_code)]
+type EvalResult<'a> = Result<Cow<'a, JsonValue>, EvalError>;
+
+#[allow(dead_code)]
+struct Evaluator<'a> {
+    note: &'a JsonValue,
+    slots: HashMap<u32, JsonValue>,
+}
+
+#[allow(dead_code)]
+impl<'a> Evaluator<'a> {
+    fn new(note: &'a JsonValue) -> Self {
+        Self {
+            note,
+            slots: HashMap::new(),
+        }
+    }
+
+    /// AiScript の `==`: null==null は true、スカラーは値比較、型不一致は false。
+    /// 非スカラー同士はコンパイラが静的に禁止しているため false に倒す
+    /// (JS 側の参照等価分岐に相当する到達不能ケース)。
+    fn ai_eq(l: &JsonValue, r: &JsonValue) -> bool {
+        match (l, r) {
+            (JsonValue::Null, JsonValue::Null) => true,
+            (JsonValue::Null, _) | (_, JsonValue::Null) => false,
+            (JsonValue::String(a), JsonValue::String(b)) => a == b,
+            (JsonValue::Number(a), JsonValue::Number(b)) => a.as_f64() == b.as_f64(),
+            (JsonValue::Bool(a), JsonValue::Bool(b)) => a == b,
+            _ => false,
+        }
+    }
+
+    fn eval(&mut self, node: &QirNode, depth: u32) -> EvalResult<'a> {
+        if depth > QIR_MAX_DEPTH {
+            return Err(EvalError);
+        }
+        let d = depth + 1;
+        match node {
+            QirNode::Str { value } => Ok(Cow::Owned(JsonValue::String(value.clone()))),
+            QirNode::Num { value } => Ok(Cow::Owned(
+                serde_json::Number::from_f64(*value)
+                    .map(JsonValue::Number)
+                    .unwrap_or(JsonValue::Null),
+            )),
+            QirNode::Bool { value } => Ok(Cow::Owned(JsonValue::Bool(*value))),
+            QirNode::Null => Ok(Cow::Owned(JsonValue::Null)),
+            QirNode::Field { path } => {
+                let mut cur = self.note;
+                for key in path {
+                    match cur {
+                        // null へのプロパティ参照はエラー、欠落キーは null
+                        JsonValue::Null => return Err(EvalError),
+                        JsonValue::Object(map) => {
+                            cur = map.get(key).unwrap_or(&JsonValue::Null);
+                        }
+                        _ => return Err(EvalError),
+                    }
+                }
+                Ok(Cow::Borrowed(cur))
+            }
+            QirNode::ObjIndex { target, key } => {
+                let target = self.eval(target, d)?;
+                match target.as_ref() {
+                    JsonValue::Object(map) => {
+                        Ok(Cow::Owned(map.get(key).cloned().unwrap_or(JsonValue::Null)))
+                    }
+                    _ => Err(EvalError),
+                }
+            }
+            QirNode::ArrLen { target } => {
+                let target = self.eval(target, d)?;
+                match target.as_ref() {
+                    JsonValue::Array(items) => {
+                        Ok(Cow::Owned(JsonValue::Number(items.len().into())))
+                    }
+                    _ => Err(EvalError),
+                }
+            }
+            QirNode::Let { bindings, body } => {
+                for b in bindings {
+                    // eager 評価 + エラー伝播 (V19)。使われない束縛でもここで落ちる
+                    let v = self.eval(&b.expr, d)?.into_owned();
+                    self.slots.insert(b.slot, v);
+                }
+                self.eval(body, d)
+            }
+            QirNode::Ref { slot } => match self.slots.get(slot) {
+                Some(v) => Ok(Cow::Owned(v.clone())),
+                // コンパイラは割当済みスロットしか参照を出さない (QIR 破損)
+                None => Err(EvalError),
+            },
+            QirNode::Not { expr } => {
+                let v = self.eval(expr, d)?;
+                match v.as_bool() {
+                    Some(b) => Ok(Cow::Owned(JsonValue::Bool(!b))),
+                    None => Err(EvalError),
+                }
+            }
+            QirNode::And { left, right } => {
+                let l = self.eval(left, d)?.as_bool().ok_or(EvalError)?;
+                if !l {
+                    return Ok(Cow::Owned(JsonValue::Bool(false)));
+                }
+                let r = self.eval(right, d)?.as_bool().ok_or(EvalError)?;
+                Ok(Cow::Owned(JsonValue::Bool(r)))
+            }
+            QirNode::Or { left, right } => {
+                let l = self.eval(left, d)?.as_bool().ok_or(EvalError)?;
+                if l {
+                    return Ok(Cow::Owned(JsonValue::Bool(true)));
+                }
+                let r = self.eval(right, d)?.as_bool().ok_or(EvalError)?;
+                Ok(Cow::Owned(JsonValue::Bool(r)))
+            }
+            QirNode::Cmp { op, left, right } => {
+                let l = self.eval(left, d)?.as_f64().ok_or(EvalError)?;
+                let r = self.eval(right, d)?.as_f64().ok_or(EvalError)?;
+                let out = match op {
+                    QirCmpOp::Lt => l < r,
+                    QirCmpOp::Lteq => l <= r,
+                    QirCmpOp::Gt => l > r,
+                    QirCmpOp::Gteq => l >= r,
+                };
+                Ok(Cow::Owned(JsonValue::Bool(out)))
+            }
+            QirNode::Eq {
+                negated,
+                left,
+                right,
+            } => {
+                let l = self.eval(left, d)?.into_owned();
+                let r = self.eval(right, d)?;
+                let eq = Self::ai_eq(&l, r.as_ref());
+                Ok(Cow::Owned(JsonValue::Bool(if *negated { !eq } else { eq })))
+            }
+            QirNode::StrTest { op, target, needle } => {
+                let target = self.eval(target, d)?;
+                let target = target.as_str().ok_or(EvalError)?;
+                let needle = self.eval(needle, d)?;
+                let needle = needle.as_str().ok_or(EvalError)?;
+                let out = match op {
+                    QirStrTestOp::Incl => target.contains(needle),
+                    QirStrTestOp::StartsWith => target.starts_with(needle),
+                    QirStrTestOp::EndsWith => target.ends_with(needle),
+                };
+                Ok(Cow::Owned(JsonValue::Bool(out)))
+            }
+            QirNode::StrMap { op, target } => {
+                let target = self.eval(target, d)?;
+                let target = target.as_str().ok_or(EvalError)?;
+                let out = match op {
+                    QirStrMapOp::Lower => target.to_lowercase(),
+                    QirStrMapOp::Upper => target.to_uppercase(),
+                };
+                Ok(Cow::Owned(JsonValue::String(out)))
+            }
+            QirNode::ArrIncl { target, needle } => {
+                let target = self.eval(target, d)?.into_owned();
+                let items = match &target {
+                    JsonValue::Array(items) => items,
+                    _ => return Err(EvalError),
+                };
+                let needle = self.eval(needle, d)?;
+                let hit = items.iter().any(|el| Self::ai_eq(el, needle.as_ref()));
+                Ok(Cow::Owned(JsonValue::Bool(hit)))
+            }
+        }
+    }
+}
+
+/// コンパイル済みクエリを 1 ノート (NormalizedNote の serde 形) に対して評価する。
+///
+/// 意味論は JS 評価器・AiScript 1.2.1 と同一で、共有 golden vector で
+/// 一致を検証する (不変条件 (a))。
+#[allow(dead_code)]
+pub fn evaluate_qir(query: &QirQuery, note: &JsonValue) -> QirVerdict {
+    if query.schema_version != QIR_SCHEMA_VERSION {
+        return QirVerdict::Error;
+    }
+    match Evaluator::new(note).eval(&query.root, 1) {
+        Ok(v) => match v.as_bool() {
+            Some(true) => QirVerdict::Match,
+            Some(false) => QirVerdict::Unmatch,
+            // トップレベルが bool でないのは per-note エラー (V20)
+            None => QirVerdict::Error,
+        },
+        Err(EvalError) => QirVerdict::Error,
+    }
+}
+
+#[cfg(test)]
+mod golden_tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    /// 共有 golden vector (不変条件 (a) の Rust 面)。
+    ///
+    /// 期待値の正本は AiScript 1.2.1 の実挙動で、JS 側は同じ vectors.json を
+    /// 参照評価器と JS QIR eval の 2 面で検証している。ここは 3 面目。
+    /// QIR は JS のコンパイラが生成したスナップショット (`pnpm gen:golden-qir`)。
+    #[derive(serde::Deserialize)]
+    struct GoldenFile {
+        cases: Vec<GoldenCase>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct GoldenCase {
+        name: String,
+        note: JsonValue,
+        expected: String,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct QirSnapshot {
+        cases: BTreeMap<String, QirQuery>,
+    }
+
+    fn read(rel: &str) -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()))
+    }
+
+    #[test]
+    fn rust_eval_matches_golden_vectors() {
+        let golden: GoldenFile =
+            serde_json::from_str(&read("../src/services/columnQuery/golden/vectors.json"))
+                .expect("parse vectors.json");
+        let snapshot: QirSnapshot = serde_json::from_str(&read(
+            "../src/services/columnQuery/golden/qir.generated.json",
+        ))
+        .expect("parse qir.generated.json — run `pnpm gen:golden-qir`");
+
+        let mut checked = 0;
+        for case in &golden.cases {
+            // 静的型エラーで QIR にコンパイルされないケースは fallback 専用ベクタ
+            let Some(query) = snapshot.cases.get(&case.name) else {
+                continue;
+            };
+            let verdict = evaluate_qir(query, &case.note);
+            let expected = match case.expected.as_str() {
+                "match" => QirVerdict::Match,
+                "unmatch" => QirVerdict::Unmatch,
+                "error" => QirVerdict::Error,
+                other => panic!("unknown expected verdict: {other}"),
+            };
+            assert_eq!(verdict, expected, "golden case `{}`", case.name);
+            checked += 1;
+        }
+        assert!(checked > 0, "no golden case was evaluated");
+    }
+
+    /// スナップショットが古いと「評価されないケース」が黙って増える。
+    /// 静的拒否ケース以外はすべて QIR を持っているはず。
+    #[test]
+    fn qir_snapshot_covers_every_compilable_case() {
+        const STATIC_REJECT: &[&str] = &[
+            "non-bool-result-error",
+            "lt-on-string-error",
+            "and-non-bool-error",
+            "not-non-bool-error",
+        ];
+        let golden: GoldenFile =
+            serde_json::from_str(&read("../src/services/columnQuery/golden/vectors.json")).unwrap();
+        let snapshot: QirSnapshot = serde_json::from_str(&read(
+            "../src/services/columnQuery/golden/qir.generated.json",
+        ))
+        .unwrap();
+        let missing: Vec<&str> = golden
+            .cases
+            .iter()
+            .map(|c| c.name.as_str())
+            .filter(|n| !STATIC_REJECT.contains(n) && !snapshot.cases.contains_key(*n))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "QIR スナップショットが古いです。`pnpm gen:golden-qir` を実行してください: {missing:?}"
+        );
     }
 }

--- a/src-tauri/src/commands/column_query.rs
+++ b/src-tauri/src/commands/column_query.rs
@@ -8,11 +8,15 @@
 //! 意味論は AiScript 1.2.1 と同一 (不変条件 (a))。全評価器は共有 golden vector
 //! (src/services/columnQuery/golden/vectors.json) で一致を検証する。
 
+use super::{AppState, Result};
+use notecli::db::CachedNoteCursor;
+use notecli::error::NoteDeckError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use specta::Type;
 use std::borrow::Cow;
 use std::collections::HashMap;
+use tauri::State;
 
 /// QIR スキーマ世代。互換性のない構造変更で上げる。
 pub const QIR_SCHEMA_VERSION: u32 = 1;
@@ -234,6 +238,87 @@ pub fn qir_validate(query: QirQuery) -> QirValidation {
     }
 }
 
+/// キャッシュ検索の結果 (Phase 3)。
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct QirSearchResult {
+    pub notes: Vec<notecli::models::NormalizedNote>,
+    /// 実際に読んだ行数 (走査上限に対する進み具合)
+    pub scanned: u32,
+    /// per-note エラーで除外した件数 (V14 の診断計上)
+    pub errors: u32,
+    /// 走査上限で打ち切ったときの継続位置。読み切った場合は null
+    pub cursor: Option<QirSearchCursor>,
+}
+
+/// 継続カーソル。次の呼び出しにそのまま渡す。
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct QirSearchCursor {
+    pub created_at: String,
+    pub note_id: String,
+}
+
+/// ローカルキャッシュをクエリで検索する (#783 Phase 3)。
+///
+/// FTS5 で粗く絞ってから QIR 評価器で判定する。押し込むリテラルの抽出は
+/// 偽陰性を出さない規則に従うので (不変条件 (b))、FTS で落ちたノートが
+/// 本来マッチするということはない。
+///
+/// 走査上限に達したら打ち切って継続カーソルを返す。呼び出し側は必要なだけ
+/// 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。
+#[tauri::command]
+#[specta::specta]
+pub async fn qir_search_cache(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    query: QirQuery,
+    limit: Option<u32>,
+    max_scanned_rows: Option<u32>,
+    cursor: Option<QirSearchCursor>,
+) -> Result<QirSearchResult> {
+    let validation = qir_validate(query.clone());
+    if !validation.ok {
+        return Err(NoteDeckError::InvalidInput(validation.errors.join(", ")));
+    }
+    let literals = extract_fts_literals(&query);
+    let limit = limit.unwrap_or(40).clamp(1, 200) as usize;
+    let max_scanned = max_scanned_rows.unwrap_or(2000).clamp(1, 20_000) as usize;
+    let after = cursor.map(|c| CachedNoteCursor {
+        created_at: c.created_at,
+        note_id: c.note_id,
+    });
+
+    let db = app_state.db().await;
+    let scan = db.scan_cached_notes(
+        &account_id,
+        &literals,
+        limit,
+        max_scanned,
+        after.as_ref(),
+        |note| match serde_json::to_value(note) {
+            Ok(value) => match evaluate_qir(&query, &value) {
+                QirVerdict::Match => Some(true),
+                QirVerdict::Unmatch => Some(false),
+                QirVerdict::Error => None,
+            },
+            // 手元の値を JSON に戻せない = 評価対象の形にできない。
+            // None を返せば scan 側が per-note エラーとして数える
+            Err(_) => None,
+        },
+    )?;
+
+    Ok(QirSearchResult {
+        notes: scan.notes,
+        scanned: scan.scanned as u32,
+        errors: scan.errors as u32,
+        cursor: scan.cursor.map(|c| QirSearchCursor {
+            created_at: c.created_at,
+            note_id: c.note_id,
+        }),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,7 +405,7 @@ pub enum QirVerdict {
 struct EvalError;
 
 #[allow(dead_code)]
-type EvalResult<'a> = Result<Cow<'a, JsonValue>, EvalError>;
+type EvalResult<'a> = std::result::Result<Cow<'a, JsonValue>, EvalError>;
 
 #[allow(dead_code)]
 struct Evaluator<'a> {

--- a/src-tauri/src/commands/column_query.rs
+++ b/src-tauri/src/commands/column_query.rs
@@ -598,3 +598,308 @@ mod golden_tests {
         );
     }
 }
+
+// --- FTS5 プリフィルタ (Phase 3b) --------------------------------------------
+
+/// FTS5 の trigram トークナイザが成立する最小文字数。これ未満は 0 件になるので
+/// 押し込むと偽陰性になる (notecli 側も同じ閾値で FTS/LIKE を分岐している)。
+const FTS_MIN_CHARS: usize = 3;
+
+/// FTS5 プリフィルタに押し込めるリテラルを抽出する (V16 の健全性規則)。
+///
+/// 不変条件 (b) は「偽陰性を出さない」こと。つまり返すリテラルは
+/// **eval が真になるノートなら必ず note.text に含まれている**ものに限る。
+/// そのために辿ってよい位置を次に絞る:
+///
+///   - トップレベルからの連言 (`And`) と `Let` の body のみ
+///   - `Or` の枝には入らない (片側が偽でも全体が真になりうる)
+///   - `Not` の下 (負極性) には入らない (真 = 含まないなので逆になる)
+///   - レシーバは `note.text` そのもの。`lower()` 等を挟んだものは押し込まない
+///   - `cw` や `user.username` は対象外 (FTS インデックスは text のみ)
+///
+/// 返り値は AND 結合で使う想定。MATCH 文字列の組み立てとエスケープは
+/// クエリを発行する側 (notecli) の責務。
+#[allow(dead_code)]
+pub fn extract_fts_literals(query: &QirQuery) -> Vec<String> {
+    let mut out = Vec::new();
+    if query.schema_version != QIR_SCHEMA_VERSION {
+        return out;
+    }
+    collect_conjunctive_literals(&query.root, &mut out);
+    out
+}
+
+/// note.text へのフィールド参照そのものか (変換を挟んでいないか)
+fn is_note_text(node: &QirNode) -> bool {
+    matches!(node, QirNode::Field { path } if path.as_slice() == ["text"])
+}
+
+fn collect_conjunctive_literals(node: &QirNode, out: &mut Vec<String>) {
+    match node {
+        QirNode::And { left, right } => {
+            collect_conjunctive_literals(left, out);
+            collect_conjunctive_literals(right, out);
+        }
+        // 束縛は eager 評価されるだけで、真偽を決めるのは body
+        QirNode::Let { body, .. } => collect_conjunctive_literals(body, out),
+        QirNode::StrTest {
+            op: QirStrTestOp::Incl,
+            target,
+            needle,
+        } => {
+            if !is_note_text(target) {
+                return;
+            }
+            if let QirNode::Str { value } = needle.as_ref() {
+                if value.chars().count() >= FTS_MIN_CHARS {
+                    out.push(value.clone());
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod fts_tests {
+    use super::*;
+
+    fn field(path: &[&str]) -> QirNode {
+        QirNode::Field {
+            path: path.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    fn incl(target: QirNode, needle: &str) -> QirNode {
+        QirNode::StrTest {
+            op: QirStrTestOp::Incl,
+            target: Box::new(target),
+            needle: Box::new(QirNode::Str {
+                value: needle.to_string(),
+            }),
+        }
+    }
+
+    fn not_null(target: QirNode) -> QirNode {
+        QirNode::Eq {
+            negated: true,
+            left: Box::new(target),
+            right: Box::new(QirNode::Null),
+        }
+    }
+
+    fn and(l: QirNode, r: QirNode) -> QirNode {
+        QirNode::And {
+            left: Box::new(l),
+            right: Box::new(r),
+        }
+    }
+
+    fn or(l: QirNode, r: QirNode) -> QirNode {
+        QirNode::Or {
+            left: Box::new(l),
+            right: Box::new(r),
+        }
+    }
+
+    fn not(e: QirNode) -> QirNode {
+        QirNode::Not { expr: Box::new(e) }
+    }
+
+    fn query(root: QirNode) -> QirQuery {
+        QirQuery {
+            schema_version: QIR_SCHEMA_VERSION,
+            root,
+        }
+    }
+
+    #[test]
+    fn extracts_conjunctive_text_literal() {
+        let q = query(and(
+            not_null(field(&["text"])),
+            incl(field(&["text"]), "misskey"),
+        ));
+        assert_eq!(extract_fts_literals(&q), vec!["misskey".to_string()]);
+    }
+
+    #[test]
+    fn extracts_every_literal_in_a_conjunction() {
+        let q = query(and(
+            incl(field(&["text"]), "alpha"),
+            incl(field(&["text"]), "bravo"),
+        ));
+        assert_eq!(
+            extract_fts_literals(&q),
+            vec!["alpha".to_string(), "bravo".to_string()]
+        );
+    }
+
+    #[test]
+    fn skips_disjunction() {
+        // どちらか片方でも真なら通るので、片方のリテラルを押し込むと偽陰性になる
+        let q = query(or(
+            incl(field(&["text"]), "alpha"),
+            incl(field(&["text"]), "bravo"),
+        ));
+        assert!(extract_fts_literals(&q).is_empty());
+    }
+
+    #[test]
+    fn skips_negation() {
+        // 真 = 含まない、なので押し込むと意味が逆になる
+        let q = query(not(incl(field(&["text"]), "alpha")));
+        assert!(extract_fts_literals(&q).is_empty());
+    }
+
+    #[test]
+    fn skips_short_literal() {
+        // trigram は 3 文字未満で 0 件を返す
+        let q = query(incl(field(&["text"]), "ab"));
+        assert!(extract_fts_literals(&q).is_empty());
+        let q = query(incl(field(&["text"]), "abc"));
+        assert_eq!(extract_fts_literals(&q), vec!["abc".to_string()]);
+    }
+
+    #[test]
+    fn skips_transformed_receiver() {
+        // lower() を挟むとケース保存でなくなるので押し込めない
+        let lowered = QirNode::StrMap {
+            op: QirStrMapOp::Lower,
+            target: Box::new(field(&["text"])),
+        };
+        let q = query(incl(lowered, "misskey"));
+        assert!(extract_fts_literals(&q).is_empty());
+    }
+
+    #[test]
+    fn skips_other_fields() {
+        // FTS インデックスが張られているのは text のみ
+        let q = query(incl(field(&["cw"]), "misskey"));
+        assert!(extract_fts_literals(&q).is_empty());
+        let q = query(incl(field(&["user", "username"]), "misskey"));
+        assert!(extract_fts_literals(&q).is_empty());
+    }
+
+    #[test]
+    fn looks_through_let_body() {
+        let q = query(QirNode::Let {
+            bindings: vec![QirBinding {
+                slot: 0,
+                expr: field(&["text"]),
+            }],
+            body: Box::new(incl(field(&["text"]), "misskey")),
+        });
+        assert_eq!(extract_fts_literals(&q), vec!["misskey".to_string()]);
+    }
+
+    #[test]
+    fn counts_unicode_chars_not_bytes() {
+        // 日本語 3 文字は 9 バイトだが trigram としては成立する
+        let q = query(incl(field(&["text"]), "技術書"));
+        assert_eq!(extract_fts_literals(&q), vec!["技術書".to_string()]);
+    }
+
+    #[test]
+    fn rejects_unknown_schema_version() {
+        let q = QirQuery {
+            schema_version: QIR_SCHEMA_VERSION + 1,
+            root: incl(field(&["text"]), "misskey"),
+        };
+        assert!(extract_fts_literals(&q).is_empty());
+    }
+
+    /// 不変条件 (b) の直接検証: eval が真になるノートは、抽出した全リテラルを
+    /// note.text に含んでいなければならない (含んでいなければ FTS プリフィルタが
+    /// そのノートを落とし、偽陰性になる)。
+    ///
+    /// proptest は入れず、QIR の形とノートの全組み合わせを回して確かめる。
+    #[test]
+    fn prefilter_never_produces_false_negatives() {
+        let shapes: Vec<(&str, QirNode)> = vec![
+            ("plain-incl", incl(field(&["text"]), "alpha")),
+            (
+                "guarded-incl",
+                and(not_null(field(&["text"])), incl(field(&["text"]), "alpha")),
+            ),
+            (
+                "conjunction",
+                and(
+                    incl(field(&["text"]), "alpha"),
+                    incl(field(&["text"]), "bravo"),
+                ),
+            ),
+            (
+                "disjunction",
+                or(
+                    incl(field(&["text"]), "alpha"),
+                    incl(field(&["text"]), "bravo"),
+                ),
+            ),
+            ("negation", not(incl(field(&["text"]), "alpha"))),
+            (
+                "mixed",
+                and(
+                    incl(field(&["text"]), "alpha"),
+                    or(
+                        incl(field(&["text"]), "bravo"),
+                        incl(field(&["text"]), "charlie"),
+                    ),
+                ),
+            ),
+            (
+                "negated-conjunction",
+                not(and(
+                    incl(field(&["text"]), "alpha"),
+                    incl(field(&["text"]), "bravo"),
+                )),
+            ),
+            (
+                "let-body",
+                QirNode::Let {
+                    bindings: vec![QirBinding {
+                        slot: 0,
+                        expr: QirNode::Bool { value: true },
+                    }],
+                    body: Box::new(incl(field(&["text"]), "alpha")),
+                },
+            ),
+            (
+                "cw-only",
+                and(not_null(field(&["cw"])), incl(field(&["cw"]), "alpha")),
+            ),
+        ];
+
+        let texts: Vec<JsonValue> = vec![
+            JsonValue::Null,
+            JsonValue::String(String::new()),
+            JsonValue::String("alpha".into()),
+            JsonValue::String("bravo".into()),
+            JsonValue::String("alpha bravo".into()),
+            JsonValue::String("alpha charlie".into()),
+            JsonValue::String("nothing here".into()),
+            JsonValue::String("ALPHA".into()),
+        ];
+        let cws: Vec<JsonValue> = vec![JsonValue::Null, JsonValue::String("alpha".into())];
+
+        for (name, root) in &shapes {
+            let q = query(root.clone());
+            let literals = extract_fts_literals(&q);
+            for text in &texts {
+                for cw in &cws {
+                    let note = serde_json::json!({ "text": text, "cw": cw });
+                    if evaluate_qir(&q, &note) != QirVerdict::Match {
+                        continue;
+                    }
+                    let haystack = text.as_str().unwrap_or("");
+                    for lit in &literals {
+                        assert!(
+                            haystack.contains(lit.as_str()),
+                            "偽陰性: shape={name} literal={lit:?} text={haystack:?} が \
+                             eval では match なのに FTS プリフィルタで落ちる"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -687,6 +687,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::create_guest_account,
             commands::cache_stats,
             commands::qir_validate,
+            commands::qir_search_cache,
             commands::account_cache_count,
             commands::clear_account_cache,
             commands::clear_all_cache,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.38.0",
+  "version": "1.39.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -81,6 +81,26 @@ async cacheStats() : Promise<Result<CacheStats, { code: string; message: string;
 async qirValidate(query: QirQuery) : Promise<QirValidation> {
     return await TAURI_INVOKE("qir_validate", { query });
 },
+/**
+ * ローカルキャッシュをクエリで検索する (#783 Phase 3)。
+ * 
+ * FTS5 で粗く絞ってから QIR 評価器で判定する。押し込むリテラルの抽出は
+ * 偽陰性を出さない規則に従うので (不変条件 (b))、FTS で落ちたノートが
+ * 本来マッチするということはない。
+ * 
+ * 走査上限に達したら打ち切って継続カーソルを返す。呼び出し側は必要なだけ
+ * 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。
+ *
+ * @see src-tauri/src/commands/column_query.rs
+ */
+async qirSearchCache(accountId: string, query: QirQuery, limit: number | null, maxScannedRows: number | null, cursor: QirSearchCursor | null) : Promise<Result<QirSearchResult, { code: string; message: string; apiCode: string | null }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("qir_search_cache", { accountId, query, limit, maxScannedRows, cursor }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /** @see src-tauri/src/commands/admin.rs */
 async accountCacheCount(accountId: string) : Promise<Result<number, { code: string; message: string; apiCode: string | null }>> {
     try {
@@ -3466,6 +3486,26 @@ schemaVersion: number;
  * トップレベル式。コンパイラが静的に bool 型であることを保証する (V20)。
  */
 root: QirNode }
+/**
+ * 継続カーソル。次の呼び出しにそのまま渡す。
+ */
+export type QirSearchCursor = { createdAt: string; noteId: string }
+/**
+ * キャッシュ検索の結果 (Phase 3)。
+ */
+export type QirSearchResult = { notes: NormalizedNote[]; 
+/**
+ * 実際に読んだ行数 (走査上限に対する進み具合)
+ */
+scanned: number; 
+/**
+ * per-note エラーで除外した件数 (V14 の診断計上)
+ */
+errors: number; 
+/**
+ * 走査上限で打ち切ったときの継続位置。読み切った場合は null
+ */
+cursor: QirSearchCursor | null }
 /**
  * 文字列変換演算 (レシーバ str・返り値 str)。
  */

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -57,6 +57,12 @@ const props = defineProps<{
   replyTo?: NormalizedNote
   renoteId?: string
   editNote?: NormalizedNote
+  /**
+   * 「削除して編集」で元ノートの内容 (本文・CW・添付・アンケート等) を
+   * フォームへ展開する (#944)。引用・返信・チャンネルは renoteId / replyTo /
+   * channelId 側で引き継ぐ。
+   */
+  initialNote?: NormalizedNote
   channelId?: string
   inline?: boolean
   initialText?: string
@@ -149,6 +155,7 @@ const {
   removePollChoice,
   resetForm,
   restoreSlot,
+  restoreFromNote,
   saveCurrentSlot,
   hasAnyContent,
 } = usePostFormState(
@@ -412,6 +419,7 @@ onMounted(async () => {
       text.value = `${mentions.join(' ')} `
     }
   }
+  if (props.initialNote) restoreFromNote(props.initialNote)
   if (props.initialText) text.value = props.initialText
   if (props.initialCw) {
     cw.value = props.initialCw

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -468,6 +468,7 @@ usePortal(postPortalRef)
       :reply-to="postForm.replyTo.value"
       :renote-id="postForm.renoteId.value"
       :edit-note="postForm.editNote.value"
+      :initial-note="postForm.initialNote.value"
       :initial-text="postForm.initialText.value"
       :initial-cw="postForm.initialCw.value"
       :initial-visibility="postForm.initialVisibility.value"

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -515,11 +515,13 @@ async function handleDeleteAndEdit(target: NormalizedNote) {
     postForm.replyTo.value = target.replyId
       ? await adapter.api.getNote(target.replyId).catch(() => undefined)
       : undefined
-    postForm.renoteId.value = undefined
+    // 引用・添付・アンケート等を引き継ぐ (#944)
+    postForm.renoteId.value = target.renoteId ?? undefined
     postForm.editNote.value = undefined
-    postForm.initialText.value = target.text ?? undefined
-    postForm.initialCw.value = target.cw ?? undefined
-    postForm.initialVisibility.value = target.visibility
+    postForm.initialNote.value = target
+    postForm.initialText.value = undefined
+    postForm.initialCw.value = undefined
+    postForm.initialVisibility.value = undefined
     postForm.show.value = true
   } catch {
     // ignore

--- a/src/components/deck/DeckLookupColumn.vue
+++ b/src/components/deck/DeckLookupColumn.vue
@@ -709,6 +709,7 @@ async function handlePosted(editedNoteId?: string) {
       :reply-to="postForm.replyTo.value"
       :renote-id="postForm.renoteId.value"
       :edit-note="postForm.editNote.value"
+      :initial-note="postForm.initialNote.value"
       :initial-text="postForm.initialText.value"
       :initial-cw="postForm.initialCw.value"
       :initial-visibility="postForm.initialVisibility.value"

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -164,12 +164,19 @@ const queryBadgeTitle = computed(() => {
 })
 
 /**
- * バッジのアイコン。逐次適用だけはアイコンフォントを使わず 🐢 を出す
- * (bolt と bolt-off は形が似ていて、色だけでは見分けがつかないため)
+ * バッジのアイコン。稲妻はストリーミングモードの表示で使っているので避け、
+ * 隣のフィルタボタンと文脈が揃うフィルタ軸で示す。
+ * 逐次適用は「遅い」ではなく「1 件ずつ時間をかけて判定する」なので砂時計。
  */
 const queryBadgeIcon = computed(() => {
-  if (columnQueryState.value.status === 'invalid') return 'ti ti-alert-triangle'
-  return 'ti ti-bolt'
+  switch (columnQueryState.value.status) {
+    case 'invalid':
+      return 'ti ti-alert-triangle'
+    case 'degraded':
+      return 'ti ti-hourglass'
+    default:
+      return 'ti ti-filter-check'
+  }
 })
 
 // 暴走で打ち切られたクエリ (#783 V15)。自動では戻さず、明示操作で再開する
@@ -312,11 +319,7 @@ defineExpose({
           :title="queryBadgeTitle"
           @click.stop="openQueryManager"
         >
-          <span
-            v-if="columnQueryState.status === 'degraded'"
-            :class="$style.queryBadgeTurtle"
-          >🐢</span>
-          <i v-else :class="queryBadgeIcon" />
+          <i :class="queryBadgeIcon" />
           <span v-if="columnQueryErrorCount > 0">{{ columnQueryErrorCount }}</span>
         </button>
         <button
@@ -528,11 +531,6 @@ defineExpose({
   background: color-mix(in srgb, var(--nd-warn) 12%, transparent);
 }
 
-/* 絵文字はアイコンフォントより字面が大きいので少し詰める */
-.queryBadgeTurtle {
-  font-size: 0.9em;
-  line-height: 1;
-}
 
 /* フィルタメニュー (#841): サブヘッダ右端の共通トグルボタン */
 .subHeaderRow {

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -143,18 +143,24 @@ usePortal(postFormPortalRef)
 // --- カラムクエリ (#783): 全ノートカラム共通のバッジ・診断表示 ---
 // 定義・編集はクエリ管理カラムに一元化。カラム側は適用状態の表示と
 // (タイムラインカラムでは) フィルタメニューのトグルだけを持つ
+/** バッジから 1 クリックでクエリ管理カラムへ (#783 V25 の調査導線) */
+function openQueryManager(): void {
+  useDeckStore().toggleSidebarColumn('queryManager', null)
+}
+
 const queryBadgeTitle = computed(() => {
   if (columnQueryState.value.status === 'invalid') {
-    return 'クエリを解釈できません — クエリ管理カラムで修正するかフィルタメニューで無効化してください'
+    return 'クエリを解釈できません — 押すとクエリ管理カラムを開きます'
   }
   const err =
     columnQueryErrorCount.value > 0
       ? ` (評価エラー ${columnQueryErrorCount.value} 件を除外)`
       : ''
+  const hint = ' — 押すとクエリ管理カラムを開きます'
   if (columnQueryState.value.status === 'degraded') {
-    return `クエリ適用中 — 1 件ずつ判定するため検索では使えません${err}`
+    return `クエリ適用中 — 1 件ずつ判定するため検索では使えません${err}${hint}`
   }
-  return `クエリ適用中${err}`
+  return `クエリ適用中${err}${hint}`
 })
 
 /** バッジのアイコン: ⚡ 高速 / 逐次適用 / 評価不能 */
@@ -289,18 +295,20 @@ defineExpose({
 
     <template #header-extra>
       <div :class="$style.subHeaderRow">
-        <span
+        <button
           v-if="columnQueryState.status !== 'none'"
+          class="_button"
           :class="[
             $style.queryBadge,
             columnQueryState.status === 'invalid' && $style.queryBadgeInvalid,
             columnQueryState.status === 'degraded' && $style.queryBadgeDegraded,
           ]"
           :title="queryBadgeTitle"
+          @click.stop="openQueryManager"
         >
           <i :class="queryBadgeIcon" />
           <span v-if="columnQueryErrorCount > 0">{{ columnQueryErrorCount }}</span>
-        </span>
+        </button>
         <div :class="$style.subHeaderMain">
           <slot name="header-extra" />
         </div>

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -76,6 +76,9 @@ const {
   columnQueryState,
   columnQueryErrorCount,
   columnQueryExcludedCount,
+  columnQuerySuspendedKeys,
+  columnQuerySuspendedCount,
+  resumeSuspendedQueries,
   notes,
   orderedIds,
   focusedNoteId,
@@ -148,8 +151,23 @@ const queryBadgeTitle = computed(() => {
     columnQueryErrorCount.value > 0
       ? ` (評価エラー ${columnQueryErrorCount.value} 件を除外)`
       : ''
+  if (columnQueryState.value.status === 'degraded') {
+    return `クエリ適用中 — 1 件ずつ判定するため検索では使えません${err}`
+  }
   return `クエリ適用中${err}`
 })
+
+/** バッジのアイコン: ⚡ 高速 / 逐次適用 / 評価不能 */
+const queryBadgeIcon = computed(() => {
+  if (columnQueryState.value.status === 'invalid') return 'ti ti-alert-triangle'
+  if (columnQueryState.value.status === 'degraded') return 'ti ti-bolt-off'
+  return 'ti ti-bolt'
+})
+
+// 暴走で打ち切られたクエリ (#783 V15)。自動では戻さず、明示操作で再開する
+const isQuerySuspended = computed(
+  () => columnQuerySuspendedKeys.value.length > 0,
+)
 
 // --- フィルタメニュー (#841): 組込トグル + クエリトグルを全ノートカラム共通で提供 ---
 const deckStore = useDeckStore()
@@ -273,10 +291,14 @@ defineExpose({
       <div :class="$style.subHeaderRow">
         <span
           v-if="columnQueryState.status !== 'none'"
-          :class="[$style.queryBadge, columnQueryState.status === 'invalid' && $style.queryBadgeInvalid]"
+          :class="[
+            $style.queryBadge,
+            columnQueryState.status === 'invalid' && $style.queryBadgeInvalid,
+            columnQueryState.status === 'degraded' && $style.queryBadgeDegraded,
+          ]"
           :title="queryBadgeTitle"
         >
-          <i :class="columnQueryState.status === 'invalid' ? 'ti ti-alert-triangle' : 'ti ti-bolt'" />
+          <i :class="queryBadgeIcon" />
           <span v-if="columnQueryErrorCount > 0">{{ columnQueryErrorCount }}</span>
         </span>
         <div :class="$style.subHeaderMain">
@@ -348,6 +370,20 @@ defineExpose({
       >
         <i class="ti ti-alert-triangle" />クエリを解釈できないため新着を停止中
       </div>
+
+      <!-- 暴走で打ち切ったクエリ: 明示操作でのみ再開する (#783 V15) -->
+      <button
+        v-else-if="isQuerySuspended"
+        class="_button"
+        :class="$style.querySuspendedBanner"
+        title="クエリの処理が終わらなかったため停止しました。再開すると取得し直します"
+        @click="resumeSuspendedQueries"
+      >
+        <i class="ti ti-player-pause" />
+        <span v-if="columnQuerySuspendedCount > 0">{{ columnQuerySuspendedCount }} 件保留中</span>
+        <span v-else>クエリを停止中</span>
+        <span :class="$style.querySuspendedAction">再開</span>
+      </button>
 
       <!-- Inline post form slot (e.g. channel column) -->
       <slot name="before-notes" :handle-posted="handlePosted" />
@@ -468,6 +504,12 @@ defineExpose({
 .queryBadgeInvalid {
   color: var(--nd-error);
   background: color-mix(in srgb, var(--nd-error) 12%, transparent);
+}
+
+/* 逐次適用に降格 = 効くが検索には使えない。ポーリングバナーと同じ扱い */
+.queryBadgeDegraded {
+  color: var(--nd-warn);
+  background: color-mix(in srgb, var(--nd-warn) 12%, transparent);
 }
 
 /* フィルタメニュー (#841): サブヘッダ右端の共通トグルボタン */

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -295,6 +295,10 @@ defineExpose({
 
     <template #header-extra>
       <div :class="$style.subHeaderRow">
+        <div :class="$style.subHeaderMain">
+          <slot name="header-extra" />
+        </div>
+        <!-- クエリバッジはフィルタボタンの隣に置く (どちらも絞り込みの状態) -->
         <button
           v-if="columnQueryState.status !== 'none'"
           class="_button"
@@ -309,9 +313,6 @@ defineExpose({
           <i :class="queryBadgeIcon" />
           <span v-if="columnQueryErrorCount > 0">{{ columnQueryErrorCount }}</span>
         </button>
-        <div :class="$style.subHeaderMain">
-          <slot name="header-extra" />
-        </div>
         <button
           v-if="showFilterBtn"
           ref="filterBtnRef"
@@ -501,6 +502,7 @@ defineExpose({
 .queryBadge {
   display: inline-flex;
   align-items: center;
+  flex-shrink: 0;
   gap: 2px;
   padding: 2px 6px;
   border-radius: var(--nd-radius-full);

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -439,6 +439,7 @@ defineExpose({
       :reply-to="postForm.replyTo.value"
       :renote-id="postForm.renoteId.value"
       :edit-note="postForm.editNote.value"
+      :initial-note="postForm.initialNote.value"
       :initial-text="postForm.initialText.value"
       :initial-cw="postForm.initialCw.value"
       :initial-visibility="postForm.initialVisibility.value"

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -163,10 +163,12 @@ const queryBadgeTitle = computed(() => {
   return `クエリ適用中${err}${hint}`
 })
 
-/** バッジのアイコン: ⚡ 高速 / 逐次適用 / 評価不能 */
+/**
+ * バッジのアイコン。逐次適用だけはアイコンフォントを使わず 🐢 を出す
+ * (bolt と bolt-off は形が似ていて、色だけでは見分けがつかないため)
+ */
 const queryBadgeIcon = computed(() => {
   if (columnQueryState.value.status === 'invalid') return 'ti ti-alert-triangle'
-  if (columnQueryState.value.status === 'degraded') return 'ti ti-bolt-off'
   return 'ti ti-bolt'
 })
 
@@ -310,7 +312,11 @@ defineExpose({
           :title="queryBadgeTitle"
           @click.stop="openQueryManager"
         >
-          <i :class="queryBadgeIcon" />
+          <span
+            v-if="columnQueryState.status === 'degraded'"
+            :class="$style.queryBadgeTurtle"
+          >🐢</span>
+          <i v-else :class="queryBadgeIcon" />
           <span v-if="columnQueryErrorCount > 0">{{ columnQueryErrorCount }}</span>
         </button>
         <button
@@ -516,10 +522,16 @@ defineExpose({
   background: color-mix(in srgb, var(--nd-error) 12%, transparent);
 }
 
-/* 逐次適用に降格 = 効くが検索には使えない。ポーリングバナーと同じ扱い */
+/* 逐次適用に降格 = 効くが検索には使えない */
 .queryBadgeDegraded {
   color: var(--nd-warn);
   background: color-mix(in srgb, var(--nd-warn) 12%, transparent);
+}
+
+/* 絵文字はアイコンフォントより字面が大きいので少し詰める */
+.queryBadgeTurtle {
+  font-size: 0.9em;
+  line-height: 1;
 }
 
 /* フィルタメニュー (#841): サブヘッダ右端の共通トグルボタン */

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -79,6 +79,8 @@ const {
   columnQuerySuspendedKeys,
   columnQuerySuspendedCount,
   resumeSuspendedQueries,
+  columnQueryMissingIds,
+  dropMissingQueryRefs,
   notes,
   orderedIds,
   focusedNoteId,
@@ -380,9 +382,22 @@ defineExpose({
         <i class="ti ti-bolt-off" />ポーリング
       </div>
 
+      <!-- 参照先が消えたクエリ: ここでしか外せないので導線を出す -->
+      <button
+        v-if="columnQueryMissingIds.length > 0"
+        class="_button"
+        :class="$style.queryInvalidBanner"
+        title="このカラムが参照しているクエリは削除されています。外すと新着の取り込みが戻ります"
+        @click="dropMissingQueryRefs"
+      >
+        <i class="ti ti-unlink" />
+        参照しているクエリが見つかりません
+        <span :class="$style.querySuspendedAction">参照を外す</span>
+      </button>
+
       <!-- クエリ評価不能 = fail-closed 中 (#783 不変条件 (f)) -->
       <div
-        v-if="columnQueryState.status === 'invalid'"
+        v-else-if="columnQueryState.status === 'invalid'"
         :class="$style.queryInvalidBanner"
         :title="queryBadgeTitle"
       >

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1345,6 +1345,7 @@ onUnmounted(() => {
       :reply-to="postForm.replyTo.value"
       :renote-id="postForm.renoteId.value"
       :edit-note="postForm.editNote.value"
+      :initial-note="postForm.initialNote.value"
       :initial-text="postForm.initialText.value"
       :initial-cw="postForm.initialCw.value"
       :initial-visibility="postForm.initialVisibility.value"

--- a/src/components/deck/DeckQueryManagerColumn.vue
+++ b/src/components/deck/DeckQueryManagerColumn.vue
@@ -104,9 +104,14 @@ const installedSections = computed<QuerySection[]>(() => {
   return sections.filter((s) => s.items.length > 0)
 })
 
-/** ⚡ = QIR コンパイル可 / false = 不能 (Phase 2 で逐次適用降格に対応予定) */
-function isFast(query: NamedQueryMeta): boolean {
-  return compileColumnQuery(query.src).ok
+/**
+ * クエリの実行形態 (#783)。
+ * fast = QIR で高速評価 / degraded = 純粋なので逐次適用へ降格 / invalid = 評価不能
+ */
+function executionOf(query: NamedQueryMeta): 'fast' | 'degraded' | 'invalid' {
+  const result = compileColumnQuery(query.src)
+  if (result.ok) return 'fast'
+  return result.degradable ? 'degraded' : 'invalid'
 }
 
 function refCount(query: NamedQueryMeta): number {
@@ -237,7 +242,7 @@ function handleOpenStoreDetail(entry: StoreQueryEntry): void {
               :description="query.description"
               :icon-url="query.iconUrl"
               :store-id="query.storeId"
-              :fast="isFast(query)"
+              :execution="executionOf(query)"
               :ref-count="refCount(query)"
               @edit="openEditor(query)"
               @delete="remove(query)"

--- a/src/components/deck/DeckSearchColumn.vue
+++ b/src/components/deck/DeckSearchColumn.vue
@@ -834,6 +834,7 @@ onUnmounted(() => {
       :reply-to="postForm.replyTo.value"
       :renote-id="postForm.renoteId.value"
       :edit-note="postForm.editNote.value"
+      :initial-note="postForm.initialNote.value"
       :initial-text="postForm.initialText.value"
       :initial-cw="postForm.initialCw.value"
       :initial-visibility="postForm.initialVisibility.value"

--- a/src/components/deck/QueryCard.vue
+++ b/src/components/deck/QueryCard.vue
@@ -25,14 +25,17 @@ const props = withDefaults(
     alreadyInstalled?: boolean
     /** library mode: storeId 有無で「ストア由来」/「ローカル保存」バッジ表示 */
     storeId?: string
-    /** library mode: QIR コンパイル可 (⚡)。false = コンパイル不能 */
-    fast?: boolean
+    /**
+     * library mode: クエリの実行形態 (#783)。
+     * fast = QIR で高速評価 / degraded = 逐次適用 (🐢) / invalid = 保存されているが評価不能
+     */
+    execution?: 'fast' | 'degraded' | 'invalid'
     /** library mode: 適用中のカラム数 */
     refCount?: number
   }>(),
   {
     mode: 'store',
-    fast: true,
+    execution: 'fast',
     refCount: 0,
   },
 )
@@ -74,10 +77,15 @@ function handlePrimaryClick() {
       <div :class="$style.row1">
         <span :class="$style.name">{{ name }}</span>
         <span
-          v-if="!isStore && !fast"
+          v-if="!isStore && execution === 'degraded'"
+          :class="$style.degradedBadge"
+          title="1 件ずつ判定します。絞り込みは効きますが、キャッシュ検索には使えません"
+        >逐次適用</span>
+        <span
+          v-else-if="!isStore && execution === 'invalid'"
           :class="$style.incompatBadge"
-          title="QIR コンパイル不能 (編集して修正してください)"
-        >コンパイル不能</span>
+          title="解釈できないため適用中のカラムは新着を停止します (編集して修正してください)"
+        >評価不能</span>
         <span :class="$style.spacer" />
         <span v-if="version" :class="$style.version">v{{ version }}</span>
       </div>
@@ -310,6 +318,13 @@ function handlePrimaryClick() {
   background: color-mix(in srgb, var(--nd-love) 15%, transparent);
   color: var(--nd-love);
   letter-spacing: 0.02em;
+}
+
+/* 逐次適用 (#783 Phase 2)。効いてはいるので警告色にとどめる */
+.degradedBadge {
+  composes: incompatBadge;
+  background: color-mix(in srgb, var(--nd-warn) 15%, transparent);
+  color: var(--nd-warn);
 }
 
 .spacer {

--- a/src/components/deck/column-common.module.scss
+++ b/src/components/deck/column-common.module.scss
@@ -224,6 +224,19 @@
   cursor: pointer;
 }
 
+/* クエリが暴走で打ち切られ保留中。押すと再開する (#783 V15) */
+.querySuspendedBanner {
+  composes: statusBanner;
+  background: color-mix(in srgb, var(--nd-warn) 70%, transparent);
+  cursor: pointer;
+}
+
+.querySuspendedAction {
+  padding-left: 8px;
+  border-left: 1px solid color-mix(in srgb, var(--nd-fgOnAccent) 40%, transparent);
+  text-decoration: underline;
+}
+
 /* Loading */
 .columnLoading {
   display: flex;

--- a/src/components/window/ColumnQueryEditorContent.vue
+++ b/src/components/window/ColumnQueryEditorContent.vue
@@ -51,6 +51,14 @@ const diagnostics = computed(() =>
 )
 
 /**
+ * QIR にできないが純粋な式は 🐢 逐次適用として保存できる (#783 Phase 2)。
+ * 診断は「なぜ降格したか」の説明であって、保存を止める理由ではない。
+ */
+const isDegraded = computed(
+  () => compiled.value?.ok === false && compiled.value.degradable,
+)
+
+/**
  * null ガード漏れの警告 (V25)。コンパイルは通るが、そのまま保存すると
  * 画像のみのノートや純リノートが丸ごと消えるので保存前に気づかせる。
  */
@@ -93,7 +101,7 @@ const dryRun = computed(() => {
 
 const canSave = computed(
   () =>
-    compiled.value?.ok === true &&
+    (compiled.value?.ok === true || isDegraded.value) &&
     queryName.value.trim() !== '' &&
     source.value.trim() !== '',
 )
@@ -175,6 +183,17 @@ async function save(): Promise<void> {
           </li>
         </ul>
       </template>
+      <template v-else-if="isDegraded">
+        <span :class="$style.statusSlow">
+          <i class="ti ti-bolt-off" />逐次適用 (1 件ずつ判定するため検索では使えません)
+        </span>
+        <ul :class="$style.degradedReasons">
+          <li v-for="(d, i) in diagnostics" :key="i">
+            <span v-if="d.line != null" :class="$style.diagLoc">{{ d.line }}行:</span>
+            {{ d.message }}
+          </li>
+        </ul>
+      </template>
       <ul v-else :class="$style.diagnostics">
         <li v-for="(d, i) in diagnostics" :key="i">
           <i class="ti ti-alert-triangle" />
@@ -252,6 +271,22 @@ async function save(): Promise<void> {
 
 .dryRun {
   opacity: 0.75;
+}
+
+/* 🐢 逐次適用 (#783 Phase 2)。エラーではないので警告色で出す */
+.statusSlow {
+  color: var(--nd-warn);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.degradedReasons {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  opacity: 0.75;
+  font-size: 0.9em;
 }
 
 .diagnostics {

--- a/src/components/window/ColumnQueryEditorContent.vue
+++ b/src/components/window/ColumnQueryEditorContent.vue
@@ -185,7 +185,7 @@ async function save(): Promise<void> {
       </template>
       <template v-else-if="isDegraded">
         <span :class="$style.statusSlow">
-          <i class="ti ti-bolt-off" />逐次適用 (1 件ずつ判定するため検索では使えません)
+          <span :class="$style.turtle">🐢</span>逐次適用 (1 件ずつ判定するため検索では使えません)
         </span>
         <ul :class="$style.degradedReasons">
           <li v-for="(d, i) in diagnostics" :key="i">
@@ -279,6 +279,11 @@ async function save(): Promise<void> {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+}
+
+.turtle {
+  font-size: 1.1em;
+  line-height: 1;
 }
 
 .degradedReasons {

--- a/src/components/window/ColumnQueryEditorContent.vue
+++ b/src/components/window/ColumnQueryEditorContent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Parser } from '@syuilo/aiscript'
 import { computed, ref } from 'vue'
 import type { NormalizedNote } from '@/adapters/types'
 import AiScriptEditor from '@/components/deck/widgets/AiScriptEditor.vue'
@@ -67,17 +68,37 @@ const warnings = computed(() =>
 )
 
 /**
- * ガードを式に差し込む。末尾式 (最後の非空行) の先頭に前置する形なので、
- * let 列や関数定義を持つソースでも定義側を壊さない。
+ * ガードを差し込んだソースを組み立てる。適用できない形なら null。
+ *
+ * 末尾式 (最後の非空行) を括弧で包んでから前置する。括弧が要るのは
+ * `A || B` のような式で、括弧なしだと && が || より強く結合してガードが
+ * 左辺にしか掛からないため。
+ *
+ * 末尾行が式として閉じていない形 (`@(note) { ... }` の `}` など) では
+ * 壊れた式になるので、組み立て結果をパースして通ったときだけ返す。
+ * AST の位置情報は式全体の範囲ではなく演算子や引数の位置を指すので、
+ * 位置ベースで囲む方法は採れない。
  */
-function applyGuard(guard: string): void {
+function buildGuarded(guard: string): string | null {
   const lines = source.value.split('\n')
   let i = lines.length - 1
   while (i >= 0 && lines[i]?.trim() === '') i--
   const target = lines[i]
-  if (i < 0 || target === undefined) return
-  lines[i] = `${guard} && ${target}`
-  source.value = lines.join('\n')
+  if (i < 0 || target === undefined) return null
+  const next = [...lines]
+  next[i] = `${guard} && (${target.trim()})`
+  const candidate = next.join('\n')
+  try {
+    new Parser().parse(candidate)
+  } catch {
+    return null
+  }
+  return candidate
+}
+
+function applyGuard(guard: string): void {
+  const next = buildGuarded(guard)
+  if (next !== null) source.value = next
 }
 
 /** 直近フォーカスした TL カラムのロード済みノートに対する dry-run。 */
@@ -173,9 +194,10 @@ async function save(): Promise<void> {
             <span v-if="w.line != null" :class="$style.diagLoc">{{ w.line }}行:</span>
             {{ w.message }}
             <button
+              v-if="buildGuarded(w.guard) !== null"
               class="_button"
               :class="$style.fixButton"
-              :title="`${w.guard} を先頭に入れます`"
+              :title="`末尾の式を ${w.guard} で守ります`"
               @click="applyGuard(w.guard)"
             >
               ガードを入れる

--- a/src/components/window/ColumnQueryEditorContent.vue
+++ b/src/components/window/ColumnQueryEditorContent.vue
@@ -50,6 +50,28 @@ const diagnostics = computed(() =>
   compiled.value && !compiled.value.ok ? compiled.value.diagnostics : [],
 )
 
+/**
+ * null ガード漏れの警告 (V25)。コンパイルは通るが、そのまま保存すると
+ * 画像のみのノートや純リノートが丸ごと消えるので保存前に気づかせる。
+ */
+const warnings = computed(() =>
+  compiled.value?.ok ? compiled.value.warnings : [],
+)
+
+/**
+ * ガードを式に差し込む。末尾式 (最後の非空行) の先頭に前置する形なので、
+ * let 列や関数定義を持つソースでも定義側を壊さない。
+ */
+function applyGuard(guard: string): void {
+  const lines = source.value.split('\n')
+  let i = lines.length - 1
+  while (i >= 0 && lines[i]?.trim() === '') i--
+  const target = lines[i]
+  if (i < 0 || target === undefined) return
+  lines[i] = `${guard} && ${target}`
+  source.value = lines.join('\n')
+}
+
 /** 直近フォーカスした TL カラムのロード済みノートに対する dry-run。 */
 const dryRun = computed(() => {
   const c = compiled.value
@@ -136,6 +158,22 @@ async function save(): Promise<void> {
             v-if="dryRun.error > 0"
           >・エラー {{ dryRun.error }} 件 (除外)</template>
         </span>
+        <!-- null ガード漏れ (V25): 保存はできるが、まず直す導線を出す -->
+        <ul v-if="warnings.length > 0" :class="$style.warnings">
+          <li v-for="w in warnings" :key="w.field">
+            <i class="ti ti-alert-triangle" />
+            <span v-if="w.line != null" :class="$style.diagLoc">{{ w.line }}行:</span>
+            {{ w.message }}
+            <button
+              class="_button"
+              :class="$style.fixButton"
+              :title="`${w.guard} を先頭に入れます`"
+              @click="applyGuard(w.guard)"
+            >
+              ガードを入れる
+            </button>
+          </li>
+        </ul>
       </template>
       <ul v-else :class="$style.diagnostics">
         <li v-for="(d, i) in diagnostics" :key="i">
@@ -153,7 +191,7 @@ async function save(): Promise<void> {
         :disabled="!canSave || !isDirty"
         @click="save"
       >
-        保存
+        {{ warnings.length > 0 ? 'このまま保存' : '保存' }}
       </button>
     </div>
   </div>
@@ -234,6 +272,28 @@ async function save(): Promise<void> {
 
 .diagLoc {
   opacity: 0.7;
+}
+
+/* null ガード漏れ (V25)。エラーではないので warn 色 + quick-fix を並べる */
+.warnings {
+  composes: diagnostics;
+  color: var(--nd-warn);
+
+  li {
+    flex-wrap: wrap;
+  }
+}
+
+.fixButton {
+  padding: 2px 8px;
+  border-radius: var(--nd-radius-full);
+  font-size: 0.9em;
+  color: var(--nd-warn);
+  background: color-mix(in srgb, var(--nd-warn) 14%, transparent);
+
+  &:hover {
+    background: color-mix(in srgb, var(--nd-warn) 24%, transparent);
+  }
 }
 
 .actions {

--- a/src/components/window/ColumnQueryEditorContent.vue
+++ b/src/components/window/ColumnQueryEditorContent.vue
@@ -159,7 +159,7 @@ async function save(): Promise<void> {
     <div v-if="source.trim() !== ''" :class="$style.status">
       <template v-if="compiled?.ok">
         <span :class="$style.statusFast">
-          <i class="ti ti-bolt" />高速クエリ (QIR {{ compiled.nodeCount }} ノード)
+          <i class="ti ti-filter-check" />高速クエリ (QIR {{ compiled.nodeCount }} ノード)
         </span>
         <span v-if="dryRun" :class="$style.dryRun">
           直近の TL カラム {{ dryRun.total }} 件中 {{ dryRun.match }} 件通過<template
@@ -185,7 +185,7 @@ async function save(): Promise<void> {
       </template>
       <template v-else-if="isDegraded">
         <span :class="$style.statusSlow">
-          <span :class="$style.turtle">🐢</span>逐次適用 (1 件ずつ判定するため検索では使えません)
+          <i class="ti ti-hourglass" />逐次適用 (1 件ずつ判定するため検索では使えません)
         </span>
         <ul :class="$style.degradedReasons">
           <li v-for="(d, i) in diagnostics" :key="i">
@@ -281,10 +281,6 @@ async function save(): Promise<void> {
   gap: 4px;
 }
 
-.turtle {
-  font-size: 1.1em;
-  line-height: 1;
-}
 
 .degradedReasons {
   margin: 0;

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -268,6 +268,7 @@ const showPostForm = ref(false)
 const postFormReplyTo = ref<NormalizedNote | undefined>()
 const postFormRenoteId = ref<string | undefined>()
 const postFormEditNote = ref<NormalizedNote | undefined>()
+const postFormInitialNote = ref<NormalizedNote | undefined>()
 
 async function handleRenote(target: NormalizedNote) {
   if (!adapter) return
@@ -281,12 +282,14 @@ async function handleRenote(target: NormalizedNote) {
 function handleReply(target: NormalizedNote) {
   postFormReplyTo.value = target
   postFormRenoteId.value = undefined
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
 function handleQuote(target: NormalizedNote) {
   postFormReplyTo.value = undefined
   postFormRenoteId.value = target.id
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
@@ -294,6 +297,7 @@ function handleEdit(target: NormalizedNote) {
   postFormReplyTo.value = undefined
   postFormRenoteId.value = undefined
   postFormEditNote.value = target
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
@@ -338,28 +342,22 @@ async function handleDeleteAndEdit(target: NormalizedNote) {
         if (import.meta.env.DEV)
           console.debug('[delete-cached-note] ignored:', e)
       })
-    if (id === note.value?.id) {
-      // Reopen post form for the focal note
-      postFormReplyTo.value = target.replyId
-        ? await adapter.api.getNote(target.replyId).catch(() => undefined)
-        : undefined
-      postFormRenoteId.value = undefined
-      postFormEditNote.value = undefined
-      showPostForm.value = true
-    } else {
+    if (id !== note.value?.id) {
       children.value = children.value.filter(
         (n) => n.id !== id && n.renoteId !== id,
       )
       ancestors.value = ancestors.value.filter(
         (n) => n.id !== id && n.renoteId !== id,
       )
-      postFormReplyTo.value = target.replyId
-        ? await adapter.api.getNote(target.replyId).catch(() => undefined)
-        : undefined
-      postFormRenoteId.value = undefined
-      postFormEditNote.value = undefined
-      showPostForm.value = true
     }
+    // Reopen post form with the deleted note's content (#944)
+    postFormReplyTo.value = target.replyId
+      ? await adapter.api.getNote(target.replyId).catch(() => undefined)
+      : undefined
+    postFormRenoteId.value = target.renoteId ?? undefined
+    postFormEditNote.value = undefined
+    postFormInitialNote.value = target
+    showPostForm.value = true
   } catch (e) {
     error.value = AppError.from(e)
   }
@@ -370,6 +368,7 @@ function closePostForm() {
   postFormReplyTo.value = undefined
   postFormRenoteId.value = undefined
   postFormEditNote.value = undefined
+  postFormInitialNote.value = undefined
 }
 
 function buildTree(
@@ -628,6 +627,7 @@ async function handlePosted(editedNoteId?: string) {
         :reply-to="postFormReplyTo"
         :renote-id="postFormRenoteId"
         :edit-note="postFormEditNote"
+        :initial-note="postFormInitialNote"
         @close="closePostForm"
         @posted="handlePosted"
       />

--- a/src/components/window/UserProfileContent.vue
+++ b/src/components/window/UserProfileContent.vue
@@ -502,6 +502,7 @@ const postFormReplyTo = ref<NormalizedNote | undefined>()
 const postFormRenoteId = ref<string | undefined>()
 const postFormEditNote = ref<NormalizedNote | undefined>()
 const postFormInitialText = ref<string | undefined>()
+const postFormInitialNote = ref<NormalizedNote | undefined>()
 
 // User action menu (mute/block/report/list/antenna 等) は
 // UserProfileMenu.vue に分離した。ここでは開閉の ref と compose 連携のみ持つ。
@@ -581,6 +582,7 @@ function handleReply(target: NormalizedNote) {
   postFormReplyTo.value = target
   postFormRenoteId.value = undefined
   postFormInitialText.value = undefined
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
@@ -588,6 +590,7 @@ function handleQuote(target: NormalizedNote) {
   postFormReplyTo.value = undefined
   postFormRenoteId.value = target.id
   postFormInitialText.value = undefined
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
@@ -596,6 +599,7 @@ function handleEdit(target: NormalizedNote) {
   postFormRenoteId.value = undefined
   postFormEditNote.value = target
   postFormInitialText.value = undefined
+  postFormInitialNote.value = undefined
   showPostForm.value = true
 }
 
@@ -635,9 +639,11 @@ async function handleDeleteAndEdit(target: NormalizedNote) {
     postFormReplyTo.value = target.replyId
       ? await adapter.value.api.getNote(target.replyId).catch(() => undefined)
       : undefined
-    postFormRenoteId.value = undefined
+    // 引用・添付・アンケート等を引き継ぐ (#944)
+    postFormRenoteId.value = target.renoteId ?? undefined
     postFormEditNote.value = undefined
     postFormInitialText.value = undefined
+    postFormInitialNote.value = target
     showPostForm.value = true
   } catch (e) {
     error.value = AppError.from(e)
@@ -649,6 +655,7 @@ function closePostForm() {
   postFormReplyTo.value = undefined
   postFormRenoteId.value = undefined
   postFormEditNote.value = undefined
+  postFormInitialNote.value = undefined
 }
 
 async function handlePosted(editedNoteId?: string) {
@@ -905,6 +912,7 @@ async function handlePosted(editedNoteId?: string) {
         :reply-to="postFormReplyTo"
         :renote-id="postFormRenoteId"
         :edit-note="postFormEditNote"
+        :initial-note="postFormInitialNote"
         :initial-text="postFormInitialText"
         @close="closePostForm"
         @posted="handlePosted"

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -165,6 +165,7 @@ export function useColumnSetup(
   const postFormInitialText = ref<string | undefined>()
   const postFormInitialCw = ref<string | undefined>()
   const postFormInitialVisibility = ref<string | undefined>()
+  const postFormInitialNote = ref<NormalizedNote | undefined>()
 
   const toast = useToast()
   const actionSound = useNoteSound(() => account.value?.host, 'syuilo/bubble2')
@@ -241,6 +242,7 @@ export function useColumnSetup(
     if (checkOffline()) return
     postFormReplyTo.value = note
     postFormRenoteId.value = undefined
+    postFormInitialNote.value = undefined
     showPostForm.value = true
   }
 
@@ -248,6 +250,7 @@ export function useColumnSetup(
     if (checkOffline()) return
     postFormReplyTo.value = undefined
     postFormRenoteId.value = note.id
+    postFormInitialNote.value = undefined
     showPostForm.value = true
   }
 
@@ -269,6 +272,7 @@ export function useColumnSetup(
     postFormReplyTo.value = undefined
     postFormRenoteId.value = undefined
     postFormEditNote.value = note
+    postFormInitialNote.value = undefined
     postFormInitialText.value = undefined
     postFormInitialCw.value = undefined
     postFormInitialVisibility.value = undefined
@@ -282,11 +286,14 @@ export function useColumnSetup(
       postFormReplyTo.value = note.replyId
         ? await adapter.api.getNote(note.replyId).catch(() => undefined)
         : undefined
-      postFormRenoteId.value = undefined
+      // 引用・添付・アンケート等を引き継ぐ (#944)。本家も削除して編集では
+      // renote / reply / channel と initialNote を引き渡している
+      postFormRenoteId.value = note.renoteId ?? undefined
       postFormEditNote.value = undefined
-      postFormInitialText.value = note.text ?? undefined
-      postFormInitialCw.value = note.cw ?? undefined
-      postFormInitialVisibility.value = note.visibility
+      postFormInitialNote.value = note
+      postFormInitialText.value = undefined
+      postFormInitialCw.value = undefined
+      postFormInitialVisibility.value = undefined
       showPostForm.value = true
     } catch (e) {
       const err = AppError.from(e)
@@ -344,6 +351,7 @@ export function useColumnSetup(
     postFormReplyTo.value = undefined
     postFormRenoteId.value = undefined
     postFormEditNote.value = undefined
+    postFormInitialNote.value = undefined
     postFormInitialText.value = undefined
     postFormInitialCw.value = undefined
     postFormInitialVisibility.value = undefined
@@ -401,6 +409,7 @@ export function useColumnSetup(
       replyTo: postFormReplyTo,
       renoteId: postFormRenoteId,
       editNote: postFormEditNote,
+      initialNote: postFormInitialNote,
       initialText: postFormInitialText,
       initialCw: postFormInitialCw,
       initialVisibility: postFormInitialVisibility,

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -631,6 +631,41 @@ describe('useNoteColumn: 🐢 逐次適用への降格 (#783 Phase 2c)', () => {
     expect(degraded.runCalls).toEqual([])
   })
 
+  it('サスペンド中に取りこぼした件数を保留として数える', async () => {
+    addAccount('acc-slow-hold')
+    degraded.suspended.add('col-acc-slow-hold:inline')
+    const { api } = mountColumn({
+      accountId: 'acc-slow-hold',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [
+        { ...note('a'), text: 'hello world' } as NormalizedNote,
+        { ...note('b'), text: 'hello there' } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(api.columnQuerySuspendedCount.value).toBe(2)
+  })
+
+  it('明示再開でサスペンドを解除し、取り込みが戻る', async () => {
+    addAccount('acc-slow-resume')
+    degraded.suspended.add('col-acc-slow-resume:inline')
+    const { api } = mountColumn({
+      accountId: 'acc-slow-resume',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [
+        { ...note('long'), text: 'hello world' } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(ids(api)).toEqual([])
+
+    api.resumeSuspendedQueries()
+    await flush()
+    expect(api.columnQuerySuspendedKeys.value).toEqual([])
+    expect(api.columnQuerySuspendedCount.value).toBe(0)
+    expect(ids(api)).toEqual(['long'])
+  })
+
   it('拒否されたクエリ (非純粋) は降格せず fail-closed のまま', async () => {
     addAccount('acc-reject')
     const { api } = mountColumn({

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -802,3 +802,50 @@ describe('useNoteColumn: 消えたクエリ参照からの復旧 (#783 追補 A)
     expect(updates).toEqual([{ noteQueryRefs: undefined }])
   })
 })
+
+describe('useNoteColumn: クエリ変更時の再適用と refetch の順序 (#783)', () => {
+  it('クエリを外したら refetch の結果が残る (再適用に上書きされない)', async () => {
+    addAccount('acc-query-toggle')
+    const column = ref<Partial<DeckColumn>>({
+      noteQuery: 'note.text == "none"',
+    })
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue([
+        { ...note('h01'), text: 'hello' } as NormalizedNote,
+        { ...note('h02'), text: 'world' } as NormalizedNote,
+      ])
+    let api: ReturnType<typeof useNoteColumn> | null = null
+    const Host = defineComponent({
+      setup() {
+        api = useNoteColumn({
+          getColumn: () =>
+            ({
+              id: 'col-query-toggle',
+              type: 'timeline',
+              accountId: 'acc-query-toggle',
+              ...column.value,
+            }) as DeckColumn,
+          fetch: () => fetchImpl(),
+          cache: { getKey: () => 'home' },
+        })
+        return () => null
+      },
+    })
+    const app = createApp(Host)
+    app.use(pinia)
+    app.mount(document.createElement('div'))
+    apps.push(app)
+    await flush()
+    // 全件フィルタ落ちで空
+    expect(ids(api as never)).toEqual([])
+
+    // クエリを外す → 再適用 (空のまま) と refetch が走る
+    column.value = {}
+    await flush(20)
+
+    // refetch の結果が残っていること (空で上書きされない)。
+    // 並びは fetch の返却順そのまま (既存挙動)
+    expect(ids(api as never)).toEqual(['h01', 'h02'])
+  })
+})

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -14,7 +14,7 @@ import type {
   TimelineFilter,
 } from '@/adapters/types'
 import { type Account, useAccountsStore } from '@/stores/accounts'
-import type { DeckColumn } from '@/stores/deck'
+import { type DeckColumn, useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
 import { matchesFilter } from '@/utils/timelineFilter'
 import { type NoteColumnConfig, useNoteColumn } from './useNoteColumn'
@@ -176,6 +176,7 @@ function mountColumn(opts: {
   filters?: Ref<TimelineFilter | undefined>
   streaming?: boolean
   noteQuery?: string
+  noteQueryRefs?: string[]
 }) {
   const tlKey = ref('home')
   let api: ReturnType<typeof useNoteColumn> | null = null
@@ -189,6 +190,7 @@ function mountColumn(opts: {
             accountId: opts.accountId,
             filters: opts.filters?.value,
             noteQuery: opts.noteQuery,
+            noteQueryRefs: opts.noteQueryRefs,
           }) as DeckColumn,
         fetch: opts.fetch,
         cache: { getKey: () => tlKey.value },
@@ -762,5 +764,41 @@ describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
       createdAt: '2026-06-30T00:00:00.000Z',
       noteId: 'h00',
     })
+  })
+})
+
+describe('useNoteColumn: 消えたクエリ参照からの復旧 (#783 追補 A)', () => {
+  it('参照先が無いクエリは fail-closed のまま id を露出する', async () => {
+    addAccount('acc-missing-ref')
+    const { api } = mountColumn({
+      accountId: 'acc-missing-ref',
+      columnId: 'col-missing',
+      noteQueryRefs: ['deleted-query'],
+      fetch: async () => [{ ...note('a'), text: 'x' } as NormalizedNote],
+    })
+    await flush()
+    // 参照が消えても勝手に外さない (再導入で戻せるように)
+    expect(api.columnQueryMissingIds.value).toEqual(['deleted-query'])
+    expect(api.columnQueryState.value.status).toBe('invalid')
+    expect(ids(api)).toEqual([])
+  })
+
+  it('参照を外すとカラム設定から取り除かれる', async () => {
+    addAccount('acc-drop-ref')
+    const deck = useDeckStore()
+    const updates: unknown[] = []
+    vi.spyOn(deck, 'updateColumn').mockImplementation((_id, patch) => {
+      updates.push(patch)
+    })
+    const { api } = mountColumn({
+      accountId: 'acc-drop-ref',
+      columnId: 'col-drop',
+      noteQueryRefs: ['deleted-query', 'another-deleted'],
+      fetch: async () => [],
+    })
+    await flush()
+
+    api.dropMissingQueryRefs()
+    expect(updates).toEqual([{ noteQueryRefs: undefined }])
   })
 })

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -39,6 +39,52 @@ vi.mock('@/bindings', () => ({
   ),
 }))
 
+/**
+ * 🐢 降格の runner を Worker 抜きで差し替える (#783 Phase 2c)。
+ * 評価ロジックは本物 (degradedBatch) をそのまま同期実行するので、
+ * カラム側の接続だけを検証できる。Worker 境界は degradedRunner.test.ts の担当。
+ */
+const degraded = vi.hoisted(() => ({
+  suspended: new Set<string>(),
+  runCalls: [] as { keys: string[]; noteCount: number }[],
+}))
+
+vi.mock('@/services/columnQuery/degradedRunner', async () => {
+  const { createDegradedBatchRunner } = await vi.importActual<
+    typeof import('@/services/columnQuery/degradedBatch')
+  >('@/services/columnQuery/degradedBatch')
+  return {
+    getSharedDegradedRunner: () => ({
+      run: async (
+        filters: { key: string; source: string }[],
+        notes: unknown[],
+      ) => {
+        degraded.runCalls.push({
+          keys: filters.map((f) => f.key),
+          noteCount: notes.length,
+        })
+        if (filters.some((f) => degraded.suspended.has(f.key))) {
+          return {
+            verdicts: notes.map(() => 'error' as const),
+            invalidFilters: [],
+            suspended: [],
+          }
+        }
+        const batch = createDegradedBatchRunner()
+        const out = batch.run(filters, notes)
+        batch.dispose()
+        return { ...out, suspended: [] }
+      },
+      isSuspended: (key: string) => degraded.suspended.has(key),
+      suspendedKeys: () => [...degraded.suspended],
+      resume: (key: string) => degraded.suspended.delete(key),
+      dispose: () => {
+        // Worker を持たないので解放するものがない
+      },
+    }),
+  }
+})
+
 const fakeStream = {
   connect: vi.fn(),
   reconnect: vi.fn(),
@@ -75,8 +121,12 @@ function note(id: string, visibility = 'public'): NormalizedNote {
   } as unknown as NormalizedNote
 }
 
-/** マイクロタスクと nextTick を数周流して非同期チェーンを収束させる */
-async function flush(rounds = 6) {
+/**
+ * マイクロタスクと nextTick を数周流して非同期チェーンを収束させる。
+ * 取り込み経路が 🐢 降格 (#783 Phase 2) に対応して async になった分、
+ * 収束に必要な周回が増えている (6 周では足りない)。
+ */
+async function flush(rounds = 10) {
   for (let i = 0; i < rounds; i++) {
     await Promise.resolve()
     await nextTick()
@@ -121,6 +171,7 @@ function mountColumn(opts: {
   fetchKey?: NoteColumnConfig['fetchKey']
   filters?: Ref<TimelineFilter | undefined>
   streaming?: boolean
+  noteQuery?: string
 }) {
   const tlKey = ref('home')
   let api: ReturnType<typeof useNoteColumn> | null = null
@@ -133,6 +184,7 @@ function mountColumn(opts: {
             type: 'timeline',
             accountId: opts.accountId,
             filters: opts.filters?.value,
+            noteQuery: opts.noteQuery,
           }) as DeckColumn,
         fetch: opts.fetch,
         cache: { getKey: () => tlKey.value },
@@ -493,5 +545,102 @@ describe('useNoteColumn: フェッチカーソル (#831 Step 0)', () => {
 
     // 旧カーソル (h03) が残っていると h09 と h03 の間がスキップされる
     expect(fetchImpl.mock.calls[3]?.[0]).toEqual({ untilId: 'h09' })
+  })
+})
+
+describe('useNoteColumn: 🐢 逐次適用への降格 (#783 Phase 2c)', () => {
+  // str.len は QIR サブセット外だが純粋なので Worker 逐次適用に降格する
+  const SLOW_QUERY = 'note.text != null && note.text.len > 3'
+
+  beforeEach(() => {
+    degraded.suspended.clear()
+    degraded.runCalls.length = 0
+  })
+
+  it('降格クエリを持つカラムは status が degraded になる', async () => {
+    addAccount('acc-slow')
+    const { api } = mountColumn({
+      accountId: 'acc-slow',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [],
+    })
+    await flush()
+    expect(api.columnQueryState.value.status).toBe('degraded')
+  })
+
+  it('REST 取得結果に降格クエリが適用される', async () => {
+    addAccount('acc-slow-rest')
+    const { api } = mountColumn({
+      accountId: 'acc-slow-rest',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [
+        { ...note('long'), text: 'hello world' } as NormalizedNote,
+        { ...note('short'), text: 'hi' } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(ids(api)).toEqual(['long'])
+    expect(degraded.runCalls.length).toBeGreaterThan(0)
+  })
+
+  it('除外したノートを診断に計上する', async () => {
+    addAccount('acc-slow-count')
+    const { api } = mountColumn({
+      accountId: 'acc-slow-count',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [
+        { ...note('long'), text: 'hello world' } as NormalizedNote,
+        { ...note('short'), text: 'hi' } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(api.columnQueryExcludedCount.value).toBeGreaterThan(0)
+  })
+
+  it('サスペンド中のクエリは fail-closed (全件除外)', async () => {
+    addAccount('acc-slow-susp')
+    degraded.suspended.add('col-acc-slow-susp:inline')
+    const { api } = mountColumn({
+      accountId: 'acc-slow-susp',
+      noteQuery: SLOW_QUERY,
+      fetch: async () => [
+        { ...note('long'), text: 'hello world' } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(ids(api)).toEqual([])
+    expect(api.columnQuerySuspendedKeys.value).toEqual([
+      'col-acc-slow-susp:inline',
+    ])
+  })
+
+  it('⚡ だけのカラムでは Worker 経路を通らない', async () => {
+    addAccount('acc-fast')
+    const { api } = mountColumn({
+      accountId: 'acc-fast',
+      // QIR にコンパイルできる = ⚡
+      noteQuery: 'note.text != null',
+      fetch: async () => [
+        { ...note('a'), text: 'x' } as NormalizedNote,
+        { ...note('b'), text: null } as NormalizedNote,
+      ],
+    })
+    await flush()
+    expect(ids(api)).toEqual(['a'])
+    expect(api.columnQueryState.value.status).toBe('active')
+    expect(degraded.runCalls).toEqual([])
+  })
+
+  it('拒否されたクエリ (非純粋) は降格せず fail-closed のまま', async () => {
+    addAccount('acc-reject')
+    const { api } = mountColumn({
+      accountId: 'acc-reject',
+      noteQuery: 'Date:now() > 0',
+      fetch: async () => [{ ...note('a'), text: 'x' } as NormalizedNote],
+    })
+    await flush()
+    expect(api.columnQueryState.value.status).toBe('invalid')
+    expect(ids(api)).toEqual([])
+    expect(degraded.runCalls).toEqual([])
   })
 })

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -23,6 +23,8 @@ import { type NoteColumnConfig, useNoteColumn } from './useNoteColumn'
 // 呼び出しは記録し、キャッシュ系アサーションで参照する
 const bindings = vi.hoisted(() => ({
   calls: [] as { name: string; args: unknown[] }[],
+  /** コマンド名ごとの応答。未設定なら空配列 (既存テストの既定) */
+  responses: {} as Record<string, unknown>,
 }))
 
 vi.mock('@/bindings', () => ({
@@ -33,7 +35,8 @@ vi.mock('@/bindings', () => ({
         (_t, name: string) =>
         (...args: unknown[]) => {
           bindings.calls.push({ name, args })
-          return Promise.resolve({ status: 'ok', data: [] })
+          const data = bindings.responses[name] ?? []
+          return Promise.resolve({ status: 'ok', data })
         },
     },
   ),
@@ -138,6 +141,7 @@ let pinia: ReturnType<typeof createPinia>
 
 beforeEach(() => {
   bindings.calls.length = 0
+  for (const k of Object.keys(bindings.responses)) delete bindings.responses[k]
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
   pinia = createPinia()
@@ -677,5 +681,86 @@ describe('useNoteColumn: 🐢 逐次適用への降格 (#783 Phase 2c)', () => {
     expect(api.columnQueryState.value.status).toBe('invalid')
     expect(ids(api)).toEqual([])
     expect(degraded.runCalls).toEqual([])
+  })
+})
+
+describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
+  const FAST_QUERY = 'note.text != null'
+  const SLOW_QUERY = 'note.text != null && note.text.len > 3'
+
+  const searchCalls = () =>
+    bindings.calls.filter((c) => c.name === 'qirSearchCache')
+  const legacyCalls = () =>
+    bindings.calls.filter((c) => c.name === 'apiGetCachedTimelineBefore')
+
+  /**
+   * オフライン fallback でキャッシュ経路に入らせる。
+   * dedup レスポンスキャッシュ (TTL 5s) を跨がないよう accountId は毎回変える
+   */
+  async function mountOfflineColumn(
+    accountId: string,
+    noteQuery: string | undefined,
+  ) {
+    addAccount(accountId)
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...note('h05'), text: 'hello' }])
+      .mockRejectedValueOnce(new Error('offline'))
+    const { api } = mountColumn({
+      accountId,
+      noteQuery,
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    await api.loadMore()
+    await flush()
+    return api
+  }
+
+  it('⚡ クエリのカラムはキャッシュ検索コマンドを使う', async () => {
+    bindings.responses.qirSearchCache = {
+      notes: [],
+      scanned: 0,
+      errors: 0,
+      cursor: null,
+    }
+    await mountOfflineColumn('acc-search-fast', FAST_QUERY)
+    expect(searchCalls()).toHaveLength(1)
+    expect(legacyCalls()).toHaveLength(0)
+  })
+
+  it('クエリが無いカラムは従来のキャッシュ経路のまま', async () => {
+    await mountOfflineColumn('acc-search-none', undefined)
+    expect(searchCalls()).toHaveLength(0)
+    expect(legacyCalls()).toHaveLength(1)
+  })
+
+  it('🐢 降格クエリは QIR を持たないので従来経路', async () => {
+    await mountOfflineColumn('acc-search-slow', SLOW_QUERY)
+    expect(searchCalls()).toHaveLength(0)
+    expect(legacyCalls()).toHaveLength(1)
+  })
+
+  it('見つかったノートを取り込み、打ち切りカーソルから次を続ける', async () => {
+    bindings.responses.qirSearchCache = {
+      notes: [{ ...note('h01'), text: 'hit' }],
+      scanned: 2000,
+      errors: 3,
+      // 走査上限で打ち切り
+      cursor: { createdAt: '2026-06-30T00:00:00.000Z', noteId: 'h00' },
+    }
+    const api = await mountOfflineColumn('acc-search-cursor', FAST_QUERY)
+    expect(ids(api)).toContain('h01')
+    // per-note エラーは診断に積まれる
+    expect(api.columnQueryErrorCount.value).toBeGreaterThanOrEqual(3)
+
+    // 次の loadMore は打ち切り位置から続ける
+    await api.loadMore()
+    await flush()
+    const second = searchCalls()[1]
+    expect(second?.args[4]).toEqual({
+      createdAt: '2026-06-30T00:00:00.000Z',
+      noteId: 'h00',
+    })
   })
 })

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -849,3 +849,50 @@ describe('useNoteColumn: クエリ変更時の再適用と refetch の順序 (#7
     expect(ids(api as never)).toEqual(['h01', 'h02'])
   })
 })
+
+describe('useNoteColumn: fail-closed から解除したときの再取得 (#957)', () => {
+  it('ストリーミングカラムが空でもクエリ変更で取り直す', async () => {
+    addAccount('acc-refetch-empty')
+    const column = ref<Partial<DeckColumn>>({
+      noteQuery: 'note.text == "none"',
+    })
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValue([
+        { ...note('h01'), text: 'hello' } as NormalizedNote,
+        { ...note('h02'), text: 'world' } as NormalizedNote,
+      ])
+    let api: ReturnType<typeof useNoteColumn> | null = null
+    const Host = defineComponent({
+      setup() {
+        api = useNoteColumn({
+          getColumn: () =>
+            ({
+              id: 'col-refetch-empty',
+              type: 'timeline',
+              accountId: 'acc-refetch-empty',
+              ...column.value,
+            }) as DeckColumn,
+          fetch: () => fetchImpl(),
+          cache: { getKey: () => 'home' },
+          // 復帰 catch-up 経路に入るのはストリーミングカラムだけ
+          streaming: { subscribe: () => ({ dispose: vi.fn() }) },
+        })
+        return () => null
+      },
+    })
+    const app = createApp(Host)
+    app.use(pinia)
+    app.mount(document.createElement('div'))
+    apps.push(app)
+    await flush()
+    // 全件フィルタ落ちで空 (fail-closed 相当)
+    expect(ids(api as never)).toEqual([])
+
+    column.value = {}
+    await flush(20)
+
+    // 空のままにせず取り直していること
+    expect(ids(api as never).length).toBeGreaterThan(0)
+  })
+})

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -500,7 +500,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
         setNotes(filtered)
       }
       if (generation !== querySignatureGeneration) return
-      await refresh()
+      // 再適用で列が空になっていても取り直す。ストリーミングカラムの
+      // catch-up は「ノートが 1 件も無ければ API を叩かない」ので、
+      // force なしだと空のまま次のストリームイベントまで埋まらない (#957)
+      await refresh({ force: true })
     })()
   })
 
@@ -1099,12 +1102,12 @@ export function useNoteColumn(config: NoteColumnConfig) {
     })
   }
 
-  async function refresh() {
+  async function refresh(opts?: { force?: boolean }) {
     if (isStreaming) {
       // ストリーミングカラムのリロードボタン: 復帰 catch-up と同じ経路で
       // 最新ページを取得し gap 判定する。手動操作なのでスロットルは無視 (#791)
       lastResumeAt = 0
-      await onResume()
+      await onResume(opts)
       return
     }
     const adapter = getAdapter()
@@ -1172,7 +1175,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
 
   let lastResumeAt = 0
 
-  async function onResume() {
+  async function onResume(opts?: { force?: boolean }) {
     const adapter = getAdapter()
     if (!adapter || !account.value) return
     if (config.validate && !config.validate()) return
@@ -1182,6 +1185,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
     lastResumeAt = now
 
     const hadNotes = rawNotes.value.length > 0
+    // クエリ変更のように「今は空だが取り直したい」場合に判定を迂回する。
+    // hadNotes は本来「まだ 1 ページも取っていない = 初回接続が担うので
+    // catch-up 不要」を見るためのもので、一時的に空になった列には当たらない
+    const shouldFetch = hadNotes || opts?.force === true
     const stillCurrent = tabGuard()
 
     // Run cache fetch and API fetch in parallel. Fetch the LATEST page (not
@@ -1195,7 +1202,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
         : Promise.resolve([] as NormalizedNote[])
 
     let apiFailed = false
-    const apiPromise = hadNotes
+    const apiPromise = shouldFetch
       ? fetchAndDedup(adapter, {}).catch((e) => {
           logWarn('resume-api', e)
           apiFailed = true

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -24,6 +24,7 @@ import {
   loadCachedTimeline,
   loadCachedTimelineBefore,
   purgeStaleCachedNotes,
+  searchCachedNotesByQuery,
 } from '@/composables/useNoteColumnCache'
 import { useNoteFocus } from '@/composables/useNoteFocus'
 import { useNoteList } from '@/composables/useNoteList'
@@ -53,6 +54,11 @@ import { AppError } from '@/utils/errors'
 import { logWarn } from '@/utils/logger'
 import { insertIntoSorted } from '@/utils/sortNotes'
 import { matchesFilter } from '@/utils/timelineFilter'
+
+/** QIR キャッシュ検索が 1 度に返すノート数 (#783 Phase 3) */
+const CACHE_SEARCH_LIMIT = 40
+/** 1 度の呼び出しで読む行数の上限。超えたら打ち切ってカーソルを返す */
+const CACHE_SEARCH_MAX_SCANNED_ROWS = 2000
 
 /** 🐢 逐次適用へ降格したクエリパーツ (Phase 2)。key はサスペンドの単位 */
 interface DegradedPart {
@@ -408,6 +414,23 @@ export function useNoteColumn(config: NoteColumnConfig) {
       querySuspendedCount.value += notes.length - admitted.length
     }
     return admitted
+  }
+
+  /**
+   * QIR キャッシュ検索に使えるクエリ (#783 Phase 3)。
+   *
+   * ⚡ の単一パーツに限る。複数パーツを And で束ねると let のスロット番号が
+   * パーツ間で衝突しうるし、🐢 パーツは QIR を持たない。該当しないカラムは
+   * 従来どおり「キャッシュから読んでフロントで絞る」経路を通る。
+   */
+  function cacheSearchableQuery(): QirQuery | null {
+    const compiled = compiledQuery.value
+    if (!compiled) return null
+    if (compiled.degraded.length > 0 || compiled.rejected.length > 0)
+      return null
+    if (compiled.missing.length > 0) return null
+    if (compiled.fast.length !== 1) return null
+    return compiled.fast[0]?.query ?? null
   }
 
   /**
@@ -938,6 +961,39 @@ export function useNoteColumn(config: NoteColumnConfig) {
     const stillCurrent = tabGuard()
     isLoading.value = true
     try {
+      const searchable = cacheSearchableQuery()
+      if (searchable) {
+        // 条件に合うノートが見つかるまでキャッシュを遡る (Phase 3)。
+        // 「40 件読んで全部フィルタで落ちる」空振りをここで吸収する
+        const cursor = fetchCursor.value
+          ? {
+              createdAt: fetchCursor.value.createdAt,
+              noteId: fetchCursor.value.id,
+            }
+          : null
+        const found = await searchCachedNotesByQuery(
+          column.accountId,
+          searchable,
+          cursor,
+          CACHE_SEARCH_LIMIT,
+          CACHE_SEARCH_MAX_SCANNED_ROWS,
+        )
+        if (!stillCurrent()) return
+        queryErrorCount.value += found.errors
+        if (found.cursor) {
+          // 走査上限で打ち切った位置から次回続ける
+          fetchCursor.value = {
+            id: found.cursor.noteId,
+            createdAt: found.cursor.createdAt,
+          }
+        } else {
+          advanceFetchCursor(found.notes)
+        }
+        if (found.notes.length > 0) {
+          await setNotesPaged(insertIntoSorted(rawNotes.value, found.notes))
+        }
+        return
+      }
       const older = await loadCachedTimelineBefore(
         column.accountId,
         cacheKey,

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -478,16 +478,28 @@ export function useNoteColumn(config: NoteColumnConfig) {
     ].join('+')
   })
 
+  /** クエリ変更の世代。遅れて返った再適用が新しい状態を壊さないためのガード */
+  let querySignatureGeneration = 0
+
   // クエリ変更時 (インライン編集・トグル・named の編集伝播): 診断をリセットし、
   // 表示中ノートへ即時適用 (絞り込み方向) + refetch (緩和方向の回収)
   watch(querySignature, (next, prev) => {
     if (next === prev) return
     queryErrorCount.value = 0
     queryExcludedCount.value = 0
-    if (rawNotes.value.length > 0) {
-      void applyQueryFilter(rawNotes.value).then(setNotes)
-    }
-    void refresh()
+    const generation = ++querySignatureGeneration
+    // 再適用と refetch は直列に流す。並行にすると、🐢 の Worker 待ちで遅れた
+    // 再適用が refetch の結果を「変更前のクエリで絞った列」で上書きしてしまう
+    // (fail-closed 中は空列なので、解除した瞬間に一覧が消える)
+    void (async () => {
+      if (rawNotes.value.length > 0) {
+        const filtered = await applyQueryFilter(rawNotes.value)
+        if (generation !== querySignatureGeneration) return
+        setNotes(filtered)
+      }
+      if (generation !== querySignatureGeneration) return
+      await refresh()
+    })()
   })
 
   async function applyQueryFilter(

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -320,8 +320,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
   const queryErrorCount = ref(0)
   /** クエリで除外したノート数 (空状態の「TL が空」との区別表示用) */
   const queryExcludedCount = ref(0)
-  /** 暴走で打ち切られサスペンド中のフィルタ (2d の「N 件保留中」表示用) */
+  /** 暴走で打ち切られサスペンド中のフィルタ (「N 件保留中」表示用) */
   const suspendedQueryKeys = shallowRef<readonly string[]>([])
+  /** サスペンド中に判定できず取り込めなかった件数 */
+  const querySuspendedCount = ref(0)
 
   const columnQueryState = computed(() => {
     const compiled = compiledQuery.value
@@ -388,6 +390,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     suspendedQueryKeys.value = compiled.degraded
       .map((d) => d.key)
       .filter((key) => runner.isSuspended(key))
+    const isSuspended = suspendedQueryKeys.value.length > 0
     const admitted: NormalizedNote[] = []
     outcome.verdicts.forEach((verdict, i) => {
       const note = notes[i]
@@ -399,7 +402,24 @@ export function useNoteColumn(config: NoteColumnConfig) {
       if (verdict === 'error') queryErrorCount.value++
       queryExcludedCount.value++
     })
+    // サスペンド中の取りこぼしは「保留」として別に数える。評価できていない
+    // だけで、条件に合わないと判定したわけではない
+    if (isSuspended) {
+      querySuspendedCount.value += notes.length - admitted.length
+    }
     return admitted
+  }
+
+  /**
+   * サスペンドを解除して取り込みを再開する (V15 の明示再開)。
+   * 自動では戻さない — 暴走したクエリを黙って走らせ直さないため。
+   */
+  function resumeSuspendedQueries(): void {
+    const runner = getSharedDegradedRunner()
+    for (const key of suspendedQueryKeys.value) runner.resume(key)
+    suspendedQueryKeys.value = []
+    querySuspendedCount.value = 0
+    void refresh()
   }
 
   /** 合成クエリの実効シグネチャ (dedup キーと変更検知を兼ねる)。 */
@@ -1315,6 +1335,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
     columnQueryExcludedCount: queryExcludedCount,
     /** 暴走で打ち切られサスペンド中のクエリ (fail-closed 中のカラムを示す) */
     columnQuerySuspendedKeys: suspendedQueryKeys,
+    columnQuerySuspendedCount: querySuspendedCount,
+    resumeSuspendedQueries,
     notes,
     orderedIds,
     focusedNoteId,

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -15,6 +15,7 @@ import type {
   ServerAdapter,
   TimelineType,
 } from '@/adapters/types'
+import type { QirQuery } from '@/bindings'
 import { useColumnLive } from '@/composables/useColumnMount'
 import { useColumnSetup } from '@/composables/useColumnSetup'
 import { useNavigation } from '@/composables/useNavigation'
@@ -38,6 +39,7 @@ import {
   compileColumnQuery,
   hashQirQuery,
 } from '@/services/columnQuery/compiler'
+import { getSharedDegradedRunner } from '@/services/columnQuery/degradedRunner'
 import { evaluateQirQuery } from '@/services/columnQuery/evaluator'
 import { isGuestAccount } from '@/stores/accounts'
 import { useColumnQueriesStore } from '@/stores/columnQueries'
@@ -51,6 +53,13 @@ import { AppError } from '@/utils/errors'
 import { logWarn } from '@/utils/logger'
 import { insertIntoSorted } from '@/utils/sortNotes'
 import { matchesFilter } from '@/utils/timelineFilter'
+
+/** 🐢 逐次適用へ降格したクエリパーツ (Phase 2)。key はサスペンドの単位 */
+interface DegradedPart {
+  label: string | null
+  key: string
+  source: string
+}
 
 export interface NoteColumnConfig {
   getColumn: () => DeckColumnType
@@ -78,7 +87,9 @@ export interface NoteColumnConfig {
    * 両方に適用される (ストリーミング挿入はカラム側 subscribe 内で適用)。
    * local/global の public 限定などサーバー応答に依存しない可視性保証 (#651)。
    */
-  filterNotes?: (notes: NormalizedNote[]) => NormalizedNote[]
+  filterNotes?: (
+    notes: NormalizedNote[],
+  ) => NormalizedNote[] | Promise<NormalizedNote[]>
   /**
    * dedup レスポンスキャッシュの追加識別子 (例: カラムフィルタの JSON)。
    * 同一アカウント・同一 TL 種別でフィルタ違いのカラムがレスポンスを
@@ -275,26 +286,43 @@ export function useNoteColumn(config: NoteColumnConfig) {
     const inline = col.noteQuery?.trim() ? col.noteQuery : null
     const refs = col.noteQueryRefs ?? []
     if (!inline && refs.length === 0) return null
-    const parts: { label: string | null; result: CompileResult }[] = []
+    // ⚡ = QIR で同期評価、🐢 = Worker で逐次適用 (Phase 2)、拒否 = fail-closed
+    const fast: { label: string | null; query: QirQuery }[] = []
+    const degraded: DegradedPart[] = []
+    const rejected: { label: string | null; result: CompileResult }[] = []
     // 参照消失 (削除・未導入) は捨てず fail-closed (仕様追補 A)
     const missing: string[] = []
-    if (inline) {
-      parts.push({ label: null, result: compileColumnQuery(inline) })
+
+    function classify(label: string | null, key: string, src: string): void {
+      const result = compileColumnQuery(src)
+      if (result.ok) {
+        fast.push({ label, query: result.query })
+      } else if (result.degradable) {
+        degraded.push({ label, key, source: src })
+      } else {
+        rejected.push({ label, result })
+      }
     }
+
+    if (inline) classify(null, `${col.id}:inline`, inline)
     for (const id of refs) {
       const named = columnQueriesStore.getQuery(id)
       if (!named) {
         missing.push(id)
         continue
       }
-      parts.push({ label: named.name, result: compileColumnQuery(named.src) })
+      // key は名前付きクエリ id。同じクエリを使う全カラムでサスペンドを共有する
+      classify(named.name, id, named.src)
     }
-    return { parts, missing }
+    return { fast, degraded, rejected, missing }
   })
   /** per-note エラーの診断計上 (V14: エラー = 除外 + 計上) */
   const queryErrorCount = ref(0)
   /** クエリで除外したノート数 (空状態の「TL が空」との区別表示用) */
   const queryExcludedCount = ref(0)
+  /** 暴走で打ち切られサスペンド中のフィルタ (2d の「N 件保留中」表示用) */
+  const suspendedQueryKeys = shallowRef<readonly string[]>([])
+
   const columnQueryState = computed(() => {
     const compiled = compiledQuery.value
     if (!compiled) return { status: 'none' as const, diagnostics: [] }
@@ -304,34 +332,74 @@ export function useNoteColumn(config: NoteColumnConfig) {
         message: `参照している名前付きクエリ (${id}) が見つかりません`,
       })
     }
-    for (const part of compiled.parts) {
-      if (part.result.ok) continue
+    for (const part of compiled.rejected) {
       const prefix = part.label ? `${part.label}: ` : ''
-      for (const d of part.result.diagnostics) {
+      for (const d of part.result.ok ? [] : part.result.diagnostics) {
         diagnostics.push({ message: `${prefix}${d.message}` })
       }
     }
     if (diagnostics.length > 0) {
       return { status: 'invalid' as const, diagnostics }
     }
+    // 🐢: 逐次適用に降格しているカラム (インデックス検索は使えない)
+    if (compiled.degraded.length > 0) {
+      return { status: 'degraded' as const, diagnostics: [] }
+    }
     return { status: 'active' as const, diagnostics: [] }
   })
 
-  function queryAdmits(note: NormalizedNote): boolean {
+  /**
+   * ⚡ パーツ (QIR) だけの同期判定。🐢 パーツは Worker が要るのでここでは見ない。
+   * 取り込み経路はまずこれで短絡し、生き残りだけを Worker に回す。
+   */
+  function queryAdmitsFast(note: NormalizedNote): boolean {
     const compiled = compiledQuery.value
     if (!compiled) return true
-    // 参照消失・コンパイル不能の残留は fail-closed (不変条件 (f))
+    // 参照消失・拒否されたクエリの残留は fail-closed (不変条件 (f))
     if (columnQueryState.value.status === 'invalid') return false
     // And 合成: 全部 match のときだけ表示 (短絡)。error = 除外 + 計上
-    for (const part of compiled.parts) {
-      if (!part.result.ok) return false // 到達しない (invalid で弾く) が防御
-      const verdict = evaluateQirQuery(part.result.query, note)
+    for (const part of compiled.fast) {
+      const verdict = evaluateQirQuery(part.query, note)
       if (verdict === 'match') continue
       if (verdict === 'error') queryErrorCount.value++
       queryExcludedCount.value++
       return false
     }
     return true
+  }
+
+  /**
+   * 🐢 パーツを Worker で評価する (Phase 2c)。⚡ で生き残ったノートだけが対象。
+   * 評価不能 (サスペンド・タイムアウト) は error = 除外 + 計上で、カラムは
+   * fail-closed のまま新着が積まれない状態になる (不変条件 (f))。
+   */
+  async function admitDegraded(
+    notes: NormalizedNote[],
+  ): Promise<NormalizedNote[]> {
+    const compiled = compiledQuery.value
+    if (!compiled || compiled.degraded.length === 0 || notes.length === 0) {
+      return notes
+    }
+    const runner = getSharedDegradedRunner()
+    const outcome = await runner.run(
+      compiled.degraded.map((d) => ({ key: d.key, source: d.source })),
+      notes,
+    )
+    suspendedQueryKeys.value = compiled.degraded
+      .map((d) => d.key)
+      .filter((key) => runner.isSuspended(key))
+    const admitted: NormalizedNote[] = []
+    outcome.verdicts.forEach((verdict, i) => {
+      const note = notes[i]
+      if (note === undefined) return
+      if (verdict === 'match') {
+        admitted.push(note)
+        return
+      }
+      if (verdict === 'error') queryErrorCount.value++
+      queryExcludedCount.value++
+    })
+    return admitted
   }
 
   /** 合成クエリの実効シグネチャ (dedup キーと変更検知を兼ねる)。 */
@@ -341,9 +409,11 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (columnQueryState.value.status === 'invalid') {
       return `invalid:${compiled.missing.join(',')}`
     }
-    return compiled.parts
-      .map((p) => (p.result.ok ? hashQirQuery(p.result.query) : 'x'))
-      .join('+')
+    return [
+      ...compiled.fast.map((p) => hashQirQuery(p.query)),
+      // 🐢 パーツは QIR を持たないのでソースそのものを署名に混ぜる
+      ...compiled.degraded.map((d) => `slow:${d.key}:${d.source.length}`),
+    ].join('+')
   })
 
   // クエリ変更時 (インライン編集・トグル・named の編集伝播): 診断をリセットし、
@@ -353,21 +423,61 @@ export function useNoteColumn(config: NoteColumnConfig) {
     queryErrorCount.value = 0
     queryExcludedCount.value = 0
     if (rawNotes.value.length > 0) {
-      setNotes(applyQueryFilter(rawNotes.value))
+      void applyQueryFilter(rawNotes.value).then(setNotes)
     }
     void refresh()
   })
 
-  function applyQueryFilter(incoming: NormalizedNote[]): NormalizedNote[] {
+  async function applyQueryFilter(
+    incoming: NormalizedNote[],
+  ): Promise<NormalizedNote[]> {
     if (!compiledQuery.value) return incoming
-    return incoming.filter((n) => queryAdmits(n))
+    return admitDegraded(incoming.filter((n) => queryAdmitsFast(n)))
   }
 
-  /** streaming 挿入にも組込フィルタ + クエリを適用する (enqueue 前段、V13/V22) */
+  /**
+   * streaming 挿入にも組込フィルタ + クエリを適用する (enqueue 前段、V13/V22)。
+   *
+   * ⚡ だけのカラムは同期のまま即 enqueue する。🐢 パーツがあるカラムは
+   * 判定が非同期になるので、判定待ちバッファへ積んで hold-and-release する。
+   */
   function enqueueWithQuery(n: NormalizedNote): void {
     if (!builtinAdmits(n)) return
-    if (!queryAdmits(n)) return
-    streamingBatch?.enqueueNote(n)
+    if (!queryAdmitsFast(n)) return
+    if ((compiledQuery.value?.degraded.length ?? 0) === 0) {
+      streamingBatch?.enqueueNote(n)
+      return
+    }
+    holdForDegraded(n)
+  }
+
+  // --- 判定待ちバッファ (hold-and-release, V22) ---
+  // 到着順を保つため、バッチは 1 本ずつ直列に流す。判定が終わったものから
+  // 順に enqueue するので、Worker の応答が前後しても表示順は入れ替わらない。
+  let heldNotes: NormalizedNote[] = []
+  let holdFlush: Promise<void> | null = null
+
+  function holdForDegraded(n: NormalizedNote): void {
+    heldNotes.push(n)
+    // 実行中なら積むだけ。flush 側のループが同じバッファを拾って続ける
+    if (holdFlush !== null) return
+    holdFlush = flushHeldNotes().finally(() => {
+      holdFlush = null
+    })
+  }
+
+  async function flushHeldNotes(): Promise<void> {
+    while (heldNotes.length > 0) {
+      const batch = heldNotes
+      heldNotes = []
+      const admitted = await admitDegraded(batch)
+      for (const note of admitted) streamingBatch?.enqueueNote(note)
+    }
+  }
+
+  /** 判定待ちのまま削除されたノートを捨てる (removePending と同じ役割) */
+  function dropHeldNote(noteId: string): void {
+    heldNotes = heldNotes.filter((n) => n.id !== noteId)
   }
 
   /**
@@ -379,10 +489,15 @@ export function useNoteColumn(config: NoteColumnConfig) {
   function onNoteUpdateWithQuery(event: NoteUpdateEvent): void {
     onNoteUpdate(event)
     if (!compiledQuery.value || event.type === 'deleted') return
-    void nextTick(() => {
+    void nextTick(async () => {
       const note = rawNotes.value.find((n) => n.id === event.noteId)
       if (!note) return
-      if (!queryAdmits(note)) {
+      if (!queryAdmitsFast(note)) {
+        setNotes(rawNotes.value.filter((n) => n.id !== event.noteId))
+        return
+      }
+      const admitted = await admitDegraded([note])
+      if (admitted.length === 0) {
         setNotes(rawNotes.value.filter((n) => n.id !== event.noteId))
       }
     })
@@ -414,10 +529,22 @@ export function useNoteColumn(config: NoteColumnConfig) {
     void refresh()
   })
 
-  /** Apply builtin filters + filterNotes if configured (組込が先 = 最安) */
-  function applyFilter(incoming: NormalizedNote[]): NormalizedNote[] {
+  /**
+   * Apply builtin filters + filterNotes if configured (組込が先 = 最安)。
+   * 🐢 カラムでは Worker 判定を挟むので非同期になる (V22)。
+   *
+   * 仕様 (V22) は「同期フック契約は ⚡ 専用」としているが、実装では ⚡ 側も
+   * 含めて経路を async に統一した。同期/非同期を呼び出し元 6 箇所で分岐させる
+   * 複雑さに対して、⚡ カラムで増えるのがマイクロタスク数周分でしかないため。
+   * ⚡ の判定そのものは同期のまま (queryAdmitsFast) で Worker は起きない。
+   */
+  async function applyFilter(
+    incoming: NormalizedNote[],
+  ): Promise<NormalizedNote[]> {
     const builtin = incoming.filter((n) => builtinAdmits(n))
-    const base = config.filterNotes ? config.filterNotes(builtin) : builtin
+    const base = config.filterNotes
+      ? await config.filterNotes(builtin)
+      : builtin
     return applyQueryFilter(base)
   }
 
@@ -478,7 +605,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     try {
       const cached = await loadCachedTimeline(column.accountId, cacheKey)
       advanceFetchCursor(cached)
-      return applyFilter(cached)
+      return await applyFilter(cached)
     } catch (e) {
       logWarn(label, e)
       return []
@@ -715,8 +842,11 @@ export function useNoteColumn(config: NoteColumnConfig) {
         setSubscription(
           config.streaming.subscribe(adapter, enqueueWithQuery, {
             onNoteUpdated: (event) => {
-              if (event.type === 'deleted')
+              if (event.type === 'deleted') {
                 streamingBatch.removePending(event.noteId)
+                // 判定待ちのまま消えたノートを取り込まない
+                dropHeldNote(event.noteId)
+              }
               onNoteUpdateWithQuery(event)
             },
           }),
@@ -795,7 +925,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
       )
       if (!stillCurrent()) return
       advanceFetchCursor(older)
-      const filtered = applyFilter(older)
+      const filtered = await applyFilter(older)
       if (filtered.length > 0) {
         await setNotesPaged(insertIntoSorted(rawNotes.value, filtered))
       }
@@ -829,7 +959,9 @@ export function useNoteColumn(config: NoteColumnConfig) {
       const older = await config.fetch(adapter, { untilId })
       if (!stillCurrent()) return
       advanceFetchCursor(older)
-      await setNotesPaged(insertIntoSorted(rawNotes.value, applyFilter(older)))
+      await setNotesPaged(
+        insertIntoSorted(rawNotes.value, await applyFilter(older)),
+      )
     } catch (e) {
       logWarn('load-more', e)
       isOffline.value = true
@@ -876,7 +1008,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
         const result = await config.refreshFetch(adapter, rawNotes.value)
         // refreshFetch 経路にも組込フィルタ + カラムクエリを適用する
         // (#783 全取り込み経路 / #841)
-        const refreshed = applyFilter(result.notes)
+        const refreshed = await applyFilter(result.notes)
         if (result.mode === 'replace') {
           setNotes(refreshed)
           resetFetchCursor(refreshed)
@@ -887,7 +1019,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
         }
       } else {
         const fetched = await config.fetch(adapter, {})
-        setNotes(applyFilter(fetched))
+        setNotes(await applyFilter(fetched))
         resetFetchCursor(fetched)
         scrollToTop()
       }
@@ -1181,6 +1313,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
     columnQueryState,
     columnQueryErrorCount: queryErrorCount,
     columnQueryExcludedCount: queryExcludedCount,
+    /** 暴走で打ち切られサスペンド中のクエリ (fail-closed 中のカラムを示す) */
+    columnQuerySuspendedKeys: suspendedQueryKeys,
     notes,
     orderedIds,
     focusedNoteId,

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -405,14 +405,16 @@ export function useNoteColumn(config: NoteColumnConfig) {
         admitted.push(note)
         return
       }
+      // サスペンド中は全件が error で返る。評価できていないだけなので
+      // 「保留」に数え、評価エラー・除外には積まない (積むとバッジの
+      // エラー件数が停止している間ずっと増え続ける)
+      if (isSuspended) {
+        querySuspendedCount.value++
+        return
+      }
       if (verdict === 'error') queryErrorCount.value++
       queryExcludedCount.value++
     })
-    // サスペンド中の取りこぼしは「保留」として別に数える。評価できていない
-    // だけで、条件に合わないと判定したわけではない
-    if (isSuspended) {
-      querySuspendedCount.value += notes.length - admitted.length
-    }
     return admitted
   }
 

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -433,6 +433,25 @@ export function useNoteColumn(config: NoteColumnConfig) {
     return compiled.fast[0]?.query ?? null
   }
 
+  /** 参照先が消えた名前付きクエリの id (削除・未導入)。fail-closed の原因 */
+  const missingQueryIds = computed(() => compiledQuery.value?.missing ?? [])
+
+  /**
+   * 消えたクエリへの参照をこのカラムから外す。
+   *
+   * 参照は自動では掃除しない (再導入で復帰させたい・黙ってフィルタが外れるのを
+   * 避けたい、仕様追補 A) が、外す手段が無いと fail-closed から抜け出せない。
+   * フィルタメニューは存在するクエリしか列挙しないので、ここが唯一の導線になる。
+   */
+  function dropMissingQueryRefs(): void {
+    const col = config.getColumn()
+    const missing = new Set(missingQueryIds.value)
+    const refs = (col.noteQueryRefs ?? []).filter((id) => !missing.has(id))
+    useDeckStore().updateColumn(col.id, {
+      noteQueryRefs: refs.length > 0 ? refs : undefined,
+    })
+  }
+
   /**
    * サスペンドを解除して取り込みを再開する (V15 の明示再開)。
    * 自動では戻さない — 暴走したクエリを黙って走らせ直さないため。
@@ -1393,6 +1412,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
     columnQuerySuspendedKeys: suspendedQueryKeys,
     columnQuerySuspendedCount: querySuspendedCount,
     resumeSuspendedQueries,
+    columnQueryMissingIds: missingQueryIds,
+    dropMissingQueryRefs,
     notes,
     orderedIds,
     focusedNoteId,

--- a/src/composables/useNoteColumnCache.ts
+++ b/src/composables/useNoteColumnCache.ts
@@ -1,4 +1,5 @@
 import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
+import type { QirQuery } from '@/bindings'
 import { useNoteStore } from '@/stores/notes'
 import { usePerformanceStore } from '@/stores/performance'
 import { catchLog } from '@/utils/logger'
@@ -79,5 +80,44 @@ export async function purgeStaleCachedNotes(
     }
   } catch {
     // Bulk verify failed — silently ignore (notes stay cached)
+  }
+}
+
+/**
+ * カラムクエリでローカルキャッシュを検索する (#783 Phase 3)。
+ *
+ * FTS5 で粗く絞ってから Rust の QIR 評価器で判定するので、条件に合うノートを
+ * 見つけるまで遡れる。`before` より古い側を、走査上限まで読んで探す。
+ *
+ * タイムライン種別では絞らない。キャッシュの所属は 1 ノート 1 種別で後勝ち
+ * 上書きなので、種別で絞ると本来あるはずのノートを取りこぼす (notecli#30 で
+ * 実体と所属を分離する再設計が計画されている)。取りこぼしより、別種別の
+ * ノートが混ざる方が気づけるため、絞らない側に倒している。
+ */
+export async function searchCachedNotesByQuery(
+  accountId: string,
+  query: QirQuery,
+  before: { createdAt: string; noteId: string } | null,
+  limit: number,
+  maxScannedRows: number,
+): Promise<{
+  notes: NormalizedNote[]
+  errors: number
+  /** 走査上限で打ち切った位置。null なら読み切っている */
+  cursor: { createdAt: string; noteId: string } | null
+}> {
+  const result = unwrap(
+    await commands.qirSearchCache(
+      accountId,
+      query,
+      limit,
+      maxScannedRows,
+      before,
+    ),
+  )
+  return {
+    notes: result.notes as unknown as NormalizedNote[],
+    errors: result.errors,
+    cursor: result.cursor,
   }
 }

--- a/src/composables/usePostFormState.test.ts
+++ b/src/composables/usePostFormState.test.ts
@@ -795,6 +795,63 @@ describe('restoreSlot / removeCurrentSlot', () => {
   })
 })
 
+describe('restoreFromNote (削除して編集)', () => {
+  it('本文・CW・公開範囲・localOnly を復元する', () => {
+    const form = mount()
+    form.restoreFromNote(
+      makeNote({
+        text: '元の本文',
+        cw: '注意',
+        visibility: 'followers',
+        localOnly: true,
+        files: [],
+      }),
+    )
+    expect(form.text.value).toBe('元の本文')
+    expect(form.cw.value).toBe('注意')
+    expect(form.showCw.value).toBe(true)
+    expect(form.visibility.value).toBe('followers')
+    expect(form.localOnly.value).toBe(true)
+  })
+
+  it('添付ファイルを復元する', () => {
+    const form = mount()
+    form.restoreFromNote(makeNote({ files: [makeFile('f1'), makeFile('f2')] }))
+    expect(form.attachedFiles.value.map((f) => f.id)).toEqual(['f1', 'f2'])
+  })
+
+  it('アンケートを復元する', () => {
+    const form = mount()
+    form.restoreFromNote(
+      makeNote({
+        files: [],
+        poll: {
+          choices: [
+            { text: 'きのこ', votes: 3, isVoted: false },
+            { text: 'たけのこ', votes: 1, isVoted: true },
+          ],
+          multiple: true,
+          expiresAt: '2026-08-10T00:00:00.000Z',
+        },
+      }),
+    )
+    expect(form.showPoll.value).toBe(true)
+    expect(form.pollChoices.value).toEqual(['きのこ', 'たけのこ'])
+    expect(form.pollMultiple.value).toBe(true)
+    expect(form.pollExpiresAt.value).toBe(
+      new Date('2026-08-10T00:00:00.000Z').getTime(),
+    )
+  })
+
+  it('CW もアンケートも無いノートでは入力欄を開かない', () => {
+    const form = mount()
+    form.restoreFromNote(makeNote({ text: 'ただの本文', cw: null, files: [] }))
+    expect(form.showCw.value).toBe(false)
+    expect(form.showPoll.value).toBe(false)
+    expect(form.pollExpiresAt.value).toBeNull()
+  })
+})
+
 describe('auto-save watch', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -725,6 +725,30 @@ export function usePostFormState(
     // Note: file attachments are not restored (IDs may be expired)
   }
 
+  /**
+   * 既存ノートの内容をフォームへ展開する (「削除して編集」#944)。
+   * 引用・返信・チャンネルはフォーム状態ではなく投稿時のコンテキストなので、
+   * ここではなく props (renoteId / replyTo / channelId) 側で引き継ぐ。
+   * restoreSlot と違い添付を復元するのは、直前まで自分のノートに紐づいていた
+   * ファイルなので ID が失効していないため。
+   */
+  function restoreFromNote(note: NormalizedNote) {
+    text.value = note.text ?? ''
+    cw.value = note.cw ?? ''
+    showCw.value = note.cw != null
+    visibility.value = note.visibility
+    localOnly.value = note.localOnly ?? false
+    if (note.files.length > 0) attachDriveFiles(note.files)
+    if (note.poll) {
+      showPoll.value = true
+      pollChoices.value = note.poll.choices.map((c) => c.text)
+      pollMultiple.value = note.poll.multiple
+      pollExpiresAt.value = note.poll.expiresAt
+        ? new Date(note.poll.expiresAt).getTime()
+        : null
+    }
+  }
+
   async function removeCurrentSlot() {
     const acc = account.value
     if (!acc) return
@@ -800,6 +824,7 @@ export function usePostFormState(
     resetForm,
     saveCurrentSlot,
     restoreSlot,
+    restoreFromNote,
     removeCurrentSlot,
     hasAnyContent,
   }

--- a/src/services/columnQuery/compiler.test.ts
+++ b/src/services/columnQuery/compiler.test.ts
@@ -100,6 +100,57 @@ describe('compileColumnQuery: 拒否 (サブセット外)', () => {
   })
 })
 
+describe('compileColumnQuery: 降格可否 (Phase 2 / V15)', () => {
+  /** サブセット外だが純粋 = Worker で逐次適用する (🐢 降格) */
+  const DEGRADABLE: Record<string, string> = {
+    'if 式': 'if note.text == null { false } else { true }',
+    'match 式':
+      'match note.visibility { case "public" => true, default => false }',
+    再帰関数: '@f(t) { f(t) }\nf(true)',
+    'var (mut)': 'var x = true\nx',
+    'str.len': 'note.text != null && note.text.len > 3',
+    'allowlist 外フィールド': 'note.tags != null',
+    '2 引数 starts_with': 'note.text != null && note.text.starts_with("a", 1)',
+    'arr リテラル': '["a", "b"].incl(note.visibility)',
+    テンプレート文字列: 'note.text == `a{1}`',
+    算術演算: 'note.files != null && note.files.len + 1 > 2',
+    関数の第一級使用: '@f(t) { true }\nlet g = f\ng(1)',
+  }
+
+  it.each(Object.entries(DEGRADABLE))('降格できる: %s', (_name, source) => {
+    const result = compileColumnQuery(source)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.degradable).toBe(true)
+  })
+
+  /** 副作用・非決定 API に到達しうる = 降格させず保存時に拒否する */
+  const REJECTED: Record<string, string> = {
+    '名前空間関数 (Math:)': 'Math:abs(1) > 0',
+    '副作用 API (Mk:)': 'Mk:api("notes/show") != null',
+    '非決定 API (Date:)': 'Date:now() > 0',
+    第一級で束縛しただけの非純粋関数: 'let f = Date:now\nf() > 0',
+    構文エラー: 'note.text !=',
+    空ソース: '',
+  }
+
+  it.each(Object.entries(REJECTED))('降格させない: %s', (_name, source) => {
+    const result = compileColumnQuery(source)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.degradable).toBe(false)
+  })
+
+  it('非純粋な識別子は診断に名前と位置が出る', () => {
+    const result = compileColumnQuery('note.text != null && Date:now() > 0')
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    const found = result.diagnostics.find((d) => d.message.includes('Date:now'))
+    expect(found).toBeDefined()
+    expect(found?.line).toBe(1)
+  })
+})
+
 describe('compileColumnQuery: 上限', () => {
   it('関数脱糖の指数爆発をノード数上限で打ち切る', () => {
     // f0 → f1 が f0 を 2 回 → ... 展開で 2^n 成長するチェーン

--- a/src/services/columnQuery/compiler.test.ts
+++ b/src/services/columnQuery/compiler.test.ts
@@ -254,3 +254,23 @@ describe('compileColumnQuery: nullable ガード診断 (V25)', () => {
     expect(compileColumnQuery('note.text.incl("a")').ok).toBe(true)
   })
 })
+
+describe('compileColumnQuery: 名前付きクエリ形の nullable ガード (V25)', () => {
+  it('引数名が note 以外でもガードを認識する', () => {
+    // ガード検出はソース上の識別子で行うので、警告キーも同じ名前で作る必要がある
+    const result = compileColumnQuery(
+      '@(n) { n.text != null && n.text.incl("a") }',
+    )
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.warnings).toEqual([])
+  })
+
+  it('引数名が note 以外のときも unguarded は警告する', () => {
+    const result = compileColumnQuery('@(n) { n.text.incl("a") }')
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.warnings.map((w) => w.field)).toEqual(['n.text'])
+    expect(result.warnings[0]?.guard).toBe('n.text != null')
+  })
+})

--- a/src/services/columnQuery/compiler.test.ts
+++ b/src/services/columnQuery/compiler.test.ts
@@ -184,3 +184,73 @@ describe('compileColumnQuery: 診断', () => {
     expect(result.diagnostics[0]?.line).toBe(2)
   })
 })
+
+describe('compileColumnQuery: nullable ガード診断 (V25)', () => {
+  /** 警告が指しているフィールドパス */
+  const warned = (source: string): string[] => {
+    const result = compileColumnQuery(source)
+    if (!result.ok) throw new Error(`compile failed: ${source}`)
+    return result.warnings.map((w) => w.field)
+  }
+
+  it('unguarded な nullable フィールドの操作を警告する', () => {
+    // 画像のみ・純リノートは text=null なので、このままだと全件エラー除外になる
+    expect(warned('note.text.incl("a")')).toEqual(['note.text'])
+  })
+
+  it('ガードしてあれば警告しない', () => {
+    expect(warned('note.text != null && note.text.incl("a")')).toEqual([])
+  })
+
+  it('別フィールドのガードでは解除されない', () => {
+    expect(warned('note.cw != null && note.text.incl("a")')).toEqual([
+      'note.text',
+    ])
+  })
+
+  it('null 比較の左右が逆でもガードとして認める', () => {
+    expect(warned('null != note.text && note.text.incl("a")')).toEqual([])
+  })
+
+  it('関数呼び出しの引数に渡す場合もガードが効く', () => {
+    // MisStore 配布クエリと同じ形
+    const src =
+      '@hit(lowered) {\n\tlowered.incl("a")\n}\n\nnote.text != null && hit(note.text.lower())'
+    expect(warned(src)).toEqual([])
+  })
+
+  it('nullable な配列の .len も警告する', () => {
+    expect(warned('note.files.len > 0')).toEqual(['note.files'])
+  })
+
+  it('nullable でないフィールドは警告しない', () => {
+    expect(warned('note.visibility == "public"')).toEqual([])
+    expect(warned('note.user.username.incl("a")')).toEqual([])
+  })
+
+  it('同じフィールドを何度使っても警告は 1 件にまとめる', () => {
+    expect(warned('note.text.incl("a") || note.text.incl("b")')).toEqual([
+      'note.text',
+    ])
+  })
+
+  it('ガードのスコープは and の右辺に限る', () => {
+    // 左辺のガードは or をまたいだ先には効かない
+    expect(
+      warned(
+        '(note.text != null && note.text.incl("a")) || note.text.incl("b")',
+      ),
+    ).toEqual(['note.text'])
+  })
+
+  it('警告にはガード式と位置が付く (quick-fix 用)', () => {
+    const result = compileColumnQuery('note.text.incl("a")')
+    if (!result.ok) throw new Error('compile failed')
+    expect(result.warnings[0]?.guard).toBe('note.text != null')
+    expect(result.warnings[0]?.line).toBe(1)
+  })
+
+  it('コンパイル自体は成功する (ブロッキングは UI 側の判断)', () => {
+    expect(compileColumnQuery('note.text.incl("a")').ok).toBe(true)
+  })
+})

--- a/src/services/columnQuery/compiler.ts
+++ b/src/services/columnQuery/compiler.ts
@@ -139,6 +139,12 @@ class Compiler {
    * and の右辺コンパイル中だけ積まれるので、or をまたいだ先には効かない。
    */
   private guardedPaths = new Set<string>()
+  /**
+   * note ルートの識別子名。`@(n) { ... }` 形式では `n` になる。
+   * ガード検出はソース上の名前で行うので、警告キーも同じ名前で作らないと
+   * 「ガードしてあるのに警告が出る」ことになる。
+   */
+  private noteRootName = 'note'
   /** unguarded な nullable 操作。フィールドごとに最初の 1 件だけ残す */
   private warnings = new Map<string, QueryWarning>()
   private inlineStack: Ast.Fn[] = []
@@ -233,6 +239,8 @@ class Compiler {
         )
       }
       const paramName = identifierName(param.dest, fn.loc)
+      // 警告・ガード検出はソース上の名前で行う (V25)
+      this.noteRootName = paramName
       const scope: Scope = new Map([[paramName, { kind: 'note' as const }]])
       return this.compileBody(fn.children, scope, fn.loc)
     }
@@ -328,7 +336,7 @@ class Compiler {
   private checkNullableReceiver(recv: Typed, loc: Ast.Loc): void {
     if ((recv.type & T_NULL) === 0) return
     if (recv.notePath === undefined) return
-    const field = `note.${recv.notePath.join('.')}`
+    const field = [this.noteRootName, ...recv.notePath].join('.')
     if (this.guardedPaths.has(field)) return
     if (this.warnings.has(field)) return
     this.warnings.set(field, {

--- a/src/services/columnQuery/compiler.ts
+++ b/src/services/columnQuery/compiler.ts
@@ -29,8 +29,27 @@ export interface QueryDiagnostic {
   column?: number
 }
 
+/**
+ * null になりうるフィールドを guard なしで操作している警告 (V25)。
+ *
+ * `note.text.incl("x")` は text=null のノート (画像のみ・純リノート) で
+ * per-note エラーになり、そのノートが丸ごと除外される。書いた本人からは
+ * 「リノートが全部消えるフィルタ」に見えるので、保存前に気づかせる。
+ */
+export interface QueryWarning extends QueryDiagnostic {
+  /** 対象フィールド (例: `note.text`) */
+  field: string
+  /** 挿入すべきガード式 (例: `note.text != null`) */
+  guard: string
+}
+
 export type CompileResult =
-  | { ok: true; query: QirQuery; nodeCount: number }
+  | {
+      ok: true
+      query: QirQuery
+      nodeCount: number
+      warnings: QueryWarning[]
+    }
   | {
       ok: false
       /**
@@ -115,6 +134,13 @@ interface Typed {
 class Compiler {
   private nodeCount = 0
   private nextSlot = 0
+  /**
+   * `X != null &&` の右辺を評価している間だけ X を non-null 扱いにする (V25)。
+   * and の右辺コンパイル中だけ積まれるので、or をまたいだ先には効かない。
+   */
+  private guardedPaths = new Set<string>()
+  /** unguarded な nullable 操作。フィールドごとに最初の 1 件だけ残す */
+  private warnings = new Map<string, QueryWarning>()
   private inlineStack: Ast.Fn[] = []
 
   /** QIR ノードを 1 つ数える。脱糖の指数爆発をここで止める (V19)。 */
@@ -150,6 +176,7 @@ class Compiler {
         ok: true,
         query: { schemaVersion: QIR_SCHEMA_VERSION, root },
         nodeCount: this.nodeCount,
+        warnings: [...this.warnings.values()],
       }
     } catch (e) {
       if (e instanceof CompileFail) {
@@ -294,6 +321,25 @@ class Compiler {
     return this.nextSlot++
   }
 
+  /**
+   * null になりうるレシーバを guard なしで操作していたら警告に積む (V25)。
+   * コンパイル自体は通す — 止めるかどうかは保存側の判断 (「このまま保存」可)。
+   */
+  private checkNullableReceiver(recv: Typed, loc: Ast.Loc): void {
+    if ((recv.type & T_NULL) === 0) return
+    if (recv.notePath === undefined) return
+    const field = `note.${recv.notePath.join('.')}`
+    if (this.guardedPaths.has(field)) return
+    if (this.warnings.has(field)) return
+    this.warnings.set(field, {
+      field,
+      guard: `${field} != null`,
+      message: `${field} は null のことがあります。ガードしないと、そのノートが丸ごと除外されます`,
+      line: loc.start.line,
+      column: loc.start.column,
+    })
+  }
+
   private compileExpr(node: Ast.Expression, scope: Scope): Typed {
     switch (node.type) {
       case 'str':
@@ -331,10 +377,23 @@ class Compiler {
       case 'and':
       case 'or': {
         const left = this.requireBoolish(node.left, scope, node.type)
-        const right = this.requireBoolish(node.right, scope, node.type)
-        return {
-          qir: this.emit({ kind: node.type, left: left.qir, right: right.qir }),
-          type: T_BOOL,
+        // `X != null && ...` の右辺では X を non-null として扱う (V25)
+        const guard =
+          node.type === 'and' ? nullGuardTarget(node.left) : undefined
+        const added = guard !== undefined && !this.guardedPaths.has(guard)
+        if (added && guard !== undefined) this.guardedPaths.add(guard)
+        try {
+          const right = this.requireBoolish(node.right, scope, node.type)
+          return {
+            qir: this.emit({
+              kind: node.type,
+              left: left.qir,
+              right: right.qir,
+            }),
+            type: T_BOOL,
+          }
+        } finally {
+          if (added && guard !== undefined) this.guardedPaths.delete(guard)
         }
       }
       case 'lt':
@@ -436,6 +495,7 @@ class Compiler {
     if (node.name === 'len') {
       const target = this.compileExpr(node.target, scope)
       if ((target.type & ~T_NULL) === T_ARR) {
+        this.checkNullableReceiver(target, node.loc)
         return {
           qir: this.emit({ kind: 'arrLen', target: target.qir }),
           type: T_NUM,
@@ -516,6 +576,7 @@ class Compiler {
     const recv = this.compileExpr(prop.target, scope)
     const recvBase = recv.type & ~T_NULL
     const name = prop.name
+    this.checkNullableReceiver(recv, prop.loc)
     if (name === 'lower' || name === 'upper') {
       if (call.args.length !== 0) {
         throw new CompileFail(`${name}() は引数を取りません`, call.loc)
@@ -676,6 +737,33 @@ class Compiler {
     }
     throw new CompileFail('末尾に式がありません', loc)
   }
+}
+
+/**
+ * `X != null` / `null != X` の形なら X のフィールドパスを返す (V25)。
+ * `==` は「null のときだけ通す」判定なので、右辺で non-null にはならない。
+ */
+function nullGuardTarget(node: Ast.Expression): string | undefined {
+  if (node.type !== 'neq') return undefined
+  const path =
+    node.right.type === 'null'
+      ? notePathOf(node.left)
+      : node.left.type === 'null'
+        ? notePathOf(node.right)
+        : undefined
+  return path
+}
+
+/** 式が note のフィールド参照そのものなら `note.a.b` 形式で返す */
+function notePathOf(node: Ast.Expression): string | undefined {
+  const segments: string[] = []
+  let cur: Ast.Expression = node
+  while (cur.type === 'prop') {
+    segments.unshift(cur.name)
+    cur = cur.target
+  }
+  if (cur.type !== 'identifier' || segments.length === 0) return undefined
+  return [cur.name, ...segments].join('.')
 }
 
 function identifierName(dest: Ast.Expression, loc: Ast.Loc): string {

--- a/src/services/columnQuery/compiler.ts
+++ b/src/services/columnQuery/compiler.ts
@@ -1,6 +1,7 @@
 import { type Ast, Parser } from '@syuilo/aiscript'
 
 import type { QirBinding, QirNode, QirQuery } from '@/bindings'
+import { collectImpureIdentifiers } from '@/services/columnQuery/purity'
 
 /**
  * カラムクエリコンパイラ: AiScript 1.2.1 AST → QIR (#783)。
@@ -30,7 +31,16 @@ export interface QueryDiagnostic {
 
 export type CompileResult =
   | { ok: true; query: QirQuery; nodeCount: number }
-  | { ok: false; diagnostics: QueryDiagnostic[] }
+  | {
+      ok: false
+      /**
+       * サブセット外だが純粋なので Worker で逐次適用できる (🐢 降格, Phase 2)。
+       * false は「副作用・非決定 API に到達しうる」か「そもそも式として
+       * 成立していない」ことを意味し、保存時に拒否する (不変条件 (c))。
+       */
+      degradable: boolean
+      diagnostics: QueryDiagnostic[]
+    }
 
 // --- 静的型 (成功時型)。エラーになりうる null 可能性も集合に含める ---
 
@@ -123,8 +133,10 @@ class Compiler {
     try {
       statements = new Parser().parse(source)
     } catch (e) {
+      // パースできない = AST が無いので Worker にも渡せない
       return {
         ok: false,
+        degradable: false,
         diagnostics: [{ message: `構文エラー: ${String(e)}` }],
       }
     }
@@ -141,9 +153,40 @@ class Compiler {
       }
     } catch (e) {
       if (e instanceof CompileFail) {
-        return { ok: false, diagnostics: [e.diagnostic] }
+        return this.failure(statements, e.diagnostic)
       }
       throw e
+    }
+  }
+
+  /**
+   * コンパイル不能を「🐢 降格できる」と「保存時に拒否する」に振り分ける
+   * (Phase 2 / V15)。降格先の Worker は AiScript Interpreter をそのまま
+   * 動かすので、サブセット境界ではなく到達可能性で判断する。
+   */
+  private failure(
+    statements: Ast.Node[],
+    diagnostic: QueryDiagnostic,
+  ): CompileResult {
+    // 空ソースは降格しても評価する式が無い
+    if (statements.length === 0) {
+      return { ok: false, degradable: false, diagnostics: [diagnostic] }
+    }
+    const impure = collectImpureIdentifiers(statements)
+    if (impure.length === 0) {
+      return { ok: false, degradable: true, diagnostics: [diagnostic] }
+    }
+    return {
+      ok: false,
+      degradable: false,
+      diagnostics: [
+        diagnostic,
+        ...impure.map((v) => ({
+          message: `${v.name} はフィルタから参照できません`,
+          line: v.line,
+          column: v.column,
+        })),
+      ],
     }
   }
 

--- a/src/services/columnQuery/degradedBatch.test.ts
+++ b/src/services/columnQuery/degradedBatch.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createDegradedBatchRunner } from './degradedBatch'
+
+const note = (over: Record<string, unknown> = {}) => ({
+  id: 'n1',
+  text: 'hello',
+  cw: null,
+  visibility: 'public',
+  files: [],
+  ...over,
+})
+
+describe('createDegradedBatchRunner: 評価', () => {
+  it('サブセット外の式を評価して match/unmatch を返す', () => {
+    const runner = createDegradedBatchRunner()
+    // str.len は QIR サブセット外 (V20) なので降格経路でしか評価できない
+    const out = runner.run(
+      [{ key: 'f1', source: 'note.text != null && note.text.len > 3' }],
+      [note({ text: 'hello' }), note({ text: 'hi' })],
+    )
+    expect(out.verdicts).toEqual(['match', 'unmatch'])
+    runner.dispose()
+  })
+
+  it('評価エラーは error になりノートを除外する', () => {
+    const runner = createDegradedBatchRunner()
+    // text=null に対して null レシーバのプロパティ呼び出し → per-note エラー
+    const out = runner.run(
+      [{ key: 'f1', source: 'note.text.len > 3' }],
+      [note({ text: 'hello' }), note({ text: null })],
+    )
+    expect(out.verdicts).toEqual(['match', 'error'])
+    runner.dispose()
+  })
+
+  it('bool でない結果は error 扱いにする', () => {
+    const runner = createDegradedBatchRunner()
+    const out = runner.run([{ key: 'f1', source: 'note.text' }], [note()])
+    expect(out.verdicts).toEqual(['error'])
+    runner.dispose()
+  })
+})
+
+describe('createDegradedBatchRunner: And 合成', () => {
+  it('全フィルタが match のときだけ match', () => {
+    const runner = createDegradedBatchRunner()
+    const out = runner.run(
+      [
+        { key: 'f1', source: 'note.text != null && note.text.len > 3' },
+        { key: 'f2', source: 'note.visibility == "public"' },
+      ],
+      [
+        note({ text: 'hello', visibility: 'public' }),
+        note({ text: 'hello', visibility: 'home' }),
+      ],
+    )
+    expect(out.verdicts).toEqual(['match', 'unmatch'])
+    runner.dispose()
+  })
+
+  it('除外が確定したノートは後続フィルタで再評価しない (短絡)', () => {
+    const runner = createDegradedBatchRunner()
+    const begun: string[] = []
+    const out = runner.run(
+      [
+        { key: 'f1', source: 'note.visibility == "public"' },
+        { key: 'f2', source: 'note.text != null && note.text.len > 3' },
+      ],
+      [note({ visibility: 'home', text: 'hello' })],
+      { onFilterBegin: (k) => begun.push(k) },
+    )
+    expect(out.verdicts).toEqual(['unmatch'])
+    // 短絡してもフィルタ単位の開始通知は出る (犯人特定のマーカー)
+    expect(begun).toEqual(['f1', 'f2'])
+    runner.dispose()
+  })
+})
+
+describe('createDegradedBatchRunner: 犯人特定のマーカー (V23)', () => {
+  it('評価するフィルタごとに開始を通知する', () => {
+    const runner = createDegradedBatchRunner()
+    const onFilterBegin = vi.fn()
+    runner.run(
+      [
+        { key: 'a', source: 'note.text != null' },
+        { key: 'b', source: 'note.cw == null' },
+      ],
+      [note()],
+      { onFilterBegin },
+    )
+    expect(onFilterBegin.mock.calls.map((c) => c[0])).toEqual(['a', 'b'])
+    runner.dispose()
+  })
+})
+
+describe('createDegradedBatchRunner: 実行不能なソース', () => {
+  it('ソースが実行不能なフィルタは全ノートを error にして報告する', () => {
+    const runner = createDegradedBatchRunner()
+    const out = runner.run(
+      [{ key: 'broken', source: 'note.text !=' }],
+      [note(), note()],
+    )
+    expect(out.verdicts).toEqual(['error', 'error'])
+    expect(out.invalidFilters).toHaveLength(1)
+    expect(out.invalidFilters[0]?.key).toBe('broken')
+    runner.dispose()
+  })
+})
+
+describe('createDegradedBatchRunner: フィルタの再利用', () => {
+  it('同じ key/source なら Interpreter を作り直さない', () => {
+    const runner = createDegradedBatchRunner()
+    const spec = [{ key: 'f1', source: 'note.text != null' }]
+    runner.run(spec, [note()])
+    expect(runner.cachedKeys()).toEqual(['f1'])
+    runner.run(spec, [note()])
+    expect(runner.cachedKeys()).toEqual(['f1'])
+    runner.dispose()
+  })
+
+  it('source が変わったら作り直す', () => {
+    const runner = createDegradedBatchRunner()
+    runner.run([{ key: 'f1', source: 'note.text != null' }], [note()])
+    const out = runner.run(
+      [{ key: 'f1', source: 'note.cw != null' }],
+      [note({ cw: null })],
+    )
+    expect(out.verdicts).toEqual(['unmatch'])
+    runner.dispose()
+  })
+
+  it('dispose でキャッシュを解放する', () => {
+    const runner = createDegradedBatchRunner()
+    runner.run([{ key: 'f1', source: 'note.text != null' }], [note()])
+    runner.dispose()
+    expect(runner.cachedKeys()).toEqual([])
+  })
+})
+
+describe('createDegradedBatchRunner: step 予算', () => {
+  it('step 予算を超える式は error になり、次のノートに影響しない', () => {
+    const runner = createDegradedBatchRunner()
+    // 予算 (FILTER_MAX_STEP) を確実に超えるループ
+    const out = runner.run(
+      [
+        {
+          key: 'heavy',
+          source: 'var i = 0\nfor (let _, 100000) { i += 1 }\ni > 0',
+        },
+        { key: 'light', source: 'note.text != null' },
+      ],
+      [note(), note()],
+    )
+    expect(out.verdicts).toEqual(['error', 'error'])
+    runner.dispose()
+  })
+
+  it('step カウンタはノートごとに戻る (累積で誤爆しない)', () => {
+    const runner = createDegradedBatchRunner()
+    // 1 ノートあたりでは予算内だが、累積すると超える程度の式を多数ノートに適用
+    const notes = Array.from({ length: 40 }, () => note({ text: 'hello' }))
+    const out = runner.run(
+      [{ key: 'f1', source: 'var i = 0\nfor (let _, 20) { i += 1 }\ni == 20' }],
+      notes,
+    )
+    expect(out.verdicts.every((v) => v === 'match')).toBe(true)
+    runner.dispose()
+  })
+})

--- a/src/services/columnQuery/degradedBatch.ts
+++ b/src/services/columnQuery/degradedBatch.ts
@@ -1,0 +1,120 @@
+import {
+  createReferenceFilter,
+  type FilterVerdict,
+  type ReferenceFilter,
+} from '@/services/columnQuery/referenceEvaluator'
+
+/**
+ * 🐢 降格フィルタのバッチ評価 (#783 Phase 2 / V23)。
+ *
+ * QIR にコンパイルできない純粋な式を AiScript Interpreter で per-note 評価する。
+ * Worker の中で動かす前提だが、Worker 境界に依存しない純ロジックとして切り出して
+ * あるので単体でテストできる (Worker 側はこれを呼ぶだけの薄い層)。
+ *
+ * V23 の実行規律のうち、ここが担うのは:
+ *   - per-filter 逐次バッチ (フィルタ外側・ノート内側のループ)
+ *   - フィルタ単位の評価開始マーカー。暴走して terminate するとき、
+ *     どのフィルタで止まったかを呼び出し側が帰属できるようにする
+ *   - step 予算とインスタンス汚染回避は referenceEvaluator 側の責務
+ *
+ * ノート単位のマーカーは出さない。postMessage の往復コストに対して、
+ * サスペンド対象がフィルタ単位である以上、得られる情報が釣り合わないため。
+ */
+
+export interface DegradedFilterSpec {
+  key: string
+  source: string
+}
+
+export interface DegradedBatchOptions {
+  /** フィルタの評価を始めるたびに呼ばれる (犯人特定のマーカー) */
+  onFilterBegin?: (key: string) => void
+}
+
+export interface InvalidFilter {
+  key: string
+  message: string
+}
+
+export interface DegradedBatchOutcome {
+  /** notes と同じ長さ。全フィルタの And 合成後の判定 */
+  verdicts: FilterVerdict[]
+  /** ソース自体が実行不能だったフィルタ (保存時に弾けなかった残留) */
+  invalidFilters: InvalidFilter[]
+}
+
+export interface DegradedBatchRunner {
+  run(
+    filters: readonly DegradedFilterSpec[],
+    notes: readonly unknown[],
+    options?: DegradedBatchOptions,
+  ): DegradedBatchOutcome
+  /** キャッシュ済みフィルタの key 一覧 (テスト・診断用) */
+  cachedKeys(): string[]
+  dispose(): void
+}
+
+interface CacheEntry {
+  source: string
+  filter: ReferenceFilter
+}
+
+export function createDegradedBatchRunner(): DegradedBatchRunner {
+  const cache = new Map<string, CacheEntry>()
+
+  function release(key: string): void {
+    const entry = cache.get(key)
+    if (!entry) return
+    entry.filter.dispose()
+    cache.delete(key)
+  }
+
+  /** source が変わっていれば作り直す。実行不能なら null */
+  function acquire(spec: DegradedFilterSpec): ReferenceFilter | null {
+    const cached = cache.get(spec.key)
+    if (cached && cached.source === spec.source) return cached.filter
+    if (cached) release(spec.key)
+    const filter = createReferenceFilter(spec.source)
+    cache.set(spec.key, { source: spec.source, filter })
+    return filter
+  }
+
+  return {
+    run(filters, notes, options) {
+      // 既定は match。以降のフィルタで非 match が出たら確定して短絡する
+      const verdicts: FilterVerdict[] = notes.map(() => 'match')
+      const invalidFilters: InvalidFilter[] = []
+
+      for (const spec of filters) {
+        options?.onFilterBegin?.(spec.key)
+        let filter: ReferenceFilter | null = null
+        try {
+          filter = acquire(spec)
+        } catch (e) {
+          // ソースが実行不能: そのフィルタは全ノートを除外する (fail-closed)
+          invalidFilters.push({ key: spec.key, message: String(e) })
+          for (let i = 0; i < verdicts.length; i++) {
+            if (verdicts[i] === 'match') verdicts[i] = 'error'
+          }
+          continue
+        }
+        if (!filter) continue
+        for (let i = 0; i < notes.length; i++) {
+          // 既に除外が確定したノートは評価しない
+          if (verdicts[i] !== 'match') continue
+          verdicts[i] = filter.evaluate(notes[i])
+        }
+      }
+
+      return { verdicts, invalidFilters }
+    },
+
+    cachedKeys() {
+      return [...cache.keys()]
+    },
+
+    dispose() {
+      for (const key of [...cache.keys()]) release(key)
+    },
+  }
+}

--- a/src/services/columnQuery/degradedRunner.test.ts
+++ b/src/services/columnQuery/degradedRunner.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  ColumnQueryWorkerRequest,
+  ColumnQueryWorkerResponse,
+} from '@/workers/columnQueryWorker'
+import { createDegradedRunner } from './degradedRunner'
+
+/**
+ * Worker の代役。postMessage された内容を記録し、テストから応答を差し込む。
+ * `hang` を立てたフィルタは begin だけ出して done を返さない (暴走の再現)。
+ */
+class FakeWorker {
+  static instances: FakeWorker[] = []
+  onmessage: ((e: MessageEvent<ColumnQueryWorkerResponse>) => void) | null =
+    null
+  onerror: ((e: unknown) => void) | null = null
+  requests: ColumnQueryWorkerRequest[] = []
+  terminated = false
+  /** このキーのフィルタに当たったら応答を止める */
+  static hangOn: string | null = null
+
+  constructor() {
+    FakeWorker.instances.push(this)
+  }
+
+  postMessage(req: ColumnQueryWorkerRequest): void {
+    this.requests.push(req)
+    queueMicrotask(() => {
+      if (this.terminated) return
+      for (const f of req.filters) {
+        this.emit({ type: 'begin', id: req.id, key: f.key })
+        if (FakeWorker.hangOn === f.key) return // done を返さない
+      }
+      this.emit({
+        type: 'done',
+        id: req.id,
+        verdicts: req.notes.map(() => 'match' as const),
+        invalidFilters: [],
+      })
+    })
+  }
+
+  terminate(): void {
+    this.terminated = true
+  }
+
+  private emit(data: ColumnQueryWorkerResponse): void {
+    this.onmessage?.({ data } as MessageEvent<ColumnQueryWorkerResponse>)
+  }
+}
+
+const makeRunner = (timeoutMs = 1000) =>
+  createDegradedRunner({
+    workerFactory: () => new FakeWorker() as unknown as Worker,
+    timeoutMs,
+  })
+
+const notes = [{ id: 'a' }, { id: 'b' }]
+
+beforeEach(() => {
+  FakeWorker.instances = []
+  FakeWorker.hangOn = null
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createDegradedRunner: 正常系', () => {
+  it('Worker の判定をそのまま返す', async () => {
+    const runner = makeRunner()
+    const p = runner.run([{ key: 'f1', source: 'true' }], notes)
+    await vi.runAllTimersAsync()
+    const out = await p
+    expect(out.verdicts).toEqual(['match', 'match'])
+    expect(out.suspended).toEqual([])
+    runner.dispose()
+  })
+
+  it('Worker は使い回す (バッチごとに作り直さない)', async () => {
+    const runner = makeRunner()
+    const spec = [{ key: 'f1', source: 'true' }]
+    await vi.runAllTimersAsync()
+    const p1 = runner.run(spec, notes)
+    await vi.runAllTimersAsync()
+    await p1
+    const p2 = runner.run(spec, notes)
+    await vi.runAllTimersAsync()
+    await p2
+    expect(FakeWorker.instances).toHaveLength(1)
+    runner.dispose()
+  })
+})
+
+describe('createDegradedRunner: 暴走の打ち切り (V15/V23)', () => {
+  it('タイムアウトで Worker を terminate する', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    const p = runner.run([{ key: 'runaway', source: 'loop {}' }], notes)
+    await vi.runAllTimersAsync()
+    await p
+    expect(FakeWorker.instances[0]?.terminated).toBe(true)
+    runner.dispose()
+  })
+
+  it('最後に開始したフィルタを犯人としてサスペンドする', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    const p = runner.run(
+      [
+        { key: 'ok', source: 'true' },
+        { key: 'runaway', source: 'loop {}' },
+      ],
+      notes,
+    )
+    await vi.runAllTimersAsync()
+    const out = await p
+    expect(out.suspended).toEqual(['runaway'])
+    expect(runner.isSuspended('runaway')).toBe(true)
+    expect(runner.isSuspended('ok')).toBe(false)
+    runner.dispose()
+  })
+
+  it('Worker を再起動して残りのフィルタを再評価する', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    const p = runner.run(
+      [
+        { key: 'runaway', source: 'loop {}' },
+        { key: 'ok', source: 'true' },
+      ],
+      notes,
+    )
+    await vi.runAllTimersAsync()
+    await p
+    // 1 台目は terminate、2 台目で残りを評価
+    expect(FakeWorker.instances).toHaveLength(2)
+    expect(
+      FakeWorker.instances[1]?.requests[0]?.filters.map((f) => f.key),
+    ).toEqual(['ok'])
+    runner.dispose()
+  })
+
+  it('サスペンドしたフィルタを含むバッチは fail-closed (全件除外)', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    const first = runner.run([{ key: 'runaway', source: 'loop {}' }], notes)
+    await vi.runAllTimersAsync()
+    await first
+
+    FakeWorker.hangOn = null
+    const second = runner.run([{ key: 'runaway', source: 'loop {}' }], notes)
+    await vi.runAllTimersAsync()
+    const out = await second
+    expect(out.verdicts).toEqual(['error', 'error'])
+    // サスペンド中は Worker を起こしもしない (1 台目は terminate 済み)
+    expect(FakeWorker.instances).toHaveLength(1)
+    runner.dispose()
+  })
+
+  it('明示再開でサスペンドを解除する', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    const first = runner.run([{ key: 'runaway', source: 'loop {}' }], notes)
+    await vi.runAllTimersAsync()
+    await first
+    expect(runner.suspendedKeys()).toEqual(['runaway'])
+
+    FakeWorker.hangOn = null
+    runner.resume('runaway')
+    expect(runner.isSuspended('runaway')).toBe(false)
+    const second = runner.run([{ key: 'runaway', source: 'note.text' }], notes)
+    await vi.runAllTimersAsync()
+    const out = await second
+    expect(out.verdicts).toEqual(['match', 'match'])
+    runner.dispose()
+  })
+})
+
+describe('createDegradedRunner: 空入力', () => {
+  it('フィルタが無ければ Worker を起こさず全件 match', async () => {
+    const runner = makeRunner()
+    const out = await runner.run([], notes)
+    expect(out.verdicts).toEqual(['match', 'match'])
+    expect(FakeWorker.instances).toHaveLength(0)
+    runner.dispose()
+  })
+
+  it('ノートが無ければ Worker を起こさない', async () => {
+    const runner = makeRunner()
+    const out = await runner.run([{ key: 'f1', source: 'true' }], [])
+    expect(out.verdicts).toEqual([])
+    expect(FakeWorker.instances).toHaveLength(0)
+    runner.dispose()
+  })
+})

--- a/src/services/columnQuery/degradedRunner.test.ts
+++ b/src/services/columnQuery/degradedRunner.test.ts
@@ -178,6 +178,25 @@ describe('createDegradedRunner: 暴走の打ち切り (V15/V23)', () => {
   })
 })
 
+describe('createDegradedRunner: 巻き添えの防止', () => {
+  it('他バッチの terminate に巻き込まれても犯人扱いしない', async () => {
+    FakeWorker.hangOn = 'runaway'
+    const runner = makeRunner()
+    // 先に暴走バッチ、後から無関係なバッチ (同じ Worker を共有する)
+    const runaway = runner.run([{ key: 'runaway', source: 'loop {}' }], notes)
+    const bystander = runner.run([{ key: 'innocent', source: 'true' }], notes)
+    await vi.runAllTimersAsync()
+    await runaway
+    const out = await bystander
+
+    // 巻き添え側は fail-closed で返るが、フィルタはサスペンドしない
+    expect(out.suspended).toEqual([])
+    expect(runner.isSuspended('innocent')).toBe(false)
+    expect(runner.isSuspended('runaway')).toBe(true)
+    runner.dispose()
+  })
+})
+
 describe('createDegradedRunner: 空入力', () => {
   it('フィルタが無ければ Worker を起こさず全件 match', async () => {
     const runner = makeRunner()

--- a/src/services/columnQuery/degradedRunner.ts
+++ b/src/services/columnQuery/degradedRunner.ts
@@ -95,6 +95,8 @@ export function createDegradedRunner(
     lastBegunKey: string | null
     timer: ReturnType<typeof setTimeout>
     onTimeout: () => void
+    /** 他バッチの巻き添えで打ち切るとき (犯人を出さずに終わらせる) */
+    abort: () => void
   }
   const pending = new Map<number, Pending>()
 
@@ -117,19 +119,32 @@ export function createDegradedRunner(
       })
     }
     w.onerror = () => {
-      // ロード失敗等。保留中は全部タイムアウトと同じ扱いにする
-      for (const [, entry] of [...pending]) {
-        clearTimeout(entry.timer)
-        entry.onTimeout()
-      }
+      // ロード失敗等。誰も暴走していないので犯人は出さず、全部中断扱いにする
+      killWorker()
     }
     worker = w
     return w
   }
 
-  function killWorker(): void {
+  /**
+   * Worker を捨てる。runner はカラム間で共有なので、terminate すると同時に
+   * 走っていた他バッチの応答も永久に来なくなる。放置すると各自のタイムアウトを
+   * 待たされたうえ、無実のフィルタが「最後に開始したもの」として犯人扱いされて
+   * サスペンドされる。捨てた時点で全部まとめて中断扱いにする。
+   *
+   * `except` はこの kill を引き起こした本人。犯人特定は呼び出し側で行うため
+   * ここでは解決しない。
+   */
+  function killWorker(except?: number): void {
     worker?.terminate()
     worker = null
+    for (const [id, entry] of [...pending]) {
+      if (id === except) continue
+      clearTimeout(entry.timer)
+      pending.delete(id)
+      // 巻き添えなので犯人を出さない (culprit=null = サスペンドせず fail-closed)
+      entry.abort()
+    }
   }
 
   /** Worker に 1 バッチ投げる。タイムアウトしたら犯人 key を返す */
@@ -149,8 +164,9 @@ export function createDegradedRunner(
       const onTimeout = () => {
         const entry = pending.get(id)
         pending.delete(id)
-        // 止められない評価を止める唯一の手段
-        killWorker()
+        // 止められない評価を止める唯一の手段。自分は犯人を返して解決するので
+        // 巻き添え処理の対象から外す
+        killWorker(id)
         resolve({ ok: false, culprit: entry?.lastBegunKey ?? null })
       }
       const timer = setTimeout(onTimeout, timeoutMs)
@@ -159,6 +175,7 @@ export function createDegradedRunner(
         lastBegunKey: null,
         timer,
         onTimeout,
+        abort: () => resolve({ ok: false, culprit: null }),
       })
       const request: ColumnQueryWorkerRequest = {
         id,

--- a/src/services/columnQuery/degradedRunner.ts
+++ b/src/services/columnQuery/degradedRunner.ts
@@ -1,0 +1,221 @@
+import type {
+  DegradedFilterSpec,
+  InvalidFilter,
+} from '@/services/columnQuery/degradedBatch'
+import type { FilterVerdict } from '@/services/columnQuery/referenceEvaluator'
+import type {
+  ColumnQueryWorkerRequest,
+  ColumnQueryWorkerResponse,
+} from '@/workers/columnQueryWorker'
+
+/**
+ * 🐢 降格フィルタの実行管理 (#783 Phase 2 / V15・V23)。
+ *
+ * 評価そのものは Worker 側 (degradedBatch) が行う。ここが持つのは
+ * 「止められない評価を確実に止め、巻き添えを最小にする」責務:
+ *
+ *   - バッチにタイムアウトを張り、超えたら `terminate()` で強制停止する。
+ *     AiScript の同期評価は abort できず、step 予算もメモリ確保を縛れないため
+ *     これが唯一の確実な停止手段になる
+ *   - 直前に届いた評価開始マーカーから犯人フィルタを特定し、**そのフィルタだけ**
+ *     サスペンドする。Worker を作り直して残りのフィルタは評価を続ける
+ *   - サスペンド中のフィルタを含むバッチは fail-closed (全件除外) にする。
+ *     解除はユーザーの明示操作 (`resume`) に限る (不変条件 (f))
+ */
+
+/** バッチ 1 回あたりの判定タイムアウト */
+export const DEGRADED_BATCH_TIMEOUT_MS = 3000
+
+export interface DegradedRunResult {
+  /** notes と同じ長さ。And 合成後の判定 */
+  verdicts: FilterVerdict[]
+  invalidFilters: InvalidFilter[]
+  /** この呼び出しでサスペンドしたフィルタ */
+  suspended: string[]
+}
+
+export interface DegradedRunner {
+  run(
+    filters: readonly DegradedFilterSpec[],
+    notes: readonly unknown[],
+  ): Promise<DegradedRunResult>
+  isSuspended(key: string): boolean
+  suspendedKeys(): string[]
+  /** ユーザーの明示操作でサスペンドを解除する */
+  resume(key: string): void
+  dispose(): void
+}
+
+export interface DegradedRunnerOptions {
+  workerFactory?: () => Worker
+  timeoutMs?: number
+}
+
+const defaultWorkerFactory = (): Worker =>
+  new Worker(new URL('../../workers/columnQueryWorker.ts', import.meta.url), {
+    type: 'module',
+  })
+
+export function createDegradedRunner(
+  options: DegradedRunnerOptions = {},
+): DegradedRunner {
+  const factory = options.workerFactory ?? defaultWorkerFactory
+  const timeoutMs = options.timeoutMs ?? DEGRADED_BATCH_TIMEOUT_MS
+  const suspended = new Set<string>()
+
+  let worker: Worker | null = null
+  let nextId = 0
+
+  interface Pending {
+    resolve: (outcome: {
+      verdicts: FilterVerdict[]
+      invalidFilters: InvalidFilter[]
+    }) => void
+    /** タイムアウト時に犯人を帰属するための、最後に開始したフィルタ */
+    lastBegunKey: string | null
+    timer: ReturnType<typeof setTimeout>
+    onTimeout: () => void
+  }
+  const pending = new Map<number, Pending>()
+
+  function getWorker(): Worker {
+    if (worker) return worker
+    const w = factory()
+    w.onmessage = (event: MessageEvent<ColumnQueryWorkerResponse>) => {
+      const msg = event.data
+      const entry = pending.get(msg.id)
+      if (!entry) return
+      if (msg.type === 'begin') {
+        entry.lastBegunKey = msg.key
+        return
+      }
+      clearTimeout(entry.timer)
+      pending.delete(msg.id)
+      entry.resolve({
+        verdicts: msg.verdicts,
+        invalidFilters: msg.invalidFilters,
+      })
+    }
+    w.onerror = () => {
+      // ロード失敗等。保留中は全部タイムアウトと同じ扱いにする
+      for (const [, entry] of [...pending]) {
+        clearTimeout(entry.timer)
+        entry.onTimeout()
+      }
+    }
+    worker = w
+    return w
+  }
+
+  function killWorker(): void {
+    worker?.terminate()
+    worker = null
+  }
+
+  /** Worker に 1 バッチ投げる。タイムアウトしたら犯人 key を返す */
+  function postBatch(
+    filters: readonly DegradedFilterSpec[],
+    notes: readonly unknown[],
+  ): Promise<
+    | {
+        ok: true
+        verdicts: FilterVerdict[]
+        invalidFilters: InvalidFilter[]
+      }
+    | { ok: false; culprit: string | null }
+  > {
+    return new Promise((resolve) => {
+      const id = nextId++
+      const onTimeout = () => {
+        const entry = pending.get(id)
+        pending.delete(id)
+        // 止められない評価を止める唯一の手段
+        killWorker()
+        resolve({ ok: false, culprit: entry?.lastBegunKey ?? null })
+      }
+      const timer = setTimeout(onTimeout, timeoutMs)
+      pending.set(id, {
+        resolve: (outcome) => resolve({ ok: true, ...outcome }),
+        lastBegunKey: null,
+        timer,
+        onTimeout,
+      })
+      const request: ColumnQueryWorkerRequest = {
+        id,
+        filters: [...filters],
+        notes: [...notes],
+      }
+      getWorker().postMessage(request)
+    })
+  }
+
+  return {
+    async run(filters, notes) {
+      if (notes.length === 0) {
+        return { verdicts: [], invalidFilters: [], suspended: [] }
+      }
+      // サスペンド中のフィルタが 1 つでも掛かっていれば fail-closed
+      if (filters.some((f) => suspended.has(f.key))) {
+        return {
+          verdicts: notes.map(() => 'error' as const),
+          invalidFilters: [],
+          suspended: [],
+        }
+      }
+      if (filters.length === 0) {
+        return {
+          verdicts: notes.map(() => 'match' as const),
+          invalidFilters: [],
+          suspended: [],
+        }
+      }
+
+      const newlySuspended: string[] = []
+      let remaining = [...filters]
+      // 犯人を 1 つずつ落として再試行する。全滅すれば fail-closed で抜ける
+      for (let attempt = 0; attempt <= filters.length; attempt++) {
+        const result = await postBatch(remaining, notes)
+        if (result.ok) {
+          return {
+            verdicts: result.verdicts,
+            invalidFilters: result.invalidFilters,
+            suspended: newlySuspended,
+          }
+        }
+        const culprit = result.culprit
+        if (culprit === null) {
+          // どのフィルタで止まったか帰属できない。バッチ全体を fail-closed
+          break
+        }
+        suspended.add(culprit)
+        newlySuspended.push(culprit)
+        remaining = remaining.filter((f) => f.key !== culprit)
+        if (remaining.length === 0) break
+      }
+
+      return {
+        verdicts: notes.map(() => 'error' as const),
+        invalidFilters: [],
+        suspended: newlySuspended,
+      }
+    },
+
+    isSuspended(key) {
+      return suspended.has(key)
+    },
+
+    suspendedKeys() {
+      return [...suspended]
+    },
+
+    resume(key) {
+      suspended.delete(key)
+    },
+
+    dispose() {
+      for (const [, entry] of pending) clearTimeout(entry.timer)
+      pending.clear()
+      killWorker()
+    },
+  }
+}

--- a/src/services/columnQuery/degradedRunner.ts
+++ b/src/services/columnQuery/degradedRunner.ts
@@ -56,6 +56,26 @@ const defaultWorkerFactory = (): Worker =>
     type: 'module',
   })
 
+/**
+ * アプリ全体で共有する runner。Worker は 1 台に固定する (V23)。
+ *
+ * サスペンドはフィルタ key 単位なので、同じ名前付きクエリを複数カラムに
+ * 適用していれば 1 度の暴走で全カラムが同時に fail-closed になる。これは
+ * 意図した挙動で、暴走するクエリを 1 つのカラムだけで走らせ続けない。
+ */
+let sharedRunner: DegradedRunner | null = null
+
+export function getSharedDegradedRunner(): DegradedRunner {
+  sharedRunner ??= createDegradedRunner()
+  return sharedRunner
+}
+
+/** テスト用: 共有 runner を破棄する */
+export function resetSharedDegradedRunner(): void {
+  sharedRunner?.dispose()
+  sharedRunner = null
+}
+
 export function createDegradedRunner(
   options: DegradedRunnerOptions = {},
 ): DegradedRunner {

--- a/src/services/columnQuery/golden/qir.generated.json
+++ b/src/services/columnQuery/golden/qir.generated.json
@@ -1,0 +1,778 @@
+{
+  "note": "Generated from vectors.json by `pnpm gen:golden-qir`. Do not edit by hand.",
+  "cases": {
+    "text-incl-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "needle": {
+            "kind": "str",
+            "value": "misskey"
+          }
+        }
+      }
+    },
+    "text-incl-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "needle": {
+            "kind": "str",
+            "value": "misskey"
+          }
+        }
+      }
+    },
+    "text-null-guarded-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "needle": {
+            "kind": "str",
+            "value": "misskey"
+          }
+        }
+      }
+    },
+    "null-receiver-error": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "strTest",
+        "op": "incl",
+        "target": {
+          "kind": "field",
+          "path": [
+            "text"
+          ]
+        },
+        "needle": {
+          "kind": "str",
+          "value": "x"
+        }
+      }
+    },
+    "let-unused-binding-error": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "let",
+        "bindings": [
+          {
+            "slot": 0,
+            "expr": {
+              "kind": "strMap",
+              "op": "lower",
+              "target": {
+                "kind": "field",
+                "path": [
+                  "text"
+                ]
+              }
+            }
+          }
+        ],
+        "body": {
+          "kind": "bool",
+          "value": true
+        }
+      }
+    },
+    "let-short-circuit-branch-error": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "let",
+        "bindings": [
+          {
+            "slot": 0,
+            "expr": {
+              "kind": "strMap",
+              "op": "lower",
+              "target": {
+                "kind": "field",
+                "path": [
+                  "text"
+                ]
+              }
+            }
+          }
+        ],
+        "body": {
+          "kind": "and",
+          "left": {
+            "kind": "bool",
+            "value": false
+          },
+          "right": {
+            "kind": "strTest",
+            "op": "incl",
+            "target": {
+              "kind": "ref",
+              "slot": 0
+            },
+            "needle": {
+              "kind": "str",
+              "value": "x"
+            }
+          }
+        }
+      }
+    },
+    "null-eq-null-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "renoteId"
+          ]
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "renote-id-present-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "renoteId"
+          ]
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "missing-key-is-null-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "cw"
+          ]
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "reactions-literal-index-missing-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "objIndex",
+          "target": {
+            "kind": "field",
+            "path": [
+              "reactions"
+            ]
+          },
+          "key": "👍"
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "reactions-literal-index-present-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": true,
+        "left": {
+          "kind": "objIndex",
+          "target": {
+            "kind": "field",
+            "path": [
+              "reactions"
+            ]
+          },
+          "key": ":igyo@.:"
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "turkish-dotted-i-lower-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "strMap",
+            "op": "lower",
+            "target": {
+              "kind": "field",
+              "path": [
+                "text"
+              ]
+            }
+          },
+          "needle": {
+            "kind": "str",
+            "value": "i̇stanbul"
+          }
+        }
+      }
+    },
+    "final-sigma-lower-final-form": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "eq",
+          "negated": false,
+          "left": {
+            "kind": "strMap",
+            "op": "lower",
+            "target": {
+              "kind": "field",
+              "path": [
+                "text"
+              ]
+            }
+          },
+          "right": {
+            "kind": "str",
+            "value": "οδος"
+          }
+        }
+      }
+    },
+    "final-sigma-lower-medial-form": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "eq",
+          "negated": false,
+          "left": {
+            "kind": "strMap",
+            "op": "lower",
+            "target": {
+              "kind": "field",
+              "path": [
+                "text"
+              ]
+            }
+          },
+          "right": {
+            "kind": "str",
+            "value": "οδοσ"
+          }
+        }
+      }
+    },
+    "eszett-upper-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "eq",
+          "negated": false,
+          "left": {
+            "kind": "strMap",
+            "op": "upper",
+            "target": {
+              "kind": "field",
+              "path": [
+                "text"
+              ]
+            }
+          },
+          "right": {
+            "kind": "str",
+            "value": "STRASSE"
+          }
+        }
+      }
+    },
+    "emoji-astral-incl-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "needle": {
+            "kind": "str",
+            "value": "👍"
+          }
+        }
+      }
+    },
+    "files-len-gt-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "files"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "cmp",
+          "op": "gt",
+          "left": {
+            "kind": "arrLen",
+            "target": {
+              "kind": "field",
+              "path": [
+                "files"
+              ]
+            }
+          },
+          "right": {
+            "kind": "num",
+            "value": 0
+          }
+        }
+      }
+    },
+    "files-missing-guarded-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "files"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "cmp",
+          "op": "gt",
+          "left": {
+            "kind": "arrLen",
+            "target": {
+              "kind": "field",
+              "path": [
+                "files"
+              ]
+            }
+          },
+          "right": {
+            "kind": "num",
+            "value": 0
+          }
+        }
+      }
+    },
+    "files-empty-eq-zero-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "or",
+        "left": {
+          "kind": "eq",
+          "negated": false,
+          "left": {
+            "kind": "field",
+            "path": [
+              "files"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "eq",
+          "negated": false,
+          "left": {
+            "kind": "arrLen",
+            "target": {
+              "kind": "field",
+              "path": [
+                "files"
+              ]
+            }
+          },
+          "right": {
+            "kind": "num",
+            "value": 0
+          }
+        }
+      }
+    },
+    "localonly-true-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "localOnly"
+          ]
+        },
+        "right": {
+          "kind": "bool",
+          "value": true
+        }
+      }
+    },
+    "localonly-missing-scalar-eq-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "localOnly"
+          ]
+        },
+        "right": {
+          "kind": "bool",
+          "value": true
+        }
+      }
+    },
+    "visibility-eq-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "visibility"
+          ]
+        },
+        "right": {
+          "kind": "str",
+          "value": "specified"
+        }
+      }
+    },
+    "fn-desugar-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "let",
+          "bindings": [
+            {
+              "slot": 0,
+              "expr": {
+                "kind": "field",
+                "path": [
+                  "text"
+                ]
+              }
+            }
+          ],
+          "body": {
+            "kind": "strTest",
+            "op": "incl",
+            "target": {
+              "kind": "ref",
+              "slot": 0
+            },
+            "needle": {
+              "kind": "str",
+              "value": "x"
+            }
+          }
+        }
+      }
+    },
+    "fn-arg-eager-inside-guard-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "not",
+        "expr": {
+          "kind": "and",
+          "left": {
+            "kind": "eq",
+            "negated": true,
+            "left": {
+              "kind": "field",
+              "path": [
+                "text"
+              ]
+            },
+            "right": {
+              "kind": "null"
+            }
+          },
+          "right": {
+            "kind": "let",
+            "bindings": [
+              {
+                "slot": 0,
+                "expr": {
+                  "kind": "strMap",
+                  "op": "lower",
+                  "target": {
+                    "kind": "field",
+                    "path": [
+                      "text"
+                    ]
+                  }
+                }
+              }
+            ],
+            "body": {
+              "kind": "strTest",
+              "op": "incl",
+              "target": {
+                "kind": "ref",
+                "slot": 0
+              },
+              "needle": {
+                "kind": "str",
+                "value": "ng"
+              }
+            }
+          }
+        }
+      }
+    },
+    "short-literal-2char-incl-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "and",
+        "left": {
+          "kind": "eq",
+          "negated": true,
+          "left": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "right": {
+            "kind": "null"
+          }
+        },
+        "right": {
+          "kind": "strTest",
+          "op": "incl",
+          "target": {
+            "kind": "field",
+            "path": [
+              "text"
+            ]
+          },
+          "needle": {
+            "kind": "str",
+            "value": "ab"
+          }
+        }
+      }
+    },
+    "user-host-null-match": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "user",
+            "host"
+          ]
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    },
+    "user-host-remote-unmatch": {
+      "schemaVersion": 1,
+      "root": {
+        "kind": "eq",
+        "negated": false,
+        "left": {
+          "kind": "field",
+          "path": [
+            "user",
+            "host"
+          ]
+        },
+        "right": {
+          "kind": "null"
+        }
+      }
+    }
+  }
+}

--- a/src/services/columnQuery/goldenVectors.test.ts
+++ b/src/services/columnQuery/goldenVectors.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { compileColumnQuery } from '@/services/columnQuery/compiler'
@@ -24,6 +26,18 @@ interface GoldenCase {
   expected: FilterVerdict
 }
 
+/**
+ * QIR は静的型検査を持つため、fallback では実行時 per-note エラーになる
+ * 「常に型エラー」の式はそもそもコンパイルされない (V20)。
+ * ここに列挙されたケースは QIR 経路では保存時拒否 = fallback 専用ベクタ。
+ */
+const QIR_STATIC_REJECT = new Set([
+  'non-bool-result-error',
+  'lt-on-string-error',
+  'and-non-bool-error',
+  'not-non-bool-error',
+])
+
 describe('golden vectors × 参照評価器 (AiScript 1.2.1)', () => {
   const cases = golden.cases as GoldenCase[]
 
@@ -40,18 +54,6 @@ describe('golden vectors × 参照評価器 (AiScript 1.2.1)', () => {
     const names = cases.map((c) => c.name)
     expect(new Set(names).size).toBe(names.length)
   })
-
-  /**
-   * QIR は静的型検査を持つため、fallback では実行時 per-note エラーになる
-   * 「常に型エラー」の式はそもそもコンパイルされない (V20)。
-   * ここに列挙されたケースは QIR 経路では保存時拒否 = fallback 専用ベクタ。
-   */
-  const QIR_STATIC_REJECT = new Set([
-    'non-bool-result-error',
-    'lt-on-string-error',
-    'and-non-bool-error',
-    'not-non-bool-error',
-  ])
 
   describe('QIR 経路 (compiler → JS evaluator) が参照評価器と一致する', () => {
     it.each(cases.map((c) => [c.name, c] as const))('%s', (_name, c) => {
@@ -100,5 +102,51 @@ describe('golden vectors × 参照評価器 (AiScript 1.2.1)', () => {
     } finally {
       filter.dispose()
     }
+  })
+})
+
+/**
+ * Rust QIR eval (Phase 3) 用の QIR スナップショット。
+ *
+ * Rust 側には AiScript コンパイラが無いため、golden vector のソースを
+ * そのままでは評価できない。コンパイル済み QIR を生成物として共有し、
+ * src-tauri のテストがこれを読んで同じ期待値に一致するか検証する
+ * (不変条件 (a) の 3 評価器一致検証のうち Rust 面)。
+ *
+ * ずれたら `pnpm gen:golden-qir` で再生成してコミットする。
+ * bindings.ts / openapi.json のスナップショットと同じ運用。
+ */
+describe('QIR スナップショット (Rust 評価器との共有)', () => {
+  const SNAPSHOT_PATH = join(
+    import.meta.dirname,
+    'golden',
+    'qir.generated.json',
+  )
+
+  function build(): unknown {
+    const compiledCases: Record<string, unknown> = {}
+    for (const c of golden.cases as GoldenCase[]) {
+      if (QIR_STATIC_REJECT.has(c.name)) continue
+      const compiled = compileColumnQuery(c.source)
+      if (!compiled.ok) throw new Error(`compile failed: ${c.name}`)
+      compiledCases[c.name] = compiled.query
+    }
+    return {
+      note: 'Generated from vectors.json by `pnpm gen:golden-qir`. Do not edit by hand.',
+      cases: compiledCases,
+    }
+  }
+
+  it('コンパイラ出力と一致する', () => {
+    const built = build()
+    if (process.env.UPDATE_GOLDEN_QIR === '1') {
+      writeFileSync(SNAPSHOT_PATH, `${JSON.stringify(built, null, 2)}\n`)
+      return
+    }
+    const committed = JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8'))
+    expect(
+      committed,
+      'QIR スナップショットが古いです。`pnpm gen:golden-qir` を実行してください',
+    ).toEqual(built)
   })
 })

--- a/src/services/columnQuery/purity.test.ts
+++ b/src/services/columnQuery/purity.test.ts
@@ -1,0 +1,94 @@
+import { Parser } from '@syuilo/aiscript'
+import { describe, expect, it } from 'vitest'
+import { collectImpureIdentifiers } from './purity'
+
+/** フィルタソースを AST 化して純粋性検査にかける */
+function check(source: string): string[] {
+  const ast = new Parser().parse(source)
+  return collectImpureIdentifiers(ast).map((v) => v.name)
+}
+
+describe('collectImpureIdentifiers: 純粋な参照', () => {
+  it('note だけを参照する式は違反なし', () => {
+    expect(check('note.text != null')).toEqual([])
+  })
+
+  it('サブセット外でも純粋なら違反なし (降格対象)', () => {
+    // str.len は v1 サブセット外 (V20) だが、参照しているのは note だけ
+    expect(check('note.text != null && note.text.len > 10')).toEqual([])
+  })
+
+  it('let で束縛した名前の参照は違反なし', () => {
+    expect(check('let t = note.text\nt != null')).toEqual([])
+  })
+
+  it('関数の引数として束縛した名前の参照は違反なし', () => {
+    expect(check('let f = @(s) { s != null }\nf(note.text)')).toEqual([])
+  })
+
+  it('each の変数束縛は違反なし', () => {
+    expect(
+      check('each (let f, note.files) { f.type }\nnote.text != null'),
+    ).toEqual([])
+  })
+
+  it('再帰関数の自己参照は違反なし (AiScript で実際に動く)', () => {
+    expect(
+      check('@f(n) { if n == 0 { 0 } else { f(n - 1) } }\nf(3) == 0'),
+    ).toEqual([])
+  })
+
+  it('for の変数束縛は違反なし', () => {
+    expect(check('for (let i, 3) { i }\nnote.text != null')).toEqual([])
+  })
+})
+
+describe('collectImpureIdentifiers: 非純粋な参照', () => {
+  it('名前空間関数の呼び出しを検出する', () => {
+    expect(check('Date:now() > 0')).toEqual(['Date:now'])
+  })
+
+  it('呼び出さず変数に束縛しただけでも検出する (関数第一級の素通り対策)', () => {
+    // V15: allowlist は呼び出し位置ではなく全識別子参照にかける
+    expect(check('let f = Date:now\nf() > 0')).toEqual(['Date:now'])
+  })
+
+  it('exists による存在検査も参照として検出する', () => {
+    expect(check('exists Async:interval')).toEqual(['Async:interval'])
+  })
+
+  it('未束縛の名前への代入を検出する', () => {
+    expect(check('globalThing = 1\nnote.text != null')).toContain('globalThing')
+  })
+
+  it('束縛より前の参照は検出する (前方参照は許さない)', () => {
+    expect(check('let a = b\nlet b = 1\nnote.text != null')).toEqual(['b'])
+  })
+
+  it('スコープを抜けた後の参照を検出する', () => {
+    expect(check('eval { let inner = 1 }\ninner == 1')).toEqual(['inner'])
+  })
+
+  it('複数の違反をすべて集める', () => {
+    expect(check('Date:now() > 0 && Math:rnd() > 0')).toEqual([
+      'Date:now',
+      'Math:rnd',
+    ])
+  })
+})
+
+describe('collectImpureIdentifiers: 安全側への倒し方', () => {
+  it('namespace 定義は未知の構文として違反にする', () => {
+    const violations = check(':: Ns { let x = 1 }\nnote.text != null')
+    expect(violations.length).toBeGreaterThan(0)
+  })
+
+  it('違反には位置情報が付く', () => {
+    const ast = new Parser().parse('note.text != null && Date:now() > 0')
+    const violations = collectImpureIdentifiers(ast)
+    expect(violations).toHaveLength(1)
+    expect(violations[0]?.name).toBe('Date:now')
+    expect(violations[0]?.line).toBe(1)
+    expect(violations[0]?.column).toBeGreaterThan(1)
+  })
+})

--- a/src/services/columnQuery/purity.ts
+++ b/src/services/columnQuery/purity.ts
@@ -1,0 +1,241 @@
+import type { Ast } from '@syuilo/aiscript'
+
+/**
+ * カラムクエリの純粋性検査 (#783 Phase 2 / V15)。
+ *
+ * QIR にコンパイルできない式は Worker で AiScript Interpreter に逐次適用する
+ * (🐢 降格) が、そこへ流してよいのは「サブセット外だが純粋」な式だけである。
+ * 副作用・非決定 API に到達しうる式は降格させず保存時に拒否する (不変条件 (c))。
+ *
+ * 判定は **全識別子参照** の allowlist で行う。呼び出し位置だけを見ると
+ * `let f = Date:now` のように第一級の関数値として束縛してから呼ぶ経路で
+ * 素通りするため。名前空間参照 (`Async:interval`) はコロン込みの単一識別子
+ * として現れるので、identifier を漏れなく拾えば同じ網にかかる。
+ *
+ * Worker 隔離・step 予算は「暴走を止める」ための層であって、到達可能性を
+ * 絞るのはこの検査の役目。両方揃って初めて (c) を満たす。
+ */
+
+/** フィルタ文脈で参照してよい自由識別子。ローカル束縛はこれとは別に許可される */
+export const FILTER_FREE_IDENTIFIERS: ReadonlySet<string> = new Set(['note'])
+
+export interface PurityViolation {
+  /** 違反した識別子名。未知構文の場合は `(構文: <type>)` 形式 */
+  name: string
+  line?: number
+  column?: number
+}
+
+/**
+ * AST を歩いて allowlist 外の自由識別子を集める。
+ * 空配列なら「純粋」= 🐢 降格の対象にしてよい。
+ *
+ * 未知のノード種別は違反として扱う (安全側に倒す)。コンパイラが未知ノードを
+ * 必ずコンパイル不能に落とす (不変条件 (d)) のと同じ理由で、知らない構文を
+ * 素通りさせない。
+ */
+export function collectImpureIdentifiers(
+  ast: readonly Ast.Node[],
+): PurityViolation[] {
+  const violations: PurityViolation[] = []
+  // スコープチェーン。末尾が最も内側
+  const scopes: Set<string>[] = [new Set()]
+
+  const bound = (name: string): boolean =>
+    FILTER_FREE_IDENTIFIERS.has(name) || scopes.some((s) => s.has(name))
+
+  const declare = (name: string): void => {
+    scopes[scopes.length - 1]?.add(name)
+  }
+
+  const violate = (name: string, loc: Ast.Loc | undefined): void => {
+    violations.push({
+      name,
+      line: loc?.start.line,
+      column: loc?.start.column,
+    })
+  }
+
+  const reference = (name: string, loc: Ast.Loc | undefined): void => {
+    if (!bound(name)) violate(name, loc)
+  }
+
+  /** 束縛パターン (identifier / 分割代入) から名前を宣言する */
+  const declarePattern = (dest: Ast.Expression): void => {
+    switch (dest.type) {
+      case 'identifier':
+        declare(dest.name)
+        return
+      case 'arr':
+        for (const el of dest.value) declarePattern(el)
+        return
+      case 'obj':
+        for (const el of dest.value.values()) declarePattern(el)
+        return
+      default:
+        // 未知の束縛形。左辺を式として歩いて参照漏れを防ぐ
+        walk(dest)
+    }
+  }
+
+  const walkAll = (nodes: readonly (Ast.Node | undefined)[]): void => {
+    for (const n of nodes) if (n) walk(n)
+  }
+
+  /** 新しいスコープで本体を歩く */
+  const scoped = (fn: () => void): void => {
+    scopes.push(new Set())
+    fn()
+    scopes.pop()
+  }
+
+  function walk(node: Ast.Node): void {
+    switch (node.type) {
+      // --- 参照・束縛 ---
+      case 'identifier':
+        reference(node.name, node.loc)
+        return
+      case 'exists':
+        // 存在検査も参照として扱う (未定義でもエラーにならないが素通りさせない)
+        reference(node.identifier.name, node.identifier.loc)
+        return
+      case 'def':
+        if (node.expr.type === 'fn') {
+          // 関数定義は自己名を参照できる (再帰が実際に動く)。先に宣言する
+          declarePattern(node.dest)
+          walk(node.expr)
+          return
+        }
+        // 関数以外の右辺は宣言前のスコープで評価される (前方参照はエラー)
+        walk(node.expr)
+        declarePattern(node.dest)
+        return
+      case 'assign':
+      case 'addAssign':
+      case 'subAssign':
+        // 代入先は既存束縛でなければならない。未束縛なら違反
+        walk(node.dest)
+        walk(node.expr)
+        return
+
+      // --- スコープを作るもの ---
+      case 'fn':
+        scoped(() => {
+          for (const p of node.params) {
+            if (p.default) walk(p.default)
+            declarePattern(p.dest)
+          }
+          walkAll(node.children)
+        })
+        return
+      case 'block':
+      case 'loop':
+        scoped(() => walkAll(node.statements))
+        return
+      case 'each':
+        walk(node.items)
+        scoped(() => {
+          declarePattern(node.var)
+          walk(node.for)
+        })
+        return
+      case 'for':
+        walkAll([node.from, node.to, node.times])
+        scoped(() => {
+          if (node.var !== undefined) declare(node.var)
+          walk(node.for)
+        })
+        return
+
+      // --- 制御構文 ---
+      case 'if':
+        walk(node.cond)
+        walk(node.then)
+        for (const ei of node.elseif) {
+          walk(ei.cond)
+          walk(ei.then)
+        }
+        if (node.else) walk(node.else)
+        return
+      case 'match':
+        walk(node.about)
+        for (const q of node.qs) {
+          walk(q.q)
+          walk(q.a)
+        }
+        if (node.default) walk(node.default)
+        return
+      case 'return':
+        walk(node.expr)
+        return
+      case 'break':
+        if (node.expr) walk(node.expr)
+        return
+      case 'continue':
+        return
+
+      // --- 複合式 ---
+      case 'call':
+        walk(node.target)
+        walkAll(node.args)
+        return
+      case 'index':
+        walk(node.target)
+        walk(node.index)
+        return
+      case 'prop':
+        // name はプロパティ名であって識別子参照ではない
+        walk(node.target)
+        return
+      case 'tmpl':
+        walkAll(node.tmpl)
+        return
+      case 'obj':
+        walkAll([...node.value.values()])
+        return
+      case 'arr':
+        walkAll(node.value)
+        return
+
+      // --- 単項 ---
+      case 'plus':
+      case 'minus':
+      case 'not':
+        walk(node.expr)
+        return
+
+      // --- 二項 ---
+      case 'pow':
+      case 'mul':
+      case 'div':
+      case 'rem':
+      case 'add':
+      case 'sub':
+      case 'lt':
+      case 'lteq':
+      case 'gt':
+      case 'gteq':
+      case 'eq':
+      case 'neq':
+      case 'and':
+      case 'or':
+        walk(node.left)
+        walk(node.right)
+        return
+
+      // --- リテラル ---
+      case 'str':
+      case 'num':
+      case 'bool':
+      case 'null':
+        return
+
+      // --- 未知・サブセット外の構文は安全側 (違反) に倒す ---
+      default:
+        violate(`(構文: ${(node as Ast.Node).type})`, (node as Ast.Node).loc)
+    }
+  }
+
+  walkAll(ast)
+  return violations
+}

--- a/src/workers/columnQueryWorker.ts
+++ b/src/workers/columnQueryWorker.ts
@@ -1,0 +1,55 @@
+/// <reference lib="webworker" />
+
+import {
+  createDegradedBatchRunner,
+  type DegradedFilterSpec,
+  type InvalidFilter,
+} from '../services/columnQuery/degradedBatch'
+import type { FilterVerdict } from '../services/columnQuery/referenceEvaluator'
+
+/**
+ * 🐢 降格フィルタの評価 Worker (#783 Phase 2 / V15)。
+ *
+ * AiScript Interpreter の per-note 評価は同期実行で外部から中断できず、
+ * step 予算もメモリ確保 (`arr.repeat` 等) を縛れない。確実に止める手段は
+ * `Worker.terminate()` しかないので、評価は必ずこの Worker で行う。
+ *
+ * ノートは structured clone でカラムごとに独立したコピーが渡るため、
+ * `Obj:set` や代入による破壊的変更がフィルタ間へ波及しない (V23)。
+ */
+
+export interface ColumnQueryWorkerRequest {
+  id: number
+  filters: DegradedFilterSpec[]
+  notes: unknown[]
+}
+
+export type ColumnQueryWorkerResponse =
+  | { type: 'begin'; id: number; key: string }
+  | {
+      type: 'done'
+      id: number
+      verdicts: FilterVerdict[]
+      invalidFilters: InvalidFilter[]
+    }
+
+const runner = createDegradedBatchRunner()
+
+self.onmessage = (event: MessageEvent<ColumnQueryWorkerRequest>) => {
+  const { id, filters, notes } = event.data
+  const outcome = runner.run(filters, notes, {
+    onFilterBegin: (key) => {
+      // 暴走して terminate されたとき、どのフィルタで止まったかを
+      // メインスレッド側が帰属できるようにする (V23 の評価開始マーカー)
+      const mark: ColumnQueryWorkerResponse = { type: 'begin', id, key }
+      self.postMessage(mark)
+    },
+  })
+  const done: ColumnQueryWorkerResponse = {
+    type: 'done',
+    id,
+    verdicts: outcome.verdicts,
+    invalidFilters: outcome.invalidFilters,
+  }
+  self.postMessage(done)
+}


### PR DESCRIPTION
カラムクエリ (#783) の Phase 2 / V25 / Phase 3 と、削除して編集の不具合修正 (#944) が入ります。

## 削除して編集で引用・添付・アンケートが失われる (#944)

引用付きのノートを「削除して編集」すると引用が外れる問題を修正しました。原因は元ノートの内容をほとんど引き継いでいなかったことで、引用だけでなく添付ファイルとアンケートも失われていました。

同じ処理がカラム・ノート詳細ウィンドウ・プロフィールウィンドウの 3 箇所に別実装されていて、3 つとも壊れていました。ウィンドウ側の 2 つは本文すら引き継がず空フォームが開いていたので、そちらも直しています。

派生する制約は #953 (チャンネルがウィンドウ経由で外れる) と #954 (「編集」メニューが本家サーバーでは必ず失敗する) に切り出しました。

## カラムクエリ: 逐次適用への降格 (#783 Phase 2)

QIR にコンパイルできない式のうち、副作用や非決定 API に到達しないものを Worker で 1 件ずつ評価するようにしました。これまでは解釈できない式として一律に停止していたため、`note.text.len > 10` のような普通の式が使えませんでした。

暴走したクエリはタイムアウトで強制停止し、そのクエリだけをサスペンドして他は動かし続けます。停止したカラムには「N 件保留中 — 再開」を出し、再開はユーザーの明示操作だけにしています (自動で走らせ直さない)。

## カラムクエリ: null ガードの診断 (#783 V25)

`note.text.incl("x")` のようにガードなしで書くと、画像のみのノートや純リノートが丸ごと除外されます。書いた本人には「リノートが全部消えるフィルタ」に見えるので、保存前に警告と「ガードを入れる」ボタンを出すようにしました。ガード済みの式に誤警告が出ないよう、null ガードの追跡を実装しています。

## カラムクエリ: ローカルキャッシュ検索 (#783 Phase 3)

Rust 側の QIR 評価器を実装し、AiScript 参照評価器 / JS / Rust の 3 評価器が共有ベクタで一致することを CI で検証するようにしました (これまで Rust 面は存在せず未検証でした)。

FTS5 で粗く絞ってから評価する経路を notecli 側の API (notedeck-dev/notecli#51) と繋ぎ、オフライン時のページングで条件に合うノートが見つかるまで遡れるようにしています。従来は 40 件読んでフロントで絞っていたため、全件フィルタ落ちが続くと「もっと読む」が空振りしていました。

キャッシュ検索はタイムライン種別で絞っていません。所属が後勝ち上書きで取りこぼすためで、notedeck-dev/notecli#30 の再設計が入ったら絞れるようになります。

## 既知の未解決

クエリの適用状態を切り替えた直後にカラムのノート一覧が空になる問題 (#957) は、レビューを受けて原因を特定し修正を入れました。復帰 catch-up が「取り込み済みノートが 1 件も無ければ API を叩かない」判定を持っており、クエリ変更で一時的に空になった列がそこに当たっていました。

ただし実機での確認ができていないため、#957 は open のままにしています。報告された症状がこれ 1 つだったとは確定していません。

このほか、レビュー指摘のうち実害のある 5 件も修正しました (削除して編集の 4 箇所目の修正漏れ、ガード quick-fix が式を壊す件、暴走の巻き添えで無実のクエリがサスペンドされる件、サスペンド中の二重計上、名前付きクエリ形でのガード誤検知)。

Closes #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added faster local note searching with pagination, scan limits, and continuation support.
  * Added degraded-mode query execution with clearer statuses, suspension controls, recovery actions, and diagnostics.
  * Added warnings and quick fixes for queries using potentially empty fields.
  * Added the ability to restore deleted notes and their settings when editing.
* **Bug Fixes**
  * Improved query reliability, ordering, error handling, and missing-reference cleanup.
  * Preserved reply, quote, attachment, visibility, poll, and renote details when restoring posts.
* **Chores**
  * Updated the application version to 1.39.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
