### PR TITLE
fix: clear_timeline の完了を待ってからコマンドを返す

### DIFF
--- a/src-tauri/src/commands/timeline.rs
+++ b/src-tauri/src/commands/timeline.rs
@@ -161,18 +161,22 @@ pub async fn api_update_antenna(
     let (client, host, token) = app_state.authed(&account_id).await?;
     let updated = client.update_antenna(&host, &token, &antenna).await?;
     // 設定変更後の旧マッチ分は個別ノートへ逆引きできないためバケット破棄 →
-    // 次回フェッチで再構築 (失敗は warn + Ok)。大バケットは writer lock を
-    // 秒単位で保持し得るため spawn_blocking で退避
+    // 次回フェッチで再構築 (失敗は warn + Ok)。writer lock を秒単位で保持し得る
+    // ため spawn_blocking で退避しつつ、完了は待ってから返す — detach すると
+    // フロントの再フェッチが ingest した直後に破棄が走り、再構築したばかりの
+    // バケットを消すレースになる
     let db = app_state.db().await;
     let account_id_owned = account_id.clone();
     let key = TimelineKey::Antenna {
         antenna_id: updated.id.clone(),
     };
-    tokio::task::spawn_blocking(move || {
-        if let Err(e) = db.clear_timeline(&account_id_owned, &key) {
-            tracing::warn!("[cache] failed to clear antenna bucket: {e}");
-        }
-    });
+    let cleared =
+        tokio::task::spawn_blocking(move || db.clear_timeline(&account_id_owned, &key)).await;
+    match cleared {
+        Ok(Err(e)) => tracing::warn!("[cache] failed to clear antenna bucket: {e}"),
+        Err(e) => tracing::warn!("[cache] clear antenna bucket task failed: {e}"),
+        Ok(Ok(_)) => {}
+    }
     Ok(updated)
 }
 

--- a/src-tauri/src/commands/user.rs
+++ b/src-tauri/src/commands/user.rs
@@ -464,17 +464,20 @@ pub async fn api_remove_user_from_list(
         .remove_user_from_list(&host, &token, &list_id, &user_id)
         .await?;
     // 除外ユーザーの既存ノートは個別逆引き不能のためバケット破棄 →
-    // 次回フェッチで再構築 (失敗は warn + Ok)
+    // 次回フェッチで再構築 (失敗は warn + Ok)。破棄の完了は待ってから返す —
+    // detach するとフロントの再フェッチ ingest 後に破棄が走るレースになる
     let db = app_state.db().await;
     let account_id_owned = account_id.clone();
     let key = TimelineKey::UserList {
         list_id: list_id.clone(),
     };
-    tokio::task::spawn_blocking(move || {
-        if let Err(e) = db.clear_timeline(&account_id_owned, &key) {
-            tracing::warn!("[cache] failed to clear user-list bucket: {e}");
-        }
-    });
+    let cleared =
+        tokio::task::spawn_blocking(move || db.clear_timeline(&account_id_owned, &key)).await;
+    match cleared {
+        Ok(Err(e)) => tracing::warn!("[cache] failed to clear user-list bucket: {e}"),
+        Err(e) => tracing::warn!("[cache] clear user-list bucket task failed: {e}"),
+        Ok(Ok(_)) => {}
+    }
     Ok(())
 }
 


### PR DESCRIPTION
#962 の CodeRabbit 指摘への対応。`api_update_antenna` / `api_remove_user_from_list` がバケット破棄（`clear_timeline`）を detach していたため、コマンド成功 → フロント再フェッチが ingest → その後に破棄が走って**再構築したばかりのバケットを消す**レースがあった。spawn_blocking のまま await に変更（失敗時 warn + Ok と tokio worker 退避は維持）。

cargo test 285 本全通過・clippy 警告ゼロ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)