### PR TITLE
feat: notecli 実体/所属分離 (V6) への追随

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.7.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=15f697860561b1a9d53aed3a89ea42cf6fd81d1f#15f697860561b1a9d53aed3a89ea42cf6fd81d1f"
+source = "git+https://github.com/notedeck-dev/notecli?rev=1f68a91a52894c9950bdb107faae61b346f6e260#1f68a91a52894c9950bdb107faae61b346f6e260"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "15f697860561b1a9d53aed3a89ea42cf6fd81d1f", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "1f68a91a52894c9950bdb107faae61b346f6e260", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -1121,7 +1121,7 @@
           {
             "name": "tl_type",
             "in": "path",
-            "description": "Timeline type: home | local | social | global",
+            "description": "Timeline type: home | local | social | global (or fork-specific basic timelines like bubble)",
             "required": true,
             "schema": {
               "type": "string"
@@ -1166,6 +1166,16 @@
                   "items": {
                     "$ref": "#/components/schemas/NormalizedNote"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or non-basic timeline key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
                 }
               }
             }

--- a/src-tauri/src/commands/admin.rs
+++ b/src-tauri/src/commands/admin.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 
 use notecli::db::{ChatEvictionConfig, EvictionConfig};
+use notecli::error::NoteDeckError;
 use notecli::models::{AccountPublic, ServerDetection};
 
 use super::{export_account_list, validate_host, AppState, Result};
@@ -72,6 +73,10 @@ pub async fn account_cache_count(
     db.account_cache_count(&account_id)
 }
 
+// 以下の cache 系コマンドは writer lock を長時間 (秒〜分オーダー) 保持し得るため
+// spawn_blocking で退避する。writer は std::sync::Mutex のため async runtime 直呼びは
+// tokio worker の連鎖枯渇を招く (前例: messaging.rs)。
+
 #[tauri::command]
 #[specta::specta]
 pub async fn clear_account_cache(
@@ -79,16 +84,19 @@ pub async fn clear_account_cache(
     account_id: String,
 ) -> Result<u64> {
     let db = app_state.db().await;
-    db.clear_account_cache(&account_id)
+    run_blocking(move || db.clear_account_cache(&account_id)).await
 }
 
 #[tauri::command]
 #[specta::specta]
 pub async fn clear_all_cache(app_state: State<'_, AppState>) -> Result<u64> {
     let db = app_state.db().await;
-    let notes = db.clear_all_notes_cache()?;
-    let _ogp = db.clear_ogp_cache()?;
-    Ok(notes)
+    run_blocking(move || {
+        let notes = db.clear_all_notes_cache()?;
+        let _ogp = db.clear_ogp_cache()?;
+        Ok(notes)
+    })
+    .await
 }
 
 /// ユーザーが UI で選んだ eviction config を即時適用する。 戻り値は削除件数。
@@ -100,7 +108,16 @@ pub async fn apply_eviction_config(
     config: EvictionConfig,
 ) -> Result<u64> {
     let db = app_state.db().await;
-    db.cleanup_with_eviction(&config)
+    run_blocking(move || db.cleanup_with_eviction(&config)).await
+}
+
+/// writer lock を長時間保持する DB 操作を blocking スレッドで実行する。
+async fn run_blocking<T: Send + 'static>(
+    f: impl FnOnce() -> std::result::Result<T, NoteDeckError> + Send + 'static,
+) -> Result<T> {
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| NoteDeckError::Internal(format!("blocking task failed: {e}")))?
 }
 
 /// notecli の `EvictionConfig::default()` を取得する。 アプリの「バランス」
@@ -156,7 +173,7 @@ pub async fn apply_chat_eviction_config(
     config: ChatEvictionConfig,
 ) -> Result<u64> {
     let db = app_state.db().await;
-    db.cleanup_chat_with_eviction(&config)
+    run_blocking(move || db.cleanup_chat_with_eviction(&config)).await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -6,8 +6,8 @@ use tauri::{Emitter, Manager, State};
 use notecli::error::NoteDeckError;
 use notecli::models::{
     Antenna, Channel, Clip, CreateNoteParams, NormalizedDriveFile, NormalizedNote,
-    NormalizedNoteReaction, RawCreateNoteResponse, RawNote, SearchOptions, TimelineOptions,
-    TimelineType, UserList,
+    NormalizedNoteReaction, RawCreateNoteResponse, RawNote, SearchOptions, TimelineKey,
+    TimelineOptions, UserList,
 };
 
 use super::{
@@ -25,25 +25,32 @@ pub async fn api_get_timeline(
     app: tauri::AppHandle,
     app_state: State<'_, AppState>,
     account_id: String,
-    timeline_type: TimelineType,
+    timeline_type: String,
     options: Option<TimelineOptions>,
 ) -> Result<Vec<NormalizedNote>> {
     let (db, client) = app_state.ready().await;
     let (host, token) = get_credentials_or_anon(&db, &account_id)?;
     let opts = options.unwrap_or_default();
-    let cache_key = if timeline_type.as_str() == "user-list" {
-        if let Some(ref list_id) = opts.list_id {
-            format!("user-list:{list_id}")
-        } else {
-            timeline_type.as_str().to_string()
+    // 境界アダプタ: フロントの呼び出し規約 getTimeline('user-list', {listId}) を
+    // canonical キーへ合成する (parse の前段。api 層は options.list_id を読まない)
+    let key = if timeline_type == "user-list" {
+        match opts.list_id {
+            Some(ref list_id) => TimelineKey::UserList {
+                list_id: list_id.clone(),
+            },
+            None => {
+                return Err(NoteDeckError::InvalidInput(
+                    "user-list timeline requires listId".to_string(),
+                ))
+            }
         }
     } else {
-        timeline_type.as_str().to_string()
+        TimelineKey::parse(&timeline_type)?
     };
     let notes = client
-        .get_timeline(&host, &token, &account_id, timeline_type, opts)
+        .get_timeline(&host, &token, &account_id, &key, opts)
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &cache_key) {
+    if let Err(e) = db.ingest_notes(&notes, &key) {
         tracing::warn!("[cache] failed to cache timeline notes: {e}");
     }
 
@@ -152,7 +159,41 @@ pub async fn api_update_antenna(
     antenna: Antenna,
 ) -> Result<Antenna> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client.update_antenna(&host, &token, &antenna).await
+    let updated = client.update_antenna(&host, &token, &antenna).await?;
+    // 設定変更後の旧マッチ分は個別ノートへ逆引きできないためバケット破棄 →
+    // 次回フェッチで再構築 (失敗は warn + Ok)。大バケットは writer lock を
+    // 秒単位で保持し得るため spawn_blocking で退避
+    let db = app_state.db().await;
+    let account_id_owned = account_id.clone();
+    let key = TimelineKey::Antenna {
+        antenna_id: updated.id.clone(),
+    };
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = db.clear_timeline(&account_id_owned, &key) {
+            tracing::warn!("[cache] failed to clear antenna bucket: {e}");
+        }
+    });
+    Ok(updated)
+}
+
+/// エンティティ削除 (antenna / clip / list — フロントは汎用 api_request で
+/// サーバー削除する) の後始末: 死にバケットの membership を破棄する。
+/// これが無いと削除済みエンティティの membership が sweep 対象外のまま
+/// per-account cap まで残留する (issue notecli#30 仕様 v5 §6-7)。
+#[tauri::command]
+#[specta::specta]
+pub async fn api_clear_timeline_cache(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    timeline_key: String,
+) -> Result<u32> {
+    // parse Err は Err 返却 (フロントのキー組み間違いを顕在化)
+    let key = TimelineKey::parse(&timeline_key)?;
+    let db = app_state.db().await;
+    let removed = tokio::task::spawn_blocking(move || db.clear_timeline(&account_id, &key))
+        .await
+        .map_err(|e| NoteDeckError::Internal(format!("clear_timeline task failed: {e}")))??;
+    Ok(removed.min(u32::MAX as u64) as u32)
 }
 
 #[tauri::command]
@@ -178,7 +219,12 @@ pub async fn api_get_antenna_notes(
             until_id.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &format!("antenna:{antenna_id}")) {
+    if let Err(e) = db.ingest_notes(
+        &notes,
+        &TimelineKey::Antenna {
+            antenna_id: antenna_id.clone(),
+        },
+    ) {
         tracing::warn!("[cache] failed to cache antenna notes: {e}");
     }
     Ok(notes)
@@ -205,7 +251,7 @@ pub async fn api_get_favorites(
             until_id.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, "favorites") {
+    if let Err(e) = db.ingest_notes(&notes, &TimelineKey::Favorites) {
         tracing::warn!("[cache] failed to cache favorites: {e}");
     }
     Ok(notes)
@@ -251,11 +297,11 @@ pub async fn api_get_mentions(
     // ダイレクト（specified）と通常メンションは別カラム・別キャッシュキー。
     // 同じキーに混ぜると read 側（cacheKey='specified' / 'mentions'）と不整合になる。
     let cache_key = if visibility.as_deref() == Some("specified") {
-        "specified"
+        TimelineKey::Specified
     } else {
-        "mentions"
+        TimelineKey::Mentions
     };
-    if let Err(e) = db.cache_notes(&notes, cache_key) {
+    if let Err(e) = db.ingest_notes(&notes, &cache_key) {
         tracing::warn!("[cache] failed to cache mentions: {e}");
     }
     Ok(notes)
@@ -296,7 +342,12 @@ pub async fn api_get_clip_notes(
             until_id.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &format!("clip:{clip_id}")) {
+    if let Err(e) = db.ingest_notes(
+        &notes,
+        &TimelineKey::Clip {
+            clip_id: clip_id.clone(),
+        },
+    ) {
         tracing::warn!("[cache] failed to cache clip notes: {e}");
     }
     Ok(notes)
@@ -348,7 +399,12 @@ pub async fn api_get_channel_notes(
             until_id.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &format!("channel:{channel_id}")) {
+    if let Err(e) = db.ingest_notes(
+        &notes,
+        &TimelineKey::Channel {
+            channel_id: channel_id.clone(),
+        },
+    ) {
         tracing::warn!("[cache] failed to cache channel notes: {e}");
     }
     Ok(notes)
@@ -379,7 +435,12 @@ pub async fn api_get_role_notes(
             until_id.as_deref(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &format!("role:{role_id}")) {
+    if let Err(e) = db.ingest_notes(
+        &notes,
+        &TimelineKey::Role {
+            role_id: role_id.clone(),
+        },
+    ) {
         tracing::warn!("[cache] failed to cache role notes: {e}");
     }
     Ok(notes)
@@ -577,7 +638,14 @@ pub async fn api_delete_favorite(
     note_id: String,
 ) -> Result<()> {
     let (client, host, token) = app_state.authed(&account_id).await?;
-    client.delete_favorite(&host, &token, &note_id).await
+    client.delete_favorite(&host, &token, &note_id).await?;
+    // サーバー成功後に favorites バケットの所属を外す (失敗は warn + Ok —
+    // サーバー状態は成功済みのため。stale は TTL/cap で最終解消)
+    let db = app_state.db().await;
+    if let Err(e) = db.remove_membership(&account_id, &TimelineKey::Favorites, &note_id) {
+        tracing::warn!("[cache] failed to remove favorites membership: {e}");
+    }
+    Ok(())
 }
 
 // --- Pin/Unpin ---
@@ -631,7 +699,18 @@ pub async fn api_remove_note_from_clip(
     let (client, host, token) = app_state.authed(&account_id).await?;
     client
         .remove_note_from_clip(&host, &token, &clip_id, &note_id)
-        .await
+        .await?;
+    let db = app_state.db().await;
+    if let Err(e) = db.remove_membership(
+        &account_id,
+        &TimelineKey::Clip {
+            clip_id: clip_id.clone(),
+        },
+        &note_id,
+    ) {
+        tracing::warn!("[cache] failed to remove clip membership: {e}");
+    }
+    Ok(())
 }
 
 // --- Note thread ---
@@ -834,12 +913,10 @@ pub async fn api_get_cached_timeline(
     timeline_type: String,
     limit: Option<i64>,
 ) -> Result<Vec<NormalizedNote>> {
+    // 不正キーは黙殺せず Err で顕在化させる (フロントは catch → [] で安全)
+    let key = TimelineKey::parse(&timeline_type)?;
     let db = app_state.db().await;
-    db.get_cached_timeline(
-        &account_id,
-        &timeline_type,
-        limit.unwrap_or(40).clamp(1, 200),
-    )
+    db.get_cached_timeline(&account_id, &key, limit.unwrap_or(40).clamp(1, 200))
 }
 
 #[tauri::command]
@@ -849,16 +926,19 @@ pub async fn api_get_cached_timeline_before(
     account_id: String,
     timeline_type: String,
     before: String,
+    before_note_id: Option<String>,
     limit: Option<i64>,
 ) -> Result<Vec<NormalizedNote>> {
     if before.len() > 30 {
         return Err(NoteDeckError::InvalidInput("Invalid date".to_string()));
     }
+    let key = TimelineKey::parse(&timeline_type)?;
     let db = app_state.db().await;
     db.get_cached_timeline_before(
         &account_id,
-        &timeline_type,
+        &key,
         &before,
+        before_note_id.as_deref(),
         limit.unwrap_or(40).clamp(1, 200),
     )
 }
@@ -870,8 +950,9 @@ pub async fn api_get_cache_date_range(
     account_id: String,
     timeline_type: String,
 ) -> Result<Option<(String, String)>> {
+    let key = TimelineKey::parse(&timeline_type)?;
     let db = app_state.db().await;
-    db.get_cache_date_range(&account_id, &timeline_type)
+    db.get_cache_date_range(&account_id, &key)
 }
 
 #[tauri::command]
@@ -913,46 +994,80 @@ pub async fn api_search_notes_local(
 
 #[tauri::command]
 #[specta::specta]
-pub async fn api_delete_cached_note(app_state: State<'_, AppState>, note_id: String) -> Result<()> {
+pub async fn api_delete_cached_note(
+    app_state: State<'_, AppState>,
+    account_id: String,
+    note_id: String,
+) -> Result<()> {
     let db = app_state.db().await;
-    db.delete_cached_note(&note_id)
+    db.delete_cached_note(&account_id, &note_id)?;
+    Ok(())
 }
 
 /// Maximum number of concurrent note verification requests
 const MAX_VERIFY_CONCURRENT: usize = 20;
 
+/// `api_verify_notes` の結果。
+#[derive(serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyNotesResult {
+    /// サーバー上に現存が確認できたノート (note_id → 最新の NormalizedNote)
+    pub verified: HashMap<String, NormalizedNote>,
+    /// サーバーが NO_SUCH_NOTE を返した = 削除が確認できたノート id。
+    /// 通信エラー・レート制限・タイムアウトはどちらにも含まれない (生存扱い) —
+    /// 復帰直後の不安定なネットワークでキャッシュを誤って恒久削除しないため
+    /// (issue notecli#30 仕様 v5 §6-8)。
+    pub missing: Vec<String>,
+}
+
 /// Bulk-verify cached notes against the server.
-/// Returns a map of note_id → fresh NormalizedNote for notes that still exist.
-/// Missing notes (404) are omitted from the result.
 #[tauri::command]
 #[specta::specta]
 pub async fn api_verify_notes(
     app_state: State<'_, AppState>,
     account_id: String,
     note_ids: Vec<String>,
-) -> Result<HashMap<String, NormalizedNote>> {
+) -> Result<VerifyNotesResult> {
     if note_ids.len() > 200 {
         return Err(NoteDeckError::InvalidInput("Too many note IDs".to_string()));
     }
     let (client, host, token) = app_state.authed_or_anon(&account_id).await?;
 
-    let verified: HashMap<String, NormalizedNote> = stream::iter(note_ids)
-        .map(|id| {
-            let host = host.clone();
-            let token = token.clone();
-            let account_id = account_id.clone();
-            let client = client.clone();
-            async move {
-                let result = client.get_note(&host, &token, &account_id, &id).await;
-                (id, result.ok())
-            }
-        })
-        .buffer_unordered(MAX_VERIFY_CONCURRENT)
-        .filter_map(
-            |(id, note): (String, Option<NormalizedNote>)| async move { note.map(|n| (id, n)) },
-        )
-        .collect()
-        .await;
+    let results: Vec<(String, std::result::Result<NormalizedNote, NoteDeckError>)> =
+        stream::iter(note_ids)
+            .map(|id| {
+                let host = host.clone();
+                let token = token.clone();
+                let account_id = account_id.clone();
+                let client = client.clone();
+                async move {
+                    let result = client.get_note(&host, &token, &account_id, &id).await;
+                    (id, result)
+                }
+            })
+            .buffer_unordered(MAX_VERIFY_CONCURRENT)
+            .collect()
+            .await;
 
-    Ok(verified)
+    let mut verified = HashMap::new();
+    let mut missing = Vec::new();
+    for (id, result) in results {
+        match result {
+            Ok(note) => {
+                verified.insert(id, note);
+            }
+            // 削除確認は NO_SUCH_NOTE のみ。それ以外のエラーは生存扱いでスキップ
+            Err(NoteDeckError::Api {
+                api_code: Some(code),
+                ..
+            }) if code == "NO_SUCH_NOTE" => {
+                missing.push(id);
+            }
+            Err(e) => {
+                tracing::debug!(note_id = %id, error = %e, "note verification inconclusive; treating as alive");
+            }
+        }
+    }
+
+    Ok(VerifyNotesResult { verified, missing })
 }

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -4,7 +4,7 @@ use notecli::api::SearchUsersOptions;
 use notecli::error::NoteDeckError;
 use notecli::models::{
     Flash, GalleryPost, MutedWordsResult, NormalizedNote, NormalizedUser, NormalizedUserDetail,
-    Page, TimelineOptions, UserReaction,
+    Page, TimelineKey, TimelineOptions, UserReaction,
 };
 
 use super::{get_credentials_or_anon, typed_request, validate_host, AppState, Result};
@@ -54,7 +54,12 @@ pub async fn api_get_user_notes(
             options.unwrap_or_default(),
         )
         .await?;
-    if let Err(e) = db.cache_notes(&notes, &format!("user:{user_id}")) {
+    if let Err(e) = db.ingest_notes(
+        &notes,
+        &TimelineKey::UserNotes {
+            user_id: user_id.clone(),
+        },
+    ) {
         tracing::warn!("[cache] failed to cache user notes: {e}");
     }
     Ok(notes)
@@ -457,7 +462,20 @@ pub async fn api_remove_user_from_list(
     let (client, host, token) = app_state.authed(&account_id).await?;
     client
         .remove_user_from_list(&host, &token, &list_id, &user_id)
-        .await
+        .await?;
+    // 除外ユーザーの既存ノートは個別逆引き不能のためバケット破棄 →
+    // 次回フェッチで再構築 (失敗は warn + Ok)
+    let db = app_state.db().await;
+    let account_id_owned = account_id.clone();
+    let key = TimelineKey::UserList {
+        list_id: list_id.clone(),
+    };
+    tokio::task::spawn_blocking(move || {
+        if let Err(e) = db.clear_timeline(&account_id_owned, &key) {
+            tracing::warn!("[cache] failed to clear user-list bucket: {e}");
+        }
+    });
+    Ok(())
 }
 
 // --- Search ---

--- a/src-tauri/src/commands/utility.rs
+++ b/src-tauri/src/commands/utility.rs
@@ -137,6 +137,9 @@ pub async fn export_db(
 /// Import notecli.db from a user-chosen file via open dialog.
 /// Replaces the current database file. Caller should relaunch the app afterwards
 /// so that Rust re-opens the new DB with a fresh connection.
+///
+/// 注意: V6 (note_timelines) 適用済みの DB は旧バージョンのアプリへ持ち込めない
+/// (refinery の missing migration で open 不能。DB 自体は無傷)。
 #[tauri::command]
 #[specta::specta]
 pub async fn import_db(app: tauri::AppHandle) -> Result<bool> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -365,7 +365,14 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
             let db = match db_handle.join().expect("db open thread panicked") {
                 Ok(d) => std::sync::Arc::new(d),
                 Err(e) => {
+                    // watch channel が埋まらず db()/ready() 系コマンドは無限待機に
+                    // なるため、フロントへ明示的に致命エラーを通知する
+                    // (V6 級 migration の正常 1 分ブロックとの区別に必要)
                     tracing::error!("Fatal: DB open failed: {e}");
+                    let _ = app_handle.emit(
+                        "nd:backend-fatal",
+                        format!("database open failed: {}", e.safe_message()),
+                    );
                     return;
                 }
             };
@@ -755,6 +762,7 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             commands::api_lookup_user,
             commands::api_get_cached_timeline,
             commands::api_delete_cached_note,
+            commands::api_clear_timeline_cache,
             commands::api_verify_notes,
             commands::api_get_cached_timeline_before,
             commands::api_get_cache_date_range,
@@ -956,7 +964,6 @@ pub fn build_specta_builder() -> tauri_specta::Builder<tauri::Wry> {
             query_runtime::query_subscribe_notifications,
             query_runtime::query_subscribe_chat_user,
             query_runtime::query_subscribe_chat_room,
-            query_runtime::query_open,
             query_runtime::query_set_runtime_state,
             query_runtime::query_close,
             query_runtime::query_get_snapshot,

--- a/src-tauri/src/query_runtime.rs
+++ b/src-tauri/src/query_runtime.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use notecli::error::NoteDeckError;
 use notecli::models::{
-    ChatMessage, NormalizedNote, NormalizedNotification, NoteUpdateBody, TimelineType,
+    ChatMessage, NormalizedNote, NormalizedNotification, NoteUpdateBody, TimelineKey,
 };
 use notecli::streaming::{StreamEvent, StreamingManager};
 use serde::{Deserialize, Serialize};
@@ -27,25 +27,13 @@ const DELTA_FLUSH_WINDOW: Duration = Duration::from_millis(16);
 #[derive(Debug, Clone, Serialize, Deserialize, Type)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum QueryKey {
+    /// notes 系購読の統一キー。`key` は `TimelineKey` の canonical 文字列
+    /// (home / antenna:{id} / channel:{id} / role:{id} / user-list:{id} / mentions)。
+    /// 折り畳まないと同一購読が 2 通りのキー表現を持ち dedup が破れる。
+    /// mentions は識別子としてのみここに属し、購読自体は main チャンネル経由。
     Timeline {
         account_id: String,
-        timeline_type: TimelineType,
-        list_id: Option<String>,
-    },
-    Antenna {
-        account_id: String,
-        antenna_id: String,
-    },
-    Channel {
-        account_id: String,
-        channel_id: String,
-    },
-    Role {
-        account_id: String,
-        role_id: String,
-    },
-    Mentions {
-        account_id: String,
+        key: String,
     },
     Notifications {
         account_id: String,
@@ -639,26 +627,38 @@ pub async fn query_subscribe_timeline(
     streaming: State<'_, StreamingManager>,
     runtime: State<'_, QueryRuntime>,
     account_id: String,
-    timeline_type: TimelineType,
+    timeline_type: String,
     list_id: Option<String>,
 ) -> Result<QuerySnapshot, NoteDeckError> {
     let db = app_state.db().await;
     let (host, token) = get_credentials(&db, &account_id)?;
     streaming.connect(&account_id, &host, &token).await?;
 
+    // 境界アダプタ: ('user-list', listId) → canonical キー合成 (api_get_timeline と同規約)
+    let tl_key = if timeline_type == "user-list" {
+        match list_id {
+            Some(ref list_id) => TimelineKey::UserList {
+                list_id: list_id.clone(),
+            },
+            None => {
+                return Err(NoteDeckError::InvalidInput(
+                    "user-list timeline requires listId".to_string(),
+                ))
+            }
+        }
+    } else {
+        TimelineKey::parse(&timeline_type)?
+    };
     let key = QueryKey::Timeline {
         account_id: account_id.clone(),
-        timeline_type: timeline_type.clone(),
-        list_id: list_id.clone(),
+        key: tl_key.as_canonical(),
     };
     let opened = runtime.open(key)?;
     if opened.source_subscription_id.is_some() {
         return Ok(opened);
     }
 
-    let subscription_id = streaming
-        .subscribe_timeline(&account_id, timeline_type, list_id)
-        .await?;
+    let subscription_id = streaming.subscribe_notes(&account_id, tl_key, None).await?;
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
@@ -675,17 +675,18 @@ pub async fn query_subscribe_antenna(
     let (host, token) = get_credentials(&db, &account_id)?;
     streaming.connect(&account_id, &host, &token).await?;
 
-    let opened = runtime.open(QueryKey::Antenna {
-        account_id: account_id.clone(),
+    let tl_key = TimelineKey::Antenna {
         antenna_id: antenna_id.clone(),
+    };
+    let opened = runtime.open(QueryKey::Timeline {
+        account_id: account_id.clone(),
+        key: tl_key.as_canonical(),
     })?;
     if opened.source_subscription_id.is_some() {
         return Ok(opened);
     }
 
-    let subscription_id = streaming
-        .subscribe_antenna(&account_id, &antenna_id)
-        .await?;
+    let subscription_id = streaming.subscribe_notes(&account_id, tl_key, None).await?;
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
@@ -702,17 +703,18 @@ pub async fn query_subscribe_channel(
     let (host, token) = get_credentials(&db, &account_id)?;
     streaming.connect(&account_id, &host, &token).await?;
 
-    let opened = runtime.open(QueryKey::Channel {
-        account_id: account_id.clone(),
+    let tl_key = TimelineKey::Channel {
         channel_id: channel_id.clone(),
+    };
+    let opened = runtime.open(QueryKey::Timeline {
+        account_id: account_id.clone(),
+        key: tl_key.as_canonical(),
     })?;
     if opened.source_subscription_id.is_some() {
         return Ok(opened);
     }
 
-    let subscription_id = streaming
-        .subscribe_channel(&account_id, &channel_id)
-        .await?;
+    let subscription_id = streaming.subscribe_notes(&account_id, tl_key, None).await?;
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
@@ -729,15 +731,18 @@ pub async fn query_subscribe_role(
     let (host, token) = get_credentials(&db, &account_id)?;
     streaming.connect(&account_id, &host, &token).await?;
 
-    let opened = runtime.open(QueryKey::Role {
-        account_id: account_id.clone(),
+    let tl_key = TimelineKey::Role {
         role_id: role_id.clone(),
+    };
+    let opened = runtime.open(QueryKey::Timeline {
+        account_id: account_id.clone(),
+        key: tl_key.as_canonical(),
     })?;
     if opened.source_subscription_id.is_some() {
         return Ok(opened);
     }
 
-    let subscription_id = streaming.subscribe_role(&account_id, &role_id).await?;
+    let subscription_id = streaming.subscribe_notes(&account_id, tl_key, None).await?;
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
@@ -753,8 +758,11 @@ pub async fn query_subscribe_mentions(
     let (host, token) = get_credentials(&db, &account_id)?;
     streaming.connect(&account_id, &host, &token).await?;
 
-    let opened = runtime.open(QueryKey::Mentions {
+    // mentions は QueryKey 識別子としてのみ Timeline に折り畳む。
+    // 購読は従来どおり main チャンネル経由 (ws_channel を持たない種別)。
+    let opened = runtime.open(QueryKey::Timeline {
         account_id: account_id.clone(),
+        key: TimelineKey::Mentions.as_canonical(),
     })?;
     if opened.source_subscription_id.is_some() {
         return Ok(opened);
@@ -839,14 +847,10 @@ pub async fn query_subscribe_chat_room(
     runtime.attach_stream_subscription(&opened.query_id, subscription_id)
 }
 
-#[tauri::command]
-#[specta::specta]
-pub async fn query_open(
-    runtime: State<'_, QueryRuntime>,
-    key: QueryKey,
-) -> Result<QuerySnapshot, NoteDeckError> {
-    runtime.open(key)
-}
+// query_open (QueryKey を invoke 引数に取る汎用オープン) は削除した。
+// 折り畳み後は key 文字列が無検証で entry 化され TimelineKey の構築規約の
+// 裏口になる上、フロント呼び出しもゼロだった。復活させる場合は
+// TimelineKey::parse による検証を必須とすること (issue notecli#30 仕様 v5 §6-5)。
 
 #[tauri::command]
 #[specta::specta]
@@ -974,10 +978,6 @@ fn runtime_error(message: impl Into<String>) -> NoteDeckError {
 fn account_id(key: &QueryKey) -> &str {
     match key {
         QueryKey::Timeline { account_id, .. }
-        | QueryKey::Antenna { account_id, .. }
-        | QueryKey::Channel { account_id, .. }
-        | QueryKey::Role { account_id, .. }
-        | QueryKey::Mentions { account_id }
         | QueryKey::Notifications { account_id }
         | QueryKey::ChatUser { account_id, .. }
         | QueryKey::ChatRoom { account_id, .. } => account_id,
@@ -994,8 +994,7 @@ mod tests {
     fn home_key(account: &str) -> QueryKey {
         QueryKey::Timeline {
             account_id: account.into(),
-            timeline_type: TimelineType::new("home"),
-            list_id: None,
+            key: "home".into(),
         }
     }
 

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -679,7 +679,6 @@ mod tests {
     use std::time::Duration;
 
     use notecli::models::NormalizedNote;
-    use notecli::models::TimelineType;
     use notecli::streaming::{
         StreamConnectionState, StreamEvent, StreamNoteCaptureEvent, StreamNoteEvent,
         StreamNotificationEvent, StreamStatusEvent,
@@ -772,8 +771,7 @@ mod tests {
     fn home_key(account: &str) -> QueryKey {
         QueryKey::Timeline {
             account_id: account.into(),
-            timeline_type: TimelineType::new("home"),
-            list_id: None,
+            key: "home".into(),
         }
     }
 

--- a/src/aiscript/events.test.ts
+++ b/src/aiscript/events.test.ts
@@ -105,8 +105,7 @@ describe('subscribeNoteDeckEvent (Phase 2: note:new / notification:new)', () => 
     return {
       kind: 'timeline',
       account_id: accountId,
-      timeline_type: 'home',
-      list_id: null,
+      key: 'home',
     }
   }
 

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -277,7 +277,7 @@ async apiUpdateUserSetting(accountId: string, key: string, value: boolean) : Pro
 }
 },
 /** @see src-tauri/src/commands/timeline.rs */
-async apiGetTimeline(accountId: string, timelineType: TimelineType, options: TimelineOptions | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
+async apiGetTimeline(accountId: string, timelineType: string, options: TimelineOptions | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_get_timeline", { accountId, timelineType, options }) };
 } catch (e) {
@@ -747,9 +747,25 @@ async apiGetCachedTimeline(accountId: string, timelineType: string, limit: numbe
 }
 },
 /** @see src-tauri/src/commands/timeline.rs */
-async apiDeleteCachedNote(noteId: string) : Promise<Result<null, { code: string; message: string; apiCode: string | null }>> {
+async apiDeleteCachedNote(accountId: string, noteId: string) : Promise<Result<null, { code: string; message: string; apiCode: string | null }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("api_delete_cached_note", { noteId }) };
+    return { status: "ok", data: await TAURI_INVOKE("api_delete_cached_note", { accountId, noteId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * エンティティ削除 (antenna / clip / list — フロントは汎用 api_request で
+ * サーバー削除する) の後始末: 死にバケットの membership を破棄する。
+ * これが無いと削除済みエンティティの membership が sweep 対象外のまま
+ * per-account cap まで残留する (issue notecli#30 仕様 v5 §6-7)。
+ *
+ * @see src-tauri/src/commands/timeline.rs
+ */
+async apiClearTimelineCache(accountId: string, timelineKey: string) : Promise<Result<number, { code: string; message: string; apiCode: string | null }>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("api_clear_timeline_cache", { accountId, timelineKey }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -757,12 +773,10 @@ async apiDeleteCachedNote(noteId: string) : Promise<Result<null, { code: string;
 },
 /**
  * Bulk-verify cached notes against the server.
- * Returns a map of note_id → fresh NormalizedNote for notes that still exist.
- * Missing notes (404) are omitted from the result.
  *
  * @see src-tauri/src/commands/timeline.rs
  */
-async apiVerifyNotes(accountId: string, noteIds: string[]) : Promise<Result<Partial<{ [key in string]: NormalizedNote }>, { code: string; message: string; apiCode: string | null }>> {
+async apiVerifyNotes(accountId: string, noteIds: string[]) : Promise<Result<VerifyNotesResult, { code: string; message: string; apiCode: string | null }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("api_verify_notes", { accountId, noteIds }) };
 } catch (e) {
@@ -771,9 +785,9 @@ async apiVerifyNotes(accountId: string, noteIds: string[]) : Promise<Result<Part
 }
 },
 /** @see src-tauri/src/commands/timeline.rs */
-async apiGetCachedTimelineBefore(accountId: string, timelineType: string, before: string, limit: number | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
+async apiGetCachedTimelineBefore(accountId: string, timelineType: string, before: string, beforeNoteId: string | null, limit: number | null) : Promise<Result<NormalizedNote[], { code: string; message: string; apiCode: string | null }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("api_get_cached_timeline_before", { accountId, timelineType, before, limit }) };
+    return { status: "ok", data: await TAURI_INVOKE("api_get_cached_timeline_before", { accountId, timelineType, before, beforeNoteId, limit }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -2004,6 +2018,9 @@ async exportDb() : Promise<Result<boolean, { code: string; message: string; apiC
  * Import notecli.db from a user-chosen file via open dialog.
  * Replaces the current database file. Caller should relaunch the app afterwards
  * so that Rust re-opens the new DB with a fresh connection.
+ * 
+ * 注意: V6 (note_timelines) 適用済みの DB は旧バージョンのアプリへ持ち込めない
+ * (refinery の missing migration で open 不能。DB 自体は無傷)。
  *
  * @see src-tauri/src/commands/utility.rs
  */
@@ -2638,7 +2655,7 @@ async aiMigrateProviderToVault(provider: string, name: string, baseUrl: string, 
 }
 },
 /** @see src-tauri/src/query_runtime.rs */
-async querySubscribeTimeline(accountId: string, timelineType: TimelineType, listId: string | null) : Promise<Result<QuerySnapshot, { code: string; message: string; apiCode: string | null }>> {
+async querySubscribeTimeline(accountId: string, timelineType: string, listId: string | null) : Promise<Result<QuerySnapshot, { code: string; message: string; apiCode: string | null }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("query_subscribe_timeline", { accountId, timelineType, listId }) };
 } catch (e) {
@@ -2704,15 +2721,6 @@ async querySubscribeChatUser(accountId: string, otherId: string) : Promise<Resul
 async querySubscribeChatRoom(accountId: string, roomId: string) : Promise<Result<QuerySnapshot, { code: string; message: string; apiCode: string | null }>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("query_subscribe_chat_room", { accountId, roomId }) };
-} catch (e) {
-    if(e instanceof Error) throw e;
-    else return { status: "error", error: e  as any };
-}
-},
-/** @see src-tauri/src/query_runtime.rs */
-async queryOpen(key: QueryKey) : Promise<Result<QuerySnapshot, { code: string; message: string; apiCode: string | null }>> {
-    try {
-    return { status: "ok", data: await TAURI_INVOKE("query_open", { key }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -3121,13 +3129,18 @@ export type EmojiChangeKind = "added" | "updated" | "deleted"
  */
 export type EvictionConfig = { 
 /**
- * 各アカウントごとの note 上限。`None` なら無制限。
+ * 各アカウントごとの note (entity) 上限。`None` なら無制限。
  */
 perAccountLimit: number | null; 
 /**
  * `cached_at` の TTL (日)。`None` なら無期限保持。
  */
-ttlDays: number | null }
+ttlDays: number | null; 
+/**
+ * バケット (account_id × timeline_key) ごとの所属行上限。`None` なら無制限。
+ * トリムは membership とその対象限定の orphan entity のみを消す。
+ */
+perTimelineLimit: number | null }
 /**
  * EXIF 1 フィールド。tag はタグ名 (例: "DateTimeOriginal", "GPSLatitude")。
  */
@@ -3534,7 +3547,14 @@ updates: NoteUpdate[] }
  * the frontend receives a discriminated union; every variant carries `id`.
  */
 export type QueryItem = ({ kind: "note" } & NormalizedNote) | ({ kind: "notification" } & NormalizedNotification) | ({ kind: "chatMessage" } & ChatMessage)
-export type QueryKey = { kind: "timeline"; account_id: string; timeline_type: TimelineType; list_id: string | null } | { kind: "antenna"; account_id: string; antenna_id: string } | { kind: "channel"; account_id: string; channel_id: string } | { kind: "role"; account_id: string; role_id: string } | { kind: "mentions"; account_id: string } | { kind: "notifications"; account_id: string } | { kind: "chatUser"; account_id: string; other_id: string } | { kind: "chatRoom"; account_id: string; room_id: string }
+export type QueryKey = 
+/**
+ * notes 系購読の統一キー。`key` は `TimelineKey` の canonical 文字列
+ * (home / antenna:{id} / channel:{id} / role:{id} / user-list:{id} / mentions)。
+ * 折り畳まないと同一購読が 2 通りのキー表現を持ち dedup が破れる。
+ * mentions は識別子としてのみここに属し、購読自体は main チャンネル経由。
+ */
+{ kind: "timeline"; account_id: string; key: string } | { kind: "notifications"; account_id: string } | { kind: "chatUser"; account_id: string; other_id: string } | { kind: "chatRoom"; account_id: string; room_id: string }
 export type QueryReadModelSnapshot = { queryId: string; revision: number; 
 /**
  * Note ids in display order (newest first). 消費側は JS noteStore から
@@ -3657,7 +3677,6 @@ export type StreamStatusEvent = { accountId: string; state: StreamConnectionStat
 export type SummaryData = { title: string | null; description: string | null; icon: string | null; sitename: string | null; thumbnail: string | null; medias: string[]; player: Player | null; url: string; sensitive: boolean }
 export type TimelineFilter = { withRenotes: boolean | null; withReplies: boolean | null; withFiles: boolean | null; withBots: boolean | null; withSensitive: boolean | null }
 export type TimelineOptions = { limit?: number; sinceId: string | null; untilId: string | null; filters?: TimelineFilter | null; listId: string | null }
-export type TimelineType = string
 /**
  * 「確認なしで使う」のプラグイン個体単位の記憶。
  * 
@@ -3850,6 +3869,21 @@ ok: boolean;
  * 失敗時の理由 (SSRF / timeout / DNS など)。secret は含まない。
  */
 error: string | null }
+/**
+ * `api_verify_notes` の結果。
+ */
+export type VerifyNotesResult = { 
+/**
+ * サーバー上に現存が確認できたノート (note_id → 最新の NormalizedNote)
+ */
+verified: Partial<{ [key in string]: NormalizedNote }>; 
+/**
+ * サーバーが NO_SUCH_NOTE を返した = 削除が確認できたノート id。
+ * 通信エラー・レート制限・タイムアウトはどちらにも含まれない (生存扱い) —
+ * 復帰直後の不安定なネットワークでキャッシュを誤って恒久削除しないため
+ * (issue notecli#30 仕様 v5 §6-8)。
+ */
+missing: string[] }
 
 /** tauri-specta globals **/
 

--- a/src/commands/cliHandlers.ts
+++ b/src/commands/cliHandlers.ts
@@ -1,6 +1,7 @@
 import type { NoteVisibility } from '@/adapters/types'
 import type { useAccountsStore } from '@/stores/accounts'
 import type { useDeckStore } from '@/stores/deck'
+import { FAVORITES_CACHE_KEY } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 export interface CliHandlerDeps {
@@ -324,14 +325,14 @@ export function createCliHandlers(
       const accountId = activeAccountId()
       if (!accountId || !args.trim()) return
       unwrap(await commands.apiCreateFavorite(accountId, args.trim()))
-      deps.deckStore.invalidateColumnByKey('favorites')
+      deps.deckStore.invalidateColumnByKey(FAVORITES_CACHE_KEY)
     },
 
     unfavorite: async (args) => {
       const accountId = activeAccountId()
       if (!accountId || !args.trim()) return
       unwrap(await commands.apiDeleteFavorite(accountId, args.trim()))
-      deps.deckStore.invalidateColumnByKey('favorites')
+      deps.deckStore.invalidateColumnByKey(FAVORITES_CACHE_KEY)
     },
 
     emojis: () => {

--- a/src/components/common/NoteMoreMenu.vue
+++ b/src/components/common/NoteMoreMenu.vue
@@ -20,6 +20,7 @@ import { usePrompt } from '@/stores/prompt'
 import { useToast } from '@/stores/toast'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
+import { clipCacheKey } from '@/utils/columnCacheKey'
 import { AppError } from '@/utils/errors'
 import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { getNoteShareUrl } from '@/utils/noteUrl'
@@ -163,7 +164,7 @@ async function addToClip(clipId: string, clipName: string) {
   if (!adapter) return
   try {
     await adapter.api.addNoteToClip(clipId, props.note.id)
-    useDeckStore().invalidateColumnByKey(`clip:${clipId}`)
+    useDeckStore().invalidateColumnByKey(clipCacheKey(clipId))
     toast.show('クリップに追加しました')
   } catch (e) {
     const err = AppError.from(e)
@@ -177,7 +178,7 @@ async function addToClip(clipId: string, clipName: string) {
       if (ok) {
         try {
           await adapter.api.removeNoteFromClip(clipId, props.note.id)
-          useDeckStore().invalidateColumnByKey(`clip:${clipId}`)
+          useDeckStore().invalidateColumnByKey(clipCacheKey(clipId))
           toast.show('クリップから解除しました')
         } catch (e2) {
           const err2 = AppError.from(e2)

--- a/src/components/deck/DeckAntennaColumn.vue
+++ b/src/components/deck/DeckAntennaColumn.vue
@@ -7,12 +7,15 @@ import type { NormalizedNote } from '@/adapters/types'
 import { useEntityCrud } from '@/composables/useEntityCrud'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
   column: DeckColumnType
 }>()
+
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
@@ -21,8 +24,7 @@ const noteColumnConfig: NoteColumnConfig = {
     adapter.api.getAntennaNotes(props.column.antennaId!, opts),
   validate: () => !!props.column.antennaId,
   cache: {
-    getKey: () =>
-      props.column.antennaId ? `antenna:${props.column.antennaId}` : null,
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {

--- a/src/components/deck/DeckChannelColumn.vue
+++ b/src/components/deck/DeckChannelColumn.vue
@@ -8,6 +8,7 @@ import type { NormalizedNote } from '@/adapters/types'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
@@ -20,6 +21,7 @@ const props = defineProps<{
 }>()
 
 const accountsStore = useAccountsStore()
+const cacheKeyDeps = accountsCacheKeyDeps()
 const account = computed(() =>
   props.column.accountId
     ? accountsStore.accountMap.get(props.column.accountId)
@@ -33,8 +35,7 @@ const noteColumnConfig: NoteColumnConfig = {
     adapter.api.getChannelNotes(props.column.channelId!, opts),
   validate: () => !!props.column.channelId,
   cache: {
-    getKey: () =>
-      props.column.channelId ? `channel:${props.column.channelId}` : null,
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {

--- a/src/components/deck/DeckClipColumn.vue
+++ b/src/components/deck/DeckClipColumn.vue
@@ -2,11 +2,14 @@
 import { useEntityCrud } from '@/composables/useEntityCrud'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
   column: DeckColumnType
 }>()
+
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
@@ -15,7 +18,7 @@ const noteColumnConfig: NoteColumnConfig = {
     adapter.api.getClipNotes(props.column.clipId!, opts),
   validate: () => !!props.column.clipId,
   cache: {
-    getKey: () => (props.column.clipId ? `clip:${props.column.clipId}` : null),
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   // カラム化できるのは自分のクリップとお気に入りしたクリップ（picker 経由）
   // = 自分が保存した面なので凍結は貫通させる。他人のクリップは

--- a/src/components/deck/DeckColumnsArea.vue
+++ b/src/components/deck/DeckColumnsArea.vue
@@ -7,9 +7,9 @@ import { useColumnResize } from '@/composables/useColumnResize'
 import { useColumnScroll } from '@/composables/useColumnScroll'
 import { useHorizontalWheel } from '@/composables/useHorizontalWheel'
 import * as snapshotStore from '@/composables/useSnapshotStore'
-import type { DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { useIsCompactLayout } from '@/stores/ui'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { COLUMN_SELECTOR } from '@/utils/themeVars'
 import DeckStackCell from './DeckStackCell.vue'
 
@@ -67,38 +67,15 @@ const horizontalWheel = useHorizontalWheel({
   columnSelector: COLUMN_SELECTOR,
 })
 
-// Derive a snapshot cache key from column config (mirrors each column's cache.getKey())
-function getColumnCacheKey(col: DeckColumn): string | null {
-  switch (col.type) {
-    case 'timeline':
-      return col.tl ?? null
-    case 'antenna':
-      return col.antennaId ? `antenna:${col.antennaId}` : null
-    case 'channel':
-      return col.channelId ? `channel:${col.channelId}` : null
-    case 'clip':
-      return col.clipId ? `clip:${col.clipId}` : null
-    case 'user':
-      return col.userId ? `user:${col.userId}` : null
-    case 'list':
-      return col.listId ? `list:${col.listId}` : null
-    case 'favorites':
-      return 'favorites'
-    case 'mentions':
-    case 'specified':
-      return 'mentions'
-    case 'explore':
-      return 'explore'
-    default:
-      return null
-  }
-}
+// Snapshot cache key: 各カラムの cache.getKey() と同一の共有導出
+// (columnCacheKey) を使う。手組みミラーの表記ゆれバグを構造的に防ぐ。
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 /** Get snapshot preview lines for an unmounted column shell */
 function getShellPreview(colId: string): string[] {
   const col = columnMap.value.get(colId)
   if (!col) return []
-  const cacheKey = getColumnCacheKey(col)
+  const cacheKey = columnCacheKey(col, cacheKeyDeps)
   if (!cacheKey) return []
   const snap = snapshotStore.restore(colId, cacheKey)
   if (!snap) return []

--- a/src/components/deck/DeckExploreColumn.vue
+++ b/src/components/deck/DeckExploreColumn.vue
@@ -18,6 +18,7 @@ import { useNoteColumn } from '@/composables/useNoteColumn'
 import { usePortal } from '@/composables/usePortal'
 import { useTabSlide } from '@/composables/useTabSlide'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { AppError } from '@/utils/errors'
 import { proxyThumbUrl } from '@/utils/mediaProxy'
 import type { ColumnTabDef } from './ColumnTabs.vue'
@@ -28,6 +29,8 @@ import DeckHeaderAccount from './DeckHeaderAccount.vue'
 const props = defineProps<{
   column: DeckColumnType
 }>()
+
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 // --- Tab ---
 type Tab = 'notes' | 'users' | 'roles'
@@ -73,7 +76,7 @@ const {
     return adapter.api.getFeaturedNotes({ limit: 30 })
   },
   cache: {
-    getKey: () => 'explore',
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
 })
 

--- a/src/components/deck/DeckFavoritesColumn.vue
+++ b/src/components/deck/DeckFavoritesColumn.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
   column: DeckColumnType
 }>()
 
+const cacheKeyDeps = accountsCacheKeyDeps()
+
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
   fetch: (adapter, opts) => adapter.api.getFavorites(opts),
   cache: {
-    getKey: () => 'favorites',
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   // 自分が保存した面。凍結は貫通させる（本家 i/favorites も貫通）。
   // ミュートは自分の意思なので適用したまま（#606）

--- a/src/components/deck/DeckListColumn.vue
+++ b/src/components/deck/DeckListColumn.vue
@@ -9,6 +9,7 @@ import { useEntityCrud } from '@/composables/useEntityCrud'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
@@ -17,6 +18,7 @@ const props = defineProps<{
 }>()
 
 const deckStore = useDeckStore()
+const cacheKeyDeps = accountsCacheKeyDeps()
 const noteColumnRef = ref<InstanceType<typeof DeckNoteColumn> | null>(null)
 
 watch(
@@ -36,8 +38,7 @@ const noteColumnConfig: NoteColumnConfig = {
     }),
   validate: () => !!props.column.listId,
   cache: {
-    getKey: () =>
-      props.column.listId ? `user-list:${props.column.listId}` : null,
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {

--- a/src/components/deck/DeckMentionsColumn.vue
+++ b/src/components/deck/DeckMentionsColumn.vue
@@ -13,6 +13,7 @@ import { useColumnSetup } from '@/composables/useColumnSetup'
 import { useCrossAccountNotes } from '@/composables/useCrossAccountNotes'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckColumn from './DeckColumn.vue'
 import DeckNoteColumn from './DeckNoteColumn.vue'
@@ -23,19 +24,19 @@ const props = defineProps<{
 
 const isSpecified = computed(() => props.column.type === 'specified')
 
+const cacheKeyDeps = accountsCacheKeyDeps()
+
 const config = computed(() =>
   isSpecified.value
     ? {
         title: 'ダイレクト',
         icon: 'ti-mail',
         emptyText: 'ダイレクトメッセージはありません',
-        cacheKey: 'specified' as const,
       }
     : {
         title: 'あなた宛て',
         icon: 'ti-at',
         emptyText: 'メンションはありません',
-        cacheKey: 'mentions' as const,
       },
 )
 
@@ -48,7 +49,7 @@ const noteColumnConfig: NoteColumnConfig = {
     isSpecified.value
       ? adapter.api.getMentions({ ...opts, visibility: 'specified' })
       : adapter.api.getMentions(opts),
-  cache: { getKey: () => config.value.cacheKey },
+  cache: { getKey: () => columnCacheKey(props.column, cacheKeyDeps) },
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {
       // useNoteColumn.connect が account.value.hasToken をガードしているので、
@@ -101,7 +102,7 @@ const {
       ? adapter.api.getMentions({ ...opts, visibility: 'specified' })
       : adapter.api.getMentions(opts),
   isCrossAccount: () => isCrossAccount.value,
-  cacheKey: () => config.value.cacheKey,
+  cacheKey: () => columnCacheKey(props.column, cacheKeyDeps),
   isLoading,
   error,
   scroller,

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -889,7 +889,7 @@ async function removeNote(note: NormalizedNote) {
   saveCache()
   noteStore.remove(id)
   commands
-    .apiDeleteCachedNote(id)
+    .apiDeleteCachedNote(note._accountId, id)
     .then((r) => unwrap(r))
     .catch((e) => {
       if (import.meta.env.DEV) console.debug('[delete-cached-note] ignored:', e)

--- a/src/components/deck/DeckRoleColumn.vue
+++ b/src/components/deck/DeckRoleColumn.vue
@@ -6,12 +6,15 @@ import {
 import type { NormalizedNote } from '@/adapters/types'
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
   column: DeckColumnType
 }>()
+
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
@@ -20,7 +23,7 @@ const noteColumnConfig: NoteColumnConfig = {
     adapter.api.getRoleNotes(props.column.roleId!, opts),
   validate: () => !!props.column.roleId,
   cache: {
-    getKey: () => (props.column.roleId ? `role:${props.column.roleId}` : null),
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   streaming: {
     subscribe: (_adapter, enqueue, callbacks) => {

--- a/src/components/deck/DeckTimelineColumn.vue
+++ b/src/components/deck/DeckTimelineColumn.vue
@@ -18,6 +18,7 @@ import { useTabSlide } from '@/composables/useTabSlide'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import type { CustomTimelineInfo } from '@/utils/customTimelines'
 import {
   clearAvailableTlCache,
@@ -41,6 +42,7 @@ const props = defineProps<{
 
 const deckStore = useDeckStore()
 const accountsStore = useAccountsStore()
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 // Guest accounts can only access public timelines (local/global), not home/social
 const accountData = accountsStore.accountMap.get(props.column.accountId ?? '')
@@ -52,6 +54,12 @@ const initialTl: TimelineType =
     ? defaultTl
     : savedTl || defaultTl
 const tlType = ref<TimelineType>(initialTl)
+// guest の TL 強制変換 (home/social → local、未設定 → local) はメモリ上だけ
+// でなく永続化する。静的キー導出 (columnCacheKey) と getKey の恒久不一致を
+// 防ぐ (notecli#30 v5 §6-13)
+if (isGuestAccountForTl && savedTl !== initialTl) {
+  deckStore.updateColumn(props.column.id, { tl: initialTl })
+}
 
 // --- Filter ---
 const columnFilters = computed<TimelineFilter>(() => props.column.filters ?? {})
@@ -119,7 +127,7 @@ const noteColumnConfig: NoteColumnConfig = {
     }
   },
   cache: {
-    getKey: () => tlType.value,
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   // フィルタ違いのカラム間で dedup レスポンスを共有しない (#651)
   fetchKey: () => JSON.stringify(columnFilters.value),

--- a/src/components/deck/DeckUserColumn.vue
+++ b/src/components/deck/DeckUserColumn.vue
@@ -2,6 +2,7 @@
 import type { NoteColumnConfig } from '@/composables/useNoteColumn'
 import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
+import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
 import DeckNoteColumn from './DeckNoteColumn.vue'
 
 const props = defineProps<{
@@ -9,6 +10,7 @@ const props = defineProps<{
 }>()
 
 const accountsStore = useAccountsStore()
+const cacheKeyDeps = accountsCacheKeyDeps()
 
 const noteColumnConfig: NoteColumnConfig = {
   getColumn: () => props.column,
@@ -17,7 +19,7 @@ const noteColumnConfig: NoteColumnConfig = {
     adapter.api.getUserNotes(props.column.userId!, opts),
   validate: () => !!props.column.userId,
   cache: {
-    getKey: () => (props.column.userId ? `user:${props.column.userId}` : null),
+    getKey: () => columnCacheKey(props.column, cacheKeyDeps),
   },
   refreshFetch: async (adapter, currentNotes) => {
     // biome-ignore lint/style/noNonNullAssertion: guarded by validate

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -308,7 +308,7 @@ async function handleDelete(target: NormalizedNote) {
     const id = target.id
     noteStore.remove(id)
     commands
-      .apiDeleteCachedNote(id)
+      .apiDeleteCachedNote(target._accountId, id)
       .then((r) => unwrap(r))
       .catch((e) => {
         if (import.meta.env.DEV)
@@ -336,7 +336,7 @@ async function handleDeleteAndEdit(target: NormalizedNote) {
     const id = target.id
     noteStore.remove(id)
     commands
-      .apiDeleteCachedNote(id)
+      .apiDeleteCachedNote(target._accountId, id)
       .then((r) => unwrap(r))
       .catch((e) => {
         if (import.meta.env.DEV)

--- a/src/composables/useColumnSetup.ts
+++ b/src/composables/useColumnSetup.ts
@@ -18,6 +18,7 @@ import { useOfflineModeStore } from '@/stores/offlineMode'
 import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
+import { FAVORITES_CACHE_KEY } from '@/utils/columnCacheKey'
 import { AppError } from '@/utils/errors'
 import { toggleFavorite } from '@/utils/toggleFavorite'
 import { toggleReaction } from '@/utils/toggleReaction'
@@ -306,7 +307,7 @@ export function useColumnSetup(
     if (!adapter || checkOffline()) return
     try {
       await toggleFavorite(adapter.api, note, notifyMutationFor(note))
-      useDeckStore().invalidateColumnByKey('favorites')
+      useDeckStore().invalidateColumnByKey(FAVORITES_CACHE_KEY)
     } catch (e) {
       const err = AppError.from(e)
       if (err.displayCode === 'ALREADY_FAVORITED') {
@@ -325,7 +326,7 @@ export function useColumnSetup(
             await adapter.api.deleteFavorite(note.id)
             note.isFavorited = false
             notifyMutationFor(note)()
-            useDeckStore().invalidateColumnByKey('favorites')
+            useDeckStore().invalidateColumnByKey(FAVORITES_CACHE_KEY)
           } catch (e2) {
             const err2 = AppError.from(e2)
             console.error('[bookmark:unfavorite]', err2.code, err2.message)

--- a/src/composables/useCrossAccountNotes.ts
+++ b/src/composables/useCrossAccountNotes.ts
@@ -203,13 +203,15 @@ export function useCrossAccountNotes(options: CrossAccountNotesOptions) {
             return fetchNotes(adapter, { untilId: lastForAccount.id })
           }
 
-          // ログアウト中: hasToken 不要でキャッシュを遡る
+          // ログアウト中: hasToken 不要でキャッシュを遡る。
+          // createdAt / id は同一ノート (lastForAccount) からペアで渡す (§6-14)
           if (!key || !lastForAccount) return []
           try {
             return await loadCachedTimelineBefore(
               acc.id,
               key,
               lastForAccount.createdAt,
+              lastForAccount.id,
             )
           } catch {
             return []

--- a/src/composables/useEntityCrud.ts
+++ b/src/composables/useEntityCrud.ts
@@ -3,6 +3,11 @@ import type { DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { usePrompt } from '@/stores/prompt'
 import { useToast } from '@/stores/toast'
+import {
+  antennaCacheKey,
+  clipCacheKey,
+  userListCacheKey,
+} from '@/utils/columnCacheKey'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
@@ -21,6 +26,8 @@ export const ENTITY_CONFIGS: Record<
     idKey: EntityIdKey
     updateEndpoint: string
     deleteEndpoint: string
+    /** エンティティ削除後に掃除する timeline キャッシュの canonical キー */
+    cacheKey: (entityId: string) => string
   }
 > = {
   clip: {
@@ -28,18 +35,21 @@ export const ENTITY_CONFIGS: Record<
     idKey: 'clipId',
     updateEndpoint: 'clips/update',
     deleteEndpoint: 'clips/delete',
+    cacheKey: clipCacheKey,
   },
   list: {
     label: 'リスト',
     idKey: 'listId',
     updateEndpoint: 'users/lists/update',
     deleteEndpoint: 'users/lists/delete',
+    cacheKey: userListCacheKey,
   },
   antenna: {
     label: 'アンテナ',
     idKey: 'antennaId',
     updateEndpoint: 'antennas/update',
     deleteEndpoint: 'antennas/delete',
+    cacheKey: antennaCacheKey,
   },
 }
 
@@ -101,6 +111,15 @@ export function useEntityCrud(type: EntityType, getColumn: () => DeckColumn) {
           [config.idKey]: entityId,
         }),
       )
+      // サーバー削除成功後、死にバケットの membership を掃除 (notecli#30 v5
+      // §6-7 / R11-1)。fire-and-forget — 失敗しても stale キャッシュが残る
+      // だけなので warn + 続行
+      commands
+        .apiClearTimelineCache(col.accountId, config.cacheKey(entityId))
+        .then((r) => unwrap(r))
+        .catch((e) => {
+          console.warn('[entity:delete] clear-timeline-cache failed:', e)
+        })
       deckStore.removeColumn(col.id)
       toast.show(`${config.label}を削除しました`)
     } catch (e) {

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -142,6 +142,8 @@ let pinia: ReturnType<typeof createPinia>
 beforeEach(() => {
   bindings.calls.length = 0
   for (const k of Object.keys(bindings.responses)) delete bindings.responses[k]
+  // VerifyNotesResult 形 (空配列既定では missing の for-of が throw する)
+  bindings.responses.apiVerifyNotes = { verified: {}, missing: [] }
   vi.useFakeTimers({ toFake: ['Date'] })
   vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
   pinia = createPinia()
@@ -521,6 +523,8 @@ describe('useNoteColumn: フェッチカーソル (#831 Step 0)', () => {
       (c) => c.name === 'apiGetCachedTimelineBefore',
     )
     expect(before?.args[2]).toBe(note('h04').createdAt)
+    // keyset cursor は createdAt と同一ノート由来の note_id をペアで渡す (§6-14)
+    expect(before?.args[3]).toBe('h04')
   })
 
   it('reconnect でカーソルがリセットされ、旧世代の位置から取り直さない', async () => {

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -166,6 +166,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     deleteHandler: handlers.delete,
     closePostForm: postForm.close,
     visibility: config.visibility,
+    accountId: () => config.getColumn().accountId,
   })
 
   // Streaming (Group A) or NoteCapture (Group B)
@@ -990,10 +991,12 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (!column.accountId || !cacheKey) return
     // createdAt ベースのページングなのでアンカーもカーソルの createdAt を使う。
     // 全件フィルタ落ちのページでもアンカーが前進し、API 経路と同型のループが
-    // キャッシュ経路に残らない
-    const anchor =
-      fetchCursor.value?.createdAt ?? rawNotes.value.at(-1)?.createdAt
-    if (!anchor) return
+    // キャッシュ経路に残らない。
+    // createdAt と id は必ず同一ソースからペアで取る — 食い違うと keyset
+    // cursor (sort_key, note_id) が別ノート由来になり遡りが破綻する (§6-14)
+    const cursorSource = fetchCursor.value ?? rawNotes.value.at(-1)
+    const anchor = cursorSource?.createdAt
+    if (!cursorSource || !anchor) return
     const stillCurrent = tabGuard()
     isLoading.value = true
     try {
@@ -1034,6 +1037,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
         column.accountId,
         cacheKey,
         anchor,
+        cursorSource.id,
       )
       if (!stillCurrent()) return
       advanceFetchCursor(older)

--- a/src/composables/useNoteColumnCache.test.ts
+++ b/src/composables/useNoteColumnCache.test.ts
@@ -1,0 +1,97 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NormalizedNote, ServerAdapter } from '@/adapters/types'
+import { useNoteStore } from '@/stores/notes'
+import { purgeStaleCachedNotes } from './useNoteColumnCache'
+
+const bindings = vi.hoisted(() => ({
+  verifyResult: null as unknown,
+  verifyCalls: [] as unknown[][],
+  deleteCalls: [] as unknown[][],
+}))
+
+vi.mock('@/bindings', () => ({
+  commands: {
+    apiVerifyNotes: (...args: unknown[]) => {
+      bindings.verifyCalls.push(args)
+      return Promise.resolve(bindings.verifyResult)
+    },
+    apiDeleteCachedNote: (...args: unknown[]) => {
+      bindings.deleteCalls.push(args)
+      return Promise.resolve({ status: 'ok', data: null })
+    },
+  },
+}))
+
+function note(id: string): NormalizedNote {
+  return {
+    id,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    text: `note ${id}`,
+    user: { id: `user-${id}` },
+    _accountId: 'acc-1',
+  } as unknown as NormalizedNote
+}
+
+const adapter = {} as ServerAdapter
+
+describe('purgeStaleCachedNotes: verify-purge (notecli#30 v5 §6-8 / §9-23)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    bindings.verifyResult = null
+    bindings.verifyCalls.length = 0
+    bindings.deleteCalls.length = 0
+  })
+
+  it('missing (NO_SUCH_NOTE 確認済み) のみ削除する', async () => {
+    const noteStore = useNoteStore()
+    noteStore.put([note('a'), note('b'), note('c')])
+    bindings.verifyResult = {
+      status: 'ok',
+      data: {
+        verified: { a: { ...note('a'), text: 'fresh a' } },
+        missing: ['b'],
+      },
+    }
+
+    await purgeStaleCachedNotes(adapter, ['a', 'b', 'c'], () => true, 'acc-1')
+
+    // 削除は missing の b のみ (accountId スコープ付き)
+    expect(bindings.deleteCalls).toEqual([['acc-1', 'b']])
+    expect(noteStore.get('b')).toBeUndefined()
+    // verified の a は fresh データで更新される
+    expect(noteStore.get('a')?.text).toBe('fresh a')
+    // verified にも missing にも無い c は「生存扱い」— 削除しない
+    expect(noteStore.get('c')).toBeDefined()
+  })
+
+  it('通信エラー相当 (verified にも missing にも無い) は一切削除しない', async () => {
+    const noteStore = useNoteStore()
+    noteStore.put([note('a'), note('b')])
+    // 全 id が検証不能だった応答 (レート制限・タイムアウト等)
+    bindings.verifyResult = {
+      status: 'ok',
+      data: { verified: {}, missing: [] },
+    }
+
+    await purgeStaleCachedNotes(adapter, ['a', 'b'], () => true, 'acc-1')
+
+    expect(bindings.deleteCalls).toEqual([])
+    expect(noteStore.get('a')).toBeDefined()
+    expect(noteStore.get('b')).toBeDefined()
+  })
+
+  it('bulk verify 自体の失敗ではキャッシュを触らない', async () => {
+    const noteStore = useNoteStore()
+    noteStore.put([note('a')])
+    bindings.verifyResult = {
+      status: 'error',
+      error: { code: 'NETWORK', message: 'offline', apiCode: null },
+    }
+
+    await purgeStaleCachedNotes(adapter, ['a'], () => true, 'acc-1')
+
+    expect(bindings.deleteCalls).toEqual([])
+    expect(noteStore.get('a')).toBeDefined()
+  })
+})

--- a/src/composables/useNoteColumnCache.ts
+++ b/src/composables/useNoteColumnCache.ts
@@ -22,11 +22,18 @@ export async function loadCachedTimeline(
   ) as unknown as NormalizedNote[]
 }
 
-/** Load older cached notes before a given timestamp. */
+/**
+ * Load older cached notes before a given cursor.
+ *
+ * `beforeNoteId` は keyset cursor の tie-break。`before` と同一ノート由来の
+ * ペアで渡すこと — 同一 createdAt が limit 以上並ぶバケットでも前進できる
+ * (notecli#30 v5 §6-14)。null なら現行互換の createdAt 包含比較。
+ */
 export async function loadCachedTimelineBefore(
   accountId: string,
   timelineType: string,
   before: string,
+  beforeNoteId: string | null,
   limit?: number,
 ): Promise<NormalizedNote[]> {
   const effectiveLimit =
@@ -36,6 +43,7 @@ export async function loadCachedTimelineBefore(
       accountId,
       timelineType,
       before,
+      beforeNoteId,
       effectiveLimit,
     ),
   ) as unknown as NormalizedNote[]
@@ -56,27 +64,25 @@ export async function purgeStaleCachedNotes(
 
   const noteStore = useNoteStore()
   try {
-    const verified = unwrap(
-      await commands.apiVerifyNotes(accountId, idsToVerify),
-    ) as Record<string, NormalizedNote>
+    const result = unwrap(await commands.apiVerifyNotes(accountId, idsToVerify))
 
     if (!isStillMounted()) return
 
-    const verifiedIds = new Set(Object.keys(verified))
-
     // Update confirmed notes with fresh data
-    for (const [id, fresh] of Object.entries(verified)) {
-      noteStore.update(id, fresh)
+    for (const [id, fresh] of Object.entries(result.verified)) {
+      if (fresh) noteStore.update(id, fresh as unknown as NormalizedNote)
     }
 
-    // Purge notes that no longer exist on the server.
-    // verify-miss は heuristic（一時的 false-negative）なので tombstone しない。
-    // 生きたノートをセッション中ずっと永久非表示にしてしまう false-positive を避ける。
-    for (const id of idsToVerify) {
-      if (!verifiedIds.has(id)) {
-        noteStore.remove(id, false)
-        commands.apiDeleteCachedNote(id).catch(catchLog('delete-cached-note'))
-      }
+    // 削除するのは `missing` (サーバーが NO_SUCH_NOTE を返した = 削除確認済み)
+    // のみ。verified にも missing にも無い id は通信エラー・レート制限等の
+    // 「生存扱い」なので触らない — 復帰直後の不安定なネットワークでキャッシュを
+    // 誤って恒久削除しない (notecli#30 v5 §6-8)。
+    // verify-miss を tombstone しないのは従来どおり (false-positive 回避)。
+    for (const id of result.missing) {
+      noteStore.remove(id, false)
+      commands
+        .apiDeleteCachedNote(accountId, id)
+        .catch(catchLog('delete-cached-note'))
     }
   } catch {
     // Bulk verify failed — silently ignore (notes stay cached)
@@ -89,10 +95,11 @@ export async function purgeStaleCachedNotes(
  * FTS5 で粗く絞ってから Rust の QIR 評価器で判定するので、条件に合うノートを
  * 見つけるまで遡れる。`before` より古い側を、走査上限まで読んで探す。
  *
- * タイムライン種別では絞らない。キャッシュの所属は 1 ノート 1 種別で後勝ち
- * 上書きなので、種別で絞ると本来あるはずのノートを取りこぼす (notecli#30 で
- * 実体と所属を分離する再設計が計画されている)。取りこぼしより、別種別の
- * ノートが混ざる方が気づけるため、絞らない側に倒している。
+ * タイムライン種別では絞らない。notecli#30 で実体 (notes_cache) と所属
+ * (note_timelines) は分離済みだが、この scan は今も全所属横断で走査する。
+ * カラムの所属バケットで絞る bucket スコープ検索は follow-up
+ * (notecli#30 v5 §12-9)。取りこぼしより、別種別のノートが混ざる方が
+ * 気づけるため、それまでは絞らない側に倒している。
  */
 export async function searchCachedNotesByQuery(
   accountId: string,

--- a/src/composables/useNoteList.ts
+++ b/src/composables/useNoteList.ts
@@ -23,6 +23,13 @@ export interface UseNoteListOptions {
   maxNotes?: number
   /** 面ごとの述語 opt-out（お気に入り・プロフィール等）。既定は全適用 */
   visibility?: VisibilityOpts
+  /**
+   * DB キャッシュ削除 (apiDeleteCachedNote) の account スコープ。streaming の
+   * deleted イベントは note 本体を持たず _accountId を参照できないため、
+   * カラム所有者の accountId を注入する。未指定なら DB 削除はスキップ
+   * (メモリ上の除去のみ)。
+   */
+  accountId?: () => string | null
 }
 
 export function useNoteList(options: UseNoteListOptions) {
@@ -136,10 +143,13 @@ export function useNoteList(options: UseNoteListOptions) {
       // noteStore.remove() triggers global onDelete listeners,
       // which clean up orderedIds/noteIds in ALL columns
       noteStore.remove(event.noteId)
-      commands.apiDeleteCachedNote(event.noteId).catch((e) => {
-        if (import.meta.env.DEV)
-          console.debug('[delete-cached-note] ignored:', e)
-      })
+      const accountId = options.accountId?.() ?? null
+      if (accountId) {
+        commands.apiDeleteCachedNote(accountId, event.noteId).catch((e) => {
+          if (import.meta.env.DEV)
+            console.debug('[delete-cached-note] ignored:', e)
+        })
+      }
       return
     }
     noteStore.applyUpdate(event, options.getMyUserId())
@@ -181,7 +191,7 @@ export function useNoteList(options: UseNoteListOptions) {
 
     if (await options.deleteHandler(note)) {
       noteStore.remove(id)
-      commands.apiDeleteCachedNote(id).catch((e) => {
+      commands.apiDeleteCachedNote(note._accountId, id).catch((e) => {
         if (import.meta.env.DEV)
           console.debug('[delete-cached-note] ignored:', e)
       })

--- a/src/core/queryRegistry.test.ts
+++ b/src/core/queryRegistry.test.ts
@@ -10,8 +10,7 @@ import {
 const timelineKey = (accountId: string): QueryKey => ({
   kind: 'timeline',
   account_id: accountId,
-  timeline_type: 'home',
-  list_id: null,
+  key: 'home',
 })
 
 describe('queryRegistry', () => {

--- a/src/core/queryRegistry.ts
+++ b/src/core/queryRegistry.ts
@@ -52,11 +52,10 @@ export function getQueryInfo(queryId: string): QueryInfo | undefined {
 
 function queryKeyToInfo(key: QueryKey): QueryInfo | null {
   switch (key.kind) {
+    // notes 系購読は 'timeline' に折り畳まれた (notecli#30 v5 §6-5)。
+    // antenna/channel/role/mentions は key.key の canonical 文字列
+    // (antenna:{id} 等) で区別される
     case 'timeline':
-    case 'antenna':
-    case 'channel':
-    case 'role':
-    case 'mentions':
       return { flavor: 'note', accountId: key.account_id }
     case 'notifications':
       return { flavor: 'notification', accountId: key.account_id }

--- a/src/utils/cacheEviction.ts
+++ b/src/utils/cacheEviction.ts
@@ -17,18 +17,21 @@ export type EvictionPreset = NonNullable<
 export const SEARCH_PRIORITY: EvictionConfig = {
   perAccountLimit: null,
   ttlDays: null,
+  perTimelineLimit: null,
 }
 
 /** 「バランス」: notecli の `EvictionConfig::default()` 相当。暴走防止のみ。 */
 export const BALANCED: EvictionConfig = {
   perAccountLimit: 1_000_000,
   ttlDays: null,
+  perTimelineLimit: null,
 }
 
 /** 「ストレージ優先」: 旧デフォルト (notecli #3) と同等のヘビー掃除。 */
 export const STORAGE_PRIORITY: EvictionConfig = {
   perAccountLimit: 50_000,
   ttlDays: 90,
+  perTimelineLimit: null,
 }
 
 /**
@@ -49,6 +52,8 @@ export function resolveEvictionConfig(
       return {
         perAccountLimit: settings['cache.perAccountLimit'] ?? null,
         ttlDays: settings['cache.ttlDays'] ?? null,
+        // バケット毎 membership 上限 (notecli#30 v5 §5)。UI 未公開・既定 null
+        perTimelineLimit: null,
       }
     default:
       return BALANCED

--- a/src/utils/columnCacheKey.test.ts
+++ b/src/utils/columnCacheKey.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import type { DeckColumn } from '@/stores/deck'
+import { columnCacheKey } from './columnCacheKey'
+
+/** guestIds に入れた accountId だけを guest 扱いにする deps */
+function deps(guestIds: string[] = []) {
+  return { isGuestAccount: (id: string) => guestIds.includes(id) }
+}
+
+function col(partial: Partial<DeckColumn> & { type: string }): DeckColumn {
+  return {
+    id: 'col-1',
+    name: null,
+    width: 300,
+    accountId: 'acc-1',
+    ...partial,
+  } as DeckColumn
+}
+
+describe('columnCacheKey: canonical キー導出 (notecli#30 v5 §6-12 / §9-10)', () => {
+  it.each<{
+    label: string
+    column: DeckColumn
+    guests?: string[]
+    expected: string | null
+  }>([
+    // --- timeline (tl / default / guest 変換) ---
+    {
+      label: 'timeline: tl=home',
+      column: col({ type: 'timeline', tl: 'home' }),
+      expected: 'home',
+    },
+    {
+      label: 'timeline: tl 未設定は default home',
+      column: col({ type: 'timeline' }),
+      expected: 'home',
+    },
+    {
+      label: 'timeline: フォーク TL はそのまま',
+      column: col({ type: 'timeline', tl: 'bubble' }),
+      expected: 'bubble',
+    },
+    {
+      label: 'timeline: guest の tl 未設定は default local',
+      column: col({ type: 'timeline' }),
+      guests: ['acc-1'],
+      expected: 'local',
+    },
+    {
+      label: 'timeline: guest の home は local へ変換',
+      column: col({ type: 'timeline', tl: 'home' }),
+      guests: ['acc-1'],
+      expected: 'local',
+    },
+    {
+      label: 'timeline: guest の social は local へ変換',
+      column: col({ type: 'timeline', tl: 'social' }),
+      guests: ['acc-1'],
+      expected: 'local',
+    },
+    {
+      label: 'timeline: guest でも global はそのまま',
+      column: col({ type: 'timeline', tl: 'global' }),
+      guests: ['acc-1'],
+      expected: 'global',
+    },
+    {
+      label: 'timeline: accountId null は非 guest 扱いで default home',
+      column: col({ type: 'timeline', accountId: null }),
+      guests: ['acc-1'],
+      expected: 'home',
+    },
+    // --- id 付き種別 ---
+    {
+      label: 'antenna',
+      column: col({ type: 'antenna', antennaId: 'a1' }),
+      expected: 'antenna:a1',
+    },
+    {
+      label: 'antenna: id 欠落は null',
+      column: col({ type: 'antenna' }),
+      expected: null,
+    },
+    {
+      label: 'channel',
+      column: col({ type: 'channel', channelId: 'ch1' }),
+      expected: 'channel:ch1',
+    },
+    {
+      label: 'clip',
+      column: col({ type: 'clip', clipId: 'cl1' }),
+      expected: 'clip:cl1',
+    },
+    {
+      label: 'user',
+      column: col({ type: 'user', userId: 'u1' }),
+      expected: 'user:u1',
+    },
+    {
+      label: 'list は user-list:{id} (旧ミラーの list:{id} は誤り)',
+      column: col({ type: 'list', listId: 'l1' }),
+      expected: 'user-list:l1',
+    },
+    {
+      label: 'role (旧ミラーは case 欠落で preview が常に空だった)',
+      column: col({ type: 'role', roleId: 'r1' }),
+      expected: 'role:r1',
+    },
+    // --- 固定キー種別 ---
+    {
+      label: 'favorites',
+      column: col({ type: 'favorites' }),
+      expected: 'favorites',
+    },
+    {
+      label: 'explore',
+      column: col({ type: 'explore' }),
+      expected: 'explore',
+    },
+    {
+      label: 'mentions',
+      column: col({ type: 'mentions' }),
+      expected: 'mentions',
+    },
+    {
+      label: 'specified は specified (旧ミラーの mentions は誤り)',
+      column: col({ type: 'specified' }),
+      expected: 'specified',
+    },
+    // --- キャッシュ非対応種別 ---
+    {
+      label: 'キャッシュを持たない種別は null',
+      column: col({ type: 'chat' }),
+      expected: null,
+    },
+  ])('$label', ({ column, guests, expected }) => {
+    expect(columnCacheKey(column, deps(guests))).toBe(expected)
+  })
+})

--- a/src/utils/columnCacheKey.ts
+++ b/src/utils/columnCacheKey.ts
@@ -1,0 +1,91 @@
+/**
+ * カラム定義から SQLite キャッシュの canonical timeline キーを導出する共有
+ * ユーティリティ (notecli#30 v5 §6-12)。
+ *
+ * 各 Deck*Column の `cache.getKey()` と DeckColumnsArea の snapshot ミラーの
+ * 両方がここを通ることで、キー手組みの表記ゆれ (list:{id} vs user-list:{id}
+ * 等) を構造的に排除する。canonical 形式の正本は notecli `TimelineKey` の
+ * doc comment。
+ *
+ * guest 判定 (hasToken 無しアカウント) は accountsStore.accountMap に依存して
+ * おり column 単独では導出できないため、呼び出し側が `isGuestAccount` を注入
+ * する。
+ */
+import { useAccountsStore } from '@/stores/accounts'
+import type { DeckColumn } from '@/stores/deck'
+
+export interface ColumnCacheKeyDeps {
+  /** accountId が guest (hasToken 無し) なら true */
+  isGuestAccount: (accountId: string) => boolean
+}
+
+/**
+ * accountsStore ベースの既定 deps。pinia が有効な文脈 (setup / ハンドラ) で
+ * 呼ぶこと。テストでは deps を直接組んで純粋関数として検証する。
+ */
+export function accountsCacheKeyDeps(): ColumnCacheKeyDeps {
+  const accountsStore = useAccountsStore()
+  return {
+    isGuestAccount: (accountId) =>
+      accountsStore.accountMap.get(accountId)?.hasToken === false,
+  }
+}
+
+/** favorites カラム・invalidateColumnByKey の共有 canonical キー */
+export const FAVORITES_CACHE_KEY = 'favorites'
+
+export const antennaCacheKey = (antennaId: string): string =>
+  `antenna:${antennaId}`
+export const channelCacheKey = (channelId: string): string =>
+  `channel:${channelId}`
+export const clipCacheKey = (clipId: string): string => `clip:${clipId}`
+export const roleCacheKey = (roleId: string): string => `role:${roleId}`
+export const userNotesCacheKey = (userId: string): string => `user:${userId}`
+export const userListCacheKey = (listId: string): string =>
+  `user-list:${listId}`
+
+/**
+ * カラムの canonical キャッシュキー。キャッシュを持たない種別・必須 id 欠落は
+ * null (= キャッシュ読み書きしない)。
+ *
+ * timeline 種別は `col.tl ?? default` (default: 'home'、guest は 'local')。
+ * guest は home/social に到達できないため 'local' へ強制変換する —
+ * DeckTimelineColumn の setup 時変換 (§6-13 で永続化) と同一規則。
+ */
+export function columnCacheKey(
+  column: DeckColumn,
+  deps: ColumnCacheKeyDeps,
+): string | null {
+  switch (column.type) {
+    case 'timeline': {
+      const isGuest = column.accountId
+        ? deps.isGuestAccount(column.accountId)
+        : false
+      const tl = column.tl ?? (isGuest ? 'local' : 'home')
+      return isGuest && (tl === 'home' || tl === 'social') ? 'local' : tl
+    }
+    case 'antenna':
+      return column.antennaId ? antennaCacheKey(column.antennaId) : null
+    case 'channel':
+      return column.channelId ? channelCacheKey(column.channelId) : null
+    case 'clip':
+      return column.clipId ? clipCacheKey(column.clipId) : null
+    case 'user':
+      return column.userId ? userNotesCacheKey(column.userId) : null
+    case 'list':
+      return column.listId ? userListCacheKey(column.listId) : null
+    case 'role':
+      return column.roleId ? roleCacheKey(column.roleId) : null
+    case 'favorites':
+      return FAVORITES_CACHE_KEY
+    case 'explore':
+      // 読み出し専用キー。書込経路はなく常に空読み (notecli TimelineKey doc 参照)
+      return 'explore'
+    case 'mentions':
+      return 'mentions'
+    case 'specified':
+      return 'specified'
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
## なぜ

notecli-dev/notecli#52 で notes キャッシュが実体 (notes_cache) と所属 (note_timelines) に分離された（notecli#30 仕様 v5）。本 PR は rev pin を bump し、cross-repo 影響の全 18 項目（仕様 §6）を適用する。これにより:

- home ∩ social 等の複数所属ノートが両カラムのキャッシュ表示に出る（後勝ち付け替えの解消 — 原症状 #651 の主因）
- streaming 由来の antenna/channel/role/user-list ノートが初めてオフライン読み出しに乗る（孤児化解消）
- リスト TL・フォーク TL（vmimi-relay 等）の WS リアルタイム配信が直る
- **復帰時にキャッシュが誤って恒久削除される誤爆を修正**（verify-purge: 404 と通信エラーの混同 — 原症状「復帰時に薄くなる」のもう一つの生産源）

## 変更内容

**backend (src-tauri):**
- fetch 系 7 コマンド + `api_get_timeline` を `ingest_notes` + `TimelineKey` に置換（`format!` キー手組みを型レベルで排除）
- `QueryKey` の antenna/channel/role/mentions kind を `Timeline { account_id, key }` に折り畳み。`query_open` 削除（無検証キーの裏口・呼び出しゼロ）
- 購読 4 コマンドを `subscribe_notes(TimelineKey)` へ統合
- キャッシュ整合フック: unfavorite / clip 除去 → `remove_membership`、antenna 更新 / list メンバー除去 → `clear_timeline`、エンティティ削除の後始末用 `api_clear_timeline_cache` 新設（死にバケットの無限蓄積防止）
- `api_verify_notes` → `VerifyNotesResult { verified, missing }`：**NO_SUCH_NOTE 確認時のみ** miss 判定。通信エラー・レート制限は生存扱い
- `api_delete_cached_note` に accountId、`api_get_cached_timeline_before` に beforeNoteId（keyset cursor ペア）
- cache 系長時間コマンド 5 つを spawn_blocking 化（writer Mutex の tokio worker 枯渇防止）、DB open 失敗時に `nd:backend-fatal` emit

**front (src):**
- キー手組みを `src/utils/columnCacheKey.ts` に集約 — **既存バグ 4 件を修正**（list snapshot `list:{id}`→`user-list:{id}` / specified snapshot `'mentions'`→`'specified'` / role ミラー欠落で preview 常に空 / tl 未設定時ミラー null）
- guest TL 強制変換の永続化、before 遡りの (createdAt, id) 同一ソースペア渡し、useNoteList への accountId 注入、`queryKeyToInfo` 折り畳み追随、cacheEviction の perTimelineLimit
- エンティティ削除成功後の `apiClearTimelineCache` fire-and-forget

## テスト

- backend: cargo test 285 本全通過・clippy 警告ゼロ・bindings.ts / openapi.json 再生成（snapshot テスト pass）
- front: vitest **2565 本全通過**（新規 23 本: columnCacheKey の全種別 table test、verify-purge の症状起点テスト「missing のみ削除・エラー相当は生存」含む）・typecheck / biome clean

## 運用注意

- 本 PR のマージ後、アプリ初回起動時に V6 migration が走る（1M 行で 1 分前後・一時的に DB サイズの最大 2 倍弱の空きディスクが必要）
- 同一 DB を共有する notetui / notebot は rev bump（第 3 段・別 issue）まで open 不能

🤖 Generated with [Claude Code](https://claude.com/claude-code)