### PR TITLE
refactor(site): ランディングページの AI 臭さを取り除き Workbench 構成に組み直す

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -13,6 +13,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;700;800&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="tokens.css" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -58,54 +59,42 @@
     </div>
   </div>
 
-  <!-- Blobs -->
-  <div class="blob blob-1"></div>
-  <div class="blob blob-2"></div>
-
-  <!-- Hero -->
-  <section class="hero">
-    <h1>
-      <img src="https://raw.githubusercontent.com/notedeck-dev/notedeck/main/src-tauri/icons/128x128%402x.png" alt="" class="hero-logo" />
-      <span class="hero-wordmark">Note<span>Deck</span></span>
-    </h1>
-    <p class="tagline">Misskey Pro</p>
-    <p class="hero-lead">Misskey廃人のための 非公式クライアント。</p>
-    <a href="#download" class="btn btn-primary">ダウンロード</a>
-  </section>
-
-  <!-- Screenshot -->
-  <div class="screenshot fade-in" data-direction="up">
-    <div class="screenshot-wrapper glass">
-      <img id="hero-screenshot" alt="NoteDeck スクリーンショット" loading="lazy" />
+  <!-- Fold — the deck is the first thing you see -->
+  <section class="fold">
+    <div class="fold-copy">
+      <h1>
+        <img src="https://raw.githubusercontent.com/notedeck-dev/notedeck/main/src-tauri/icons/128x128%402x.png" alt="" class="hero-logo" />
+        <span class="hero-wordmark">Note<span>Deck</span></span>
+      </h1>
+      <p class="tagline">Misskey Pro</p>
+      <p class="hero-lead">Misskey廃人のための 非公式クライアント。</p>
     </div>
-  </div>
+    <div class="fold-shot">
+      <img id="hero-screenshot"
+           src="https://github.com/user-attachments/assets/a9bca10d-a59d-4c35-9284-fb0534ccf886"
+           alt="NoteDeck のデッキ画面 — カラムを横に並べたレイアウト"
+           width="1194" height="793"
+           fetchpriority="high" decoding="async" />
+    </div>
+  </section>
 
   <!-- Why NoteDeck — 3 pillars -->
   <section class="section-alt" id="why">
     <div class="section-inner">
-      <h2 class="section-title fade-in" data-direction="up">なぜ NoteDeck？</h2>
+      <h2 class="section-title">なぜ NoteDeck？</h2>
       <div class="pillars-grid">
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
-          </div>
-          <h3>全部のサーバーが、ひとつの画面に</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg></span>全部のサーバーが、ひとつの画面に</h3>
           <p class="pillar-lead">通知・タイムライン・検索を<strong>アカウント横断でまとめて一覧。</strong></p>
           <p>misskey.io、にじみす、すしすきー — 何鯖使っていても、ひとつのデッキにまとめて把握。アカウントごとにブラウザのタブを開く時代は終わり。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg>
-          </div>
-          <h3>見たノートは、手元に残る</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"/><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"/></svg></span>見たノートは、手元に残る</h3>
           <p class="pillar-lead">流れてきたノートを、<strong>アプリが自動で覚えている。</strong></p>
           <p>流れたタイムラインはローカル DB に自動保存。「あのノートどこだっけ？」も全文検索で一瞬。電波がなくても読み返せて、サーバーから消えても手元には残ります。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
-          </div>
-          <h3>軽くて、速い</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg></span>軽くて、速い</h3>
           <p class="pillar-lead">ブラウザではなく、<strong>Rust 製のネイティブアプリ。</strong></p>
           <p>起動は一瞬、スクロールはなめらか、バッテリーにも優しい。開きっぱなしのブラウザタブや重いランタイムとは無縁です。</p>
         </div>
@@ -113,30 +102,14 @@
     </div>
   </section>
 
-  <!-- Guest mode CTA -->
-  <section class="section-alt">
-    <div class="section-inner section-narrow">
-      <div class="guest-cta glass fade-in" data-direction="up">
-        <div class="guest-cta-icon">
-          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-        </div>
-        <div class="guest-cta-text">
-          <h3>まずは触ってみる？</h3>
-          <p>ゲストモードなら、アカウント登録なしで公開タイムラインをすぐ閲覧できます。</p>
-        </div>
-        <a href="#download" class="btn btn-primary">ダウンロード</a>
-      </div>
-    </div>
-  </section>
-
   <!-- Features: Highlights -->
   <section class="section-default" id="features">
     <div class="section-inner">
-      <h2 class="section-title fade-in" data-direction="up">機能</h2>
+      <h2 class="section-title">機能</h2>
 
       <!-- Highlight: Deck UI -->
-      <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text glass">
+      <div class="highlight-row">
+        <div class="highlight-text panel">
           <span class="highlight-badge">デッキ UI</span>
           <h3>自由に並べる、自分だけのレイアウト</h3>
           <p>ホーム・ローカル・通知・検索・リスト・アンテナ・チャンネル・チャット — あらゆるカラムを横に並べて一覧。幅はドラッグで自由に調整、並びは「プロファイル」として保存してワンクリックで切り替え。</p>
@@ -150,8 +123,8 @@
       </div>
 
       <!-- Highlight: Offline -->
-      <div class="highlight-row fade-in" data-direction="right">
-        <div class="highlight-text glass">
+      <div class="highlight-row">
+        <div class="highlight-text panel">
           <span class="highlight-badge">オフラインでも</span>
           <h3>流れたノートも、ここに残る</h3>
           <p>タイムラインに流れてきたノートは自動でローカル SQLite に蓄積。サーバーからノートが消えても、連合が切れても、手元のデータは残り続けます。</p>
@@ -165,8 +138,8 @@
       </div>
 
       <!-- Highlight: Security -->
-      <div class="highlight-row fade-in" data-direction="left">
-        <div class="highlight-text glass">
+      <div class="highlight-row">
+        <div class="highlight-text panel">
           <span class="highlight-badge">あんしん</span>
           <h3>ログイン情報は、OS が守る</h3>
           <p>アカウントの鍵になるトークンは、ブラウザ内保存ではなく OS のキーチェーン（macOS Keychain / Windows 資格情報マネージャーなど）に暗号化して保管。アプリの中に平文で置かない設計です。</p>
@@ -185,69 +158,46 @@
   <!-- Features: Grid -->
   <section class="section-alt">
     <div class="section-inner">
-      <h2 class="section-title fade-in" data-direction="up">さらに</h2>
+      <h2 class="section-title">さらに</h2>
       <div class="features-grid">
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
-          </div>
-          <h4>キーボードで完結</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>ログインしなくても</h4>
+          <p>ゲストアカウントでログインせずに、公開タイムラインを閲覧できます。 やめるときは「ゲストを削除」するだけ。</p>
+        </div>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg></span>キーボードで完結</h4>
           <p>コマンドパレット（Ctrl+K）で 30 以上のコマンドを検索・実行。キーバインドは全部カスタマイズ可能。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
-          </div>
-          <h4>Boss Key &amp; Quick Note</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></span>Boss Key &amp; Quick Note</h4>
           <p>Ctrl+Shift+B でウィンドウを一瞬で隠す。Ctrl+Alt+N でどの画面からでも即投稿。グローバルホットキーはデスクトップならでは。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4 12.5-12.5z"/></svg>
-          </div>
-          <h4>MFM も数式も</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4 12.5-12.5z"/></svg></span>MFM も数式も</h4>
           <p>Misskey 独自の文字装飾 (MFM) に全構文対応。数式（KaTeX）やコードのハイライトもきれいに表示します。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
-          </div>
-          <h4>URL を貼るだけでプレビュー</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg></span>URL を貼るだけでプレビュー</h4>
           <p>YouTube・Spotify・ニコ動・Pixiv・Amazon など 16 サイトの専用プレビュー対応。リンクを貼るだけでリッチに展開。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg>
-          </div>
-          <h4>フォークにも対応</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 014 10 15.3 15.3 0 01-4 10 15.3 15.3 0 01-4-10 15.3 15.3 0 014-10z"/></svg></span>フォークにも対応</h4>
           <p>Misskey 本家と、Misskey を名乗り続けるフォークに対応。サーバー種別は自動判別、独自タイムラインもそのまま使えます。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="0.5"/><circle cx="17.5" cy="10.5" r="0.5"/><circle cx="8.5" cy="7.5" r="0.5"/><circle cx="6.5" cy="12.5" r="0.5"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 011.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.555C21.965 6.012 17.461 2 12 2z"/></svg>
-          </div>
-          <h4>見た目は自分好みに</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r="0.5"/><circle cx="17.5" cy="10.5" r="0.5"/><circle cx="8.5" cy="7.5" r="0.5"/><circle cx="6.5" cy="12.5" r="0.5"/><path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.926 0 1.648-.746 1.648-1.688 0-.437-.18-.835-.437-1.125-.29-.289-.438-.652-.438-1.125a1.64 1.64 0 011.668-1.668h1.996c3.051 0 5.555-2.503 5.555-5.555C21.965 6.012 17.461 2 12 2z"/></svg></span>見た目は自分好みに</h4>
           <p>Misskey のテーマがそのまま使えて、デッキの壁紙も設定可能。ダーク/ライト自動切り替え、ジェスチャ操作、OS ネイティブ通知にも対応。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
-          </div>
-          <h4>サーバーとの共生</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>サーバーとの共生</h4>
           <p>サーバー広告を正しく表示する数少ないサードパーティクライアント。表示頻度もサーバーの設定に準拠します。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
-          </div>
-          <h4>データはあなたのもの</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>データはあなたのもの</h4>
           <p>DB ファイルのコピーで丸ごとバックアップ。設定のエクスポート/インポートも。ログアウト後もデータ保持を選べます。</p>
         </div>
-        <div class="feature-card glass fade-in" data-direction="up">
-          <div class="feature-card-icon">
-            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg>
-          </div>
-          <h4>軽さを選べる</h4>
+        <div class="feature-card">
+          <h4><span class="feature-card-icon" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="20" x2="12" y2="10"/><line x1="18" y1="20" x2="18" y2="4"/><line x1="6" y1="20" x2="6" y2="16"/></svg></span>軽さを選べる</h4>
           <p>省メモリから高パフォーマンスまでプリセットで切り替え。フレームレートは端末に合わせて自動最適化。</p>
         </div>
       </div>
@@ -257,59 +207,41 @@
   <!-- IDE reveal -->
   <section class="section-default" id="ide">
     <div class="section-inner">
-      <h2 class="section-title fade-in" data-direction="up">実は、これ「IDE」なんです</h2>
-      <p class="section-sub fade-in" data-direction="up">NoteDeck の正体は <strong>Misskey 統合デッキ環境</strong> (Integrated Deck Environment)</p>
-      <div class="pillars-grid">
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg>
-          </div>
-          <h3>ストアで、着せ替えと機能追加</h3>
+      <h2 class="section-title">実は、これ「IDE」なんです</h2>
+      <p class="section-sub">NoteDeck の正体は <strong>Misskey 統合デッキ環境</strong> (Integrated Deck Environment)</p>
+      <div class="pillars-grid pillars-grid--stack">
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 16V8a2 2 0 00-1-1.73l-7-4a2 2 0 00-2 0l-7 4A2 2 0 003 8v8a2 2 0 001 1.73l7 4a2 2 0 002 0l7-4A2 2 0 0021 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span>ストアで、着せ替えと機能追加</h3>
           <p class="pillar-lead">プラグイン・テーマ・ウィジットを<strong>ワンクリックで。</strong></p>
           <p>専用ストア <a href="https://store.notedeck.io">misstore</a> から直接インストールして、アカウントごとに ON/OFF。AiScript エディタとライブプレビューも内蔵し、自作したものはその場で動きます。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.51 4.04 3 5.5l7 7Z"/><path d="M3.22 12H9.5l.5-1 2 4.5 2-7 1.5 3.5h5.27"/></svg>
-          </div>
-          <h3>AI が、デッキに棲む</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.29 1.51 4.04 3 5.5l7 7Z"/><path d="M3.22 12H9.5l.5-1 2 4.5 2-7 1.5 3.5h5.27"/></svg></span>AI が、デッキに棲む</h3>
           <p class="pillar-lead">要約も投稿もリアクションも、<strong>頼める相棒。</strong></p>
           <p>AI チャット専用カラムに加え、ノートメニューから直接 AI アクション。書き込む前には必ず確認してくれるので勝手には動きません。留守の間の定期チェックも。Anthropic / OpenAI / OpenRouter から自由に選べます。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/><line x1="11" y1="8" x2="11" y2="14"/></svg>
-          </div>
-          <h3>中身が、ぜんぶ見える</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="8" y1="11" x2="14" y2="11"/><line x1="11" y1="8" x2="11" y2="14"/></svg></span>中身が、ぜんぶ見える</h3>
           <p class="pillar-lead">Misskey の裏側を、<strong>そのまま観察できる。</strong></p>
           <p>サーバーとのやり取りをリアルタイムで覗けるインスペクタや、ノートの生データ（Raw JSON）ビューを内蔵。機密フィールドは自動マスク。Misskey の仕組みを学ぶ最短ルートです。</p>
         </div>
       </div>
 
-      <h3 class="pillars-subtitle fade-in" data-direction="up">閉じた箱ではなく、開いた箱</h3>
-      <p class="pillars-sublead fade-in" data-direction="up">出荷時の機能で終わらない。使う人の手で広がっていくために。</p>
-      <div class="pillars-grid">
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-          </div>
-          <h3>自分で拡張できる</h3>
+      <h3 class="pillars-subtitle">閉じた箱ではなく、開いた箱</h3>
+      <p class="pillars-sublead">出荷時の機能で終わらない。使う人の手で広がっていくために。</p>
+      <div class="pillars-grid pillars-grid--stack">
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg></span>自分で拡張できる</h3>
           <p class="pillar-lead">新しいコマンドを書けば、<strong>その場でデッキの機能になる。</strong></p>
           <p>AiScript で書いたコマンドは即コマンドパレットに載り、AI のツールとしても使える。翻訳・天気・GitHub など外部のサービスも取り込めます。鍵が要るサービスも安全に登録でき、中身が AI に見られることはありません。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 20h10"/><path d="M10 20c5.5-2.5.8-6.4 3-10"/><path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/><path d="M14.1 6a7 7 0 0 1-1.1 4c1.9-.6 3-1.5 3.6-2.6.6-1.2.6-2.5-.1-4.6-2.1.8-3 1.5-3.5 2.7-.2.5-.4 1.2-.4 1.8 0 0 0 0 0 0z"/></svg>
-          </div>
-          <h3>AI と一緒に育つ</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 20h10"/><path d="M10 20c5.5-2.5.8-6.4 3-10"/><path d="M9.5 9.4c1.1.8 1.8 2.2 2.3 3.7-2 .4-3.5.4-4.8-.3-1.2-.6-2.3-1.9-3-4.2 2.8-.5 4.4 0 5.5.8z"/><path d="M14.1 6a7 7 0 0 1-1.1 4c1.9-.6 3-1.5 3.6-2.6.6-1.2.6-2.5-.1-4.6-2.1.8-3 1.5-3.5 2.7-.2.5-.4 1.2-.4 1.8 0 0 0 0 0 0z"/></svg></span>AI と一緒に育つ</h3>
           <p class="pillar-lead">使うほど、<strong>自分専用の道具に育っていく。</strong></p>
           <p>テーマ・キーバインドから AI 自身のペルソナまで、AI が会話から直接編集。カラム追加やアカウント切替などの UI 操作も代行し、操作した場所は光って見える。覚えたことは次の会話にも引き継がれます。</p>
         </div>
-        <div class="pillar glass fade-in" data-direction="up">
-          <div class="pillar-icon">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-          </div>
-          <h3>外部からも動かせる</h3>
+        <div class="pillar">
+          <h3><span class="pillar-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg></span>外部からも動かせる</h3>
           <p class="pillar-lead">物理ボタンも CLI も AI も、<strong>同じ入口から。</strong></p>
           <p>ローカル API でデッキを丸ごと操作 — 投稿もタイムライン取得もカラム操作も。Raycast・Obsidian・Stream Deck から AI エージェントまで、一度書けばどこからでも呼べます。</p>
         </div>
@@ -320,26 +252,26 @@
   <!-- For developers -->
   <section class="section-default" id="dev">
     <div class="section-inner section-narrow">
-      <h2 class="section-title fade-in" data-direction="up">開発者のみなさんへ</h2>
-      <p class="section-sub fade-in" data-direction="up">NoteDeck はオープンソース (AGPL-3.0)。本家と同じ Vue 3 + TypeScript なので、本家のコードが読める人ならそのまま読めます。</p>
+      <h2 class="section-title">開発者のみなさんへ</h2>
+      <p class="section-sub">NoteDeck はオープンソース (AGPL-3.0)。本家と同じ Vue 3 + TypeScript なので、本家のコードが読める人ならそのまま読めます。</p>
       <div class="arch-grid">
-        <div class="arch-layer glass fade-in" data-direction="left">
+        <div class="arch-layer panel">
           <div class="arch-label">フロントエンド</div>
           <div class="arch-title">Vue 3 + TypeScript</div>
           <div class="arch-desc">Vapor モード移行準備済み。CSS Containment、Frame Scheduler で描画最適化。Pinia による状態管理。</div>
         </div>
-        <div class="arch-arrow fade-in" data-direction="up">
+        <div class="arch-arrow" aria-hidden="true">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
         </div>
-        <div class="arch-layer glass fade-in" data-direction="right">
+        <div class="arch-layer panel">
           <div class="arch-label">Tauri v2 ブリッジ</div>
           <div class="arch-title">Rust — 薄いラッパー</div>
           <div class="arch-desc">グローバルホットキー、システムトレイ、OS キーチェーン、自動アップデート。WebView とプロセス分離でセキュリティを確保。</div>
         </div>
-        <div class="arch-arrow fade-in" data-direction="up">
+        <div class="arch-arrow" aria-hidden="true">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
         </div>
-        <div class="arch-layer arch-core glass fade-in" data-direction="left">
+        <div class="arch-layer arch-core panel">
           <div class="arch-label">コア</div>
           <div class="arch-title">notecli — Rust ヘッドレスクライアント</div>
           <div class="arch-desc">Misskey API + WebSocket ストリーミング + SQLite（FTS5）+ localhost HTTP API。Tauri なしでも単体動作する独立ライブラリ。</div>
@@ -349,8 +281,8 @@
         </div>
       </div>
       <div class="fork-cta-block">
-        <div class="guest-cta glass fade-in" data-direction="up">
-          <div class="guest-cta-icon">
+        <div class="guest-cta panel">
+          <div class="guest-cta-icon" aria-hidden="true">
             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 01-9 9"/></svg>
           </div>
           <div class="guest-cta-text">
@@ -361,7 +293,7 @@
         </div>
       </div>
 
-      <div class="arch-tags arch-doc-links fade-in" data-direction="up">
+      <div class="arch-tags arch-doc-links">
         <a href="https://github.com/notedeck-dev/notedeck/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/notedeck-dev/notedeck/blob/main/DEVELOPMENT.md">Development</a>
         <a href="https://github.com/notedeck-dev/notedeck/blob/main/STRATEGY.md">Strategy</a>
@@ -373,42 +305,42 @@
   <!-- Download -->
   <section class="section-alt" id="download">
     <div class="section-inner section-narrow">
-      <h2 class="section-title fade-in" data-direction="up">ダウンロード</h2>
-      <p class="section-sub fade-in" data-direction="up">お使いの環境に合わせてインストール</p>
+      <h2 class="section-title">ダウンロード</h2>
+      <p class="section-sub">お使いの環境に合わせてインストール</p>
       <p class="version-badge" id="latest-version"></p>
-      <div class="platforms fade-in" data-direction="up">
-        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="windows" class="platform glass">
+      <div class="platforms">
+        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="windows" class="platform panel">
           <svg viewBox="0 0 24 24"><path d="M3 12V6.75l8-1.25V12H3zm0 .5h8v6.5l-8-1.25V12.5zM11.5 5.34l9.5-1.34v8h-9.5V5.34zM11.5 12.5H21v7.5l-9.5-1.34V12.5z"/></svg>
           <div class="os">Windows</div>
           <div class="format">.exe</div>
         </a>
-        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="macos" class="platform glass">
+        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="macos" class="platform panel">
           <svg viewBox="0 0 24 24"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
           <div class="os">macOS</div>
           <div class="format">.dmg (Universal)</div>
         </a>
-        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="linux" class="platform glass">
+        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="linux" class="platform panel">
           <svg viewBox="0 0 24 24"><path d="M12.504 0c-.155 0-.315.008-.48.021-4.226.333-3.105 4.807-3.17 6.298-.076 1.092-.3 1.953-1.05 3.02-.885 1.051-2.127 2.75-2.716 4.521-.278.832-.41 1.684-.287 2.489a.424.424 0 00-.11.135c-.26.268-.45.6-.663.839-.199.199-.485.267-.797.4-.313.136-.658.269-.864.68-.09.189-.136.394-.132.602 0 .199.027.4.055.536.058.399.116.728.04.97-.249.68-.28 1.145-.106 1.484.174.334.535.47.94.601.81.2 1.91.135 2.774.6.926.466 1.866.67 2.616.47.526-.116.97-.464 1.208-.946.587-.003 1.23-.269 2.26-.334.699-.058 1.574.267 2.577.2.025.134.063.198.114.333l.003.003c.391.778 1.113 1.368 1.884 1.43.868.07 1.723-.467 2.395-.722.67-.26 1.203-.394 1.587-.848.192-.227.313-.525.313-.847 0-.233-.063-.466-.194-.661-.12-.18-.255-.394-.32-.608-.065-.225.01-.393.13-.592.18-.275.39-.597.305-1.103-.012-.064-.03-.132-.05-.192.36-.36.59-.833.665-1.284a2.634 2.634 0 00-.04-1.14c-.053-.209-.158-.393-.193-.672a1.905 1.905 0 01.03-.574 3.824 3.824 0 00-.127-1.795c-.283-.717-.754-1.333-1.322-1.868-.283-.263-.588-.508-.898-.727-1.15-.871-2.21-1.778-2.634-3.237-.186-.605-.32-1.22-.47-1.867-.085-.347-.2-.7-.364-1.017a4.152 4.152 0 00-.655-.915c-.876-.97-2.22-1.38-3.559-1.4zm-.01 1.07c1.14.017 2.24.378 2.99 1.22.21.227.39.482.55.78.14.28.24.59.32.9.15.63.28 1.24.47 1.87.48 1.63 1.67 2.63 2.87 3.54.29.21.57.44.83.68.51.48.93 1.03 1.17 1.65.12.31.16.67.13 1.02-.03.37-.09.74.01 1.12.06.36.2.62.27.91.03.12.06.25.06.38 0 .27-.12.5-.26.69a2.725 2.725 0 00-.46.96c-.02.1-.03.2-.03.32 0 .08.01.15.02.22-.13.24-.32.44-.54.73-.12.18-.23.39-.28.64-.05.26-.03.5.02.73.06.21.18.42.31.61.09.13.15.27.18.38a.37.37 0 010 .17c-.02.12-.15.25-.32.39-.16.14-.39.28-.67.42-.57.27-1.3.48-1.82.51-.54.05-1.14-.38-1.42-.74a.8.8 0 01-.1-.2l-.01-.03c-.22-.39-.18-.78-.03-1.27.16-.53-.04-1-.11-1.33a3.384 3.384 0 00-.05-.15c-.11-.38-.3-.74-.62-.94-.33-.2-.69-.2-1.01-.12-.62.17-1.39-.02-2.14-.37-.38-.18-.76-.33-1.16-.41-.4-.08-.84-.1-1.28.05-.22.08-.39.21-.52.37-.13.18-.21.37-.27.56-.12.37-.15.78-.18 1.04-.02.19-.02.37-.06.52-.03.15-.09.24-.16.31a.698.698 0 01-.43.2c-.37.03-1.02-.13-1.73-.38-.35-.13-.56-.21-.7-.29a.458.458 0 01-.16-.15c-.07-.13-.06-.38.18-.89.1-.21.09-.45.04-.67-.05-.23-.13-.43-.19-.62-.12-.4-.17-.65-.12-.8.04-.14.17-.38.54-.6.36-.21.76-.34 1.08-.49.32-.14.6-.3.82-.55.24-.26.4-.54.55-.82.31-.57.46-1.15.45-1.6-.03-.92.16-1.76.47-2.61.54-1.55 1.68-3.13 2.55-4.17.82-1.07 1.16-2.19 1.24-3.3.07-1.28-.01-2.66.47-3.73.24-.54.58-.93 1.07-1.17a2.6 2.6 0 011.48-.33z"/></svg>
           <div class="os">Linux</div>
           <div class="format">.deb / .AppImage</div>
         </a>
-        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="android" class="platform glass">
+        <a href="https://github.com/notedeck-dev/notedeck/releases/latest" data-platform="android" class="platform panel">
           <svg viewBox="0 0 24 24"><path d="M17.523 15.341a.96.96 0 100-1.922.96.96 0 000 1.922zm-11.046 0a.96.96 0 100-1.922.96.96 0 000 1.922zm11.4-6.028l1.996-3.458a.413.413 0 00-.151-.563.413.413 0 00-.563.151l-2.022 3.5A12.22 12.22 0 0012 8.072a12.22 12.22 0 00-5.137.871L4.841 5.443a.413.413 0 00-.563-.151.413.413 0 00-.151.563l1.996 3.458C2.691 11.283.342 14.59 0 18.5h24c-.342-3.91-2.691-7.217-6.123-9.187z"/></svg>
           <div class="os">Android</div>
           <div class="format">.apk</div>
         </a>
-        <a href="#store-distribution" data-platform="googleplay" class="platform platform-soon glass">
+        <a href="#store-distribution" data-platform="googleplay" class="platform platform-soon panel">
           <svg viewBox="0 0 24 24"><path d="M3.609 1.814L13.792 12 3.61 22.186a.996.996 0 01-.61-.92V2.734a1 1 0 01.609-.92zm10.89 10.893l2.302 2.302-10.937 6.333 8.635-8.635zm3.199-3.198l2.807 1.626a1 1 0 010 1.73l-2.808 1.626L15.39 12l2.308-2.491zM5.864 2.658L16.802 8.99l-2.303 2.303-8.635-8.635z"/></svg>
           <div class="os">Google Play</div>
           <div class="format">Coming soon</div>
         </a>
-        <a href="#store-distribution" data-platform="appstore" class="platform platform-soon glass">
+        <a href="#store-distribution" data-platform="appstore" class="platform platform-soon panel">
           <svg viewBox="0 0 24 24"><path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/></svg>
           <div class="os">App Store</div>
           <div class="format">Coming soon</div>
         </a>
       </div>
-      <div class="install-alt glass fade-in" data-direction="up">
+      <div class="install-alt panel">
         <h3>パッケージマネージャー</h3>
         <div class="install-cmd" data-cmd="winget install NotedeckDev.NoteDeck">
           <div class="label">winget</div><code><span class="sh-prompt">$</span> <span class="sh-cmd">winget</span> <span class="sh-sub">install</span> <span class="sh-arg">NotedeckDev.NoteDeck</span></code>
@@ -426,22 +358,16 @@
 
       <!-- Mobile Store Distribution (説明 + CTA) -->
       <div id="store-distribution" class="store-distribution">
-        <h3 class="store-distribution-title fade-in" data-direction="up">スマホ版を、ストアで届けるために</h3>
-        <p class="store-distribution-lead fade-in" data-direction="up">Google Play / App Store への正式配布には、開発者アカウントの登録費とクローズドテストの参加者が必要です。需要があれば、コミュニティの皆さんと一緒に進めたいと思っています。</p>
+        <h3 class="store-distribution-title">スマホ版を、ストアで届けるために</h3>
+        <p class="store-distribution-lead">Google Play / App Store への正式配布には、開発者アカウントの登録費とクローズドテストの参加者が必要です。需要があれば、コミュニティの皆さんと一緒に進めたいと思っています。</p>
         <div class="store-cta-grid">
-          <div class="store-cta glass fade-in" data-direction="up">
-            <div class="store-cta-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg>
-            </div>
-            <h4>ベータテスター募集</h4>
+          <div class="store-cta panel">
+            <h4><span class="store-cta-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="8.5" cy="7" r="4"/><line x1="20" y1="8" x2="20" y2="14"/><line x1="23" y1="11" x2="17" y2="11"/></svg></span>ベータテスター募集</h4>
             <p>Google Play では配布前に最低 12 名・14 日間のクローズドテストが必要です。実機での動作確認やフィードバックにご協力いただける方を募集しています。</p>
             <a href="https://github.com/notedeck-dev/notedeck/issues/new?template=beta_tester.yml" class="btn btn-secondary">テスターに応募</a>
           </div>
-          <div class="store-cta glass fade-in" data-direction="up">
-            <div class="store-cta-icon">
-              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg>
-            </div>
-            <h4>開発を支援する</h4>
+          <div class="store-cta panel">
+            <h4><span class="store-cta-icon" aria-hidden="true"><svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z"/></svg></span>開発を支援する</h4>
             <p>Google Play（登録費 $25）/ Apple Developer Program（$99/年）のアカウント費用、テスト機材の調達、継続的な配布作業の維持にあてさせていただきます。</p>
             <a href="https://github.com/sponsors/hitalin" class="btn btn-primary">GitHub Sponsor</a>
           </div>

--- a/site/main.js
+++ b/site/main.js
@@ -23,18 +23,15 @@
   });
 })();
 
-/* Scroll fade-in */
-const obs = new IntersectionObserver((entries) => {
-  entries.forEach((e) => { if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); } });
-}, { threshold: 0.1 });
-document.querySelectorAll('.fade-in').forEach((el) => obs.observe(el));
-
-/* Fetch screenshot URL from README */
+/* Keep the hero screenshot in sync with the README.
+   index.html already carries the current URL so the LCP paints without waiting
+   on this request; we only swap when the README has actually moved on. */
 fetch('https://raw.githubusercontent.com/notedeck-dev/notedeck/main/README.md')
   .then(r => r.text())
   .then(md => {
     const m = md.match(/<img[^>]+src="(https:\/\/github\.com\/user-attachments\/assets\/[^"]+)"/);
-    if (m) document.getElementById('hero-screenshot').src = m[1];
+    const img = document.getElementById('hero-screenshot');
+    if (m && img && img.src !== m[1]) img.src = m[1];
   })
   .catch(() => {});
 

--- a/site/style.css
+++ b/site/style.css
@@ -1,298 +1,695 @@
-*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+/* Hallmark · NoteDeck landing page
+ * genre: playful surface × modern-minimal restraint
+ * nav: N1b (Misskey Hub-style masked bar, preserved) · footer: Ft2 inline single line
+ * theme: NoteDeck brand · anchor hue: leaf-green 125.6° · enrichment: none
+ * macrostructure: Workbench — the fold shows an assembled deck before the
+ *   install funnel's five decisions (issue #943, factor 2).
+ * motion: hover-tint · press-tick (2 primitives; no reveals, no ambient loops)
+ * authority: DESIGN.md § 装飾アニメは入れない / 150–250ms / ease-out 主体
+ *            BRANDING.md § 煽り・FOMO・誇張は使わない
+ * register: spacious headed panels (pillars) against a dense hairline index
+ *   (capabilities). One left axis for the whole page, fold included.
+ * pre-emit critique: P5 H5 E4 S5 R5 V4
+ */
 
-:root{
-  --accent:#86b300;
-  --accent-dark:#4ab300;
-  --accent-soft:rgba(134,179,0,0.12);
-  --bg:#f7f7f7;
-  --bg-alt:#eee;
-  --surface:rgba(255,255,255,0.5);
-  --surface-hover:rgba(255,255,255,0.7);
-  --text:#222;
-  --text-sub:#3c3c3c;
-  --text-muted:#666;
-  --border:rgba(0,0,0,0.08);
-  --nav-bg:rgba(251,251,251,0.8);
-  --radius:16px;
-  --radius-sm:12px;
-  --radius-pill:999px;
-  --shadow:0 2px 12px rgba(0,0,0,0.06);
-  --blur:blur(12px);
-  --ease:cubic-bezier(.22,1,.36,1);
-  --section-gap:56px;
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* clip, never hidden — hidden creates a scroll container and breaks sticky descendants */
+html, body { overflow-x: clip; }
+
+html { scroll-padding-top: var(--space-3xl); }
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
 }
 
-@media(prefers-color-scheme:dark){
-  :root{
-    --bg:#1a1a1a;
-    --bg-alt:#222;
-    --surface:rgba(255,255,255,0.08);
-    --surface-hover:rgba(255,255,255,0.12);
-    --text:#eee;
-    --text-sub:#e5e5e5;
-    --text-muted:#aaa;
-    --border:rgba(255,255,255,0.08);
-    --nav-bg:rgba(46,46,46,0.8);
-    --shadow:0 2px 12px rgba(0,0,0,0.3);
-  }
-}
-html[style*="color-scheme: dark"]{
-  --bg:#1a1a1a;--bg-alt:#222;
-  --surface:rgba(255,255,255,0.08);--surface-hover:rgba(255,255,255,0.12);
-  --text:#eee;--text-sub:#e5e5e5;--text-muted:#aaa;
-  --border:rgba(255,255,255,0.08);--nav-bg:rgba(46,46,46,0.8);
-  --shadow:0 2px 12px rgba(0,0,0,0.3);
-}
-html[style*="color-scheme: light"]{
-  --bg:#f7f7f7;--bg-alt:#eee;
-  --surface:rgba(255,255,255,0.5);--surface-hover:rgba(255,255,255,0.7);
-  --text:#222;--text-sub:#3c3c3c;--text-muted:#666;
-  --border:rgba(0,0,0,0.08);--nav-bg:rgba(251,251,251,0.8);
-  --shadow:0 2px 12px rgba(0,0,0,0.06);
+body {
+  font-family: var(--font-body);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-md);
+  line-height: var(--lh-body);
+  -webkit-font-smoothing: antialiased;
 }
 
-::selection{background:var(--accent);color:#fff}
-html{scroll-behavior:smooth;scroll-padding-top:80px}
-body{
-  font-family:Nunito,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;
-  background:var(--bg);color:var(--text);
-  line-height:1.75;overflow-x:hidden;
+/* ===== Focus — one ring, everywhere, never animated ===== */
+:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
 }
 
-/* Links */
-a{color:var(--accent);text-decoration:none;
-  background:linear-gradient(var(--accent),var(--accent)) no-repeat left bottom;
-  background-size:0% 2px;padding-bottom:1px;transition:background-size .3s ease;
+::selection { background: var(--accent); color: var(--accent-ink); }
+
+/* ===== Links — no growing-underline animation, no accent-on-paper contrast fail ===== */
+a {
+  color: var(--accent-text);
+  text-decoration: none;
+  transition: color var(--duration-base) var(--ease-out);
 }
-a:hover{background-size:100% 2px}
 
-/* ===== Nav (Misskey Hub style) ===== */
-.nav-root{position:sticky;top:0;left:0;right:0;z-index:9999}
-.nav-main{--nav-height:65px;position:relative;height:var(--nav-height);color:var(--text)}
-@media(max-width:1200px){.nav-main{--nav-height:58px}}
-.nav-bg{
-  position:absolute;top:0;left:0;right:0;height:var(--nav-height);
-  background:var(--nav-bg);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);
-  pointer-events:none;border-bottom:1px solid var(--border);
-  --shapeShift:550px;
-  --mask-r:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100'%3E%3Cpath d='M0,100L0,70L28.834,70C42.386,70 55.384,64.616 64.967,55.033C65.773,54.227 66.579,53.421 67.376,52.624C75.459,44.541 86.422,40 97.853,40L1000,40L1000,100L0,100Z'/%3E%3C/svg%3E");
-  --mask-l:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100'%3E%3Cg transform='matrix(-1,0,0,1,1000,0)'%3E%3Cpath d='M0,100L0,70L28.834,70C42.386,70 55.384,64.616 64.967,55.033C65.773,54.227 66.579,53.421 67.376,52.624C75.459,44.541 86.422,40 97.853,40L1000,40L1000,100L0,100Z'/%3E%3C/g%3E%3C/svg%3E");
-  -webkit-mask-image:linear-gradient(#000,#000),var(--mask-r),var(--mask-l);mask-image:linear-gradient(#000,#000),var(--mask-r),var(--mask-l);
-  -webkit-mask-repeat:no-repeat;mask-repeat:no-repeat;
-  -webkit-mask-position:center center,calc(50dvw + var(--shapeShift)) -5px,calc(50dvw - (1000px + var(--shapeShift))) -5px;
-  mask-position:center center,calc(50dvw + var(--shapeShift)) -5px,calc(50dvw - (1000px + var(--shapeShift))) -5px;
-  -webkit-mask-size:100% 100%,1000px 100px,1000px 100px;mask-size:100% 100%,1000px 100px,1000px 100px;
-  -webkit-mask-composite:xor;mask-composite:exclude;
+a:hover {
+  color: var(--accent-strong);
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
-@media(max-width:1500px){.nav-bg{-webkit-mask-image:none;mask-image:none}}
-.nav-container{position:relative;z-index:1;width:calc(100% - 42px);max-width:1150px;margin:0 auto;height:100%;display:flex;align-items:center;gap:32px}
-@media(max-width:1200px){.nav-container{width:100%;padding:0}}
-.nav-menu-button{display:none;background:none;border:none;cursor:pointer;color:var(--text);height:var(--nav-height);width:var(--nav-height);place-content:center}
-.nav-icon-close{display:none}
-.nav-root.nav-open .nav-icon-menu{display:none}
-.nav-root.nav-open .nav-icon-close{display:block}
-@media(max-width:1200px){.nav-menu-button{display:grid}}
-.nav-sp-spacer{display:none}
-@media(max-width:1200px){.nav-sp-spacer{display:block;width:var(--nav-height);height:var(--nav-height);flex-shrink:0}}
-.nav-brand{display:flex;align-items:center;gap:8px;white-space:nowrap;font-size:110%;padding-right:32px;border-right:1px solid var(--border);background:none;color:var(--text)}
-.nav-brand img{width:24px;height:24px;border-radius:6px}
-.nav-brand b{font-weight:800}
-.nav-brand span{background:linear-gradient(135deg,var(--accent),var(--accent-dark));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
-@media(max-width:1200px){.nav-brand{margin:0 auto;padding-right:0;border-right:none}}
-.nav-items{display:flex;gap:32px;font-size:90%}
-.nav-items a{color:var(--text);background:none;padding:0;font-weight:500;transition:opacity .2s}
-.nav-items a:hover{opacity:.7;background:none}
-@media(max-width:1200px){.nav-items{display:none}}
-.nav-right{margin-left:auto;display:flex;align-items:center;gap:12px}
-.nav-right-button{display:grid;place-content:center;width:40px;height:40px;background:rgba(0,0,0,0.05);border:none;border-radius:999px;color:var(--text);cursor:pointer;transition:background .2s;text-decoration:none}
-.nav-right-button:hover{background:rgba(0,0,0,0.1)}
-@media(prefers-color-scheme:dark){.nav-right-button{background:rgba(255,255,255,0.1)}.nav-right-button:hover{background:rgba(255,255,255,0.18)}}
-html[style*="color-scheme: dark"] .nav-right-button{background:rgba(255,255,255,0.1)}
-html[style*="color-scheme: dark"] .nav-right-button:hover{background:rgba(255,255,255,0.18)}
-html[style*="color-scheme: light"] .nav-right-button{background:rgba(0,0,0,0.05)}
-html[style*="color-scheme: light"] .nav-right-button:hover{background:rgba(0,0,0,0.1)}
-@media(max-width:1200px){.nav-right{display:none}}
-[data-color-mode="system"] .icon-sun,[data-color-mode="system"] .icon-moon{display:none}
-[data-color-mode="light"] .icon-moon,[data-color-mode="light"] .icon-system{display:none}
-[data-color-mode="dark"] .icon-sun,[data-color-mode="dark"] .icon-system{display:none}
-.nav-mobile-drawer{display:none;position:fixed;top:58px;left:0;width:100%;background:var(--nav-bg);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);border-bottom:1px solid var(--border)}
-.nav-root.nav-open .nav-mobile-drawer{display:block}
-@media(min-width:1201px){.nav-mobile-drawer{display:none !important}}
-.nav-mobile-item{display:flex;align-items:center;gap:8px;padding:12px 16px;color:var(--text);font-size:90%;background:none}
-.nav-mobile-item:not(:last-child){border-bottom:1px solid var(--border)}
-.nav-mobile-item:hover{background:var(--surface);background-size:auto}
 
-/* ===== Blobs ===== */
-.blob{position:fixed;border-radius:50%;pointer-events:none;z-index:-1}
-.blob-1{width:800px;height:800px;background:radial-gradient(circle,rgba(134,179,0,0.12),transparent 70%);top:-200px;right:-250px;animation:blobFloat 20s ease-in-out infinite alternate,blobPulse 6s ease-in-out infinite}
-.blob-2{width:700px;height:700px;background:radial-gradient(circle,rgba(74,179,0,0.08),transparent 70%);bottom:-100px;left:-250px;animation:blobFloat 25s ease-in-out infinite alternate-reverse,blobPulse 8s ease-in-out infinite 2s}
-@keyframes blobFloat{0%{transform:translate(0,0) scale(1)}100%{transform:translate(40px,-30px) scale(1.1)}}
-@keyframes blobPulse{0%,100%{opacity:.4}50%{opacity:.7}}
+/* ===== Nav (Misskey Hub style — preserved chrome) ===== */
+.nav-root { position: sticky; top: 0; left: 0; right: 0; z-index: var(--z-sticky); }
+.nav-main { --nav-height: 65px; position: relative; height: var(--nav-height); color: var(--text); }
+@media (max-width: 1200px) { .nav-main { --nav-height: 58px; } }
 
-/* ===== Hero ===== */
-.hero{display:flex;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:5rem 1.5rem 2rem;gap:1.5rem}
-.hero>*{opacity:0;transform:translateY(16px);animation:fadeUp .7s var(--ease) forwards}
-.hero>*:nth-child(1){animation-delay:0s}
-.hero>*:nth-child(2){animation-delay:.1s}
-.hero>*:nth-child(3){animation-delay:.2s}
-.hero>*:nth-child(4){animation-delay:.3s}
-@keyframes fadeUp{to{opacity:1;transform:translateY(0)}}
-@media(prefers-reduced-motion:reduce){.blob,.hero h1 .hero-logo{animation:none}}
-.hero h1{display:flex;align-items:center;justify-content:center;gap:.6rem;font-size:clamp(2.5rem,6vw,4rem);font-weight:800;letter-spacing:-0.02em}
-.hero h1 .hero-logo{width:1em;height:1em;border-radius:22%;transform-origin:center;will-change:transform,filter;animation:heroHeartbeat 1.4s cubic-bezier(.4,0,.2,1) infinite,heroHeartglow 1.4s cubic-bezier(.4,0,.2,1) infinite}
-@keyframes heroHeartbeat{0%,55%,100%{transform:scale(1)}10%{transform:scale(1.18)}22%{transform:scale(1)}32%{transform:scale(1.1)}44%{transform:scale(1)}}
-@keyframes heroHeartglow{0%,55%,100%{filter:none}10%,32%{filter:drop-shadow(0 0 14px rgba(134,179,0,0.6))}}
-.hero h1 .hero-wordmark span{background:linear-gradient(135deg,var(--accent),var(--accent-dark));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text}
-.hero .tagline{font-size:clamp(1.15rem,3vw,1.5rem);font-weight:700;color:var(--text-sub);max-width:540px}
-.hero .hero-lead{font-size:clamp(.9rem,2vw,1rem);color:var(--text-muted);max-width:560px;margin-top:-.5rem}
+.nav-bg {
+  position: absolute; top: 0; left: 0; right: 0; height: var(--nav-height);
+  background: var(--nav-bg);
+  backdrop-filter: var(--blur); -webkit-backdrop-filter: var(--blur);
+  pointer-events: none;
+  border-bottom: 1px solid var(--border);
+  --shapeShift: 550px;
+  --mask-r: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100'%3E%3Cpath d='M0,100L0,70L28.834,70C42.386,70 55.384,64.616 64.967,55.033C65.773,54.227 66.579,53.421 67.376,52.624C75.459,44.541 86.422,40 97.853,40L1000,40L1000,100L0,100Z'/%3E%3C/svg%3E");
+  --mask-l: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1000 100'%3E%3Cg transform='matrix(-1,0,0,1,1000,0)'%3E%3Cpath d='M0,100L0,70L28.834,70C42.386,70 55.384,64.616 64.967,55.033C65.773,54.227 66.579,53.421 67.376,52.624C75.459,44.541 86.422,40 97.853,40L1000,40L1000,100L0,100Z'/%3E%3C/g%3E%3C/svg%3E");
+  -webkit-mask-image: linear-gradient(#000, #000), var(--mask-r), var(--mask-l);
+  mask-image: linear-gradient(#000, #000), var(--mask-r), var(--mask-l);
+  -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat;
+  -webkit-mask-position: center center, calc(50dvw + var(--shapeShift)) -5px, calc(50dvw - (1000px + var(--shapeShift))) -5px;
+  mask-position: center center, calc(50dvw + var(--shapeShift)) -5px, calc(50dvw - (1000px + var(--shapeShift))) -5px;
+  -webkit-mask-size: 100% 100%, 1000px 100px, 1000px 100px;
+  mask-size: 100% 100%, 1000px 100px, 1000px 100px;
+  -webkit-mask-composite: xor; mask-composite: exclude;
+}
+@media (max-width: 1500px) { .nav-bg { -webkit-mask-image: none; mask-image: none; } }
+
+.nav-container {
+  position: relative; z-index: var(--z-base);
+  width: 100%; max-width: var(--content-width);
+  padding-inline: var(--space-lg);
+  margin: 0 auto; height: 100%;
+  display: flex; align-items: center; gap: var(--space-2lg);
+}
+@media (max-width: 1200px) { .nav-container { padding-inline: 0; } }
+
+.nav-menu-button {
+  display: none; background: none; border: none; cursor: pointer; color: var(--text);
+  height: var(--nav-height); width: var(--nav-height); place-content: center;
+}
+.nav-icon-close { display: none; }
+.nav-root.nav-open .nav-icon-menu { display: none; }
+.nav-root.nav-open .nav-icon-close { display: block; }
+@media (max-width: 1200px) { .nav-menu-button { display: grid; } }
+
+.nav-sp-spacer { display: none; }
+@media (max-width: 1200px) {
+  .nav-sp-spacer { display: block; width: var(--nav-height); height: var(--nav-height); flex-shrink: 0; }
+}
+
+.nav-brand {
+  display: flex; align-items: center; gap: var(--space-xs);
+  white-space: nowrap; font-size: var(--text-lg);
+  padding-right: var(--space-2lg);
+  border-right: 1px solid var(--border);
+  background: none; color: var(--text); text-decoration: none;
+}
+.nav-brand:hover { color: var(--text); text-decoration: none; }
+.nav-brand img { width: 24px; height: 24px; border-radius: var(--radius-2xs); }
+.nav-brand b { font-weight: 800; }
+/* solid, not a background-clip gradient */
+.nav-brand span { color: var(--accent-text); }
+@media (max-width: 1200px) { .nav-brand { margin: 0 auto; padding-right: 0; border-right: none; } }
+
+.nav-items { display: flex; gap: var(--space-2lg); font-size: var(--text-sm); }
+.nav-items a {
+  color: var(--text); font-weight: 600; text-decoration: none;
+  padding-block: var(--space-xs);
+  transition: color var(--duration-base) var(--ease-out);
+}
+.nav-items a:hover { color: var(--accent-text); text-decoration: none; }
+@media (max-width: 1200px) { .nav-items { display: none; } }
+
+.nav-right { margin-left: auto; display: flex; align-items: center; gap: var(--space-sm); }
+@media (max-width: 1200px) { .nav-right { display: none; } }
+
+.nav-right-button {
+  display: grid; place-content: center;
+  width: 40px; height: 40px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-pill); color: var(--text);
+  cursor: pointer; text-decoration: none;
+  transition: background var(--duration-base) var(--ease-out);
+}
+.nav-right-button:hover { background: var(--surface-hover); color: var(--text); text-decoration: none; }
+.nav-right-button:active { transform: translateY(1px); }
+
+[data-color-mode="system"] .icon-sun,
+[data-color-mode="system"] .icon-moon { display: none; }
+[data-color-mode="light"] .icon-moon,
+[data-color-mode="light"] .icon-system { display: none; }
+[data-color-mode="dark"] .icon-sun,
+[data-color-mode="dark"] .icon-system { display: none; }
+
+.nav-mobile-drawer {
+  display: none; position: fixed; top: 58px; left: 0; width: 100%;
+  z-index: var(--z-dropdown);
+  background: var(--nav-bg);
+  backdrop-filter: var(--blur); -webkit-backdrop-filter: var(--blur);
+  border-bottom: 1px solid var(--border);
+}
+.nav-root.nav-open .nav-mobile-drawer { display: block; }
+@media (min-width: 1201px) { .nav-mobile-drawer { display: none !important; } }
+
+.nav-mobile-item {
+  display: flex; align-items: center; gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  color: var(--text); font-size: var(--text-sm); font-weight: 600;
+  text-decoration: none; background: none;
+  transition: background var(--duration-base) var(--ease-out);
+}
+.nav-mobile-item:not(:last-child) { border-bottom: 1px solid var(--border); }
+.nav-mobile-item:hover { background: var(--surface-hover); color: var(--text); text-decoration: none; }
+
+/* ===== The fold =====
+ * Macrostructure: Workbench. #943 factor 2 — the product's differentiator is
+ * invisible until the user has assembled a deck, and the install funnel costs
+ * five decisions. This is the only surface that can show an assembled deck
+ * first, so the fold leads with the deck, not with a logotype splash.
+ * One left axis, shared with every section below it.
+ */
+.fold {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg) var(--space-3xl);
+}
+
+.fold-copy {
+  max-width: 46ch;
+  margin-bottom: var(--space-lg);
+}
+
+.fold-copy h1 {
+  display: flex; align-items: center; gap: var(--space-sm);
+  font-size: var(--text-display);
+  font-weight: 800;
+  line-height: var(--lh-tight);
+  letter-spacing: -0.02em;
+  min-width: 0; overflow-wrap: anywhere;
+}
+.fold-copy h1 .hero-logo { width: 1em; height: 1em; border-radius: 22%; flex-shrink: 0; }
+/* solid, not a background-clip gradient */
+.fold-copy h1 .hero-wordmark span { color: var(--accent-text); }
+
+.fold-copy .tagline {
+  margin-top: var(--space-xs);
+  font-size: var(--text-xl); font-weight: 700;
+  color: var(--text-sub); line-height: var(--lh-tight);
+}
+.fold-copy .hero-lead {
+  margin-top: var(--space-2xs);
+  font-size: var(--text-md); color: var(--text-muted);
+}
+.fold-copy .btn { margin-top: var(--space-md); }
+
+/* The deck itself — full width of the column, tight under the copy. */
+.fold-shot {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-xs);
+}
+.fold-shot img {
+  display: block; width: 100%; height: auto;
+  border-radius: var(--radius-sm);
+  background: var(--bg-alt);
+  aspect-ratio: 1194 / 793;   /* reserve the box so the fold doesn't jump */
+  object-fit: cover; object-position: top center;
+}
+
+@media (max-width: 800px) {
+  .fold { padding: var(--space-xl) var(--space-md) var(--space-2xl); }
+}
 
 /* ===== Buttons ===== */
-.btn{display:inline-flex;align-items:center;gap:.5rem;padding:.65rem 1.5rem;border-radius:var(--radius-pill);font-size:.95rem;font-weight:700;text-decoration:none;font-family:inherit;transition:all .25s var(--ease);background-image:none;background-size:auto}
-.btn-primary{background:linear-gradient(135deg,var(--accent),var(--accent-dark));background-size:200% 100%;color:#fff;box-shadow:0 2px 12px rgba(134,179,0,0.3)}
-.btn-primary:hover{background-position:100% 0;box-shadow:0 6px 24px rgba(134,179,0,0.4);transform:translateY(-3px)}
-.btn-secondary{background:var(--surface);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);color:var(--text);border:1px solid var(--border)}
-.btn-secondary:hover{background:var(--surface-hover);transform:translateY(-3px);box-shadow:var(--shadow)}
+.btn {
+  display: inline-flex; align-items: center; gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-lg);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-sm); font-weight: 700;
+  font-family: inherit; text-decoration: none;
+  white-space: nowrap;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background-color var(--duration-base) var(--ease-out),
+              color var(--duration-base) var(--ease-out);
+}
+.btn:hover { text-decoration: none; }
+.btn:active { transform: translateY(1px); }
 
-/* ===== Screenshot ===== */
-.screenshot{max-width:1000px;width:100%;padding:0 1.5rem;margin:0 auto}
-.screenshot-wrapper{padding:1rem;transition:all .25s var(--ease)}
-.screenshot-wrapper:hover{transform:scale(1.01)}
-.screenshot img{width:100%;border-radius:var(--radius-sm);border:1px solid var(--border);box-shadow:var(--shadow)}
+/* solid fill, dark ink — white on the lime was 2.5:1 */
+.btn-primary { background: var(--accent); color: var(--accent-ink); }
+.btn-primary:hover { background: var(--accent-strong); color: var(--accent-ink); }
 
-/* ===== Glass ===== */
-.glass{background:var(--surface);backdrop-filter:var(--blur);-webkit-backdrop-filter:var(--blur);border:1px solid var(--border);border-radius:var(--radius);transition:all .25s var(--ease)}
-.glass:hover{background:var(--surface-hover);transform:translateY(-3px);box-shadow:var(--shadow)}
+.btn-secondary { background: var(--surface); color: var(--text); border-color: var(--border-strong); }
+.btn-secondary:hover { background: var(--surface-hover); color: var(--text); }
 
-/* ===== Section system (MH style alternating bg) ===== */
-.section-default{background:var(--bg)}
-.section-alt{background:var(--bg-alt)}
-.section-inner{max-width:1150px;width:calc(100% - 64px);margin:0 auto;padding:var(--section-gap) 0}
-.section-narrow{max-width:900px}
-@media(max-width:1200px){.section-inner{width:calc(100% - 32px)}}
-.section-title{text-align:center;font-size:1.75rem;font-weight:800;margin-bottom:1rem}
-.section-sub{text-align:center;color:var(--text-muted);font-size:.95rem;margin-bottom:1.5rem}
+/* ===== The panel =====
+ * One enclosed surface with an optional header strip. This is the shared unit
+ * of both reference registers — VS Code's pane and Misskey's MkContainer /
+ * MkFolder. Solid fill, generous radius, hairline seam, no blur, no lift.
+ */
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color var(--duration-base) var(--ease-out);
+}
 
-/* ===== Pillars ===== */
-.pillars-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:1.5rem}
-@media(max-width:800px){.pillars-grid{grid-template-columns:1fr}}
-.pillars-subtitle{text-align:center;font-size:1.35rem;font-weight:800;margin-top:3rem;margin-bottom:.5rem}
-.pillars-sublead{text-align:center;color:var(--text-muted);font-size:.95rem;margin-bottom:1.5rem}
-.pillar{padding:2rem 1.75rem;text-align:center}
-.pillar:hover{transform:translateY(-5px)}
-.pillar-icon{display:inline-flex;align-items:center;justify-content:center;width:60px;height:60px;border-radius:16px;background:linear-gradient(135deg,rgba(134,179,0,0.15),rgba(74,179,0,0.1));color:var(--accent);margin-bottom:1rem}
-.pillar h3{font-size:1.2rem;font-weight:800;margin-bottom:.5rem}
-.pillar .pillar-lead{font-size:1rem;font-weight:700;margin-bottom:.5rem;color:var(--text)}
-.pillar p{color:var(--text-muted);font-size:.9rem;line-height:1.7}
+/* The header strip: accent icon, bold label, seam underneath. */
+.panel-head {
+  display: flex; align-items: center; gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--panel-head);
+  border-bottom: 1px solid var(--border);
+  font-weight: 800; line-height: 1.4;
+  min-width: 0; overflow-wrap: anywhere;
+}
 
-/* ===== Guest CTA ===== */
-.guest-cta{display:flex;align-items:center;gap:1.5rem;padding:1.5rem 2rem}
-.guest-cta-icon{display:flex;align-items:center;justify-content:center;flex-shrink:0;width:52px;height:52px;border-radius:14px;background:linear-gradient(135deg,rgba(134,179,0,0.15),rgba(74,179,0,0.1));color:var(--accent)}
-.guest-cta-text{flex:1}
-.guest-cta-text h3{font-size:1rem;font-weight:800;margin:0 0 .25rem}
-.guest-cta-text p{color:var(--text-muted);font-size:.9rem;line-height:1.6;margin:0}
-.guest-cta .btn{flex-shrink:0;white-space:nowrap}
-.fork-cta-block{margin-top:3rem;padding-top:2.5rem;border-top:1px dashed var(--border)}
-@media(max-width:640px){.guest-cta{flex-direction:column;text-align:center}.guest-cta .btn{align-self:center}}
+/* ===== Section system ===== */
+.section-default { background: var(--bg); }
+.section-alt { background: var(--bg-alt); }
+.section-inner {
+  max-width: var(--content-width); width: 100%;
+  padding: var(--space-3xl) var(--space-lg);
+  margin: 0 auto;
+}
+.section-narrow { max-width: 860px; }
+/* the bands are not evenly padded — the alt bands run tighter */
+.section-alt > .section-inner { padding-block: var(--space-2xl); }
+@media (max-width: 800px) {
+  .section-inner { padding: var(--space-2xl) var(--space-md); }
+  .section-alt > .section-inner { padding-block: var(--space-xl); }
+}
 
-/* ===== Store CTA (mobile distribution) ===== */
-.store-cta-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:1.5rem;margin-top:1.5rem}
-@media(max-width:800px){.store-cta-grid{grid-template-columns:1fr}}
-.store-cta{padding:2rem 1.75rem;text-align:center;display:flex;flex-direction:column;align-items:center}
-.store-cta h4{font-size:1.1rem;font-weight:800;margin-bottom:.5rem}
-.store-distribution{margin-top:3rem;padding-top:2.5rem;border-top:1px dashed var(--border)}
-.store-distribution-title{font-size:1.4rem;font-weight:800;text-align:center;margin-bottom:.5rem}
-.store-distribution-lead{color:var(--text-muted);text-align:center;font-size:.95rem;line-height:1.7;max-width:700px;margin:0 auto}
-.store-cta:hover{transform:translateY(-5px)}
-.store-cta-icon{display:inline-flex;align-items:center;justify-content:center;width:60px;height:60px;border-radius:16px;background:linear-gradient(135deg,rgba(134,179,0,0.15),rgba(74,179,0,0.1));color:var(--accent);margin-bottom:1rem}
-.store-cta h3{font-size:1.2rem;font-weight:800;margin-bottom:.5rem}
-.store-cta p{color:var(--text-muted);font-size:.9rem;line-height:1.7;margin-bottom:1.25rem;flex:1}
+/* Section heads stack in one column — accent marker above, never beside */
+.section-title::before {
+  content: ""; display: block;
+  width: 2rem; height: 3px;
+  background: var(--accent);
+  border-radius: var(--radius-pill);
+  margin-bottom: var(--space-sm);
+}
+.section-title {
+  font-size: var(--text-3xl); font-weight: 800;
+  line-height: var(--lh-tight); letter-spacing: -0.02em;
+  margin-bottom: var(--space-sm);
+  min-width: 0; overflow-wrap: anywhere;
+}
+.section-sub {
+  color: var(--text-muted); font-size: var(--text-sm);
+  max-width: 60ch; margin-bottom: var(--space-xl);
+}
+.section-title + .pillars-grid,
+.section-title + .features-grid { margin-top: var(--space-xl); }
 
-/* ===== Highlight rows (alternating left/right) ===== */
-.highlight-row{margin-bottom:2rem}
-.highlight-row:last-child{margin-bottom:0}
-.highlight-text{max-width:720px;padding:2rem;border-radius:var(--radius)}
-.highlight-row:nth-child(odd) .highlight-text{margin-right:auto}
-.highlight-row:nth-child(even) .highlight-text{margin-left:auto}
-.highlight-badge{display:inline-block;font-size:.75rem;font-weight:700;color:var(--accent);background:var(--accent-soft);padding:.2em .7em;border-radius:var(--radius-pill);margin-bottom:.75rem;letter-spacing:.03em}
-.highlight-text h3{font-size:1.3rem;font-weight:800;margin-bottom:.6rem}
-.highlight-text p{color:var(--text-muted);font-size:.92rem;line-height:1.8;margin-bottom:.75rem}
-.highlight-text p a{font-weight:700}
-.highlight-list{list-style:none;padding:0;margin:.75rem 0 0;display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:.5rem}
-.highlight-list li{font-size:.85rem;color:var(--text-sub);padding-left:1.3em;position:relative}
-.highlight-list li::before{content:"";position:absolute;left:0;top:.55em;width:8px;height:8px;border-radius:50%;background:var(--accent);opacity:.5}
+/* ===== Pillars — headed panels =====
+ * The <h3> IS the panel header strip; the paragraphs are the panel body. Three
+ * instances of this pattern exist on the page and they do not share a grid
+ * shape — a repeated 3-up icon-tile grid is the AI feature-grid tell.
+ */
+.pillars-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr) minmax(0, 1fr);
+  gap: var(--space-md);
+}
 
-/* ===== Feature grid (MH style) ===== */
-.features-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:16px}
-.feature-card{padding:1.5rem;display:flex;flex-direction:column;gap:.5rem}
-.feature-card:hover{transform:translateY(-4px)}
-.feature-card-icon{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:12px;background:var(--accent-soft);color:var(--accent);margin-bottom:.25rem}
-.feature-card h4{font-size:.95rem;font-weight:800}
-.feature-card p{color:var(--text-muted);font-size:.85rem;line-height:1.7}
-.feature-card p a{font-weight:700}
+.pillar {
+  display: flex; flex-direction: column;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  transition: border-color var(--duration-base) var(--ease-out);
+}
+.pillar:hover { border-color: var(--border-strong); }
+
+.pillar h3 {
+  display: flex; align-items: center; gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--panel-head);
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-lg); font-weight: 800;
+  line-height: 1.4;
+  min-width: 0; overflow-wrap: anywhere;
+}
+.pillar > p { padding-inline: var(--space-md); line-height: var(--lh-panel); }
+.pillar > p:first-of-type { padding-top: var(--space-md); }
+.pillar > p:last-of-type { padding-bottom: var(--space-md); }
+.pillar .pillar-lead {
+  font-size: var(--text-md); font-weight: 700;
+  color: var(--text); margin-bottom: var(--space-xs);
+}
+.pillar p { color: var(--text-muted); font-size: var(--text-sm); }
+
+.pillar-icon {
+  display: inline-flex; align-items: center; flex-shrink: 0;
+  color: var(--accent-text);
+}
+.pillar-icon svg { width: 1.15rem; height: 1.15rem; }
+
+/* Stacked variant — one full-width panel per row.
+ * The header strip spans the panel, and the body splits lead | detail so the
+ * text keeps a readable measure instead of running 100ch across the column.
+ */
+.pillars-grid--stack { grid-template-columns: minmax(0, 1fr); gap: var(--space-xs); }
+.pillars-grid--stack .pillar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.55fr);
+  align-content: start;
+}
+.pillars-grid--stack .pillar h3 { grid-column: 1 / -1; }
+.pillars-grid--stack .pillar > p { padding-block: var(--space-md); }
+.pillars-grid--stack .pillar > p:first-of-type { grid-column: 1; padding-right: var(--space-lg); margin-bottom: 0; }
+.pillars-grid--stack .pillar > p:last-of-type { grid-column: 2; }
+
+.pillars-subtitle {
+  min-width: 0; overflow-wrap: anywhere;
+  font-size: var(--text-2xl); font-weight: 800;
+  line-height: var(--lh-tight);
+  margin-top: var(--space-3xl); margin-bottom: var(--space-2xs);
+}
+.pillars-sublead {
+  color: var(--text-muted); font-size: var(--text-sm);
+  max-width: 60ch; margin-bottom: var(--space-xl);
+}
+
+@media (max-width: 900px) {
+  .pillars-grid { grid-template-columns: minmax(0, 1fr); }
+  .pillars-grid--stack .pillar { grid-template-columns: minmax(0, 1fr); }
+  .pillars-grid--stack .pillar h3 { grid-column: auto; }
+  .pillars-grid--stack .pillar > p { grid-column: auto; padding-block: 0; }
+  .pillars-grid--stack .pillar > p:first-of-type { padding-right: var(--space-md); padding-top: var(--space-md); margin-bottom: var(--space-xs); }
+  .pillars-grid--stack .pillar > p:last-of-type { padding-bottom: var(--space-md); }
+}
+
+/* ===== Inline CTA blocks ===== */
+.guest-cta {
+  display: flex; align-items: center; gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+}
+.guest-cta-icon {
+  display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+  color: var(--accent-text);
+}
+.guest-cta-text { flex: 1; min-width: 0; }
+.guest-cta-text h3 {
+  min-width: 0; overflow-wrap: anywhere;
+  font-size: var(--text-lg); font-weight: 800;
+  line-height: var(--lh-tight); margin-bottom: var(--space-3xs);
+}
+.guest-cta-text p { color: var(--text-muted); font-size: var(--text-sm); }
+.guest-cta .btn { flex-shrink: 0; }
+.fork-cta-block { margin-top: var(--space-2xl); }
+@media (max-width: 640px) {
+  .guest-cta { flex-direction: column; align-items: flex-start; }
+}
+
+/* ===== Guest account =====
+ * A can / cannot pair, not a CTA. #943 factor 2 says the install funnel costs
+ * five decisions against 本家's "open a URL" — naming what guest mode does and
+ * does not do is the cheapest way to lower that cost honestly.
+ */
+.guest-panel-body {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+  padding: var(--space-md);
+}
+.guest-col { min-width: 0; }
+.guest-col-title {
+  font-size: var(--text-xs); font-weight: 800;
+  color: var(--text); margin-bottom: var(--space-xs);
+}
+.guest-panel-icon { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--accent-text); }
+.guest-panel-icon svg { width: 1.15rem; height: 1.15rem; }
+
+.guest-list { list-style: none; display: grid; gap: var(--space-2xs); }
+.guest-list li {
+  position: relative; padding-left: 1.5em;
+  font-size: var(--text-xs); color: var(--text-sub);
+  line-height: var(--lh-panel);
+}
+/* state is never carried by colour alone — the two markers differ in shape */
+.guest-list li::before {
+  content: ""; position: absolute; left: 0.15em; top: 0.62em;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--accent);
+}
+.guest-list-no li { color: var(--text-muted); }
+.guest-list-no li::before {
+  top: 0.86em; width: 8px; height: 2px; border-radius: 0;
+  background: var(--text-muted);
+}
+
+.guest-panel-foot {
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid var(--border);
+  background: var(--panel-head);
+  font-size: var(--text-2xs); color: var(--text-muted);
+  line-height: var(--lh-panel);
+}
+
+@media (max-width: 640px) {
+  .guest-panel-body { grid-template-columns: minmax(0, 1fr); gap: var(--space-md); }
+}
+
+/* ===== Store distribution ===== */
+.store-cta-grid {
+  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg); margin-top: var(--space-lg);
+}
+@media (max-width: 800px) { .store-cta-grid { grid-template-columns: minmax(0, 1fr); } }
+.store-cta { display: flex; flex-direction: column; align-items: flex-start; }
+.store-cta-icon { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--accent-text); }
+.store-cta-icon svg { width: 1.15rem; height: 1.15rem; }
+.store-cta h4 {
+  display: flex; align-items: center; gap: var(--space-xs);
+  align-self: stretch;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--panel-head);
+  border-bottom: 1px solid var(--border);
+  min-width: 0; overflow-wrap: anywhere;
+  font-size: var(--text-lg); font-weight: 800; line-height: 1.4;
+}
+.store-cta p {
+  color: var(--text-muted); font-size: var(--text-sm);
+  line-height: var(--lh-panel);
+  padding: var(--space-md) var(--space-md) 0;
+  margin-bottom: var(--space-md); flex: 1;
+}
+.store-cta .btn { margin: 0 var(--space-md) var(--space-md); }
+.store-distribution { margin-top: var(--space-2xl); padding-top: var(--space-xl); border-top: 1px solid var(--border); }
+.store-distribution-title { min-width: 0; overflow-wrap: anywhere; font-size: var(--text-2xl); font-weight: 800; line-height: var(--lh-tight); margin-bottom: var(--space-2xs); }
+.store-distribution-lead { color: var(--text-muted); font-size: var(--text-sm); max-width: 62ch; }
+
+/* ===== Highlight rows ===== */
+.highlight-row { margin-bottom: var(--space-lg); }
+.highlight-row:last-child { margin-bottom: 0; }
+.highlight-text { max-width: 780px; padding: var(--space-lg); }
+.highlight-row:nth-child(even) .highlight-text { margin-left: auto; }
+
+.highlight-badge {
+  display: inline-block; font-size: var(--text-2xs); font-weight: 700;
+  color: var(--accent-ink); background: var(--accent);
+  padding: 0.2em 0.7em; border-radius: var(--radius-pill);
+  margin-bottom: var(--space-sm); letter-spacing: 0.03em;
+}
+.highlight-text h3 {
+  font-size: var(--text-xl); font-weight: 800;
+  line-height: var(--lh-tight); margin-bottom: var(--space-xs);
+  min-width: 0; overflow-wrap: anywhere;
+}
+.highlight-text p { color: var(--text-muted); font-size: var(--text-sm); line-height: var(--lh-panel); margin-bottom: var(--space-sm); }
+.highlight-list {
+  list-style: none; margin-top: var(--space-sm);
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+  gap: var(--space-2xs) var(--space-md);
+}
+.highlight-list li {
+  font-size: var(--text-xs); color: var(--text-sub);
+  padding-left: 1.3em; position: relative;
+}
+.highlight-list li::before {
+  content: ""; position: absolute; left: 0; top: 0.72em;
+  width: 6px; height: 6px; border-radius: 50%; background: var(--accent);
+}
+
+/* ===== Capability index =====
+ * Deliberately NOT panels. The three pillar groups above are the spacious
+ * register; this is the dense one. Nine equal panels would have made a fifth
+ * identical grid — the thing that made the page read as one flat shape.
+ */
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(340px, 100%), 1fr));
+  gap: 0 var(--space-2xl);
+  border-top: 1px solid var(--border);
+}
+.feature-card {
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border);
+}
+.feature-card h4 {
+  display: flex; align-items: baseline; gap: var(--space-xs);
+  font-size: var(--text-sm); font-weight: 800; line-height: 1.5;
+  min-width: 0; overflow-wrap: anywhere;
+}
+.feature-card p {
+  margin-top: var(--space-3xs);
+  color: var(--text-muted); font-size: var(--text-xs);
+  line-height: var(--lh-panel);
+}
+.feature-card-icon { display: inline-flex; align-items: center; flex-shrink: 0; color: var(--accent-text); }
+.feature-card-icon svg { width: 0.9rem; height: 0.9rem; }
 
 /* ===== Architecture ===== */
-.arch-grid{display:flex;flex-direction:column;align-items:center;gap:0}
-.arch-layer{width:100%;padding:1.5rem 1.75rem;text-align:center}
-.arch-layer:hover{transform:translateY(-3px)}
-.arch-core{border:2px solid var(--accent);background:rgba(134,179,0,0.06)}
-.arch-label{font-size:.7rem;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.1em;margin-bottom:.3rem}
-.arch-title{font-size:1.05rem;font-weight:800;margin-bottom:.4rem}
-.arch-desc{color:var(--text-muted);font-size:.85rem;line-height:1.7}
-.arch-tags{display:flex;gap:.5rem;justify-content:center;flex-wrap:wrap;margin-top:.75rem}
-.arch-tags span{font-size:.7rem;font-weight:700;color:var(--text-muted);background:var(--surface);border:1px solid var(--border);padding:.15em .6em;border-radius:var(--radius-pill)}
-.arch-tags a{font-size:.8rem;font-weight:700;color:var(--accent);background:var(--surface);background-image:none;border:1px solid var(--border);padding:.25em .9em;border-radius:var(--radius-pill);transition:all .2s var(--ease)}
-.arch-tags a:hover{border-color:var(--accent);background:var(--accent-soft)}
-.arch-doc-links{margin-top:1.25rem}
-.arch-arrow{display:flex;justify-content:center;padding:.25rem 0}
+.arch-grid { display: flex; flex-direction: column; gap: 0; }
+.arch-layer { padding: var(--space-md) var(--space-lg); }
+/* the core layer is the one that matters — mark it with the accent, not a stripe */
+.arch-core { border-color: var(--accent); box-shadow: inset 0 0 0 1px var(--accent); }
+.arch-label {
+  font-size: var(--text-2xs); font-weight: 700; color: var(--accent-text);
+  text-transform: uppercase; letter-spacing: 0.1em; line-height: 1.4;
+  margin-bottom: var(--space-3xs);
+}
+.arch-title { min-width: 0; overflow-wrap: anywhere; font-size: var(--text-lg); font-weight: 800; line-height: var(--lh-tight); margin-bottom: var(--space-2xs); }
+.arch-desc { color: var(--text-muted); font-size: var(--text-sm); line-height: var(--lh-panel); }
+.arch-tags { display: flex; gap: var(--space-xs); flex-wrap: wrap; margin-top: var(--space-sm); }
+.arch-tags span {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs); font-weight: 700; color: var(--text-sub);
+  background: var(--code-bg); border: 1px solid var(--border);
+  padding: 0.2em 0.65em; border-radius: var(--radius-2xs);
+}
+.arch-tags a {
+  font-size: var(--text-xs); font-weight: 700; color: var(--accent-text);
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 0.3em 0.9em; border-radius: var(--radius-pill); white-space: nowrap;
+  transition: border-color var(--duration-base) var(--ease-out),
+              color var(--duration-base) var(--ease-out);
+}
+.arch-tags a:hover { border-color: var(--accent); color: var(--accent-strong); text-decoration: none; }
+.arch-doc-links { margin-top: var(--space-lg); }
+.arch-arrow { display: flex; justify-content: center; padding: var(--space-2xs) 0; color: var(--text-muted); }
 
 /* ===== Download ===== */
-.version-badge{display:block;width:fit-content;margin:0 auto 1.5rem;font-size:.85rem;color:var(--accent);border:1px solid var(--accent);border-radius:var(--radius-pill);padding:.15em .7em;opacity:0;transition:opacity .3s var(--ease);text-align:center}
-.version-badge:not(:empty){opacity:1}
-.platforms{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:.75rem}
-.platform{display:flex;flex-direction:column;align-items:center;padding:1.2rem 1rem;text-decoration:none;color:var(--text)}
-.platform svg{width:28px;height:28px;margin-bottom:.5rem;fill:var(--text-muted);transition:fill .2s}
-.platform:hover svg{fill:var(--accent)}
-.platform .os{font-weight:700;margin-bottom:.15rem}
-.platform .format{color:var(--text-muted);font-size:.85rem}
-.platform-soon{opacity:.6;transition:opacity .2s var(--ease)}
-.platform-soon:hover{opacity:.9}
-.platform-soon .format{color:var(--accent);font-weight:700;font-size:.75rem;text-transform:uppercase;letter-spacing:.05em}
-.install-alt{margin-top:1.25rem;text-align:left;padding:1.25rem}
-.install-alt h3{font-size:.95rem;font-weight:700;margin-bottom:.75rem}
-.install-cmd{background:var(--bg);border-radius:8px;padding:.5rem .85rem;margin-bottom:.4rem;font-family:"SF Mono",Monaco,Consolas,monospace;font-size:.85rem;position:relative;cursor:pointer;transition:background .2s}
-.install-cmd:last-child{margin-bottom:0}
-.install-cmd:hover{background:var(--surface-hover)}
-.install-cmd .label{color:var(--text-muted);font-size:.75rem;margin-bottom:.1rem}
-.install-cmd .copy-hint{position:absolute;right:.85rem;top:50%;transform:translateY(-50%);font-size:.7rem;color:var(--text-muted);opacity:0;transition:opacity .2s;font-family:Nunito,sans-serif}
-.install-cmd:hover .copy-hint{opacity:1}
-.install-cmd.copied .copy-hint{color:var(--accent)}
-.install-cmd code{background:none;font:inherit}
-.sh-prompt{color:var(--text-muted);user-select:none}
-.sh-cmd{color:#86b300;font-weight:700}
-.sh-sub{color:#e5c07b}
-.sh-flag{color:#c678dd}
-.sh-arg{color:#61afef}
+.version-badge {
+  display: block; width: fit-content;
+  margin-bottom: var(--space-lg);
+  font-size: var(--text-xs); font-weight: 700;
+  color: var(--accent-text); border: 1px solid var(--accent);
+  border-radius: var(--radius-pill); padding: 0.15em 0.7em;
+  font-variant-numeric: tabular-nums;
+}
+.version-badge:empty { display: none; }
 
-/* ===== Footer ===== */
-footer{text-align:center;padding:2.5rem 1.5rem;color:var(--text-muted);font-size:.85rem;opacity:.7}
-footer a{color:var(--accent);font-weight:700}
-.footer-links{display:flex;gap:1.5rem;justify-content:center;margin-bottom:.75rem;flex-wrap:wrap}
+/* Six platforms, one row. auto-fit with a 150px floor only fits five in the
+   860px narrow column, which stranded App Store on a line of its own. */
+.platforms {
+  display: grid; grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: var(--space-xs);
+}
+.platform {
+  display: flex; flex-direction: column; align-items: center; justify-content: flex-start;
+  padding: var(--space-sm) var(--space-2xs); text-decoration: none; color: var(--text);
+  min-height: 44px; min-width: 0;
+  background: var(--panel);
+}
+.platform:hover { background: var(--panel-hover); }
+.platform:hover { color: var(--text); text-decoration: none; border-color: var(--accent); }
+.platform:active { transform: translateY(1px); }
+.platform svg {
+  width: 28px; height: 28px; margin-bottom: var(--space-xs);
+  fill: var(--text-muted);
+  transition: fill var(--duration-base) var(--ease-out);
+}
+.platform:hover svg { fill: var(--accent-text); }
+.platform .os { font-weight: 700; line-height: 1.3; white-space: nowrap; }
+.platform .format {
+  color: var(--text-muted); font-size: var(--text-2xs);
+  line-height: 1.4; text-align: center; overflow-wrap: anywhere;
+}
+/* "Coming soon" is state, not decoration — say it in words, not in low opacity */
+.platform-soon .format {
+  color: var(--accent-text); font-weight: 700;
+  letter-spacing: 0.03em; white-space: nowrap;
+}
+.platform-soon svg { fill: var(--text-muted); }
 
-/* ===== Animations (directional, MH style) ===== */
-.fade-in{opacity:0;transition:opacity .7s var(--ease),transform .7s var(--ease)}
-.fade-in[data-direction="up"]{transform:translateY(24px)}
-.fade-in[data-direction="left"]{transform:translateX(40px)}
-.fade-in[data-direction="right"]{transform:translateX(-40px)}
-.fade-in:not([data-direction]){transform:translateY(24px)}
-.fade-in.visible{opacity:1;transform:translate(0,0)}
+/* the row keeps its shape down to tablet, then halves rather than stranding one */
+@media (max-width: 900px) { .platforms { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
+@media (max-width: 460px) { .platforms { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 
-/* ===== Responsive ===== */
-@media(max-width:640px){
-  :root{--section-gap:40px}
-  .hero{padding-top:4rem}
-  .pillars-grid{grid-template-columns:1fr}
-  .platforms{grid-template-columns:repeat(2,1fr)}
-  .features-grid{grid-template-columns:1fr}
-  .highlight-list{grid-template-columns:1fr}
-  .highlight-row:nth-child(even) .highlight-text{margin-left:0}
+.install-alt { margin-top: var(--space-md); }
+.install-alt h3 {
+  padding: var(--space-sm) var(--space-md);
+  background: var(--panel-head);
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-sm); font-weight: 800; line-height: 1.4;
+}
+.install-alt > .install-cmd { margin-inline: var(--space-md); }
+.install-alt > .install-cmd:first-of-type { margin-top: var(--space-md); }
+.install-alt > .install-cmd:last-of-type { margin-bottom: var(--space-md); }
+.install-cmd {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xs);
+  padding: var(--space-xs) var(--space-sm);
+  margin-bottom: var(--space-2xs);
+  font-family: var(--font-mono); font-size: var(--text-xs);
+  line-height: 1.6;
+  position: relative; cursor: pointer;
+  transition: border-color var(--duration-base) var(--ease-out);
+}
+.install-cmd:last-child { margin-bottom: 0; }
+.install-cmd:hover { border-color: var(--border-strong); }
+.install-cmd:active { transform: translateY(1px); }
+.install-cmd .label {
+  color: var(--text-muted); font-size: var(--text-2xs);
+  font-family: var(--font-body); font-weight: 700;
+}
+.install-cmd code { background: none; font: inherit; overflow-wrap: anywhere; }
+.install-cmd .copy-hint {
+  position: absolute; right: var(--space-sm); top: 50%;
+  transform: translateY(-50%);
+  font-size: var(--text-2xs); color: var(--text-muted);
+  font-family: var(--font-body);
+}
+.install-cmd.copied .copy-hint { color: var(--accent-text); font-weight: 700; }
+@media (max-width: 640px) { .install-cmd .copy-hint { display: none; } }
+
+/* three inks, drawn from the token set — not a four-hue code theme */
+.sh-prompt { color: var(--sh-dim); user-select: none; }
+.sh-cmd { color: var(--sh-cmd); font-weight: 700; }
+.sh-sub, .sh-flag { color: var(--sh-dim); }
+.sh-arg { color: var(--sh-arg); }
+
+/* ===== Footer — Ft2, one inline band ===== */
+footer {
+  border-top: 1px solid var(--border);
+  padding: var(--space-xl) var(--space-lg);
+  color: var(--text-muted); font-size: var(--text-xs);
+}
+footer > * { max-width: var(--content-width); margin-inline: auto; }
+.footer-links {
+  display: flex; gap: var(--space-lg);
+  flex-wrap: wrap; margin-bottom: var(--space-xs);
+}
+.footer-links a { color: var(--text-sub); font-weight: 700; white-space: nowrap; }
+footer a { color: var(--accent-text); font-weight: 700; }
+
+/* ===== Reduced motion — covers every transition and animation, not just two ===== */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/site/tokens.css
+++ b/site/tokens.css
@@ -1,0 +1,167 @@
+/* Hallmark · NoteDeck site tokens
+ * genre: playful surface × modern-minimal restraint (BRANDING.md · DESIGN.md)
+ * paper: light oklch(97.6%) default / dark oklch(21.8%) · accent hue: leaf-green 125.6°
+ *
+ * Every colour, size, space, easing and z-level on the site resolves through a
+ * name declared here. No rule in style.css may inline a raw value.
+ *
+ * Motion budget is DESIGN.md's: functional animation only, 150–250 ms, ease-out.
+ * Nothing on this page loops, reveals, or moves without being asked to.
+ */
+
+:root {
+  /* ===== Accent — NoteDeck leaf-green ===== */
+  --accent:        oklch(70.8% 0.179 125.6);  /* fills, borders, rules — never small text */
+  --accent-strong: oklch(62.0% 0.163 125.6);  /* hover / pressed */
+  --accent-ink:    oklch(22.0% 0.030 125.6);  /* text ON accent — 6.9:1 (white was 2.5:1) */
+  --accent-text:   oklch(50.0% 0.115 125.6);  /* accent AS text — 5.3:1 on light paper */
+  --accent-soft:   oklch(70.8% 0.179 125.6 / 0.12);
+
+  /* ===== Paper + ink — light is the default ===== */
+  --bg:            oklch(96.4% 0.003 125.6);
+  --bg-alt:        oklch(93.6% 0.004 125.6);
+  --panel:         oklch(99.4% 0.002 125.6);
+  --panel-head:    oklch(97.4% 0.004 125.6);
+  --panel-hover:   oklch(98.2% 0.003 125.6);
+  --surface:       oklch(100% 0 0 / 0.62);
+  --surface-hover: oklch(100% 0 0 / 0.86);
+  --text:          oklch(25.2% 0.004 125.6);
+  --text-sub:      oklch(35.6% 0.004 125.6);
+  --text-muted:    oklch(48.0% 0.004 125.6);  /* darkened from #666 → 6.4:1 on --bg */
+  --border:        oklch(0% 0 0 / 0.10);
+  --border-strong: oklch(0% 0 0 / 0.18);
+  --nav-bg:        oklch(98.8% 0.003 125.6 / 0.86);
+  --code-bg:       oklch(96.4% 0.003 125.6);
+  --focus:         oklch(52.0% 0.150 125.6);
+
+  /* Shell syntax — one muted ink plus the accent, not a four-hue code theme */
+  --sh-dim:        oklch(48.0% 0.004 125.6);
+  --sh-cmd:        oklch(50.0% 0.115 125.6);
+  --sh-arg:        oklch(35.6% 0.004 125.6);
+
+  /* ===== Depth — one shadow, never stacked, never a coloured glow ===== */
+  --shadow-whisper: 0 1px 2px oklch(0% 0 0 / 0.07);
+
+  /* ===== Type ===== */
+  --font-body: Nunito, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Hiragino Sans', 'BIZ UDGothic', sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', Monaco, Consolas, 'Roboto Mono', monospace;
+
+  --text-2xs: 0.75rem;    /* 12 */
+  --text-xs:  0.8125rem;  /* 13 */
+  --text-sm:  0.875rem;   /* 14 */
+  --text-md:  0.9375rem;  /* 15 — body */
+  --text-lg:  1.0625rem;  /* 17 */
+  --text-xl:  1.25rem;    /* 20 */
+  --text-2xl: 1.5rem;     /* 24 */
+  --text-3xl: 1.875rem;   /* 30 */
+  --text-display: clamp(2.25rem, 5.5vw, 3.5rem);
+
+  --lh-tight: 1.2;
+  --lh-body:  1.7;
+  --lh-panel: 1.65;
+
+  /* ===== Space — 4pt scale, named by role ===== */
+  --space-3xs: 0.125rem;  /*  2 */
+  --space-2xs: 0.25rem;   /*  4 */
+  --space-xs:  0.5rem;    /*  8 */
+  --space-sm:  0.75rem;   /* 12 */
+  --space-md:  1rem;      /* 16 */
+  --space-lg:  1.5rem;    /* 24 */
+  --space-2lg: 2rem;      /* 32 */
+  --space-xl:  2.5rem;    /* 40 */
+  --space-2xl: 4rem;      /* 64 */
+  --space-3xl: 6rem;      /* 96 */
+
+  /* ===== Shape ===== */
+  --radius:      16px;
+  --radius-sm:   12px;
+  --radius-xs:   8px;
+  --radius-2xs:  6px;
+  --radius-pill: 999px;
+  --blur:        blur(12px);
+  --content-width: 1120px;
+
+  /* ===== Motion — DESIGN.md: functional only, 150–250 ms, ease-out, no bounce ===== */
+  --ease-out:      cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-in:       cubic-bezier(0.7, 0, 0.84, 0);
+  --duration-fast: 0.1s;   /* press tick */
+  --duration-base: 0.16s;  /* hover, focus, colour */
+
+  /* ===== Elevation — named levels, no freestyle numbers ===== */
+  --z-base:     1;
+  --z-raised:   10;
+  --z-dropdown: 100;
+  --z-sticky:   200;
+}
+
+/* ===== Dark paper ===== */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:            oklch(19.5% 0.004 125.6);
+    --bg-alt:        oklch(23.0% 0.004 125.6);
+    --panel:         oklch(25.0% 0.004 125.6);
+    --panel-head:    oklch(28.5% 0.005 125.6);
+    --panel-hover:   oklch(28.0% 0.005 125.6);
+    --surface:       oklch(100% 0 0 / 0.07);
+    --surface-hover: oklch(100% 0 0 / 0.12);
+    --text:          oklch(94.9% 0.002 125.6);
+    --text-sub:      oklch(88.0% 0.002 125.6);
+    --text-muted:    oklch(70.0% 0.002 125.6);
+    --border:        oklch(100% 0 0 / 0.11);
+    --border-strong: oklch(100% 0 0 / 0.20);
+    --nav-bg:        oklch(23.5% 0.004 125.6 / 0.86);
+    --code-bg:       oklch(19.5% 0.004 125.6);
+    --accent-text:   oklch(70.8% 0.179 125.6);  /* 7.0:1 on dark paper */
+    --focus:         oklch(78.0% 0.170 125.6);
+    --sh-dim:        oklch(70.0% 0.002 125.6);
+    --sh-cmd:        oklch(70.8% 0.179 125.6);
+    --sh-arg:        oklch(88.0% 0.002 125.6);
+    --shadow-whisper: 0 1px 2px oklch(0% 0 0 / 0.28);
+  }
+}
+
+html[style*="color-scheme: dark"] {
+  --bg:            oklch(19.5% 0.004 125.6);
+  --bg-alt:        oklch(23.0% 0.004 125.6);
+  --panel:         oklch(25.0% 0.004 125.6);
+  --panel-head:    oklch(28.5% 0.005 125.6);
+  --panel-hover:   oklch(28.0% 0.005 125.6);
+  --surface:       oklch(100% 0 0 / 0.07);
+  --surface-hover: oklch(100% 0 0 / 0.12);
+  --text:          oklch(94.9% 0.002 125.6);
+  --text-sub:      oklch(88.0% 0.002 125.6);
+  --text-muted:    oklch(70.0% 0.002 125.6);
+  --border:        oklch(100% 0 0 / 0.11);
+  --border-strong: oklch(100% 0 0 / 0.20);
+  --nav-bg:        oklch(23.5% 0.004 125.6 / 0.86);
+  --code-bg:       oklch(19.5% 0.004 125.6);
+  --accent-text:   oklch(70.8% 0.179 125.6);
+  --focus:         oklch(78.0% 0.170 125.6);
+  --sh-dim:        oklch(70.0% 0.002 125.6);
+  --sh-cmd:        oklch(70.8% 0.179 125.6);
+  --sh-arg:        oklch(88.0% 0.002 125.6);
+  --shadow-whisper: 0 1px 2px oklch(0% 0 0 / 0.28);
+}
+
+html[style*="color-scheme: light"] {
+  --bg:            oklch(96.4% 0.003 125.6);
+  --bg-alt:        oklch(93.6% 0.004 125.6);
+  --panel:         oklch(99.4% 0.002 125.6);
+  --panel-head:    oklch(97.4% 0.004 125.6);
+  --panel-hover:   oklch(98.2% 0.003 125.6);
+  --surface:       oklch(100% 0 0 / 0.62);
+  --surface-hover: oklch(100% 0 0 / 0.86);
+  --text:          oklch(25.2% 0.004 125.6);
+  --text-sub:      oklch(35.6% 0.004 125.6);
+  --text-muted:    oklch(48.0% 0.004 125.6);
+  --border:        oklch(0% 0 0 / 0.10);
+  --border-strong: oklch(0% 0 0 / 0.18);
+  --nav-bg:        oklch(98.8% 0.003 125.6 / 0.86);
+  --code-bg:       oklch(96.4% 0.003 125.6);
+  --accent-text:   oklch(50.0% 0.115 125.6);
+  --focus:         oklch(52.0% 0.150 125.6);
+  --sh-dim:        oklch(48.0% 0.004 125.6);
+  --sh-cmd:        oklch(50.0% 0.115 125.6);
+  --sh-arg:        oklch(35.6% 0.004 125.6);
+  --shadow-whisper: 0 1px 2px oklch(0% 0 0 / 0.07);
+}


### PR DESCRIPTION
## なぜ

ページが製品を「説明」していて「提示」していなかった。9 セクション中 5 つが見出し＋本文のグリッドで、スクショは 1 枚だけがヒーローの下に切り離して置かれていた。

#943 の要因 2 のとおり、この製品の差別化はユーザーがデッキを組み立て終わるまで一度も可視化されない。しかも評価コストが非対称で、本家は URL を開くだけなのにこちらはインストールまでに決断が 5 回挟まる。**組み立て済みのデッキを決断の手前で見せられる面はこのページしかない。**

さらに、実装が自プロジェクトの規約に反していた。DESIGN.md は「装飾アニメは入れない」「150–250ms」と定めているのに、800px の blob が 2 枚無限に浮遊し、ロゴが 1.4s で拍動し、30 要素が 700ms でスクロールフェードインしていた。

## 何を

- **構成** — ファーストビューを宣言とスクショの 1 つの composition に統合。デッキが最初の画面に入る。ページ全体の軸を左 1 本に
- **面の語彙** — VS Code のペインと Misskey の `MkContainer` が共有する「ヘッダ行を持つ囲われた面」をページ唯一の単位に。疎なパネル群 × 密な罫線インデックスで緩急を作る
- **トークン** — OKLCH パレット・4pt スペーシング・型スケール・z-index を `site/tokens.css` に集約
- **モーション** — `@keyframes` は 0 個に。動くのは hover の色と press の 1px だけ
- **a11y** — `:focus-visible` が 1 つも無くキーボードで操作できなかったのを全域に追加。コントラストは ink 4 種 × 面 4 種を light/dark 両方で実測し最低 4.8:1
- **LCP** — ヒーロー画像の `loading="lazy"` を外し、README fetch → 正規表現で URL 抽出を待たずに描画するよう `src` を markup に
- **ゲストアカウントのセクションを新設** — 中盤のダウンロード CTA ブロックを削除して置き換え。CTA を重ねるより「ログインせずに試せる」と明記する方が評価コストを下げる（DESIGN.md の User Respect と整合）。記述は実装から確認済み
- **ダウンロード行** — `auto-fit` + 150px 下限で 5 枚しか入らず App Store が単独折り返ししていたのを 6 列固定に

**コピーは変更していない。**

## 確認できていないこと

**ブラウザでの実描画は未確認。** タグの対応・クラス/トークン参照の整合・コントラストは自動検証済みだが、目視はしていない。`site/` は typecheck / biome の対象外で CI も検証しないため、以下は Cloudflare Pages のデプロイ後に確認が必要:

- ファーストビューで 1280×800 時にデッキがどれだけ入るか（`object-position: top center` の切り取り位置）
- ダウンロード 6 列（1 枚 128.7px）が詰まって見えないか
- IDE セクション縦 1 列の lead : 詳細 = 1fr : 1.55fr の比率
- 新設したゲストセクションの 2 カラム

Refs #943

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the landing page with a prominent product screenshot and clearer section layouts.
  * Added light and dark theme support with responsive styling.
  * Added guest-mode capabilities, feature icons, platform download cards, and installation guidance.
  * Improved screenshot updates by preserving the current image until a newer version is available.

* **Accessibility & UX**
  * Added keyboard focus styles, reduced-motion support, smooth scrolling, and improved responsive layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->