### PR TITLE
Release v1.42.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.0",
+  "version": "1.42.1",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.0"
+version = "1.42.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.0"
+version = "1.42.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.0"
+    "version": "1.42.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -470,6 +470,9 @@ fn run_inner() -> Result<(), Box<dyn std::error::Error>> {
         // やトレイで隠したウィンドウを誤って再表示しないため。
         // 期限は通常起動の最悪値より十分外側の保険。チューニング禁止。
         // autostart の --minimized (未実装の予約語) を実装する際は要再検討。
+        // モバイルは対象外 — is_visible/show が WebviewWindow に存在せず、
+        // そもそも可視性を OS が握るので不可視のまま残る状態が起きない。
+        #[cfg(desktop)]
         {
             let fuse_handle = app.app_handle().clone();
             std::thread::spawn(move || {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckPluginManagerColumn.vue
+++ b/src/components/deck/DeckPluginManagerColumn.vue
@@ -26,6 +26,7 @@ import {
   type PluginScope,
   usePluginsStore,
 } from '@/stores/plugins'
+import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { openSafeUrl } from '@/utils/url'
@@ -319,13 +320,18 @@ const { confirm } = useConfirm()
 async function deleteFromLibrary(plugin: PluginMeta) {
   const ok = await confirm({
     title: 'プラグインを削除',
-    message: `「${plugin.name}」をライブラリから削除しますか？プラグインのコードも消えます。この操作は取り消せません。`,
+    message: `「${plugin.name}」をライブラリから削除しますか？プラグインのコードも消えます。`,
     okLabel: '削除',
     type: 'danger',
   })
   if (!ok) return
   abortPlugin(plugin.installId)
-  pluginsStore.removePlugin(plugin.installId)
+  const undo = pluginsStore.removePlugin(plugin.installId)
+  if (undo) {
+    useToast().show('プラグインを削除しました', 'info', {
+      action: { label: '元に戻す', onClick: undo },
+    })
+  }
 }
 </script>
 

--- a/src/components/deck/DeckQueryManagerColumn.vue
+++ b/src/components/deck/DeckQueryManagerColumn.vue
@@ -16,6 +16,7 @@ import {
   type StoreQueryEntry,
   useMisStoreStore,
 } from '@/stores/misstore'
+import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { openSafeUrl } from '@/utils/url'
 import ColumnSection from './ColumnSection.vue'
@@ -138,11 +139,17 @@ async function remove(query: NamedQueryMeta): Promise<void> {
     message:
       used > 0
         ? `「${query.name}」は ${used} 個のカラムで使用中です。削除するとそれらのカラムは評価不能 (fail-closed) になります。削除しますか？`
-        : `「${query.name}」を削除しますか？`,
+        : `「${query.name}」を削除しますか？クエリの本文も消えます。`,
+    okLabel: '削除',
     type: 'danger',
   })
   if (!ok) return
-  await queriesStore.removeQuery(query.id)
+  const undo = await queriesStore.removeQuery(query.id)
+  if (undo) {
+    useToast().show('クエリを削除しました', 'info', {
+      action: { label: '元に戻す', onClick: undo },
+    })
+  }
 }
 
 // --- Store tab ---

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -5,6 +5,7 @@ import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
+import { useConfirm } from '@/stores/confirm'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import {
   getThemeDetailUrl,
@@ -12,6 +13,7 @@ import {
   useMisStoreStore,
 } from '@/stores/misstore'
 import { useThemeStore } from '@/stores/theme'
+import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { MI_DARK, MI_LIGHT } from '@/theme/builtinThemes'
 import type { MisskeyTheme } from '@/theme/types'
@@ -306,18 +308,60 @@ function editTheme(entry: ThemeEntry) {
   })
 }
 
-function removeTheme(entry: ThemeEntry) {
+const { confirm } = useConfirm()
+
+/** このカラムのアカウントを外すとテーマ本体ごと消えるか (installedFor が空になる)。 */
+function isLastAccountForTheme(theme: MisskeyTheme): boolean {
+  const installedFor = theme.$notedeck?.installedFor
+  if (!installedFor) return false
+  return installedFor.every((id) => id === accountId.value)
+}
+
+async function removeTheme(entry: ThemeEntry) {
   if (!isCrossAccount.value && accountId.value) {
     // per-account カラムからの除去は「このアカウントから外す」のみ
     // (installedFor から accountId を抜き、空になれば完全削除)。同時に
     // accountThemeCache の per-column 適用も解除して meta default にフォール
     // バックさせる (ユーザーが × したテーマがそのカラムに当たり続けると混乱)。
+    //
+    // ただし紐付けが自分だけのときは本体ごと消える。無言で消さず、完全削除と
+    // 同じ confirm → 元に戻せるトーストを通す (#988)。
     const mode = entry.theme.base ?? 'dark'
-    themeStore.unlinkAccountFromTheme(entry.theme.id, accountId.value)
+    if (isLastAccountForTheme(entry.theme)) {
+      const ok = await confirm({
+        title: 'テーマを削除',
+        message: `「${entry.theme.name}」はこのアカウントにのみ紐付いています。外すとテーマ自体が削除されます。削除しますか？`,
+        okLabel: '削除',
+        type: 'danger',
+      })
+      if (!ok) return
+    }
+    const undo = themeStore.unlinkAccountFromTheme(
+      entry.theme.id,
+      accountId.value,
+    )
     themeStore.clearAccountTheme(mode, accountId.value)
+    if (undo) {
+      useToast().show('テーマを削除しました', 'info', {
+        action: { label: '元に戻す', onClick: undo },
+      })
+    }
   } else {
-    // cross-account (Global) からは完全削除
-    themeStore.removeTheme(entry.theme.id)
+    // cross-account (Global) からは完全削除。他の配布物 (skill / widget /
+    // plugin / query) と同じく confirm → 元に戻せるトースト (#988)
+    const ok = await confirm({
+      title: 'テーマを削除',
+      message: `「${entry.theme.name}」を削除しますか？テーマの設定も消えます。`,
+      okLabel: '削除',
+      type: 'danger',
+    })
+    if (!ok) return
+    const undo = themeStore.removeTheme(entry.theme.id)
+    if (undo) {
+      useToast().show('テーマを削除しました', 'info', {
+        action: { label: '元に戻す', onClick: undo },
+      })
+    }
   }
 }
 

--- a/src/components/window/ThemeEditorContent.vue
+++ b/src/components/window/ThemeEditorContent.vue
@@ -20,7 +20,9 @@ import EditorItemHeader from '@/components/window/EditorItemHeader.vue'
 import { useClipboardFeedback } from '@/composables/useClipboardFeedback'
 import { useEditorTabs } from '@/composables/useEditorTabs'
 import { useWindowExternalFile } from '@/composables/useWindowExternalFile'
+import { useConfirm } from '@/stores/confirm'
 import { useThemeStore } from '@/stores/theme'
+import { useToast } from '@/stores/toast'
 import { DARK_BASE, LIGHT_BASE } from '@/theme/builtinThemes'
 import { parseColor } from '@/theme/colorUtils'
 import { compileMisskeyTheme } from '@/theme/compiler'
@@ -42,6 +44,7 @@ const props = defineProps<{
 }>()
 
 const themeStore = useThemeStore()
+const { confirm } = useConfirm()
 
 const { tab, containerRef: editorRef } = useEditorTabs(
   ['visual', 'code'] as const,
@@ -405,9 +408,23 @@ function loadFromInstalled(theme: MisskeyTheme) {
 }
 
 // Delete installed theme
-function deleteInstalledTheme(theme: MisskeyTheme, e: Event) {
+// 他の配布物 (skill / widget / plugin / query) と同じく confirm → 元に戻せる
+// トースト (#988)
+async function deleteInstalledTheme(theme: MisskeyTheme, e: Event) {
   e.stopPropagation()
-  themeStore.removeTheme(theme.id)
+  const ok = await confirm({
+    title: 'テーマを削除',
+    message: `「${theme.name}」を削除しますか？テーマの設定も消えます。`,
+    okLabel: '削除',
+    type: 'danger',
+  })
+  if (!ok) return
+  const undo = themeStore.removeTheme(theme.id)
+  if (undo) {
+    useToast().show('テーマを削除しました', 'info', {
+      action: { label: '元に戻す', onClick: undo },
+    })
+  }
 }
 
 // Section expand states (default: all collapsed)

--- a/src/stores/columnQueries.test.ts
+++ b/src/stores/columnQueries.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/utils/settingsFs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/utils/settingsFs')>(
+      '@/utils/settingsFs',
+    )
+  return { ...actual, isTauri: false }
+})
+
+import { useColumnQueriesStore } from '@/stores/columnQueries'
+
+describe('useColumnQueriesStore.removeQuery (undo) — #988', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('元の位置に戻す undo を返す', async () => {
+    const store = useColumnQueriesStore()
+    await store.createQuery({ name: 'a', src: 'true' })
+    const b = await store.createQuery({ name: 'b', src: 'note.text != null' })
+    await store.createQuery({ name: 'c', src: 'true' })
+
+    const undo = await store.removeQuery(b.id)
+    expect(store.getQuery(b.id)).toBeUndefined()
+    expect(undo).toBeTypeOf('function')
+
+    undo?.()
+    expect(store.queries.map((q) => q.name)).toEqual(['a', 'b', 'c'])
+    expect(store.getQuery(b.id)?.src).toBe('note.text != null')
+  })
+
+  it('未知の id には undefined を返す', async () => {
+    const store = useColumnQueriesStore()
+    expect(await store.removeQuery('nope')).toBeUndefined()
+  })
+
+  it('undo までに同じ id が再追加されていたら二重化しない', async () => {
+    const store = useColumnQueriesStore()
+    const a = await store.createQuery({ name: 'a', src: 'true' })
+
+    const undo = await store.removeQuery(a.id)
+    store.queries = [{ ...a, name: 'readded' }]
+    undo?.()
+
+    expect(store.queries.filter((q) => q.id === a.id)).toHaveLength(1)
+    expect(store.getQuery(a.id)?.name).toBe('readded')
+  })
+})

--- a/src/stores/columnQueries.ts
+++ b/src/stores/columnQueries.ts
@@ -171,10 +171,17 @@ export const useColumnQueriesStore = defineStore('columnQueries', () => {
     await persist(next)
   }
 
-  async function removeQuery(id: string): Promise<void> {
+  /**
+   * クエリを削除する。削除を取り消す undo を返す (#988 — skill / widget と同じ
+   * 「confirm → 削除 → 元に戻すトースト」に揃えるため)。未知の id なら undefined。
+   * カラム側の参照 (noteQueryRefs) は削除時に剥がしていないので、undo で復活
+   * すれば fail-closed だったカラムがそのまま元に戻る。
+   */
+  async function removeQuery(id: string): Promise<(() => void) | undefined> {
     ensureLoaded()
-    const target = queries.value.find((q) => q.id === id)
-    if (!target) return
+    const idx = queries.value.findIndex((q) => q.id === id)
+    const target = queries.value[idx]
+    if (!target) return undefined
     queries.value = queries.value.filter((q) => q.id !== id)
     persistMirror()
     if (settingsFs.isTauri) {
@@ -183,6 +190,16 @@ export const useColumnQueriesStore = defineStore('columnQueries', () => {
       } catch (e) {
         console.warn('[columnQueries] delete failed', e)
       }
+    }
+    return () => {
+      if (queries.value.some((q) => q.id === id)) return
+      const at = Math.min(idx, queries.value.length)
+      queries.value = [
+        ...queries.value.slice(0, at),
+        target,
+        ...queries.value.slice(at),
+      ]
+      void persist(target)
     }
   }
 

--- a/src/stores/plugins.test.ts
+++ b/src/stores/plugins.test.ts
@@ -24,7 +24,22 @@ vi.mock('@/utils/storage', () => {
     setStorageJson: (key: string, value: unknown) => {
       mem.set(key, value)
     },
-    removeStorageByPrefix: vi.fn(),
+    getStorageByPrefix: (prefix: string) => {
+      const out: Record<string, string> = {}
+      for (const [key, value] of mem) {
+        if (key.startsWith(prefix) && typeof value === 'string')
+          out[key] = value
+      }
+      return out
+    },
+    setStorageString: (key: string, value: string) => {
+      mem.set(key, value)
+    },
+    removeStorageByPrefix: (prefix: string) => {
+      for (const key of [...mem.keys()]) {
+        if (key.startsWith(prefix)) mem.delete(key)
+      }
+    },
     __mem: mem,
   }
 })
@@ -39,7 +54,12 @@ import {
   type PluginMeta,
   usePluginsStore,
 } from '@/stores/plugins'
-import { STORAGE_KEYS, setStorageJson } from '@/utils/storage'
+import {
+  getStorageByPrefix,
+  STORAGE_KEYS,
+  setStorageJson,
+  setStorageString,
+} from '@/utils/storage'
 
 function makePlugin(partial: Partial<PluginMeta>): PluginMeta {
   return {
@@ -255,5 +275,59 @@ describe('レガシーデータ移行 (#771)', () => {
     const p = store.getPlugin('p1')
     expect(p?.global).toBeUndefined()
     expect(p?.installedFor).toEqual(['yami.ski:u1', 'misskey.cloud:u2'])
+  })
+})
+
+describe('removePlugin (undo) — #988', () => {
+  it('元の位置に戻す undo を返す', () => {
+    setStorageJson(STORAGE_KEYS.plugins, [
+      makePlugin({ installId: 'p1' }),
+      makePlugin({ installId: 'p2', src: '### { name: "p2" }' }),
+      makePlugin({ installId: 'p3' }),
+    ])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+
+    const undo = store.removePlugin('p2')
+    expect(store.getPlugin('p2')).toBeUndefined()
+    expect(undo).toBeTypeOf('function')
+
+    undo?.()
+    expect(store.plugins.map((p) => p.installId)).toEqual(['p1', 'p2', 'p3'])
+    expect(store.getPlugin('p2')?.src).toBe('### { name: "p2" }')
+  })
+
+  it('未知の installId には undefined を返す', () => {
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    expect(store.removePlugin('nope')).toBeUndefined()
+  })
+
+  it('undo で AiScript の保存領域も復元する', () => {
+    setStorageJson(STORAGE_KEYS.plugins, [makePlugin({ installId: 'p1' })])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+    setStorageString(`${STORAGE_KEYS.aiscriptPlugin('p1')}:counter`, '42')
+
+    const undo = store.removePlugin('p1')
+    expect(getStorageByPrefix(STORAGE_KEYS.aiscriptPlugin('p1'))).toEqual({})
+
+    undo?.()
+    expect(getStorageByPrefix(STORAGE_KEYS.aiscriptPlugin('p1'))).toEqual({
+      [`${STORAGE_KEYS.aiscriptPlugin('p1')}:counter`]: '42',
+    })
+  })
+
+  it('undo までに同じ installId が再追加されていたら二重化しない', () => {
+    setStorageJson(STORAGE_KEYS.plugins, [makePlugin({ installId: 'p1' })])
+    const store = usePluginsStore()
+    store.ensureLoaded()
+
+    const undo = store.removePlugin('p1')
+    store.plugins = [makePlugin({ installId: 'p1', name: 'readded' })]
+    undo?.()
+
+    expect(store.plugins.filter((p) => p.installId === 'p1')).toHaveLength(1)
+    expect(store.getPlugin('p1')?.name).toBe('readded')
   })
 })

--- a/src/stores/plugins.ts
+++ b/src/stores/plugins.ts
@@ -8,10 +8,12 @@ import { accountScopeKey, useAccountsStore } from '@/stores/accounts'
 import { pushSnapshot } from '@/utils/historyFs'
 import * as settingsFs from '@/utils/settingsFs'
 import {
+  getStorageByPrefix,
   getStorageJson,
   removeStorageByPrefix,
   STORAGE_KEYS,
   setStorageJson,
+  setStorageString,
 } from '@/utils/storage'
 
 interface BuiltInPluginTemplate {
@@ -316,11 +318,20 @@ export const usePluginsStore = defineStore('plugins', () => {
     persist(plugin)
   }
 
-  function removePlugin(installId: string) {
+  /**
+   * プラグインをライブラリから削除する。削除を取り消す undo を返す (#988 —
+   * skill / widget と同じ「confirm → 削除 → 元に戻すトースト」に揃えるため)。
+   * 未知の installId なら undefined。
+   */
+  function removePlugin(installId: string): (() => void) | undefined {
     ensureLoaded()
-    const removed = plugins.value.find((p) => p.installId === installId)
+    const idx = plugins.value.findIndex((p) => p.installId === installId)
+    const removed = plugins.value[idx]
     // Clean up plugin localStorage entries
-    removeStorageByPrefix(STORAGE_KEYS.aiscriptPlugin(installId))
+    // undo で戻せるよう消す前にスナップショットを取る (widgets と同型)
+    const storagePrefix = STORAGE_KEYS.aiscriptPlugin(installId)
+    const savedStorage = getStorageByPrefix(storagePrefix)
+    removeStorageByPrefix(storagePrefix)
     plugins.value = plugins.value.filter((p) => p.installId !== installId)
     // Sync: localStorage only (file deletion handles the rest)
     savePluginsToStorage(plugins.value)
@@ -331,6 +342,27 @@ export const usePluginsStore = defineStore('plugins', () => {
         .catch((e) =>
           console.warn('[plugins] failed to delete plugin files:', e),
         )
+    }
+    if (!removed) return undefined
+    return () => {
+      if (plugins.value.some((p) => p.installId === installId)) return
+      const at = Math.min(idx, plugins.value.length)
+      plugins.value = [
+        ...plugins.value.slice(0, at),
+        removed,
+        ...plugins.value.slice(at),
+      ]
+      savePluginsToStorage(plugins.value)
+      for (const [key, value] of Object.entries(savedStorage)) {
+        setStorageString(key, value)
+      }
+      if (initialized.value) {
+        pluginFiles
+          .persistItem(removed)
+          .catch((e) =>
+            console.warn('[plugins] failed to restore plugin files:', e),
+          )
+      }
     }
   }
 

--- a/src/stores/theme.dom.test.ts
+++ b/src/stores/theme.dom.test.ts
@@ -62,3 +62,100 @@ describe('useThemeStore — セーフモード (#794)', () => {
     expect(document.head.querySelector('style[data-nd-custom-css]')).toBeNull()
   })
 })
+
+const BLUE: MisskeyTheme = {
+  id: 'blue-theme',
+  name: 'Blue',
+  base: 'dark',
+  props: { bg: '#0000ff' },
+}
+
+describe('useThemeStore.removeTheme (undo) — #988', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('元の位置に戻す undo を返す', () => {
+    const store = useThemeStore()
+    store.installedThemes = [RED, BLUE]
+
+    const undo = store.removeTheme(RED.id)
+    expect(store.installedThemes.map((t) => t.id)).toEqual([BLUE.id])
+    expect(undo).toBeTypeOf('function')
+
+    undo?.()
+    expect(store.installedThemes.map((t) => t.id)).toEqual([RED.id, BLUE.id])
+    expect(store.installedThemes[0]?.props.bg).toBe('#ff0000')
+  })
+
+  it('未知の id には undefined を返す', () => {
+    const store = useThemeStore()
+    expect(store.removeTheme('nope')).toBeUndefined()
+  })
+
+  it('undo で選択中テーマの指定も復元する', () => {
+    const store = useThemeStore()
+    store.installedThemes = [RED]
+    store.selectedDarkThemeId = RED.id
+    store.selectedLightThemeId = RED.id
+
+    const undo = store.removeTheme(RED.id)
+    expect(store.selectedDarkThemeId).toBeNull()
+    expect(store.selectedLightThemeId).toBeNull()
+
+    undo?.()
+    expect(store.selectedDarkThemeId).toBe(RED.id)
+    expect(store.selectedLightThemeId).toBe(RED.id)
+  })
+
+  it('undo までに同じ id が再追加されていたら二重化しない', () => {
+    const store = useThemeStore()
+    store.installedThemes = [RED]
+
+    const undo = store.removeTheme(RED.id)
+    store.installedThemes = [{ ...RED, name: 'Readded' }]
+    undo?.()
+
+    expect(store.installedThemes.filter((t) => t.id === RED.id)).toHaveLength(1)
+    expect(store.installedThemes[0]?.name).toBe('Readded')
+  })
+})
+
+describe('useThemeStore.unlinkAccountFromTheme — #988', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('紐付けが自分だけなら本体が消えるので undo を返す', () => {
+    const store = useThemeStore()
+    store.installedThemes = [{ ...RED, $notedeck: { installedFor: ['acc-1'] } }]
+
+    const undo = store.unlinkAccountFromTheme(RED.id, 'acc-1')
+    expect(store.installedThemes).toHaveLength(0)
+    expect(undo).toBeTypeOf('function')
+
+    undo?.()
+    expect(store.installedThemes.map((t) => t.id)).toEqual([RED.id])
+  })
+
+  it('他アカウントの紐付けが残るなら本体は消えず undo も返さない', () => {
+    const store = useThemeStore()
+    store.installedThemes = [
+      { ...RED, $notedeck: { installedFor: ['acc-1', 'acc-2'] } },
+    ]
+
+    const undo = store.unlinkAccountFromTheme(RED.id, 'acc-1')
+    expect(undo).toBeUndefined()
+    expect(store.installedThemes[0]?.$notedeck?.installedFor).toEqual(['acc-2'])
+  })
+})

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -322,14 +322,22 @@ export const useThemeStore = defineStore('theme', () => {
     }
   }
 
-  function removeTheme(id: string): void {
-    const removed = installedThemes.value.find((t) => t.id === id)
+  /**
+   * インストール済みテーマを削除する。削除を取り消す undo を返す (#988 —
+   * skill / widget と同じ「confirm → 削除 → 元に戻すトースト」に揃えるため)。
+   * 未知の id なら undefined。
+   */
+  function removeTheme(id: string): (() => void) | undefined {
+    const idx = installedThemes.value.findIndex((t) => t.id === id)
+    const removed = installedThemes.value[idx]
     installedThemes.value = installedThemes.value.filter((t) => t.id !== id)
     // Clear selection if removed (computed setter → settingsStore)
-    if (selectedDarkThemeId.value === id) {
+    const wasDark = selectedDarkThemeId.value === id
+    const wasLight = selectedLightThemeId.value === id
+    if (wasDark) {
       selectedDarkThemeId.value = null
     }
-    if (selectedLightThemeId.value === id) {
+    if (wasLight) {
       selectedLightThemeId.value = null
     }
     // Sync: update localStorage cache only (no need to rewrite remaining theme files)
@@ -341,26 +349,52 @@ export const useThemeStore = defineStore('theme', () => {
         .deleteThemeFile(removed)
         .catch((e) => console.warn('[theme] failed to delete theme file:', e))
     }
+    if (!removed) return undefined
+    return () => {
+      if (installedThemes.value.some((t) => t.id === id)) return
+      const at = Math.min(idx, installedThemes.value.length)
+      installedThemes.value = [
+        ...installedThemes.value.slice(0, at),
+        removed,
+        ...installedThemes.value.slice(at),
+      ]
+      if (wasDark) selectedDarkThemeId.value = id
+      if (wasLight) selectedLightThemeId.value = id
+      setStorageJson(STORAGE_KEYS.themeInstalledThemes, installedThemes.value)
+      applyCurrentTheme()
+      if (initialized.value) {
+        themeFileSync
+          .persistSingleTheme(removed)
+          .catch((e) =>
+            console.warn('[theme] failed to restore theme file:', e),
+          )
+      }
+    }
   }
 
   /**
    * テーマの per-account 紐付け (`$notedeck.installedFor`) から accountId を外す。
    * installedFor が空になれば installedThemes 自体からも削除する。
    * per-account テーマカラムでの「× ボタン」=「このアカウントから外す」用。
+   *
+   * 本体ごと消えた場合のみ、削除を取り消す undo を返す (#988)。紐付けが残る
+   * ケースは可逆な「外す」なので undo は返さない (widget の detach と同じ)。
    */
-  function unlinkAccountFromTheme(themeId: string, accountId: string): void {
+  function unlinkAccountFromTheme(
+    themeId: string,
+    accountId: string,
+  ): (() => void) | undefined {
     const theme = installedThemes.value.find((t) => t.id === themeId)
     if (!theme || !theme.$notedeck?.installedFor) {
       // 紐付けが無いテーマ (Global ローカル / 古い installedFor 無し) の場合は
       // per-account からの除去はそもそも責務外 → no-op
-      return
+      return undefined
     }
     const remaining = theme.$notedeck.installedFor.filter(
       (id) => id !== accountId,
     )
     if (remaining.length === 0) {
-      removeTheme(themeId)
-      return
+      return removeTheme(themeId)
     }
     const updated: MisskeyTheme = {
       ...theme,
@@ -377,6 +411,7 @@ export const useThemeStore = defineStore('theme', () => {
           console.warn('[theme] failed to persist installedFor update:', e),
         )
     }
+    return undefined
   }
 
   function renameTheme(themeId: string, newName: string): void {


### PR DESCRIPTION
## Release v1.42.1

v1.42.0 は Android のリリースビルドがコンパイルエラーで落ちたため公開していない。その修正と、配布物削除まわりの UX 統一 (#988) を載せた差し替えリリース。

### 修正

**Android ビルドの復旧**
- 起動ヒューズ (#985 で追加) が `WebviewWindow::show()` / `is_visible()` を無条件に呼んでいて、デスクトップ限定 API のため Android で `E0599` になっていた。ヒューズ全体を `#[cfg(desktop)]` に閉じた。モバイルは可視性を OS が握るので、そもそもヒューズが不要

**配布物削除の UX 統一 (#988)**
- テーマ・プラグイン・クエリの削除で、確認ダイアログとトーストの挙動が実装ごとにばらついていたのを揃えた

### v1.42.0 から引き継ぐ変更

起動クリティカルパスの改善 (#985) 一式:

- `manualChunks` を全廃し、起動クリティカルパスから 3.9MB のチャンクを外した
- 実効性のなかった UI シェルキャッシュを廃止
- 起動クリティカルパスの計測点を追加し、About ウィンドウで各フェーズの内訳を確認できるようにした
- ウィンドウ表示の最後の砦と backend-fatal の可視化を追加
- 起動の謳い文句と起動関連ドキュメントを実測値に合わせて修正

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
