### PR TITLE
Release v1.42.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.5",
+  "version": "1.42.6",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.5"
+version = "1.42.6"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.5"
+version = "1.42.6"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.5"
+    "version": "1.42.6"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.5",
+  "version": "1.42.6",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/theme/colorUtils.ts
+++ b/src/theme/colorUtils.ts
@@ -1,11 +1,23 @@
 type RGBA = [r: number, g: number, b: number, a: number]
 
+// Misskey は tinycolor に値を渡すため `#` の無いベア hex (`e2deda`) も色として通る。
+// 実際に l-botanical.json5 の bg がこの書き方をしているので同じ表記を受け入れる。
+const HEX_RE = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+// ベア hex を `#` 付きに揃える。CSS / SVG の fill にそのまま入れられる形にするため。
+export function normalizeColor(value: string): string {
+  const trimmed = value.trim()
+  return HEX_RE.test(trimmed) && !trimmed.startsWith('#')
+    ? `#${trimmed}`
+    : trimmed
+}
+
 export function parseColor(value: string): RGBA | null {
   value = value.trim()
 
-  // #RGB or #RRGGBB or #RRGGBBAA
-  if (value.startsWith('#')) {
-    const hex = value.slice(1)
+  // #RGB or #RRGGBB or #RRGGBBAA (先頭の `#` は省略可)
+  if (HEX_RE.test(value)) {
+    const hex = value.startsWith('#') ? value.slice(1) : value
     if (hex.length === 3) {
       return [
         parseInt(hex.charAt(0) + hex.charAt(0), 16),

--- a/src/theme/compiler.ts
+++ b/src/theme/compiler.ts
@@ -65,7 +65,7 @@ export function compileMisskeyTheme(
     }
 
     // Literal color value
-    return expr
+    return color.normalizeColor(expr)
   }
 
   // Compile all props

--- a/tests/theme/colorUtils.test.ts
+++ b/tests/theme/colorUtils.test.ts
@@ -4,6 +4,7 @@ import {
   darken,
   hue,
   lighten,
+  normalizeColor,
   parseColor,
   saturate,
   toRgba,
@@ -32,8 +33,27 @@ describe('parseColor', () => {
     expect(parseColor('rgba(255, 255, 255, 0.5)')).toEqual([255, 255, 255, 0.5])
   })
 
+  it('parses bare hex without #', () => {
+    expect(parseColor('e2deda')).toEqual([226, 222, 218, 1])
+    expect(parseColor('fff')).toEqual([255, 255, 255, 1])
+  })
+
   it('returns null for invalid input', () => {
     expect(parseColor('not-a-color')).toBeNull()
+  })
+})
+
+describe('normalizeColor', () => {
+  it('prefixes bare hex with #', () => {
+    expect(normalizeColor('e2deda')).toBe('#e2deda')
+    expect(normalizeColor('fff')).toBe('#fff')
+    expect(normalizeColor('e2dedaCC')).toBe('#e2dedaCC')
+  })
+
+  it('leaves already-valid values untouched', () => {
+    expect(normalizeColor('#e2deda')).toBe('#e2deda')
+    expect(normalizeColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)')
+    expect(normalizeColor('transparent')).toBe('transparent')
   })
 })
 

--- a/tests/theme/compiler.test.ts
+++ b/tests/theme/compiler.test.ts
@@ -23,6 +23,17 @@ describe('compileMisskeyTheme', () => {
     expect(compiled.fg).toBe('#dadada')
   })
 
+  it('normalizes bare hex literals to # form', () => {
+    const theme: MisskeyTheme = {
+      id: 't',
+      name: 't',
+      props: { bg: 'e2deda', panel: ':darken<2<@bg' },
+    }
+    const compiled = compileMisskeyTheme(theme, EMPTY_BASE)
+    expect(compiled.bg).toBe('#e2deda')
+    expect(parseColor(compiled.panel)).not.toBeNull()
+  })
+
   it('resolves @ref property references', () => {
     const theme: MisskeyTheme = {
       id: 't',


### PR DESCRIPTION
## 変更内容

- fix: `#` 無しのベア hex を色として解釈できるようにする (#999)
- chore: bump version to 1.42.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for hexadecimal color values without a leading `#`.
  * Theme color processing now automatically normalizes valid 3-, 6-, and 8-digit hexadecimal values.

* **Bug Fixes**
  * Improved color parsing while preserving support for RGB, RGBA, and existing valid formats.
  * Ensured derived color expressions remain parseable after normalization.

* **Chores**
  * Updated the application version to 1.42.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->