### PR TITLE
feat(column-query): キャッシュ検索をカラムの所属バケットで絞る

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.8.1"
-source = "git+https://github.com/notedeck-dev/notecli?rev=272edaebf1131b092bb0e111ca21bdb29d079c77#272edaebf1131b092bb0e111ca21bdb29d079c77"
+source = "git+https://github.com/notedeck-dev/notecli?rev=203d9d80dc16bd53646d24a2abcd7357dd598532#203d9d80dc16bd53646d24a2abcd7357dd598532"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "272edaebf1131b092bb0e111ca21bdb29d079c77", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "203d9d80dc16bd53646d24a2abcd7357dd598532", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/src/commands/column_query.rs
+++ b/src-tauri/src/commands/column_query.rs
@@ -265,14 +265,21 @@ pub struct QirSearchCursor {
 /// 偽陰性を出さない規則に従うので (不変条件 (b))、FTS で落ちたノートが
 /// 本来マッチするということはない。
 ///
+/// `timeline_key` (canonical 文字列) を渡すと当該バケット所属のみを母集合に
+/// する。実体/所属分離 (notecli#30) 以前は所属が後勝ち上書きで種別絞りが
+/// 取りこぼしになるため全体走査しかなかったが、その妥協は解消済み。
+/// null は従来どおりアカウントの全キャッシュを走査する。
+///
 /// 走査上限に達したら打ち切って継続カーソルを返す。呼び出し側は必要なだけ
-/// 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。
+/// 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。カーソルは
+/// 同じ timeline_key の続き読みにのみ使うこと。
 #[tauri::command]
 #[specta::specta]
 pub async fn qir_search_cache(
     app_state: State<'_, AppState>,
     account_id: String,
     query: QirQuery,
+    timeline_key: Option<String>,
     limit: Option<u32>,
     max_scanned_rows: Option<u32>,
     cursor: Option<QirSearchCursor>,
@@ -281,6 +288,11 @@ pub async fn qir_search_cache(
     if !validation.ok {
         return Err(NoteDeckError::InvalidInput(validation.errors.join(", ")));
     }
+    // 不正キーは黙殺せず Err で顕在化 (キャッシュ読み出し系と同方針)
+    let scope = timeline_key
+        .as_deref()
+        .map(notecli::models::TimelineKey::parse)
+        .transpose()?;
     let literals = extract_fts_literals(&query);
     let limit = limit.unwrap_or(40).clamp(1, 200) as usize;
     let max_scanned = max_scanned_rows.unwrap_or(2000).clamp(1, 20_000) as usize;
@@ -292,6 +304,7 @@ pub async fn qir_search_cache(
     let db = app_state.db().await;
     let scan = db.scan_cached_notes(
         &account_id,
+        scope.as_ref(),
         &literals,
         limit,
         max_scanned,

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -88,14 +88,20 @@ async qirValidate(query: QirQuery) : Promise<QirValidation> {
  * 偽陰性を出さない規則に従うので (不変条件 (b))、FTS で落ちたノートが
  * 本来マッチするということはない。
  * 
+ * `timeline_key` (canonical 文字列) を渡すと当該バケット所属のみを母集合に
+ * する。実体/所属分離 (notecli#30) 以前は所属が後勝ち上書きで種別絞りが
+ * 取りこぼしになるため全体走査しかなかったが、その妥協は解消済み。
+ * null は従来どおりアカウントの全キャッシュを走査する。
+ * 
  * 走査上限に達したら打ち切って継続カーソルを返す。呼び出し側は必要なだけ
- * 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。
+ * 繰り返す (一度の呼び出しで巨大キャッシュを読み切らせない)。カーソルは
+ * 同じ timeline_key の続き読みにのみ使うこと。
  *
  * @see src-tauri/src/commands/column_query.rs
  */
-async qirSearchCache(accountId: string, query: QirQuery, limit: number | null, maxScannedRows: number | null, cursor: QirSearchCursor | null) : Promise<Result<QirSearchResult, { code: string; message: string; apiCode: string | null }>> {
+async qirSearchCache(accountId: string, query: QirQuery, timelineKey: string | null, limit: number | null, maxScannedRows: number | null, cursor: QirSearchCursor | null) : Promise<Result<QirSearchResult, { code: string; message: string; apiCode: string | null }>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("qir_search_cache", { accountId, query, limit, maxScannedRows, cursor }) };
+    return { status: "ok", data: await TAURI_INVOKE("qir_search_cache", { accountId, query, timelineKey, limit, maxScannedRows, cursor }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -733,6 +733,8 @@ describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
     await mountOfflineColumn('acc-search-fast', FAST_QUERY)
     expect(searchCalls()).toHaveLength(1)
     expect(legacyCalls()).toHaveLength(0)
+    // カラムの所属バケットで母集合を絞る (notecli#30 §12-9)
+    expect(searchCalls()[0]?.args[2]).toBe('home')
   })
 
   it('クエリが無いカラムは従来のキャッシュ経路のまま', async () => {
@@ -764,7 +766,7 @@ describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
     await api.loadMore()
     await flush()
     const second = searchCalls()[1]
-    expect(second?.args[4]).toEqual({
+    expect(second?.args[5]).toEqual({
       createdAt: '2026-06-30T00:00:00.000Z',
       noteId: 'h00',
     })

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -1010,9 +1010,11 @@ export function useNoteColumn(config: NoteColumnConfig) {
               noteId: fetchCursor.value.id,
             }
           : null
+        // カラムの所属バケットで母集合を絞る (notecli#30 §12-9 で妥協解消)
         const found = await searchCachedNotesByQuery(
           column.accountId,
           searchable,
+          cacheKey,
           cursor,
           CACHE_SEARCH_LIMIT,
           CACHE_SEARCH_MAX_SCANNED_ROWS,

--- a/src/composables/useNoteColumnCache.ts
+++ b/src/composables/useNoteColumnCache.ts
@@ -95,15 +95,16 @@ export async function purgeStaleCachedNotes(
  * FTS5 で粗く絞ってから Rust の QIR 評価器で判定するので、条件に合うノートを
  * 見つけるまで遡れる。`before` より古い側を、走査上限まで読んで探す。
  *
- * タイムライン種別では絞らない。notecli#30 で実体 (notes_cache) と所属
- * (note_timelines) は分離済みだが、この scan は今も全所属横断で走査する。
- * カラムの所属バケットで絞る bucket スコープ検索は follow-up
- * (notecli#30 v5 §12-9)。取りこぼしより、別種別のノートが混ざる方が
- * 気づけるため、それまでは絞らない側に倒している。
+ * `timelineKey` (canonical 形式 — columnCacheKey が導出する) を渡すと、
+ * カラムの所属バケットのみを母集合にする。実体/所属分離 (notecli#30) 以前は
+ * 所属が後勝ち上書きで種別絞りが取りこぼしになるため全体走査に倒していたが、
+ * その妥協は解消済み (notecli#30 v5 §12-9)。null は全所属横断で走査する。
+ * カーソルは同じ timelineKey の続き読みにのみ使うこと。
  */
 export async function searchCachedNotesByQuery(
   accountId: string,
   query: QirQuery,
+  timelineKey: string | null,
   before: { createdAt: string; noteId: string } | null,
   limit: number,
   maxScannedRows: number,
@@ -117,6 +118,7 @@ export async function searchCachedNotesByQuery(
     await commands.qirSearchCache(
       accountId,
       query,
+      timelineKey,
       limit,
       maxScannedRows,
       before,


### PR DESCRIPTION
## なぜ

カラムクエリのキャッシュ遡り検索（#783 Phase 3）はタイムライン種別で絞っていない。notecli#30 以前は所属が後勝ち上書きで母集合を保証できず、種別で絞ると「本来あるはずのノートが出てこない」取りこぼしになるため、気づける側（別種別が混ざる）に倒した意図的な妥協だった（068bb210 が notecli#30 待ちと明文化）。

実体/所属分離（V6）が入ったので、この妥協を解消する（notecli#30 仕様 v5 §12-9）。

## 変更内容

- notecli rev を `203d9d8`（notedeck-dev/notecli#57: `scan_cached_notes` に scope 追加）に bump
- `qir_search_cache` に `timelineKey: string | null` を追加 — canonical キーで当該バケット所属のみを母集合にする。parse 失敗は Err で顕在化、null は従来の全体走査（挙動不変）
- フロント: `loadMoreFromCache` の searchable 分岐で `columnCacheKey` 由来の `cacheKey` を渡す — **クエリ付きカラムの遡り検索に別種別のノートが混ざらなくなる**
- `useNoteColumnCache` の妥協コメントを解消済みの記述に更新、bindings.ts / openapi.json 再生成

## テスト

- backend: cargo test 285 本全通過・clippy 警告ゼロ
- front: vitest 2565 本全通過（dom テストにバケットキー引数の検証を追加）・typecheck / biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)