### PR TITLE
Release v1.42.5

### DIFF
--- a/SKILLS.md
+++ b/SKILLS.md
@@ -2,7 +2,7 @@
 
 NoteDeck の AI チャット機能で使う **SKILL (= Markdown 形式の指示書)** を書くための技術リファレンス。
 
-> **入門ガイド・ベストプラクティス例集・配布手順** は misstore 側のドキュメント (近日公開予定) を参照してください。本書は NoteDeck コア仕様に対応する **API リファレンス** に近い性格です。
+> **入門ガイド・ベストプラクティス例集・配布手順** は misstore 側のドキュメント ([CONTRIBUTING](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [レジストリ形式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md)) を参照してください。本書は NoteDeck コア仕様に対応する **API リファレンス** に近い性格です。
 
 ---
 
@@ -12,7 +12,7 @@ NoteDeck の AI チャット機能で使う **SKILL (= Markdown 形式の指示�
 - AI の振る舞い・キャラ性・応答ガイドラインを Markdown で記述
 - Tauri の `app_data_dir/notedeck/skills/*.md` に置かれる (Linux: `~/.local/share/com.notedeck.desktop/notedeck/skills/`、macOS: `~/Library/Application Support/com.notedeck.desktop/notedeck/skills/`、Windows: `%APPDATA%\com.notedeck.desktop\notedeck\skills\`)
 - 複数の SKILL は順に連結されて 1 つの system prompt になる
-- misstore で配布可能 (Markdown 1 ファイル単位)
+- [misstore](https://store.notedeck.io) で配布可能 (Markdown 1 ファイル単位、[配布手順](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md))
 
 スキルは **AI に "読ませる"** 指示書であり、AI が "実行できる" 機能 (= **capability**) とは別物です。
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.4",
+  "version": "1.42.5",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/scripts/check-dist-budget.mjs
+++ b/scripts/check-dist-budget.mjs
@@ -72,8 +72,19 @@ if (jsTotal > BUDGET_ENTRY_STATIC_JS) {
   )
 }
 
+// self-XSS 警告 (#994) が出力に残っているか。minify の dropConsole は
+// `console.log(...)` と静的に判定できる呼び出しを丸ごと消すため、素直に書くと
+// 本番ビルドでだけ警告が無言で消える (実際に消えていた)。dev では出るので
+// 気づけない。文言が entry 静的閉包に含まれることを検査して止める
+if (![...seen].some((f) => readFileSync(join(DIST, f), 'utf8').includes('はすべて詐欺です'))) {
+  problems.push(
+    'self-XSS 警告 (#994) が entry 静的閉包に無い。minify の dropConsole に\n' +
+      '    消されている可能性が高い (src/utils/selfXssWarning.ts)',
+  )
+}
+
 if (problems.length > 0) {
-  console.error('check-dist-budget: 起動クリティカルパスの予算超過\n')
+  console.error('check-dist-budget: dist 出力の検査に失敗\n')
   for (const p of problems) console.error(`  ${p}\n`)
   process.exit(1)
 }

--- a/site/docs/dev/index.md
+++ b/site/docs/dev/index.md
@@ -26,4 +26,4 @@ NoteDeck は入れた機能を使うだけでなく、自分で機能を足せ�
 
 ## 配る
 
-作ったものは [MisStore](https://store.notedeck.io) で配布できます。提出の手順とキュレーションの基準は MisStore 側のドキュメントを参照してください。テーマは NoteDeck 固有の形式ではないため、素の Misskey にもそのまま配れます。
+作ったものは [MisStore](https://store.notedeck.io) で配布できます。提出の手順とキュレーションの基準は MisStore 側のドキュメント（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式リファレンス](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md)）を参照してください。テーマは NoteDeck 固有の形式ではないため、素の Misskey にもそのまま配れます。

--- a/site/docs/dev/plugin.md
+++ b/site/docs/dev/plugin.md
@@ -58,4 +58,4 @@
 
 ## 作る・配る
 
-AI カラムで「〇〇するプラグインを作って」と頼むのが最短です。手で書く場合は設定フォルダに置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます。
+AI カラムで「〇〇するプラグインを作って」と頼むのが最短です。手で書く場合は設定フォルダに置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md#プラグイン)）。

--- a/site/docs/dev/query.md
+++ b/site/docs/dev/query.md
@@ -35,4 +35,4 @@ note.files.len  note.reactions["絵文字名"]
 
 ## 入れる・配る
 
-[ストア](/docs/guide/store)から入れたクエリをそのまま使うことも、編集して自分用に直すこともできます。作ったものは [MisStore](https://store.notedeck.io) で配布できます。
+[ストア](/docs/guide/store)から入れたクエリをそのまま使うことも、編集して自分用に直すこともできます。作ったものは [MisStore](https://store.notedeck.io) で配布できます（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md#クエリ)）。

--- a/site/docs/dev/skill.md
+++ b/site/docs/dev/skill.md
@@ -54,6 +54,6 @@ AI に渡されるデータからは、トークンやパスワードにあた�
 
 ## 作る・配る
 
-AI カラムで「〇〇するスキルを作って」と頼めます。手で書く場合は設定フォルダに Markdown を 1 ファイル置くだけです。作ったものは [MisStore](https://store.notedeck.io) で配布できます。
+AI カラムで「〇〇するスキルを作って」と頼めます。手で書く場合は設定フォルダに Markdown を 1 ファイル置くだけです。作ったものは [MisStore](https://store.notedeck.io) で配布できます（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md#スキル)）。
 
 capability の一覧と権限の詳細は、リポジトリの [SKILLS.md](https://github.com/notedeck-dev/notedeck/blob/main/SKILLS.md) を参照してください。

--- a/site/docs/dev/theme.md
+++ b/site/docs/dev/theme.md
@@ -53,4 +53,4 @@ Misskey 本体のテーマ形式には `props` の中で `$名前` として定�
 
 ## 作る・配る
 
-AI カラムで「〇〇なイメージのテーマを作って」と頼めます。手で書く場合は設定フォルダに置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます。
+AI カラムで「〇〇なイメージのテーマを作って」と頼めます。手で書く場合は設定フォルダに置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md#テーマ)）。

--- a/site/docs/dev/widget.md
+++ b/site/docs/dev/widget.md
@@ -41,4 +41,4 @@ Ui:render([
 
 ## 作る・配る
 
-AI カラムで「〇〇を表示するウィジェットを作って」と頼めます。手で書く場合は設定フォルダにコード本体とメタ情報の 2 ファイルを置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます。
+AI カラムで「〇〇を表示するウィジェットを作って」と頼めます。手で書く場合は設定フォルダにコード本体とメタ情報の 2 ファイルを置きます。作ったものは [MisStore](https://store.notedeck.io) で配布できます（[提出のしかた](https://github.com/notedeck-dev/misstore/blob/main/CONTRIBUTING.md) / [書式](https://github.com/notedeck-dev/misstore/blob/main/docs/registry-format.md#ウィジェット)）。

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.4"
+version = "1.42.5"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.4"
+version = "1.42.5"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.4"
+    "version": "1.42.5"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.4",
+  "version": "1.42.5",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -741,17 +741,13 @@ function handlePickerReaction(reaction: string) {
               :class="$style.edited"
               :title="formatTime(effectiveNote.updatedAt)"
             >(edited)</span>
-            <svg
+            <i
               v-for="mode in activeModeFlags"
               :key="mode.key"
-              :class="$style.visibilityIcon"
-              viewBox="0 0 24 24"
-              width="14"
-              height="14"
+              class="ti"
+              :class="[`ti-${mode.icon}`, $style.visibilityIcon]"
               :title="mode.label + 'モード'"
-            >
-              <path :d="mode.icon" fill="currentColor" />
-            </svg>
+            />
             <i
               v-if="effectiveNote.localOnly"
               class="ti ti-rocket-off"

--- a/src/components/common/MkPostForm.vue
+++ b/src/components/common/MkPostForm.vue
@@ -591,16 +591,7 @@ function onPaste(e: ClipboardEvent) {
             :title="noteModeLabel(key as string)"
             @click="noteModeFlags[key as string] = !noteModeFlags[key as string]"
           >
-            <svg viewBox="0 0 24 24" width="18" height="18">
-              <path
-                :d="noteModeIcon(key as string)"
-                stroke="currentColor"
-                stroke-width="1.5"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                fill="none"
-              />
-            </svg>
+            <i class="ti" :class="`ti-${noteModeIcon(key as string, val)}`" />
           </button>
 
           <!-- Visibility (hidden in inline channel mode: always public) -->

--- a/src/composables/postFormConstants.ts
+++ b/src/composables/postFormConstants.ts
@@ -32,5 +32,3 @@ export const visibilityOptions: VisibilityOption[] = [
 ]
 
 export const defaultVisibility = visibilityOptions[0] as VisibilityOption
-
-export const DEFAULT_MODE_ICON = 'M12 2a10 10 0 100 20 10 10 0 000-20z'

--- a/src/composables/usePostFormState.test.ts
+++ b/src/composables/usePostFormState.test.ts
@@ -66,7 +66,7 @@ vi.mock('@/composables/useMemos', () => ({
   deleteMemo: (...a: unknown[]) => deleteMemoMock(...a),
 }))
 vi.mock('@/utils/customTimelines', () => ({
-  CUSTOM_TL_ICONS: {},
+  modeIcon: () => 'moon',
   detectAvailableTimelines: (...a: unknown[]) =>
     detectAvailableTimelinesMock(...a),
 }))

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -7,7 +7,6 @@ import type {
 } from '@/adapters/types'
 import { applyNotePostInterruptors } from '@/aiscript/plugin-api'
 import {
-  DEFAULT_MODE_ICON,
   defaultVisibility,
   MAX_TEXT_LENGTH,
   type VisibilityOption,
@@ -33,10 +32,7 @@ import { useConfirm } from '@/stores/confirm'
 import { useSettingsStore } from '@/stores/settings'
 import { useThemeStore } from '@/stores/theme'
 import { useToast } from '@/stores/toast'
-import {
-  CUSTOM_TL_ICONS,
-  detectAvailableTimelines,
-} from '@/utils/customTimelines'
+import { detectAvailableTimelines, modeIcon } from '@/utils/customTimelines'
 import { AppError } from '@/utils/errors'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 
@@ -564,9 +560,9 @@ export function usePostFormState(
     return match?.[1] ?? noteKey
   }
 
-  function noteModeIcon(noteKey: string): string {
-    const label = noteModeLabel(noteKey).toLowerCase()
-    return CUSTOM_TL_ICONS[label] ?? DEFAULT_MODE_ICON
+  /** Tabler アイコン名 (`ti-` プレフィックスなし)。オフ側もフォーク本家に合わせる */
+  function noteModeIcon(noteKey: string, active: boolean): string {
+    return modeIcon(noteKey, active)
   }
 
   function insertAtCursor(

--- a/src/utils/customTimelines.test.ts
+++ b/src/utils/customTimelines.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { modeIcon, noteModeBadgeIcon } from './customTimelines'
+
+describe('modeIcon', () => {
+  it('yami モードは月 (yamisskey 本家の ti-moon / ti-moon-off に合わせる)', () => {
+    expect(modeIcon('isInYamiMode', true)).toBe('moon')
+    expect(modeIcon('isInYamiMode', false)).toBe('moon-off')
+  })
+
+  it('hana モードは花 (はなみすきー本家の独自グリフに合わせる)', () => {
+    expect(modeIcon('isInHanaMode', true)).toBe('flower')
+    expect(modeIcon('isInHanaMode', false)).toBe('flower-off')
+  })
+
+  it('ノート単位のキーでも同じアイコンになる', () => {
+    expect(modeIcon('isNoteInHanaMode', true)).toBe('flower')
+    expect(modeIcon('isNoteInYamiMode', false)).toBe('moon-off')
+  })
+
+  it('未知のモードはトグルアイコンにフォールバックする', () => {
+    expect(modeIcon('isInFooMode', true)).toBe('toggle-right')
+    expect(modeIcon('isInFooMode', false)).toBe('toggle-left')
+  })
+})
+
+describe('noteModeBadgeIcon', () => {
+  it('既知のモードはトグルの on 側と同じアイコンになる', () => {
+    expect(noteModeBadgeIcon('isNoteInYamiMode')).toBe('moon')
+    expect(noteModeBadgeIcon('isNoteInHanaMode')).toBe('flower')
+  })
+
+  it('未知のモードはトグルではなく中立な印にフォールバックする', () => {
+    expect(noteModeBadgeIcon('isNoteInFooMode')).toBe('circle-dot')
+    expect(noteModeBadgeIcon('customFlag')).toBe('circle-dot')
+  })
+})

--- a/src/utils/customTimelines.ts
+++ b/src/utils/customTimelines.ts
@@ -17,6 +17,8 @@ export interface CustomTimelineInfo {
 // Regex patterns for policy/mode scanning (module-level to avoid recompilation in loops)
 const TL_AVAILABLE_RE = /^(.+)TlAvailable$/
 const MODE_RE = /^isIn(.+)Mode$/
+// アカウント単位 (isIn*Mode) とノート単位 (isNoteIn*Mode) の両方からモード名を取る
+const MODE_NAME_RE = /^is(?:Note)?In(.+)Mode$/
 
 // Standard timeline endpoints — excluded from custom detection
 const STANDARD_TL_ENDPOINTS = new Set([
@@ -403,11 +405,37 @@ export function modeLabel(key: string): string {
   return `${match[1]}モード`
 }
 
-/** モードの Tabler アイコン名 (`ti-` プレフィックスなし) */
+/**
+ * モード名 → Tabler アイコン名 (`ti-` プレフィックスなし) の on/off 対。
+ * フォーク本家の実装に合わせる:
+ * - yamisskey: やみノート切り替えが `ti-moon` / `ti-moon-off`、ノートのバッジも `ti-moon`
+ * - はなみすきー: はなモードが独自グリフ `ti-hanamisskey-hanamode` (花)、通常モードが
+ *   `ti-users-group`。独自グリフは Tabler の配布フォントに無いので `flower` で代替し、
+ *   off 側は yami と同じく `-off` 対で揃える (トグルとして読めることを優先)
+ */
+const MODE_ICONS: Record<string, { on: string; off: string }> = {
+  yami: { on: 'moon', off: 'moon-off' },
+  hana: { on: 'flower', off: 'flower-off' },
+}
+
+/** `isInYamiMode` / `isNoteInYamiMode` → `yami`。パターン外は null */
+function modeName(key: string): string | null {
+  return key.match(MODE_NAME_RE)?.[1]?.toLowerCase() ?? null
+}
+
+/** モードトグルの Tabler アイコン名 (`ti-` プレフィックスなし) */
 export function modeIcon(key: string, active: boolean): string {
-  // Known mode icons — fall back to generic toggle icon
-  if (key === 'isInYamiMode') return active ? 'moon' : 'moon-off'
-  return active ? 'toggle-right' : 'toggle-left'
+  const icons = MODE_ICONS[modeName(key) ?? '']
+  if (!icons) return active ? 'toggle-right' : 'toggle-left'
+  return active ? icons.on : icons.off
+}
+
+/**
+ * ノートに付けるモードバッジの Tabler アイコン名。トグルではないので、
+ * 未知のモードはトグルアイコンではなく中立な印にフォールバックする。
+ */
+export function noteModeBadgeIcon(key: string): string {
+  return MODE_ICONS[modeName(key) ?? '']?.on ?? 'circle-dot'
 }
 
 /**

--- a/src/utils/noteViewModel.test.ts
+++ b/src/utils/noteViewModel.test.ts
@@ -158,7 +158,16 @@ describe('deriveActiveModeFlags', () => {
     })
     expect(flags).toHaveLength(1)
     expect(flags[0]).toMatchObject({ key: 'isNoteInYamiMode', label: 'Yami' })
-    expect(flags[0]?.icon).toBeTruthy()
+    expect(flags[0]?.icon).toBe('moon')
+  })
+
+  it('フォークごとのモードに対応するアイコンを付ける', () => {
+    expect(deriveActiveModeFlags({ isNoteInHanaMode: true })[0]?.icon).toBe(
+      'flower',
+    )
+    expect(deriveActiveModeFlags({ isNoteInFooMode: true })[0]?.icon).toBe(
+      'circle-dot',
+    )
   })
 
   it('パターン外のキーはキー名をそのままラベルにする', () => {

--- a/src/utils/noteViewModel.ts
+++ b/src/utils/noteViewModel.ts
@@ -1,5 +1,5 @@
 import type { NormalizedNote, NoteVisibility } from '@/adapters/types'
-import { CUSTOM_TL_ICONS } from '@/utils/customTimelines'
+import { noteModeBadgeIcon } from '@/utils/customTimelines'
 import { extractUrlFromMfm } from '@/utils/extractUrlFromMfm'
 import { parseMfm } from '@/utils/mfm'
 
@@ -83,11 +83,10 @@ export function canRenoteNote(
   return v === 'public' || v === 'home' || (v === 'followers' && isOwnNote)
 }
 
-const DEFAULT_MODE_ICON = 'M12 2a10 10 0 100 20 10 10 0 000-20z'
-
 export interface ActiveModeFlag {
   key: string
   label: string
+  /** Tabler アイコン名 (`ti-` プレフィックスなし) */
   icon: string
 }
 
@@ -101,11 +100,7 @@ export function deriveActiveModeFlags(
     .map(([key]) => {
       const match = key.match(/^isNoteIn(.+)Mode$/)
       const label = match?.[1] ?? key
-      return {
-        key,
-        label,
-        icon: CUSTOM_TL_ICONS[label.toLowerCase()] ?? DEFAULT_MODE_ICON,
-      }
+      return { key, label, icon: noteModeBadgeIcon(key) }
     })
 }
 

--- a/src/utils/selfXssWarning.ts
+++ b/src/utils/selfXssWarning.ts
@@ -9,24 +9,30 @@
  * ことを優先している。
  */
 export function printSelfXssWarning(): void {
-  console.log(
+  // vite の minify は dropConsole を有効にしており (#985)、`console.log(...)`
+  // と静的に判定できる呼び出しは本番ビルドで丸ごと消える。この警告は本番でこそ
+  // 出す必要があるので、参照を経由して呼ぶ。出力に残っているかは
+  // scripts/check-dist-budget.mjs が検査する
+  const log = console.log.bind(console)
+
+  log(
     '%c警告',
     'color: #f00; background-color: #ff0; font-size: 36px; padding: 4px;',
   )
-  console.log(
+  log(
     '%c「この画面に何か貼り付けろ」はすべて詐欺です。',
     'color: #f00; font-weight: 900; font-family: "Hiragino Sans W9", "Hiragino Kaku Gothic ProN", sans-serif; font-size: 24px;',
   )
-  console.log(
+  log(
     '%cここに何かを貼り付けると、悪意のあるユーザーにアカウントを乗っ取られたり、個人情報を盗まれたりする可能性があります。',
     'font-size: 16px; font-weight: 700;',
   )
-  console.log(
+  log(
     '%c貼り付けようとしているものが何なのかを正確に理解していない場合は、%c今すぐ作業を中止してこのウィンドウを閉じてください。',
     'font-size: 16px;',
     'font-size: 20px; font-weight: 700; color: #f00;',
   )
-  console.log(
+  log(
     '詳しくはこちらをご確認ください。 https://misskey-hub.net/docs/for-users/resources/self-xss/',
   )
 }


### PR DESCRIPTION
## 変更内容

- fix: はなモード・はなノートのアイコンが汎用の丸だった (#997)
- fix: self-XSS 警告が本番ビルドで消えていた (#994)
- chore: bump version to 1.42.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer icons for Yami, Hana, and custom note modes.
  - Added consistent fallback icons for unknown modes.
  - Updated note and post composer mode indicators to use a unified icon style.

- **Bug Fixes**
  - Improved visibility and badge icon consistency across notes and custom timelines.
  - Ensured the self-XSS warning remains visible in production builds.

- **Documentation**
  - Added direct links to MisStore submission procedures and format references.

- **Chores**
  - Updated the application version to 1.42.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->