### PR TITLE
Release v1.42.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.2",
+  "version": "1.42.3",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.2"
+version = "1.42.3"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.2"
+version = "1.42.3"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.2"
+    "version": "1.42.3"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.2",
+  "version": "1.42.3",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/CommandPalette.vue
+++ b/src/components/common/CommandPalette.vue
@@ -21,6 +21,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
 import { fuzzyMatch } from '@/utils/fuzzyMatch'
 import { isImeComposing } from '@/utils/ime'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { shortcutLabel } from '@/utils/shortcutLabel'
 
 const commandStore = useCommandStore()
@@ -508,7 +509,7 @@ function primaryShortcut(cmd: Command): string | null {
             @click="selectQuickPickItem(item)"
             @mouseenter="selectedIndex = flatQuickPickList.indexOf(item)"
           >
-            <img v-if="item.avatarUrl" :src="item.avatarUrl" :class="$style.itemAvatar" />
+            <img v-if="item.avatarUrl" :src="proxyThumbUrl(item.avatarUrl, 56)" :class="$style.itemAvatar" />
             <i v-else :class="['ti ti-' + item.icon, $style.itemIcon]" />
             <div :class="$style.itemContent">
               <span :class="$style.itemLabel">{{ item.label }}</span>

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -560,7 +560,7 @@ function onPaste(e: ClipboardEvent) {
               >
                 <span :class="$style.accountOptionAvatarWrap">
                   <img
-                    :src="getAccountAvatarUrl(acc)"
+                    :src="proxyThumbUrl(getAccountAvatarUrl(acc), 56)"
                     :class="$style.accountOptionAvatar"
                     width="24"
                     height="24"
@@ -781,7 +781,7 @@ function onPaste(e: ClipboardEvent) {
       <div v-if="replyTo" :class="$style.replyPreview">
         <img
           v-if="replyTo.user.avatarUrl"
-          :src="replyTo.user.avatarUrl"
+          :src="proxyThumbUrl(replyTo.user.avatarUrl, 56)"
           :class="$style.replyAvatar"
         />
         <div :class="$style.replyContent">
@@ -798,7 +798,7 @@ function onPaste(e: ClipboardEvent) {
       <div v-if="quoteNote && !replyTo" :class="[$style.replyPreview, $style.quotePreview]">
         <img
           v-if="quoteNote.user.avatarUrl"
-          :src="quoteNote.user.avatarUrl"
+          :src="proxyThumbUrl(quoteNote.user.avatarUrl, 56)"
           :class="$style.replyAvatar"
         />
         <div :class="$style.replyContent">

--- a/src/components/common/MkUrlPreview.vue
+++ b/src/components/common/MkUrlPreview.vue
@@ -197,7 +197,7 @@ function hostname(url: string): string {
         ]"
       >
         <img
-          :src="data.thumbnail ? (proxyUrl(data.thumbnail) ?? data.thumbnail) : data.icon!"
+          :src="data.thumbnail ? (proxyThumbUrl(data.thumbnail, 256) ?? data.thumbnail) : data.icon!"
           :class="[$style.urlPreviewImage, { [$style.isIcon]: !data.thumbnail }]"
           loading="lazy"
           decoding="async"

--- a/src/components/common/NoteReactionUsersModal.vue
+++ b/src/components/common/NoteReactionUsersModal.vue
@@ -10,7 +10,7 @@ import { useNavigation } from '@/composables/useNavigation'
 import { useVaporTransition } from '@/composables/useVaporTransition'
 import { useAccountsStore } from '@/stores/accounts'
 import { useUiStore } from '@/stores/ui'
-import { proxyEmojiUrl } from '@/utils/mediaProxy'
+import { proxyEmojiUrl, proxyThumbUrl } from '@/utils/mediaProxy'
 import MkEmoji from './MkEmoji.vue'
 import MkMfm from './MkMfm.vue'
 
@@ -153,7 +153,7 @@ defineExpose({ open })
             >
               <img
                 v-if="u.user.avatarUrl"
-                :src="u.user.avatarUrl"
+                :src="proxyThumbUrl(u.user.avatarUrl, 56)"
                 :class="$style.avatar"
                 width="32"
                 height="32"

--- a/src/components/common/ReorderableList.vue
+++ b/src/components/common/ReorderableList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { usePointerReorder } from '@/composables/usePointerReorder'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 
 export interface ReorderableItem {
   icon: string
@@ -44,7 +45,7 @@ const { dragFromIndex, dragOverIndex, startDrag } = usePointerReorder({
       <span :class="$style.label">{{ item.label }}</span>
       <span v-if="item.stackCount && item.stackCount > 1" :class="$style.stackBadge">{{ item.stackCount }}</span>
       <span v-if="item.serverIconUrl || item.avatarUrl" :class="$style.badges">
-        <img v-if="item.avatarUrl" :src="item.avatarUrl" :class="$style.badgeImg" />
+        <img v-if="item.avatarUrl" :src="proxyThumbUrl(item.avatarUrl, 56)" :class="$style.badgeImg" />
         <img v-if="item.serverIconUrl" :src="item.serverIconUrl" :class="$style.badgeImg" />
       </span>
       <button class="_button" :class="$style.removeBtn" @click="emit('remove', i)">

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -410,7 +410,7 @@ function close() {
           :class="$style.addTypeBtn"
           @click="addSelectableColumn(item)"
         >
-          <img v-if="item.avatarUrl" :src="item.avatarUrl" :class="$style.selectItemAvatar" />
+          <img v-if="item.avatarUrl" :src="proxyThumbUrl(item.avatarUrl, 56)" :class="$style.selectItemAvatar" />
           <i v-else class="ti" :class="`ti-${COLUMN_ICONS[selectConfig.type]}`" />
           <span>{{ item.name }}</span>
         </button>

--- a/src/components/deck/DeckAboutMisskeyColumn.vue
+++ b/src/components/deck/DeckAboutMisskeyColumn.vue
@@ -19,6 +19,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useServersStore } from '@/stores/servers'
 import { AppError } from '@/utils/errors'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { openSafeUrl } from '@/utils/url'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
@@ -266,7 +267,7 @@ onMounted(() => {
             :class="$style.memberCard"
             @click="openLink(m.github)"
           >
-            <img :src="m.avatar" :alt="m.username" :class="$style.memberAvatar" loading="lazy" />
+            <img :src="proxyThumbUrl(m.avatar, 56)" :alt="m.username" :class="$style.memberAvatar" loading="lazy" />
             <span :class="$style.memberName">@{{ m.username }}</span>
           </button>
         </div>

--- a/src/components/deck/DeckGalleryColumn.vue
+++ b/src/components/deck/DeckGalleryColumn.vue
@@ -12,7 +12,7 @@ import { useServerImages } from '@/composables/useServerImages'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckColumn from './DeckColumn.vue'
 import DeckHeaderAccount from './DeckHeaderAccount.vue'
@@ -173,7 +173,7 @@ fetchGallery()
               <div :class="$style.galleryGridFooter">
                 <span v-if="post.user" :class="$style.galleryGridUser">
                   <img
-                    :src="post.user.avatarUrl || '/avatar-default.svg'"
+                    :src="proxyThumbUrl(post.user.avatarUrl || '/avatar-default.svg', 56)"
                     :class="$style.galleryGridAvatar"
                     @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'"
                   />

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1216,7 +1216,7 @@ onUnmounted(() => {
                   />
                   <template v-else>
                     <img v-if="notif.type === 'app' && notif.icon" :src="notif.icon" :class="[$style.notifFallbackAvatar, $style.notifAppIcon]" alt="" />
-                    <img v-else-if="resolveNotifAccount(notif)?.avatarUrl" :src="resolveNotifAccount(notif)!.avatarUrl!" :class="$style.notifFallbackAvatar" />
+                    <img v-else-if="resolveNotifAccount(notif)?.avatarUrl" :src="proxyThumbUrl(resolveNotifAccount(notif)!.avatarUrl!, 56)" :class="$style.notifFallbackAvatar" />
                   </template>
                   <img
                     v-if="shouldShowServerBadge(notif) && resolveNotifServerIcon(notif)"

--- a/src/components/deck/DeckPlayColumn.vue
+++ b/src/components/deck/DeckPlayColumn.vue
@@ -10,6 +10,7 @@ import { useTabSlide } from '@/composables/useTabSlide'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import type { ColumnTabDef } from './ColumnTabs.vue'
 import ColumnTabs from './ColumnTabs.vue'
@@ -158,7 +159,7 @@ function scrollToTop() {
             <div :class="$style.playCardTitle">{{ item.title }}</div>
             <div v-if="item.summary" :class="$style.playCardSummary">{{ item.summary }}</div>
             <div :class="$style.playCardMeta">
-              <img :src="item.user.avatarUrl || '/avatar-default.svg'" :class="$style.playCardAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
+              <img :src="proxyThumbUrl(item.user.avatarUrl || '/avatar-default.svg', 56)" :class="$style.playCardAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
               <span :class="$style.playCardAuthor">
                 <MkMfm v-if="item.user.name" :text="item.user.name" :emojis="item.user.emojis" :server-host="account?.host" plain />
                 <template v-else>{{ item.user.username }}</template>

--- a/src/components/deck/DeckStreamInspectorColumn.vue
+++ b/src/components/deck/DeckStreamInspectorColumn.vue
@@ -368,7 +368,7 @@ function onDetailWheel(e: WheelEvent) {
           <span :class="$style.rowKind">{{ kindLabel(entry.kind) }}</span>
           <span :class="$style.rowBadges">
             <template v-if="!isScopedToAccount">
-              <img v-if="entry.observer.avatar" :src="entry.observer.avatar" :class="$style.badge" />
+              <img v-if="entry.observer.avatar" :src="proxyThumbUrl(entry.observer.avatar, 56)" :class="$style.badge" />
               <img
                 v-if="entry.observer.serverIcon"
                 :src="entry.observer.serverIcon"
@@ -380,7 +380,7 @@ function onDetailWheel(e: WheelEvent) {
               </template>
             </template>
             <template v-if="entry.subject">
-              <img v-if="entry.subject.avatar" :src="entry.subject.avatar" :class="$style.badge" />
+              <img v-if="entry.subject.avatar" :src="proxyThumbUrl(entry.subject.avatar, 56)" :class="$style.badge" />
               <img
                 v-if="entry.subject.serverIcon"
                 :src="entry.subject.serverIcon"

--- a/src/components/window/GalleryDetailContent.vue
+++ b/src/components/window/GalleryDetailContent.vue
@@ -6,7 +6,7 @@ import MkMfm from '@/components/common/MkMfm.vue'
 import { safeUrl } from '@/composables/useDriveFolder'
 import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
-import { proxyUrl } from '@/utils/mediaProxy'
+import { proxyThumbUrl, proxyUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { webUiUrl } from '@/utils/url'
 
@@ -238,7 +238,7 @@ function onKeydown(e: KeyboardEvent) {
         <div :class="$style.meta">
           <div :class="$style.user">
             <img
-              :src="detailPost.user.avatarUrl || '/avatar-default.svg'"
+              :src="proxyThumbUrl(detailPost.user.avatarUrl || '/avatar-default.svg', 56)"
               :class="$style.userAvatar"
               @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'"
             />

--- a/src/components/window/PageDetailContent.vue
+++ b/src/components/window/PageDetailContent.vue
@@ -22,6 +22,7 @@ import { useAccountsStore } from '@/stores/accounts'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
 import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { parseMfm } from '@/utils/mfm'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { webUiUrl } from '@/utils/url'
@@ -294,7 +295,7 @@ onMounted(loadPage)
 
       <div :class="$style.footer">
         <div :class="$style.author">
-          <img :src="page.user.avatarUrl || '/avatar-default.svg'" :class="$style.authorAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
+          <img :src="proxyThumbUrl(page.user.avatarUrl || '/avatar-default.svg', 56)" :class="$style.authorAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
           By @{{ page.user.username }}
         </div>
         <div :class="$style.dates">

--- a/src/components/window/PlayDetailContent.vue
+++ b/src/components/window/PlayDetailContent.vue
@@ -20,6 +20,7 @@ import { useWindowExternalLink } from '@/composables/useWindowExternalLink'
 import { useAccountsStore } from '@/stores/accounts'
 import { useWindowsStore } from '@/stores/windows'
 import { AppError } from '@/utils/errors'
+import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { webUiUrl } from '@/utils/url'
 
@@ -242,7 +243,7 @@ onMounted(loadFlash)
 
           <div :class="$style.footer">
             <div :class="$style.author">
-              <img :src="flash.user.avatarUrl || '/avatar-default.svg'" :class="$style.authorAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
+              <img :src="proxyThumbUrl(flash.user.avatarUrl || '/avatar-default.svg', 56)" :class="$style.authorAvatar" @error="(e: Event) => (e.target as HTMLImageElement).src = '/avatar-error.svg'" />
               By @{{ flash.user.username }}
             </div>
             <div :class="$style.dates">


### PR DESCRIPTION
## 変更

v1.42.2 を Windows で実測して見つかった、画像の原寸デコード 2 件を潰す。

- **残りのアバターも 56px バケットに揃える** (`b3f7d686`)
  ギャラリーの投稿者アバターが 320x320 を 14px で表示していた (面積比 **522 倍**、プロキシ非経由)。
  前回は `getAccountAvatarUrl(account)` のパターンだけを直したため `user.avatarUrl` を直接渡す面が
  残っていた。同じ取りこぼしを繰り返さないよう、無変換でアバター URL を渡していた **16 箇所すべて**を
  一度に揃えた。
- **URL プレビューのサムネイルを 256px バケットで読む** (`0024b286`)
  720x900 の OGP 画像を 80x104 で表示していた (面積比 **78 倍**、1 枚 2.47MB)。
  サムネイル枠は 100px 幅なので DPR 2 を賄う 256px に収めた。

## v1.42.2 で確認できたこと

前リリースの修正はいずれも実測で効果を確認済み。

| 対象 | 修正前 | v1.42.2 |
|---|---|---|
| ウィンドウ出現 (ウォーム n=5 中央値) | 641 ms | **453 ms (-29%)** |
| アバターデコレーション (1 枚) | 8.58 MB / 1500px | **0.205 MB / 232px** |
| 配布物アイコン | 配布元へ直リンク | **17/17 プロキシ経由・直リンク 0** |

ウィンドウ出現はネイティブ描画の競合 (Aria 1.5.10 = 642 ms) を下回った。

## 関連

- #991 メモリ使用量
- #979 配布物アイコン (前リリースで対応済み)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Avatar images across menus, posts, notifications, galleries, and detail views now use optimized 56px thumbnails.
  - URL preview thumbnails now use optimized 256px images for more consistent rendering.

- **Bug Fixes**
  - Improved avatar loading consistency by applying thumbnail processing throughout the interface while preserving existing fallback behavior.

- **Chores**
  - Updated the application and API specification version to 1.42.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->