### PR TITLE
feat(column-query): And 合成とオンライン時のキャッシュ検索チェーン

### DIFF
--- a/src/composables/useNoteColumn.dom.test.ts
+++ b/src/composables/useNoteColumn.dom.test.ts
@@ -14,6 +14,7 @@ import type {
   TimelineFilter,
 } from '@/adapters/types'
 import { type Account, useAccountsStore } from '@/stores/accounts'
+import { useColumnQueriesStore } from '@/stores/columnQueries'
 import { type DeckColumn, useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
 import { matchesFilter } from '@/utils/timelineFilter'
@@ -749,6 +750,43 @@ describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
     expect(legacyCalls()).toHaveLength(1)
   })
 
+  it('⚡ 2 個 (インライン + 名前付き) でもキャッシュ検索コマンドを使う (#965)', async () => {
+    bindings.responses.qirSearchCache = {
+      notes: [],
+      scanned: 0,
+      errors: 0,
+      cursor: null,
+    }
+    // 名前付きクエリをプールに登録 (ensureLoaded 後でないと push が上書きされる)
+    const queriesStore = useColumnQueriesStore()
+    queriesStore.ensureLoaded()
+    queriesStore.queries.push({
+      id: 'q-vis-965',
+      name: 'public only',
+      src: 'note.visibility == "public"',
+      createdAt: 0,
+      updatedAt: 0,
+    })
+    addAccount('acc-search-multi')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...note('h05'), text: 'hello' }])
+      .mockRejectedValueOnce(new Error('offline'))
+    const { api } = mountColumn({
+      accountId: 'acc-search-multi',
+      noteQuery: FAST_QUERY,
+      noteQueryRefs: ['q-vis-965'],
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    await api.loadMore()
+    await flush()
+
+    // 従来は複数パーツで黙って従来経路に落ちていた (#965 で And 合成)
+    expect(searchCalls()).toHaveLength(1)
+    expect(legacyCalls()).toHaveLength(0)
+  })
+
   it('見つかったノートを取り込み、打ち切りカーソルから次を続ける', async () => {
     bindings.responses.qirSearchCache = {
       notes: [{ ...note('h01'), text: 'hit' }],
@@ -770,6 +808,105 @@ describe('useNoteColumn: QIR キャッシュ検索 (#783 Phase 3)', () => {
       createdAt: '2026-06-30T00:00:00.000Z',
       noteId: 'h00',
     })
+  })
+})
+
+describe('useNoteColumn: オンライン loadMore のキャッシュ検索チェーン (#964)', () => {
+  const FAST_QUERY = 'note.text != null'
+
+  const searchCalls = () =>
+    bindings.calls.filter((c) => c.name === 'qirSearchCache')
+
+  it('API ページが全件フィルタ落ちならキャッシュ検索を 1 パスだけチェーンする', async () => {
+    bindings.responses.qirSearchCache = {
+      notes: [{ ...note('c01'), text: 'cached hit' }],
+      scanned: 100,
+      errors: 0,
+      cursor: null,
+    }
+    addAccount('acc-chain-empty')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...note('h05'), text: 'hello' }]) // connect
+      .mockResolvedValueOnce([
+        { ...note('h04'), text: null },
+        { ...note('h03'), text: null },
+      ]) // loadMore: 全件クエリ落ち
+    const { api } = mountColumn({
+      accountId: 'acc-chain-empty',
+      noteQuery: FAST_QUERY,
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+    expect(ids(api)).toEqual(['h05'])
+
+    await api.loadMore()
+    await flush()
+
+    // オンラインのままキャッシュ検索が 1 回だけ走り、ヒットがカラムに載る
+    expect(searchCalls()).toHaveLength(1)
+    expect(ids(api)).toContain('c01')
+    expect(api.isOffline.value).toBe(false)
+    // 検索は API が前進させたカーソル (生ページの最古 h03) より古い側を走査
+    expect(searchCalls()[0]?.args[5]).toEqual({
+      createdAt: note('h03').createdAt,
+      noteId: 'h03',
+    })
+  })
+
+  it('フィルタ通過ノートが 1 件でもあればチェーンしない', async () => {
+    addAccount('acc-chain-skip')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...note('h05'), text: 'hello' }]) // connect
+      .mockResolvedValueOnce([
+        { ...note('h04'), text: 'world' },
+        { ...note('h03'), text: null },
+      ]) // loadMore: 1 件は通過
+    const { api } = mountColumn({
+      accountId: 'acc-chain-skip',
+      noteQuery: FAST_QUERY,
+      fetch: () => fetchImpl(),
+    })
+    await flush()
+
+    await api.loadMore()
+    await flush()
+
+    expect(searchCalls()).toHaveLength(0)
+    expect(ids(api)).toEqual(['h05', 'h04'])
+  })
+
+  it('チェーンで得た打ち切りカーソルが次回 loadMore に引き継がれる', async () => {
+    bindings.responses.qirSearchCache = {
+      notes: [{ ...note('c02'), text: 'cached hit' }],
+      scanned: 2000,
+      errors: 0,
+      // 走査上限で打ち切り
+      cursor: { createdAt: '2026-06-30T00:00:00.000Z', noteId: 'c00' },
+    }
+    addAccount('acc-chain-cursor')
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce([{ ...note('h05'), text: 'hello' }]) // connect
+      .mockResolvedValueOnce([{ ...note('h04'), text: null }]) // loadMore: 全落ち → チェーン
+      .mockResolvedValueOnce([]) // 次の loadMore
+    const { api } = mountColumn({
+      accountId: 'acc-chain-cursor',
+      noteQuery: FAST_QUERY,
+      fetch: (_a, opts) => fetchImpl(opts),
+    })
+    await flush()
+
+    await api.loadMore()
+    await flush()
+    expect(searchCalls()).toHaveLength(1)
+
+    await api.loadMore()
+    await flush()
+
+    // チェーンが前進させたカーソル (c00) から続きを取りに行く
+    expect(fetchImpl.mock.calls[2]?.[0]).toEqual({ untilId: 'c00' })
   })
 })
 

--- a/src/composables/useNoteColumn.ts
+++ b/src/composables/useNoteColumn.ts
@@ -40,6 +40,7 @@ import {
   compileColumnQuery,
   hashQirQuery,
 } from '@/services/columnQuery/compiler'
+import { composeQir } from '@/services/columnQuery/composeQir'
 import { getSharedDegradedRunner } from '@/services/columnQuery/degradedRunner'
 import { evaluateQirQuery } from '@/services/columnQuery/evaluator'
 import { isGuestAccount } from '@/stores/accounts'
@@ -428,9 +429,10 @@ export function useNoteColumn(config: NoteColumnConfig) {
   /**
    * QIR キャッシュ検索に使えるクエリ (#783 Phase 3)。
    *
-   * ⚡ の単一パーツに限る。複数パーツを And で束ねると let のスロット番号が
-   * パーツ間で衝突しうるし、🐢 パーツは QIR を持たない。該当しないカラムは
-   * 従来どおり「キャッシュから読んでフロントで絞る」経路を通る。
+   * ⚡ パーツのみで構成されるカラムに限る (🐢 パーツは QIR を持たない)。
+   * 複数 ⚡ は let スロットを renumber したうえで And 合成する (#965)。
+   * 該当しないカラムは従来どおり「キャッシュから読んでフロントで絞る」
+   * 経路を通る。
    */
   function cacheSearchableQuery(): QirQuery | null {
     const compiled = compiledQuery.value
@@ -438,8 +440,8 @@ export function useNoteColumn(config: NoteColumnConfig) {
     if (compiled.degraded.length > 0 || compiled.rejected.length > 0)
       return null
     if (compiled.missing.length > 0) return null
-    if (compiled.fast.length !== 1) return null
-    return compiled.fast[0]?.query ?? null
+    if (compiled.fast.length === 0) return null
+    return composeQir(compiled.fast.map((f) => f.query))
   }
 
   /** 参照先が消えた名前付きクエリの id (削除・未導入)。fail-closed の原因 */
@@ -990,6 +992,52 @@ export function useNoteColumn(config: NoteColumnConfig) {
     noteScrollerRef.value?.restoreScrollAnchor?.(anchor.id, anchor.offset)
   }
 
+  /**
+   * QIR キャッシュ検索の 1 パス (#783 Phase 3)。
+   *
+   * fetchCursor より古い側を走査上限まで遡り、条件に合うノートを見つけて
+   * カラムへ取り込む。「40 件読んで全部フィルタで落ちる」空振りをここで
+   * 吸収する。オフラインの loadMoreFromCache と、オンライン loadMore の
+   * 空振りチェーン (#964) が共用する。
+   */
+  async function runCacheSearchPass(
+    searchable: QirQuery,
+    stillCurrent: () => boolean,
+  ): Promise<void> {
+    const column = config.getColumn()
+    const cacheKey = config.cache?.getKey()
+    if (!column.accountId || !cacheKey) return
+    const cursor = fetchCursor.value
+      ? {
+          createdAt: fetchCursor.value.createdAt,
+          noteId: fetchCursor.value.id,
+        }
+      : null
+    // カラムの所属バケットで母集合を絞る (notecli#30 §12-9 で妥協解消)
+    const found = await searchCachedNotesByQuery(
+      column.accountId,
+      searchable,
+      cacheKey,
+      cursor,
+      CACHE_SEARCH_LIMIT,
+      CACHE_SEARCH_MAX_SCANNED_ROWS,
+    )
+    if (!stillCurrent()) return
+    queryErrorCount.value += found.errors
+    if (found.cursor) {
+      // 走査上限で打ち切った位置から次回続ける
+      fetchCursor.value = {
+        id: found.cursor.noteId,
+        createdAt: found.cursor.createdAt,
+      }
+    } else {
+      advanceFetchCursor(found.notes)
+    }
+    if (found.notes.length > 0) {
+      await setNotesPaged(insertIntoSorted(rawNotes.value, found.notes))
+    }
+  }
+
   /** Helper to load older notes from SQLite cache */
   async function loadMoreFromCache() {
     const column = config.getColumn()
@@ -1008,37 +1056,7 @@ export function useNoteColumn(config: NoteColumnConfig) {
     try {
       const searchable = cacheSearchableQuery()
       if (searchable) {
-        // 条件に合うノートが見つかるまでキャッシュを遡る (Phase 3)。
-        // 「40 件読んで全部フィルタで落ちる」空振りをここで吸収する
-        const cursor = fetchCursor.value
-          ? {
-              createdAt: fetchCursor.value.createdAt,
-              noteId: fetchCursor.value.id,
-            }
-          : null
-        // カラムの所属バケットで母集合を絞る (notecli#30 §12-9 で妥協解消)
-        const found = await searchCachedNotesByQuery(
-          column.accountId,
-          searchable,
-          cacheKey,
-          cursor,
-          CACHE_SEARCH_LIMIT,
-          CACHE_SEARCH_MAX_SCANNED_ROWS,
-        )
-        if (!stillCurrent()) return
-        queryErrorCount.value += found.errors
-        if (found.cursor) {
-          // 走査上限で打ち切った位置から次回続ける
-          fetchCursor.value = {
-            id: found.cursor.noteId,
-            createdAt: found.cursor.createdAt,
-          }
-        } else {
-          advanceFetchCursor(found.notes)
-        }
-        if (found.notes.length > 0) {
-          await setNotesPaged(insertIntoSorted(rawNotes.value, found.notes))
-        }
+        await runCacheSearchPass(searchable, stillCurrent)
         return
       }
       const older = await loadCachedTimelineBefore(
@@ -1083,9 +1101,21 @@ export function useNoteColumn(config: NoteColumnConfig) {
       const older = await config.fetch(adapter, { untilId })
       if (!stillCurrent()) return
       advanceFetchCursor(older)
-      await setNotesPaged(
-        insertIntoSorted(rawNotes.value, await applyFilter(older)),
-      )
+      const filtered = await applyFilter(older)
+      await setNotesPaged(insertIntoSorted(rawNotes.value, filtered))
+      if (filtered.length === 0) {
+        // API ページは取れたがフィルタ後の獲得が 0 (ページ自体が空も含む)。
+        // オンラインでもキャッシュ検索を 1 パスだけチェーンしてカラムを
+        // 埋める (#964)。1 回の loadMore につきチェーンは 1 回まで。
+        // 二重読みにならない理由: この API ページは api_get_timeline 経由で
+        // ingest 済みで、キャッシュ検索は fetchCursor (直前の
+        // advanceFetchCursor で API ページの最古まで前進済み) より古い側
+        // だけを走査するため。
+        const searchable = cacheSearchableQuery()
+        if (searchable && stillCurrent()) {
+          await runCacheSearchPass(searchable, stillCurrent)
+        }
+      }
     } catch (e) {
       logWarn('load-more', e)
       isOffline.value = true

--- a/src/services/columnQuery/composeQir.test.ts
+++ b/src/services/columnQuery/composeQir.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest'
+
+import type { QirNode, QirQuery } from '@/bindings'
+import { compileColumnQuery } from '@/services/columnQuery/compiler'
+import { composeQir } from '@/services/columnQuery/composeQir'
+import { evaluateQirQuery } from '@/services/columnQuery/evaluator'
+
+function compile(src: string): QirQuery {
+  const result = compileColumnQuery(src)
+  if (!result.ok) {
+    throw new Error(`compile failed: ${src}`)
+  }
+  return result.query
+}
+
+/** let の定義スロットと ref の参照スロットを収集する */
+function collectSlots(
+  node: QirNode,
+  out = { defs: [] as number[], refs: [] as number[] },
+): { defs: number[]; refs: number[] } {
+  switch (node.kind) {
+    case 'str':
+    case 'num':
+    case 'bool':
+    case 'null':
+    case 'field':
+      break
+    case 'ref':
+      out.refs.push(node.slot)
+      break
+    case 'let':
+      for (const b of node.bindings) {
+        out.defs.push(b.slot)
+        collectSlots(b.expr, out)
+      }
+      collectSlots(node.body, out)
+      break
+    case 'objIndex':
+    case 'arrLen':
+    case 'strMap':
+      collectSlots(node.target, out)
+      break
+    case 'not':
+      collectSlots(node.expr, out)
+      break
+    case 'and':
+    case 'or':
+    case 'cmp':
+    case 'eq':
+      collectSlots(node.left, out)
+      collectSlots(node.right, out)
+      break
+    case 'strTest':
+    case 'arrIncl':
+      collectSlots(node.target, out)
+      collectSlots(node.needle, out)
+      break
+  }
+  return out
+}
+
+describe('composeQir', () => {
+  it('空配列は null、1 個はそのまま返す', () => {
+    expect(composeQir([])).toBeNull()
+    const single = compile('note.text != null')
+    expect(composeQir([single])).toBe(single)
+  })
+
+  it('2 パーツの合成は両条件の And になる', () => {
+    const textQuery = compile('note.text != null && note.text.incl("alpha")')
+    const visQuery = compile('note.visibility == "public"')
+    const composed = composeQir([textQuery, visQuery])
+    expect(composed).not.toBeNull()
+    if (!composed) return
+
+    const both = { text: 'alpha day', visibility: 'public' }
+    const textOnly = { text: 'alpha day', visibility: 'home' }
+    const visOnly = { text: 'beta', visibility: 'public' }
+    const neither = { text: null, visibility: 'home' }
+    expect(evaluateQirQuery(composed, both)).toBe('match')
+    expect(evaluateQirQuery(composed, textOnly)).toBe('unmatch')
+    expect(evaluateQirQuery(composed, visOnly)).toBe('unmatch')
+    expect(evaluateQirQuery(composed, neither)).toBe('unmatch')
+  })
+
+  it('let スロットが衝突するパーツを renumber して合成する (回帰)', () => {
+    // 各パーツは独立にコンパイルされスロットが 0 起点で割り当てられるため、
+    // let を使うパーツ同士 (中間式の束縛も slot を消費する) は必ず衝突する。
+    // renumber しない合成は「slot は式全体で一意」という QIR の契約
+    // (column_query.rs QirBinding) を壊す
+    const partA = compile('let t = note.text\nt != null && t.incl("alpha")')
+    const partB = compile('note.cw == null\nnote.visibility == "public"')
+    const slotsA = collectSlots(partA.root)
+    const slotsB = collectSlots(partB.root)
+    // 前提: 両パーツとも let スロットを持ち、番号が重なっている
+    expect(slotsA.defs.length).toBeGreaterThan(0)
+    expect(slotsB.defs.length).toBeGreaterThan(0)
+    expect(slotsA.defs.some((s) => slotsB.defs.includes(s))).toBe(true)
+
+    const composed = composeQir([partA, partB])
+    expect(composed).not.toBeNull()
+    if (!composed) return
+
+    // renumber により定義スロットは合成後も全体で一意 (renumber を外すと
+    // partB の let が partA と同じ番号のまま残りここで落ちる)
+    const { defs, refs } = collectSlots(composed.root)
+    expect(new Set(defs).size).toBe(defs.length)
+    // 参照が未定義スロットを指していない (renumber は定義と参照を同時にずらす)
+    const defSet = new Set(defs)
+    for (const slot of refs) {
+      expect(defSet.has(slot)).toBe(true)
+    }
+
+    // 合成後も各パーツの評価が And として正しい
+    const cases: { note: Record<string, unknown>; expected: string }[] = [
+      {
+        note: { text: 'alpha!', cw: null, visibility: 'public' },
+        expected: 'match',
+      },
+      {
+        note: { text: 'beta', cw: null, visibility: 'public' },
+        expected: 'unmatch',
+      },
+      {
+        note: { text: 'alpha!', cw: null, visibility: 'home' },
+        expected: 'unmatch',
+      },
+      {
+        note: { text: null, cw: null, visibility: 'public' },
+        expected: 'unmatch',
+      },
+    ]
+    for (const c of cases) {
+      expect(evaluateQirQuery(composed, c.note)).toBe(c.expected)
+      // 単体評価との一致 (合成が各パーツの意味を変えていない)
+      const a = evaluateQirQuery(partA, c.note)
+      const b = evaluateQirQuery(partB, c.note)
+      const expected =
+        a === 'match' && b === 'match'
+          ? 'match'
+          : a === 'error' || (a === 'match' && b === 'error')
+            ? 'error'
+            : 'unmatch'
+      expect(evaluateQirQuery(composed, c.note)).toBe(expected)
+    }
+  })
+
+  it('3 パーツでもスロットは全体で一意になる', () => {
+    const parts = [
+      compile('let t = note.text\nt != null'),
+      compile('let v = note.visibility\nv == "public"'),
+      compile('let c = note.cw\nc == null'),
+    ]
+    const composed = composeQir(parts)
+    expect(composed).not.toBeNull()
+    if (!composed) return
+    const { defs } = collectSlots(composed.root)
+    expect(defs.length).toBe(3)
+    expect(new Set(defs).size).toBe(3)
+    expect(
+      evaluateQirQuery(composed, { text: 'x', visibility: 'public', cw: null }),
+    ).toBe('match')
+    expect(
+      evaluateQirQuery(composed, { text: 'x', visibility: 'public', cw: 'w' }),
+    ).toBe('unmatch')
+  })
+
+  it('schemaVersion が一致しないパーツは合成できない', () => {
+    const a = compile('note.text != null')
+    const b = compile('note.visibility == "public"')
+    expect(composeQir([a, { ...b, schemaVersion: b.schemaVersion + 1 }])).toBe(
+      null,
+    )
+  })
+})

--- a/src/services/columnQuery/composeQir.ts
+++ b/src/services/columnQuery/composeQir.ts
@@ -1,0 +1,122 @@
+import type { QirNode, QirQuery } from '@/bindings'
+
+/**
+ * 複数 ⚡ パーツの QIR を And 合成する (#965)。
+ *
+ * let のスロット番号はパーツごとに 0 起点で独立に割り当てられるため、
+ * そのまま束ねるとパーツ間で衝突し「slot は式全体で一意」という QIR の
+ * 契約 (column_query.rs QirBinding) が壊れる。合成前に各パーツのスロットを
+ * 「前パーツまでの最大スロット + 1」でオフセットして一意性を保つ。
+ *
+ * スロットを持つノードは let (bindings[].slot = 定義) と ref (slot = 参照)
+ * の 2 種のみ (bindings.ts / evaluator.ts / column_query.rs の QirNode 定義)。
+ */
+
+/** ノード以下で使われている最大スロット番号。スロットが無ければ -1 */
+function maxSlot(node: QirNode): number {
+  switch (node.kind) {
+    case 'str':
+    case 'num':
+    case 'bool':
+    case 'null':
+    case 'field':
+      return -1
+    case 'ref':
+      return node.slot
+    case 'let': {
+      let max = maxSlot(node.body)
+      for (const b of node.bindings) {
+        max = Math.max(max, b.slot, maxSlot(b.expr))
+      }
+      return max
+    }
+    case 'objIndex':
+    case 'arrLen':
+    case 'strMap':
+      return maxSlot(node.target)
+    case 'not':
+      return maxSlot(node.expr)
+    case 'and':
+    case 'or':
+    case 'cmp':
+    case 'eq':
+      return Math.max(maxSlot(node.left), maxSlot(node.right))
+    case 'strTest':
+    case 'arrIncl':
+      return Math.max(maxSlot(node.target), maxSlot(node.needle))
+  }
+}
+
+/** スロット番号 (let の定義と ref の参照の両方) を offset だけずらした複製 */
+function shiftSlots(node: QirNode, offset: number): QirNode {
+  if (offset === 0) return node
+  switch (node.kind) {
+    case 'str':
+    case 'num':
+    case 'bool':
+    case 'null':
+    case 'field':
+      return node
+    case 'ref':
+      return { kind: 'ref', slot: node.slot + offset }
+    case 'let':
+      return {
+        kind: 'let',
+        bindings: node.bindings.map((b) => ({
+          slot: b.slot + offset,
+          expr: shiftSlots(b.expr, offset),
+        })),
+        body: shiftSlots(node.body, offset),
+      }
+    case 'objIndex':
+      return { ...node, target: shiftSlots(node.target, offset) }
+    case 'arrLen':
+      return { ...node, target: shiftSlots(node.target, offset) }
+    case 'strMap':
+      return { ...node, target: shiftSlots(node.target, offset) }
+    case 'not':
+      return { ...node, expr: shiftSlots(node.expr, offset) }
+    case 'and':
+    case 'or':
+    case 'cmp':
+    case 'eq':
+      return {
+        ...node,
+        left: shiftSlots(node.left, offset),
+        right: shiftSlots(node.right, offset),
+      }
+    case 'strTest':
+    case 'arrIncl':
+      return {
+        ...node,
+        target: shiftSlots(node.target, offset),
+        needle: shiftSlots(node.needle, offset),
+      }
+  }
+}
+
+/**
+ * QIR パーツ列を単一の QIR に And 合成する。
+ *
+ * - 空配列 → null
+ * - 1 個 → そのまま返す (再構築しない)
+ * - 複数 → スロットを renumber して左結合の And で束ねる。評価順・短絡は
+ *   queryAdmitsFast のパーツ順 And と同じ (先頭パーツが unmatch なら後続は
+ *   評価されない)
+ * - schemaVersion が全パーツで一致しないものは合成できない → null
+ */
+export function composeQir(parts: QirQuery[]): QirQuery | null {
+  const first = parts[0]
+  if (first === undefined) return null
+  if (parts.some((p) => p.schemaVersion !== first.schemaVersion)) return null
+  if (parts.length === 1) return first
+  let root = first.root
+  let nextOffset = maxSlot(first.root) + 1
+  for (const part of parts.slice(1)) {
+    const shifted = shiftSlots(part.root, nextOffset)
+    // スロットを持たないパーツでは maxSlot が -1 → オフセットは前進しない
+    nextOffset = Math.max(nextOffset, maxSlot(shifted) + 1)
+    root = { kind: 'and', left: root, right: shifted }
+  }
+  return { schemaVersion: first.schemaVersion, root }
+}


### PR DESCRIPTION
closes #964, closes #965（#783 レビュー指摘 2・3 の解消）

## #965: 複数 ⚡ クエリの And 合成

`cacheSearchableQuery()` は ⚡ パーツがちょうど 1 個のときしか QIR を返さず、名前付きクエリを 2 個トグルする普通の使い方で黙ってキャッシュ検索が無効になっていた。

- `composeQir(parts)` 新設: let スロットはパーツごと 0 起点のため、**「前パーツまでの最大スロット + 1」で renumber**してから左結合の二項 And で合成（`column_query.rs` QirBinding の「slot は式全体で一意」契約を維持）。スロット保持ノードは `let`（定義）と `ref`（参照）の 2 種のみであることを bindings / evaluator / Rust の三面で確認
- `fast.length === 1` 制約を撤廃（degraded / rejected / missing なしは従来どおり要求）
- テスト: 合成評価が両条件の AND になる・スロット衝突の回帰（renumber を外すと落ちる形）・schemaVersion 不一致 → null・⚡2 個カラムで qirSearchCache が呼ばれる dom テスト

## #964: オンライン時もキャッシュ検索でカラムを埋める

Phase 3 のキャッシュ検索はオフライン経路でしか通らず、主眼だった「マッチ率が低いクエリでもカラムが埋まる」がオンラインで効かなかった。

- issue 案 (b) を N=1 で採用: オンラインの `loadMore` で「API ページは取得できたが**フィルタ後の獲得が 0**」（ページ空も含む）のとき、同一呼び出し内でキャッシュ検索を 1 パス連結
- 二重読みなし: API ページは `api_get_timeline` で ingest 済み、キャッシュ検索は fetchCursor（API が進めた位置）より古い側のみ走査
- キャッシュ検索 1 パスを `runCacheSearchPass()` に抽出し、オフライン経路（`loadMoreFromCache`）と共用。チェーンの打ち切りカーソルは fetchCursor に立ち、次回 loadMore に自然に引き継がれる
- テスト: 全件フィルタ落ち → チェーン発火してヒットが載る・通過時は非チェーン・カーソル引き継ぎ

## テスト

vitest **2584 本全通過**（新規 9: composeQir 5・dom 4）・typecheck / biome clean（変更分）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)