### PR TITLE
chore: bump version to 1.40.0 / notecli を v0.8.1 に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.39.0",
+  "version": "1.40.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3166,8 +3166,8 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "notecli"
-version = "0.7.0"
-source = "git+https://github.com/notedeck-dev/notecli?rev=1f68a91a52894c9950bdb107faae61b346f6e260#1f68a91a52894c9950bdb107faae61b346f6e260"
+version = "0.8.1"
+source = "git+https://github.com/notedeck-dev/notecli?rev=272edaebf1131b092bb0e111ca21bdb29d079c77#272edaebf1131b092bb0e111ca21bdb29d079c77"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.39.0"
+version = "1.40.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "notedeck"
-version = "1.39.0"
+version = "1.40.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "1f68a91a52894c9950bdb107faae61b346f6e260", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "272edaebf1131b092bb0e111ca21bdb29d079c77", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.39.0"
+    "version": "1.40.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
リリース準備。バージョンを 1.40.0 に同期し、notecli の rev を v0.8.1（272edae）に更新して v0.8.0 のレビュー指摘修正を取り込む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)