### PR TITLE
Release v1.42.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.1",
+  "version": "1.42.2",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.1"
+version = "1.42.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.1"
+version = "1.42.2"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.1"
+    "version": "1.42.2"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.1",
+  "version": "1.42.2",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MemoCard.vue
+++ b/src/components/common/MemoCard.vue
@@ -7,7 +7,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { type Account, getAccountAvatarUrl } from '@/stores/accounts'
 import { useEmojisStore } from '@/stores/emojis'
 import { useWindowsStore } from '@/stores/windows'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import MkAvatar from './MkAvatar.vue'
 import MkMfm from './MkMfm.vue'
 
@@ -143,7 +143,7 @@ const VISIBILITY_ICONS: Record<NoteVisibility, string> = {
          (DeckAiColumn の personaIndicator と同じパターン)。
          通常 memo: 普通の MkAvatar (img) 表示。 -->
     <button
-      v-if="isPersona && avatarUrl"
+      v-if="isPersona && isProxiable(avatarUrl)"
       type="button"
       :class="$style.personaAvatar"
       :title="displayName"

--- a/src/components/common/MemoCard.vue
+++ b/src/components/common/MemoCard.vue
@@ -7,6 +7,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { type Account, getAccountAvatarUrl } from '@/stores/accounts'
 import { useEmojisStore } from '@/stores/emojis'
 import { useWindowsStore } from '@/stores/windows'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import MkAvatar from './MkAvatar.vue'
 import MkMfm from './MkMfm.vue'
 
@@ -150,7 +151,7 @@ const VISIBILITY_ICONS: Record<NoteVisibility, string> = {
     >
       <span
         :class="$style.personaAvatarInner"
-        :style="{ '--icon-url': `url('${avatarUrl}')` }"
+        :style="{ '--icon-url': proxyCssUrl(avatarUrl, 48) }"
         aria-hidden="true"
       />
     </button>

--- a/src/components/common/MkAvatar.vue
+++ b/src/components/common/MkAvatar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { type CSSProperties, computed, ref, useCssModule, watch } from 'vue'
 import type { AvatarDecoration } from '@/adapters/types'
-import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 
 const props = withDefaults(
   defineProps<{
@@ -67,6 +67,16 @@ function onAvatarError(e: Event) {
   }
 }
 
+/**
+ * デコレーションはアバターの 200% 幅で描画される (.avatarDecoration)。
+ * その 2 倍 = size * 4 を要求して DPR 2 まで賄う。原寸を読むと配布素材が
+ * 1500x1500 のこともあり、164px 表示に対して面積比 84 倍のビットマップを
+ * デコードすることになる (#991)。アニメ素材はプロキシ側が変換を素通しする。
+ */
+function decorationSrc(d: AvatarDecoration): string | undefined {
+  return proxyThumbUrl(d.url, props.size * 4)
+}
+
 function computeDecorationStyle(d: AvatarDecoration): CSSProperties {
   const style: CSSProperties = {}
   const angle = d.angle ?? 0
@@ -129,7 +139,7 @@ const statusClass = computed(() =>
     <img
       v-for="(d, i) in props.decorations"
       :key="d.id"
-      :src="proxyUrl(d.url)"
+      :src="decorationSrc(d)"
       :class="$style.avatarDecoration"
       :style="decorationStyles[i]"
       loading="lazy"

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -40,7 +40,7 @@ import { useSettingsStore } from '@/stores/settings'
 import { useToast } from '@/stores/toast'
 import { onCustomEmojiImgError } from '@/utils/emojiImgError'
 import { formatTime } from '@/utils/formatTime'
-import { proxyEmojiUrl, proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
 import {
   buildReactionsData,
   canRenoteNote,
@@ -677,7 +677,7 @@ function handlePickerReaction(reaction: string) {
     >
       <img
         v-if="effectiveNote.reply!.user.avatarUrl"
-        :src="proxyUrl(effectiveNote.reply!.user.avatarUrl)"
+        :src="proxyThumbUrl(effectiveNote.reply!.user.avatarUrl, 56)"
         :class="$style.replyToAvatar"
         width="20"
         height="20"

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -34,6 +34,7 @@ import { useSettingsStore } from '@/stores/settings'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { buildPreviewNote } from '@/utils/buildPreviewNote'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { buildReplyMentions } from '@/utils/replyMentions'
 import {
   formatScheduleAbsolute,
@@ -537,7 +538,7 @@ function onPaste(e: ClipboardEvent) {
             >
               <span :class="$style.accountAvatarWrap">
                 <img
-                  :src="getAccountAvatarUrl(account)"
+                  :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)"
                   :class="$style.accountAvatar"
                 />
                 <img

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -32,6 +32,7 @@ import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { useToast } from '@/stores/toast'
 import { logWarn } from '@/utils/logger'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const props = defineProps<{
@@ -448,7 +449,7 @@ function close() {
           :title="isGuestAccount(account) && requiresAuth ? 'ゲストアカウントではこのカラムを使えません' : ''"
           @click="(!account.hasToken && requiresAuth) ? showLoginPrompt() : addColumnForAccount(account.id)"
         >
-          <img :src="getAccountAvatarUrl(account)" :class="$style.addAccountAvatar" />
+          <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.addAccountAvatar" />
           <span>{{ getAccountLabel(account) }}</span>
         </button>
       </template>

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -43,7 +43,7 @@ import {
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { resolveIdentity } from '@/utils/identity'
 import { isImeComposing } from '@/utils/ime'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -867,7 +867,7 @@ function onKeydown(e: KeyboardEvent) {
         :title="`Persona: ${currentPersona.displayName} (エージェント設定で変更)`"
       >
         <span
-          v-if="currentPersona.avatarUrl"
+          v-if="isProxiable(currentPersona.avatarUrl)"
           :class="$style.personaIndicatorAvatar"
           :style="{ '--icon-url': proxyCssUrl(currentPersona.avatarUrl, 48) }"
           aria-hidden="true"

--- a/src/components/deck/DeckAiColumn.vue
+++ b/src/components/deck/DeckAiColumn.vue
@@ -43,6 +43,7 @@ import {
 import { highlightCode, highlighterLoaded } from '@/utils/highlight'
 import { resolveIdentity } from '@/utils/identity'
 import { isImeComposing } from '@/utils/ime'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import { renderSimpleMarkdown } from '@/utils/simpleMarkdown'
 import DeckColumnComponent from './DeckColumn.vue'
 
@@ -868,7 +869,7 @@ function onKeydown(e: KeyboardEvent) {
         <span
           v-if="currentPersona.avatarUrl"
           :class="$style.personaIndicatorAvatar"
-          :style="{ '--icon-url': `url('${currentPersona.avatarUrl}')` }"
+          :style="{ '--icon-url': proxyCssUrl(currentPersona.avatarUrl, 48) }"
           aria-hidden="true"
         />
         <i v-else class="ti ti-user-circle" />

--- a/src/components/deck/DeckChatColumn.vue
+++ b/src/components/deck/DeckChatColumn.vue
@@ -1035,7 +1035,7 @@ onBeforeUnmount(() => {
       </button>
 
       <div v-if="!isCrossAccount && account" :class="$style.headerAccount">
-        <img :src="getAccountAvatarUrl(account)" :class="$style.headerAvatar" />
+        <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
         <img
           :class="$style.headerFavicon"
           :src="serverIconUrl || proxyThumbUrl(`https://${account.host}/favicon.ico`, 28)"

--- a/src/components/deck/DeckDriveColumn.vue
+++ b/src/components/deck/DeckDriveColumn.vue
@@ -22,6 +22,7 @@ import { useToast } from '@/stores/toast'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckColumn from './DeckColumn.vue'
 
@@ -382,7 +383,7 @@ fetchDrive()
         <i :class="uploading ? 'ti ti-loader-2 nd-spin' : 'ti ti-upload'" />
       </button>
       <div v-if="account" :class="$style.headerAccount">
-        <img :src="getAccountAvatarUrl(account)" :class="$style.headerAvatar" />
+        <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
       </div>
     </template>
 

--- a/src/components/deck/DeckHeaderAccount.vue
+++ b/src/components/deck/DeckHeaderAccount.vue
@@ -10,7 +10,7 @@ defineProps<{
 
 <template>
   <div v-if="account" :class="$style.headerAccount">
-    <img :src="getAccountAvatarUrl(account)" :class="$style.headerAvatar" />
+    <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
     <img
       :class="$style.headerFavicon"
       :src="serverIconUrl || proxyThumbUrl(`https://${account.host}/favicon.ico`, 28)"

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1061,7 +1061,7 @@ onUnmounted(() => {
 
     <template #header-meta>
       <div v-if="!isCrossAccount && account" :class="$style.headerAccount">
-        <img :src="getAccountAvatarUrl(account)" :class="$style.headerAvatar" />
+        <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
         <img :class="$style.headerFavicon" :src="serverIconUrl || proxyThumbUrl(`https://${account.host}/favicon.ico`, 28)" :title="account.host" @error="($event.target as HTMLImageElement).src = '/server-icon-error.svg'" />
       </div>
     </template>

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -17,7 +17,7 @@ import {
 } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import { openSafeUrl } from '@/utils/url'
 import ColumnSection from './ColumnSection.vue'
 import type { ColumnTabDef } from './ColumnTabs.vue'
@@ -264,7 +264,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
             >
               <div :class="$style.icon">
                 <span
-                  v-if="skill.iconUrl"
+                  v-if="isProxiable(skill.iconUrl)"
                   :class="$style.iconImg"
                   :style="{ '--icon-url': proxyCssUrl(skill.iconUrl, 48) }"
                   aria-hidden="true"
@@ -381,7 +381,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
           >
             <div :class="$style.icon">
               <span
-                v-if="entry.iconUrl"
+                v-if="isProxiable(entry.iconUrl)"
                 :class="$style.iconImg"
                 :style="{ '--icon-url': proxyCssUrl(entry.iconUrl, 48) }"
                 aria-hidden="true"

--- a/src/components/deck/DeckSkillColumn.vue
+++ b/src/components/deck/DeckSkillColumn.vue
@@ -17,6 +17,7 @@ import {
 } from '@/stores/skills'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import { openSafeUrl } from '@/utils/url'
 import ColumnSection from './ColumnSection.vue'
 import type { ColumnTabDef } from './ColumnTabs.vue'
@@ -265,7 +266,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
                 <span
                   v-if="skill.iconUrl"
                   :class="$style.iconImg"
-                  :style="{ '--icon-url': `url('${skill.iconUrl}')` }"
+                  :style="{ '--icon-url': proxyCssUrl(skill.iconUrl, 48) }"
                   aria-hidden="true"
                 />
                 <i v-else class="ti ti-sparkles" />
@@ -382,7 +383,7 @@ function handleOpenStoreDetail(entry: StoreSkillEntry) {
               <span
                 v-if="entry.iconUrl"
                 :class="$style.iconImg"
-                :style="{ '--icon-url': `url('${entry.iconUrl}')` }"
+                :style="{ '--icon-url': proxyCssUrl(entry.iconUrl, 48) }"
                 aria-hidden="true"
               />
               <i v-else class="ti ti-sparkles" />

--- a/src/components/deck/DeckThemeManagerColumn.vue
+++ b/src/components/deck/DeckThemeManagerColumn.vue
@@ -419,7 +419,7 @@ function storeEntryToTheme(entry: StoreThemeEntry): MisskeyTheme {
 
     <template #header-meta>
       <div v-if="!isCrossAccount && account" :class="$style.headerAccount">
-        <img :src="getAccountAvatarUrl(account)" :class="$style.headerAvatar" />
+        <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
         <img
           :class="$style.headerFavicon"
           :src="serverIconUrl || proxyThumbUrl(`https://${account.host}/favicon.ico`, 28)"

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 
 type Mode = 'installed' | 'store' | 'library'
 
@@ -70,7 +70,7 @@ const incompatTitle = computed(() => {
   >
     <div :class="$style.icon">
       <span
-        v-if="iconUrl"
+        v-if="isProxiable(iconUrl)"
         :class="$style.iconImg"
         :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"

--- a/src/components/deck/PluginCard.vue
+++ b/src/components/deck/PluginCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 
 type Mode = 'installed' | 'store' | 'library'
 
@@ -71,7 +72,7 @@ const incompatTitle = computed(() => {
       <span
         v-if="iconUrl"
         :class="$style.iconImg"
-        :style="{ '--icon-url': `url('${iconUrl}')` }"
+        :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"
       />
       <i v-else class="ti ti-puzzle" />

--- a/src/components/deck/QueryCard.vue
+++ b/src/components/deck/QueryCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 
 /**
  * カラムクエリのアイテムカード (#783)。
@@ -69,7 +69,7 @@ function handlePrimaryClick() {
   >
     <div :class="$style.icon">
       <span
-        v-if="iconUrl"
+        v-if="isProxiable(iconUrl)"
         :class="$style.iconImg"
         :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"

--- a/src/components/deck/QueryCard.vue
+++ b/src/components/deck/QueryCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 
 /**
  * カラムクエリのアイテムカード (#783)。
@@ -70,7 +71,7 @@ function handlePrimaryClick() {
       <span
         v-if="iconUrl"
         :class="$style.iconImg"
-        :style="{ '--icon-url': `url('${iconUrl}')` }"
+        :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"
       />
       <i v-else class="ti ti-filter" />

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 
 type Mode = 'store' | 'library'
 
@@ -72,7 +72,7 @@ function handlePrimaryClick() {
   >
     <div :class="$style.icon">
       <span
-        v-if="iconUrl"
+        v-if="isProxiable(iconUrl)"
         :class="$style.iconImg"
         :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"

--- a/src/components/deck/WidgetCard.vue
+++ b/src/components/deck/WidgetCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 
 type Mode = 'store' | 'library'
 
@@ -73,7 +74,7 @@ function handlePrimaryClick() {
       <span
         v-if="iconUrl"
         :class="$style.iconImg"
-        :style="{ '--icon-url': `url('${iconUrl}')` }"
+        :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
         aria-hidden="true"
       />
       <i v-else class="ti ti-layout-dashboard" />

--- a/src/components/window/EditorItemHeader.vue
+++ b/src/components/window/EditorItemHeader.vue
@@ -10,7 +10,7 @@
  *
  * icon スロットを使うとアイコン枠の中身を差し替えられる (テーマの配色プレビュー等)。
  */
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 
 defineProps<{
   /** MisStore registry の iconUrl。カードと同じく mask で currentColor 塗り */
@@ -26,7 +26,7 @@ defineProps<{
     <div :class="$style.icon">
       <slot name="icon">
         <span
-          v-if="iconUrl"
+          v-if="isProxiable(iconUrl)"
           :class="$style.iconImg"
           :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
           aria-hidden="true"

--- a/src/components/window/EditorItemHeader.vue
+++ b/src/components/window/EditorItemHeader.vue
@@ -10,6 +10,8 @@
  *
  * icon スロットを使うとアイコン枠の中身を差し替えられる (テーマの配色プレビュー等)。
  */
+import { proxyCssUrl } from '@/utils/mediaProxy'
+
 defineProps<{
   /** MisStore registry の iconUrl。カードと同じく mask で currentColor 塗り */
   iconUrl?: string
@@ -26,7 +28,7 @@ defineProps<{
         <span
           v-if="iconUrl"
           :class="$style.iconImg"
-          :style="{ '--icon-url': `url('${iconUrl}')` }"
+          :style="{ '--icon-url': proxyCssUrl(iconUrl, 48) }"
           aria-hidden="true"
         />
         <i v-else :class="`ti ti-${fallbackIcon}`" />

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -19,6 +19,7 @@ import {
   type PluginScope,
   usePluginsStore,
 } from '@/stores/plugins'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import { pluginSrcFilename } from '@/utils/settingsFs'
 
 const props = defineProps<{
@@ -335,7 +336,7 @@ async function importPlugin() {
         <span
           v-if="plugin.iconUrl"
           :class="$style.headerIconImg"
-          :style="{ '--icon-url': `url('${plugin.iconUrl}')` }"
+          :style="{ '--icon-url': proxyCssUrl(plugin.iconUrl, 48) }"
           aria-hidden="true"
         />
         <i v-else class="ti ti-puzzle" />

--- a/src/components/window/PluginsContent.vue
+++ b/src/components/window/PluginsContent.vue
@@ -19,7 +19,7 @@ import {
   type PluginScope,
   usePluginsStore,
 } from '@/stores/plugins'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import { pluginSrcFilename } from '@/utils/settingsFs'
 
 const props = defineProps<{
@@ -334,7 +334,7 @@ async function importPlugin() {
            以前は配布アイコンを持つプラグインでも常に puzzle を出していた -->
       <div :class="$style.headerIcon">
         <span
-          v-if="plugin.iconUrl"
+          v-if="isProxiable(plugin.iconUrl)"
           :class="$style.headerIconImg"
           :style="{ '--icon-url': proxyCssUrl(plugin.iconUrl, 48) }"
           aria-hidden="true"

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -39,6 +39,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { useWidgetsStore } from '@/stores/widgets'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const MkPostForm = defineAsyncComponent(
@@ -319,7 +320,7 @@ function toggleAutoRun() {
         <span
           v-if="widget.iconUrl"
           :class="$style.headerIconImg"
-          :style="{ '--icon-url': `url('${widget.iconUrl}')` }"
+          :style="{ '--icon-url': proxyCssUrl(widget.iconUrl, 48) }"
           aria-hidden="true"
         />
         <i v-else class="ti ti-layout-dashboard" />

--- a/src/components/window/WidgetEditContent.vue
+++ b/src/components/window/WidgetEditContent.vue
@@ -39,7 +39,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useAiScriptLogsStore } from '@/stores/aiscriptLogs'
 import { useToast } from '@/stores/toast'
 import { useWidgetsStore } from '@/stores/widgets'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
 const MkPostForm = defineAsyncComponent(
@@ -318,7 +318,7 @@ function toggleAutoRun() {
     <div v-if="widget" :class="$style.header">
       <div :class="$style.headerIcon">
         <span
-          v-if="widget.iconUrl"
+          v-if="isProxiable(widget.iconUrl)"
           :class="$style.headerIconImg"
           :style="{ '--icon-url': proxyCssUrl(widget.iconUrl, 48) }"
           aria-hidden="true"

--- a/src/components/window/ai-settings/AiPersonaSection.vue
+++ b/src/components/window/ai-settings/AiPersonaSection.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { useAiConfig } from '@/composables/useAiConfig'
 import { useSkillsStore } from '@/stores/skills'
+import { proxyCssUrl } from '@/utils/mediaProxy'
 import AiSettingsSection from './AiSettingsSection.vue'
 
 const { config } = useAiConfig()
@@ -62,7 +63,7 @@ const currentPersonaSkill = computed(() => {
         <span
           v-if="s.iconUrl"
           :class="$style.logo"
-          :style="{ '--icon-url': `url('${s.iconUrl}')` }"
+          :style="{ '--icon-url': proxyCssUrl(s.iconUrl, 48) }"
           aria-hidden="true"
         />
         <i v-else class="ti ti-user-circle" :class="$style.logoFallback" />

--- a/src/components/window/ai-settings/AiPersonaSection.vue
+++ b/src/components/window/ai-settings/AiPersonaSection.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { useAiConfig } from '@/composables/useAiConfig'
 import { useSkillsStore } from '@/stores/skills'
-import { proxyCssUrl } from '@/utils/mediaProxy'
+import { isProxiable, proxyCssUrl } from '@/utils/mediaProxy'
 import AiSettingsSection from './AiSettingsSection.vue'
 
 const { config } = useAiConfig()
@@ -61,7 +61,7 @@ const currentPersonaSkill = computed(() => {
         <!-- SVG icon を accent 色で render (DeckAiColumn.personaIndicator と同じ
              mask + currentColor パターン) -->
         <span
-          v-if="s.iconUrl"
+          v-if="isProxiable(s.iconUrl)"
           :class="$style.logo"
           :style="{ '--icon-url': proxyCssUrl(s.iconUrl, 48) }"
           aria-hidden="true"

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -161,3 +161,41 @@ describe('proxyCssUrl', () => {
     expect(css.endsWith('")')).toBe(true)
   })
 })
+
+/**
+ * アイコンを描くかフォールバックの Tabler アイコンに倒すかの述語 (#979)。
+ *
+ * これらのアイコンは mask で描いているため、url() が none になると
+ * 「マスクなし = 要素全体がベタ塗り」になる。URL があるかどうかで v-if を
+ * 切ると、プロキシに載らない URL のときに四角が出てしまう。
+ */
+describe('isProxiable', () => {
+  it('https だけがプロキシに載る', async () => {
+    const { isProxiable } = await loadModule()
+    expect(isProxiable(REMOTE)).toBe(true)
+    expect(isProxiable('http://example.com/x.png')).toBe(false)
+    expect(isProxiable('data:image/png;base64,AAAA')).toBe(false)
+    expect(isProxiable('/local/icon.svg')).toBe(false)
+    expect(isProxiable(null)).toBe(false)
+    expect(isProxiable(undefined)).toBe(false)
+    expect(isProxiable('')).toBe(false)
+  })
+
+  // ここがずれると v-if は真なのに mask が none になり、ベタ塗りが復活する
+  it('proxyCssUrl が none を返す条件と完全に一致する', async () => {
+    const { isProxiable, proxyCssUrl } = await loadModule()
+    const urls = [
+      REMOTE,
+      'https://example.com/a.png',
+      'http://example.com/x.png',
+      'data:image/png;base64,AAAA',
+      '/local/icon.svg',
+      '',
+      null,
+      undefined,
+    ]
+    for (const u of urls) {
+      expect(isProxiable(u)).toBe(proxyCssUrl(u, 48) !== 'none')
+    }
+  })
+})

--- a/src/utils/mediaProxy.dom.test.ts
+++ b/src/utils/mediaProxy.dom.test.ts
@@ -111,3 +111,53 @@ describe('URL 文字列キャッシュの追い出し (#893)', () => {
     expect(proxyUrl(REMOTE)).toBe(first)
   })
 })
+
+/**
+ * CSS の url() 値としてプロキシ URL を組み立てる口 (#979)。
+ *
+ * ストア配布物のアイコンは第三者がメタデータで URL を指定できるため、
+ * 文字列補間で url('...') を組み立てると、クォートを含む値で url() を
+ * 閉じて別のプロパティを注入できてしまう。プロキシを通った URL だけを
+ * CSS に入れ、素通し (https 以外) は none に倒すことで塞ぐ。
+ */
+describe('proxyCssUrl', () => {
+  it('https の URL はプロキシ経由の url() 値になる', async () => {
+    const { proxyCssUrl } = await loadModule()
+    const css = proxyCssUrl(REMOTE, 48)
+    expect(css).toBe(`url("${BASE}?url=${encodeURIComponent(REMOTE)}&w=48")`)
+  })
+
+  it('https 以外は none に倒す (素通し URL を CSS に入れない)', async () => {
+    const { proxyCssUrl } = await loadModule()
+    expect(proxyCssUrl('http://example.com/x.png', 48)).toBe('none')
+    expect(proxyCssUrl('data:image/png;base64,AAAA', 48)).toBe('none')
+    expect(proxyCssUrl('/local/icon.svg', 48)).toBe('none')
+  })
+
+  it('null / undefined / 空文字は none', async () => {
+    const { proxyCssUrl } = await loadModule()
+    expect(proxyCssUrl(null, 48)).toBe('none')
+    expect(proxyCssUrl(undefined, 48)).toBe('none')
+    expect(proxyCssUrl('', 48)).toBe('none')
+  })
+
+  // encodeURIComponent は ' と ) をエンコードしないので、url() は
+  // ダブルクォートで囲む必要がある。" は %22 になるため閉じられない。
+  it.each([
+    [
+      'ダブルクォート',
+      `https://e.example/x.png"); background: url("https://evil.example/y.png`,
+    ],
+    [
+      'シングルクォート',
+      `https://e.example/x.png'); background: url('https://evil.example/y.png`,
+    ],
+  ])('%s を含む URL でも url() を閉じられない', async (_name, evil) => {
+    const { proxyCssUrl } = await loadModule()
+    const css = proxyCssUrl(evil, 48)
+    // 開始と終了の 2 つだけ = 途中で文字列を閉じられていない
+    expect((css.match(/"/g) ?? []).length).toBe(2)
+    expect(css.startsWith('url("')).toBe(true)
+    expect(css.endsWith('")')).toBe(true)
+  })
+})

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -76,6 +76,28 @@ export function proxyThumbUrl(
 }
 
 /**
+ * CSS の `url()` 値としてプロキシ URL を返す (#979)。
+ *
+ * ストア配布物 (プラグイン・ウィジェット・クエリ・スキル) のアイコンは
+ * 第三者がメタデータで URL を指定できる。文字列補間で `url('...')` を
+ * 組み立てると、クォートを含む値で url() を閉じて別のプロパティを
+ * 注入できてしまうため、**プロキシを通った URL だけ**を CSS に入れる。
+ *
+ * `buildProxyUrl` は https 以外を素通しするが、素通し URL は CSS に
+ * 渡さず `none` に倒す。配布元ホストへ直接リクエストが飛ぶのを防ぐ
+ * (相手に「いつ誰が開いたか」と IP が見える) のが本来の目的なので、
+ * プロキシに乗らない URL は表示しないのが正しい。
+ */
+export function proxyCssUrl(
+  url: string | null | undefined,
+  width: number,
+): string {
+  const proxied = proxyThumbUrl(url, width)
+  if (!proxied?.startsWith(HTTP_MEDIA_BASE)) return 'none'
+  return `url("${proxied}")`
+}
+
+/**
  * カスタム絵文字の共通サムネイル口。
  *
  * 本家 media-proxy の `emoji=1` と同じ「最大高さ 128px」基準 (#921)。

--- a/src/utils/mediaProxy.ts
+++ b/src/utils/mediaProxy.ts
@@ -39,11 +39,24 @@ function evictOldestIfFull(map: Map<string, unknown>, key: string) {
   if (oldest !== undefined) map.delete(oldest)
 }
 
+/**
+ * プロキシに載せられる URL か。
+ *
+ * アイコンを描くか、フォールバックの Tabler アイコンに倒すかの判定に使う
+ * (#979)。配布物アイコンは `mask` で描いているため、`proxyCssUrl` が
+ * `none` を返す URL に対して要素を出すと、**マスクなし = 要素全体が
+ * ベタ塗り**になる。「URL があるか」ではなく「プロキシに載るか」で
+ * v-if を切ること。
+ */
+export function isProxiable(url: string | null | undefined): url is string {
+  return !!url?.startsWith('https://')
+}
+
 function buildProxyUrl(
   url: string | null | undefined,
   sizeQuery?: string,
 ): string | undefined {
-  if (!url?.startsWith('https://')) return url ?? undefined
+  if (!isProxiable(url)) return url ?? undefined
   const key = sizeQuery ? `${url}|${sizeQuery}` : url
   let cached = proxyUrlCache.get(key)
   if (!cached) {


### PR DESCRIPTION
v1.42.1 の修正リリース。

## 変更

- fix(security): 配布物アイコンをプロキシ経由にして CSS 注入も塞ぐ (#979)
- fix(ui): プロキシに載らないアイコンはベタ塗りでなくフォールバックに倒す
- fix(ui): 小さく表示するアバターを 56px バケットに統一
- fix(ui): アバターデコレーションを表示サイズ相当で読む
- chore: bump version to 1.42.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved avatar, icon, and decoration rendering with supported media proxying across the app.
  * Added safe fallbacks for missing or unsupported image URLs.
  * Applied appropriately sized thumbnails for account and reply avatars.

* **Bug Fixes**
  * Improved image security by preventing unsafe or unsupported URLs from being embedded directly.
  * Added coverage for secure proxy URL generation and injection prevention.

* **Chores**
  * Updated the application version to 1.42.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->