### PR TITLE
Release v1.42.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.7",
+  "version": "1.42.8",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.7"
+version = "1.42.8"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.8.1"
-source = "git+https://github.com/notedeck-dev/notecli?rev=1164ca17d28fdd16f87550b59d5e8ac9dcd765f2#1164ca17d28fdd16f87550b59d5e8ac9dcd765f2"
+source = "git+https://github.com/notedeck-dev/notecli?rev=af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a#af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.8.1"
-source = "git+https://github.com/notedeck-dev/notecli?rev=af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a#af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a"
+source = "git+https://github.com/notedeck-dev/notecli?rev=9548c18b8e86c8fe42b442573bd48775c83d365d#9548c18b8e86c8fe42b442573bd48775c83d365d"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.8.1"
-source = "git+https://github.com/notedeck-dev/notecli?rev=2d7305ea82f184047191c899966d03b88ebef5d7#2d7305ea82f184047191c899966d03b88ebef5d7"
+source = "git+https://github.com/notedeck-dev/notecli?rev=1164ca17d28fdd16f87550b59d5e8ac9dcd765f2#1164ca17d28fdd16f87550b59d5e8ac9dcd765f2"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3167,7 +3167,7 @@ checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 [[package]]
 name = "notecli"
 version = "0.8.1"
-source = "git+https://github.com/notedeck-dev/notecli?rev=9548c18b8e86c8fe42b442573bd48775c83d365d#9548c18b8e86c8fe42b442573bd48775c83d365d"
+source = "git+https://github.com/notedeck-dev/notecli?rev=0b0d39dabde7530767895ae6cd59aad62cfe3ea4#0b0d39dabde7530767895ae6cd59aad62cfe3ea4"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "1164ca17d28fdd16f87550b59d5e8ac9dcd765f2", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "9548c18b8e86c8fe42b442573bd48775c83d365d", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "0b0d39dabde7530767895ae6cd59aad62cfe3ea4", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "2d7305ea82f184047191c899966d03b88ebef5d7", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "1164ca17d28fdd16f87550b59d5e8ac9dcd765f2", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "Misskey Pro — integrated deck environment (IDE) for Misskey pow
 edition = "2021"
 license = "AGPL-3.0-only"
 [dependencies]
-notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "af25bc0035406a4a8f18e9ef8c26ab1203f5fb2a", features = ["specta"] }
+notecli = { git = "https://github.com/notedeck-dev/notecli", rev = "9548c18b8e86c8fe42b442573bd48775c83d365d", features = ["specta"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-notification = "2"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.7"
+version = "1.42.8"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.7"
+    "version": "1.42.8"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.7",
+  "version": "1.42.8",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -44,6 +44,7 @@ import { useReadMarker } from '@/composables/useReadMarker'
 import { useTabSlide } from '@/composables/useTabSlide'
 import { getStreamHealth } from '@/core/streamHealth'
 import { createBoundedCache } from '@/services/boundedCache'
+import { mergeNotifications as mergeNotificationLists } from '@/services/notificationMerge'
 import { syncNotificationNotes } from '@/services/notificationNoteSync'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
@@ -317,17 +318,12 @@ const followRequestStates = ref<Record<string, 'accepted' | 'rejected'>>({})
 function mergeNotifications(
   fresh: NormalizedNotification[],
   cached: NormalizedNotification[],
-  limit = perfStore.get('maxNotifications'),
 ): NormalizedNotification[] {
-  const map = new Map<string, NormalizedNotification>()
-  for (const n of cached) map.set(n.id, n)
-  for (const n of fresh) map.set(n.id, n) // fresh overwrites cached
-  // ISO 8601 strings are lexicographically sortable — avoid Date object allocation
-  return [...map.values()]
-    .sort((a, b) =>
-      b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0,
-    )
-    .slice(0, limit)
+  return mergeNotificationLists(
+    fresh,
+    cached,
+    perfStore.get('maxNotifications'),
+  )
 }
 
 /** Debounced cache save — flushes on unmount */
@@ -448,11 +444,10 @@ function flushRafBuffer() {
   if (rafBuffer.length === 0) return
   const batch = rafBuffer
   rafBuffer = []
-  const updated = [...batch, ...notifications.value]
-  notifications.value =
-    updated.length > perfStore.get('maxNotifications')
-      ? updated.slice(0, perfStore.get('maxNotifications'))
-      : updated
+  // 単純 prepend だと、復帰時に resumeBackfill の REST 補完で取り込み済みの
+  // 通知がストリーム再配信からも届いたとき重複表示になる (#1006)。
+  // REST 経路と同じマージ規則 (ID 一意) を通す
+  notifications.value = mergeNotifications(batch, notifications.value)
   saveCache()
 }
 

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -48,7 +48,9 @@ import { syncNotificationNotes } from '@/services/notificationNoteSync'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
+import { useOfflineModeStore } from '@/stores/offlineMode'
 import { usePerformanceStore } from '@/stores/performance'
+import { useRealtimeModeStore } from '@/stores/realtimeMode'
 import { useServersStore } from '@/stores/servers'
 import { useSuspensionsStore } from '@/stores/suspensions'
 import { useToast } from '@/stores/toast'
@@ -117,6 +119,15 @@ const {
 } = useColumnSetup(() => props.column)
 
 const isLoggedOut = computed(() => account.value?.hasToken === false)
+
+// ポーリング中はライブ更新の供給元が定期取得であることを示す (#1003)。
+// オフラインモード中も isRealtime は false になるが、それはポーリング
+// ではないので出さない
+const realtimeModeStore = useRealtimeModeStore()
+const offlineModeStore = useOfflineModeStore()
+const isPollingMode = computed(
+  () => !realtimeModeStore.isRealtime && !offlineModeStore.isOfflineMode,
+)
 
 const crossSubscriptions: ChannelSubscription[] = []
 
@@ -1096,6 +1107,10 @@ onUnmounted(() => {
     />
 
     <div v-else :class="$style.notifBody">
+      <div v-if="isPollingMode && !isLoggedOut" :class="$style.pollingBanner">
+        <i class="ti ti-bolt-off" />ポーリング
+      </div>
+
       <div v-if="isLoading && notifications.length === 0" :class="$style.columnLoading">
         <LoadingSpinner />
       </div>

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -129,8 +129,17 @@ const offlineModeStore = useOfflineModeStore()
 const isPollingMode = computed(
   () => !realtimeModeStore.isRealtime && !offlineModeStore.isOfflineMode,
 )
+// そもそも取得しに行く先があるか。cross-account は account が常に undefined
+// なので isLoggedOut では判定できない (全アカウントがログアウトでも false)
+const hasAuthenticatedAccount = computed(() =>
+  isCrossAccount.value
+    ? accountsStore.accounts.some((a) => a.hasToken)
+    : account.value?.hasToken === true,
+)
 
 const crossSubscriptions: ChannelSubscription[] = []
+/** connectCrossAccount の並行実行を識別する世代番号 (#1005) */
+let crossReconnectGeneration = 0
 
 const { navigateToUser: navToUser, navigateToNote: navToNote } = useNavigation()
 const noteSound = useNoteSound(() => account.value?.host, 'syuilo/n-ea')
@@ -737,11 +746,22 @@ async function connectPerAccount(useCache = false) {
 }
 
 async function connectCrossAccount(useCache = false) {
+  // この呼び出しの世代。#1005 でアカウント集合の変化と復帰補完の両方から
+  // 呼ばれるようになり、並行実行が現実的になった。古い呼び出しが新しい
+  // 呼び出しの購読を dispose して旧アカウント集合で張り直すのを防ぐため、
+  // await をまたいだあとは自分が最新でなければ何も書かずに降りる
+  const generation = ++crossReconnectGeneration
+  const isStale = () => generation !== crossReconnectGeneration
+
   error.value = null
   isLoading.value = true
   noMoreData.value = false
   const accounts = accountsStore.accounts.filter((a) => a.hasToken)
-  const cached = loadCache()
+  // 削除済みアカウントの通知を永続キャッシュから復活させない。
+  // 表示中リストの filter (下の watch) だけでは localStorage に残った分が
+  // ここでマージされて戻ってしまう
+  const aliveAccountIds = new Set(accountsStore.accounts.map((a) => a.id))
+  const cached = loadCache().filter((n) => aliveAccountIds.has(n._accountId))
 
   if (useCache && cached.length > 0) {
     notifications.value = cached
@@ -755,6 +775,7 @@ async function connectCrossAccount(useCache = false) {
         return fetchNotifications(adapter.api, acc.host)
       }),
     )
+    if (isStale()) return
 
     const allNotifs: NormalizedNotification[] = []
     for (const r of results) {
@@ -775,6 +796,7 @@ async function connectCrossAccount(useCache = false) {
     // Set up streaming for each account
     for (const acc of accounts) {
       const adapter = await multiAdapters.getOrCreate(acc.id)
+      if (isStale()) return
       if (!adapter) continue
       adapter.stream.connect()
       crossSubscriptions.push(
@@ -794,13 +816,15 @@ async function connectCrossAccount(useCache = false) {
       )
     }
   } catch (e) {
+    if (isStale()) return
     if (cached.length > 0) {
       notifications.value = cached
     } else {
       error.value = AppError.from(e)
     }
   } finally {
-    isLoading.value = false
+    // 新しい呼び出しがロード中なら、その表示状態を奪わない
+    if (!isStale()) isLoading.value = false
   }
 }
 
@@ -1122,7 +1146,7 @@ onUnmounted(() => {
     />
 
     <div v-else :class="$style.notifBody">
-      <div v-if="isPollingMode && !isLoggedOut" :class="$style.pollingBanner">
+      <div v-if="isPollingMode && hasAuthenticatedAccount" :class="$style.pollingBanner">
         <i class="ti ti-bolt-off" />ポーリング
       </div>
 

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -636,6 +636,22 @@ watch(
   },
 )
 
+// cross-account: アカウントの追加/削除で購読を張り直す (#1005)。
+// 追加分は購読が無く、カラムを開き直すまでストリームされなかった。
+// connectCrossAccount は全購読を dispose して作り直すので、削除で残る
+// 死に購読の掃除も兼ねる
+watch(
+  () =>
+    accountsStore.accounts
+      .filter((a) => a.hasToken)
+      .map((a) => a.id)
+      .join(','),
+  () => {
+    if (!isCrossAccount.value) return
+    void connectCrossAccount(true)
+  },
+)
+
 // When account loses token (logout with keep-data), switch to cache display
 watch(
   () => account.value?.hasToken,
@@ -1019,19 +1035,23 @@ watch(
   () => void resumeBackfill(),
 )
 
-// WS 瞬断からの再接続でも切断中に欠けた通知を埋める (#704 K)
+// WS 瞬断からの再接続でも切断中に欠けた通知を埋める (#704 K)。
+// cross-account は全アカウントの health を見て、どれか 1 つでも
+// 切断→復帰したら補完する (#1005)
 watch(
-  () =>
-    props.column.accountId
-      ? getStreamHealth(props.column.accountId)?.state
-      : undefined,
-  (state, prev) => {
-    if (
-      state === 'connected' &&
-      (prev === 'reconnecting' || prev === 'disconnected')
-    ) {
-      void resumeBackfill()
-    }
+  () => {
+    const ids = props.column.accountId
+      ? [props.column.accountId]
+      : accountsStore.accounts.filter((a) => a.hasToken).map((a) => a.id)
+    return Object.fromEntries(ids.map((id) => [id, getStreamHealth(id)?.state]))
+  },
+  (states, prev) => {
+    const recovered = Object.entries(states).some(
+      ([id, state]) =>
+        state === 'connected' &&
+        (prev?.[id] === 'reconnecting' || prev?.[id] === 'disconnected'),
+    )
+    if (recovered) void resumeBackfill()
   },
 )
 

--- a/src/composables/useDeckInit.ts
+++ b/src/composables/useDeckInit.ts
@@ -17,6 +17,7 @@ import { handleDeepLink } from '@/composables/useDeepLink'
 import { initOgpListener } from '@/composables/useOgpPreview'
 import { destroyApiBridge, initApiBridge } from '@/core/apiBridge'
 import { reattachQueryDeltaListener } from '@/core/queryDeltaBus'
+import { useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { usePluginsStore } from '@/stores/plugins'
@@ -93,6 +94,14 @@ export function useDeckInit(options: {
 
     // Critical: start streaming immediately
     deckStore.startSync()
+
+    // 永続化されたリアルタイムモードをバックエンドへ適用する (#1004)。
+    // UI 表示は settings から復元されるが、バックエンドは適用を受けるまで
+    // 常に realtime で動く。アカウント一覧が要るのでロード完了後に呼ぶ
+    // (loadAccounts は冪等で、main.ts が開始済みの Promise を返すだけ)
+    void useAccountsStore()
+      .loadAccounts()
+      .then(() => useRealtimeModeStore().applyPersistedMode())
 
     // Load navbar from file (async, non-blocking)
     deckStore.initNavbar()

--- a/src/composables/useDeckInit.ts
+++ b/src/composables/useDeckInit.ts
@@ -102,6 +102,11 @@ export function useDeckInit(options: {
     void useAccountsStore()
       .loadAccounts()
       .then(() => useRealtimeModeStore().applyPersistedMode())
+      .catch((e) => {
+        // モード適用に失敗してもアプリ起動は続行する (次回起動で矯正される)。
+        // ここで握らないと unhandled rejection になる
+        console.warn('[realtime-mode] failed to apply persisted mode:', e)
+      })
 
     // Load navbar from file (async, non-blocking)
     deckStore.initNavbar()

--- a/src/services/notificationMerge.test.ts
+++ b/src/services/notificationMerge.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import type { NormalizedNotification } from '@/adapters/types'
+import { mergeNotifications } from '@/services/notificationMerge'
+
+function makeNotif(
+  id: string,
+  createdAt: string,
+  partial: Partial<NormalizedNotification> = {},
+): NormalizedNotification {
+  return {
+    id,
+    _accountId: 'acc1',
+    _serverHost: 'example.com',
+    createdAt,
+    type: 'reaction',
+    ...partial,
+  } as NormalizedNotification
+}
+
+describe('mergeNotifications', () => {
+  it('同一 ID は fresh が勝って 1 件になる', () => {
+    const cached = [
+      makeNotif('a', '2026-01-01T00:00:02.000Z', { type: 'follow' }),
+    ]
+    const fresh = [makeNotif('a', '2026-01-01T00:00:02.000Z')]
+
+    const merged = mergeNotifications(fresh, cached, 100)
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.type).toBe('reaction')
+  })
+
+  it('createdAt の降順に並ぶ', () => {
+    const merged = mergeNotifications(
+      [makeNotif('mid', '2026-01-01T00:00:02.000Z')],
+      [
+        makeNotif('old', '2026-01-01T00:00:01.000Z'),
+        makeNotif('new', '2026-01-01T00:00:03.000Z'),
+      ],
+      100,
+    )
+
+    expect(merged.map((n) => n.id)).toEqual(['new', 'mid', 'old'])
+  })
+
+  it('limit を超えた古い分は切り捨てる', () => {
+    const merged = mergeNotifications(
+      [makeNotif('new', '2026-01-01T00:00:03.000Z')],
+      [
+        makeNotif('mid', '2026-01-01T00:00:02.000Z'),
+        makeNotif('old', '2026-01-01T00:00:01.000Z'),
+      ],
+      2,
+    )
+
+    expect(merged.map((n) => n.id)).toEqual(['new', 'mid'])
+  })
+
+  it('復帰時: REST 補完で取り込み済みの通知がライブ到着と交差しても重複しない (#1006)', () => {
+    // resumeBackfill が REST で X を取り込んだ後、ストリーム再配信の X が
+    // 描画バッファから届くケース。ID 単位で一意に保たれること
+    const existing = [
+      makeNotif('x', '2026-01-01T00:00:02.000Z'),
+      makeNotif('old', '2026-01-01T00:00:01.000Z'),
+    ]
+    const liveBatch = [
+      makeNotif('x', '2026-01-01T00:00:02.000Z'),
+      makeNotif('y', '2026-01-01T00:00:03.000Z'),
+    ]
+
+    const merged = mergeNotifications(liveBatch, existing, 100)
+
+    expect(merged.map((n) => n.id)).toEqual(['y', 'x', 'old'])
+  })
+
+  it('バッチ内の重複も 1 件になる', () => {
+    const merged = mergeNotifications(
+      [
+        makeNotif('x', '2026-01-01T00:00:01.000Z'),
+        makeNotif('x', '2026-01-01T00:00:01.000Z'),
+      ],
+      [],
+      100,
+    )
+
+    expect(merged).toHaveLength(1)
+  })
+})

--- a/src/services/notificationMerge.test.ts
+++ b/src/services/notificationMerge.test.ts
@@ -74,6 +74,10 @@ describe('mergeNotifications', () => {
     expect(merged.map((n) => n.id)).toEqual(['y', 'x', 'old'])
   })
 
+  // 同一性は通知 ID のみで判定する。表示側 (仮想スクローラのキー・フォロー
+  // リクエスト状態・既読マーカー) も ID を一意キーにしているため、ここだけ
+  // accountId 複合キーにすると描画キーが重複する。サーバー間の ID 衝突は
+  // #1010 で表示側ごと揃えて扱う
   it('バッチ内の重複も 1 件になる', () => {
     const merged = mergeNotifications(
       [

--- a/src/services/notificationMerge.ts
+++ b/src/services/notificationMerge.ts
@@ -1,0 +1,25 @@
+import type { NormalizedNotification } from '@/adapters/types'
+
+/**
+ * 通知リストのマージ規則 (ID 単位で一意、createdAt 降順、limit で切り詰め)。
+ *
+ * REST 取得分とキャッシュのマージだけでなく、ライブ到着分の描画バッファ
+ * 反映もこの規則を通す。復帰時は resumeBackfill の REST 補完とストリーム
+ * 再配信が同じ通知を運んでくるため、経路ごとに独自の結合をすると重複表示
+ * になる (#1006)。
+ */
+export function mergeNotifications(
+  fresh: NormalizedNotification[],
+  cached: NormalizedNotification[],
+  limit: number,
+): NormalizedNotification[] {
+  const map = new Map<string, NormalizedNotification>()
+  for (const n of cached) map.set(n.id, n)
+  for (const n of fresh) map.set(n.id, n) // fresh overwrites cached
+  // ISO 8601 strings are lexicographically sortable — avoid Date object allocation
+  return [...map.values()]
+    .sort((a, b) =>
+      b.createdAt > a.createdAt ? 1 : b.createdAt < a.createdAt ? -1 : 0,
+    )
+    .slice(0, limit)
+}

--- a/src/stores/offlineMode.ts
+++ b/src/stores/offlineMode.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { computed } from 'vue'
 import { useAccountsStore } from '@/stores/accounts'
+import { useRealtimeModeStore } from '@/stores/realtimeMode'
 import { useSettingsStore } from '@/stores/settings'
 import { useStreamingStore } from '@/stores/streaming'
 import { useUiStore } from '@/stores/ui'
@@ -24,6 +25,10 @@ export const useOfflineModeStore = defineStore('offlineMode', () => {
 
   async function disable(): Promise<void> {
     isOfflineMode.value = false
+    // polling モードなら輸送路を再開する (#1004)。enable() の disconnectAll
+    // が polling タスクも止めるため、再適用しないと復帰時の connect で
+    // 実動作が realtime に化ける
+    useRealtimeModeStore().applyPersistedMode()
     // Trigger reconnection via reactive deck-resume signal
     useUiStore().emitDeckResume()
   }

--- a/src/stores/realtimeMode.test.ts
+++ b/src/stores/realtimeMode.test.ts
@@ -1,0 +1,107 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { type Account, useAccountsStore } from '@/stores/accounts'
+import { useOfflineModeStore } from '@/stores/offlineMode'
+import { usePerformanceStore } from '@/stores/performance'
+import { useRealtimeModeStore } from '@/stores/realtimeMode'
+import { useSettingsStore } from '@/stores/settings'
+
+const spy = vi.hoisted(() => ({ streamSetMode: vi.fn() }))
+
+vi.mock('@/bindings', () => ({
+  commands: new Proxy(
+    {},
+    {
+      get: (_t, name: string) => {
+        if (name === 'streamSetMode') {
+          return (...args: unknown[]) => {
+            spy.streamSetMode(...args)
+            return Promise.resolve({ status: 'ok', data: null })
+          }
+        }
+        return () => Promise.resolve({ status: 'ok', data: null })
+      },
+    },
+  ),
+}))
+
+function account(id: string, hasToken = true): Account {
+  return {
+    id,
+    host: 'misskey.example',
+    userId: `user-${id}`,
+    username: id,
+    displayName: null,
+    avatarUrl: null,
+    software: 'misskey-dev/misskey',
+    hasToken,
+  } satisfies Account
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  spy.streamSetMode.mockReset()
+})
+
+describe('applyPersistedMode', () => {
+  it('polling が永続されているとき、token を持つ全アカウントへ polling を適用する', () => {
+    useSettingsStore().set('modes.realtime', false)
+    const accounts = useAccountsStore()
+    accounts.addAccount(account('acc1'))
+    accounts.addAccount(account('acc2', false))
+
+    useRealtimeModeStore().applyPersistedMode()
+
+    const intervalMs = usePerformanceStore().get('streamPollingInterval') * 1000
+    expect(spy.streamSetMode).toHaveBeenCalledTimes(1)
+    expect(spy.streamSetMode).toHaveBeenCalledWith(
+      'acc1',
+      'polling',
+      intervalMs,
+    )
+  })
+
+  it('realtime が永続されているときは何も送らない (バックエンドの既定動作)', () => {
+    useAccountsStore().addAccount(account('acc1'))
+
+    useRealtimeModeStore().applyPersistedMode()
+
+    expect(spy.streamSetMode).not.toHaveBeenCalled()
+  })
+
+  it('オフラインモード中はネットワークを起こさない', () => {
+    useSettingsStore().set('modes.realtime', false)
+    useSettingsStore().set('modes.offline', true)
+    useAccountsStore().addAccount(account('acc1'))
+
+    useRealtimeModeStore().applyPersistedMode()
+
+    expect(spy.streamSetMode).not.toHaveBeenCalled()
+  })
+})
+
+describe('オフラインモード解除', () => {
+  it('polling モードなら輸送路を polling で再開する', async () => {
+    useSettingsStore().set('modes.realtime', false)
+    useSettingsStore().set('modes.offline', true)
+    useAccountsStore().addAccount(account('acc1'))
+
+    await useOfflineModeStore().disable()
+
+    const intervalMs = usePerformanceStore().get('streamPollingInterval') * 1000
+    expect(spy.streamSetMode).toHaveBeenCalledWith(
+      'acc1',
+      'polling',
+      intervalMs,
+    )
+  })
+
+  it('realtime モードなら何も送らない (復帰は deck-resume 経由の connect に委ねる)', async () => {
+    useSettingsStore().set('modes.offline', true)
+    useAccountsStore().addAccount(account('acc1'))
+
+    await useOfflineModeStore().disable()
+
+    expect(spy.streamSetMode).not.toHaveBeenCalled()
+  })
+})

--- a/src/stores/realtimeMode.ts
+++ b/src/stores/realtimeMode.ts
@@ -37,6 +37,18 @@ export const useRealtimeModeStore = defineStore('realtimeMode', () => {
     )
   }
 
+  /**
+   * 永続化されたモードをバックエンドの実動作へ適用する (#1004)。
+   * 起動時とオフラインモード解除時に呼ぶ。realtime はバックエンドの既定
+   * (connect = WS) なので、polling のときだけ明示的に送る。オフライン中は
+   * ネットワークを起こさない (解除時の再適用に委ねる)。
+   */
+  function applyPersistedMode(): void {
+    if (enabled.value) return
+    if (useOfflineModeStore().isOfflineMode) return
+    applyToAllAccounts()
+  }
+
   function setRealtimeMode(value: boolean): void {
     enabled.value = value
     applyToAllAccounts()
@@ -49,6 +61,7 @@ export const useRealtimeModeStore = defineStore('realtimeMode', () => {
   return {
     enabled,
     isRealtime,
+    applyPersistedMode,
     setRealtimeMode,
     toggle,
   }


### PR DESCRIPTION
ポーリングモード周りの取りこぼしをまとめて解消したリリース (#984 の調査から派生した 5 件)。

## 変更一覧

- chore: bump version to 1.42.8
- fix(chat): ポーリングモードでチャットをライブ更新する (#1008)
- fix(notification): ライブ到着分の描画バッファ反映を ID 一意のマージ規則に通す (#1006)
- fix(notification): cross-account カラムの再接続補完とアカウント追随を機能させる (#1005)
- fix(notification): ポーリングモードで通知・メンションをライブ更新する (#1003)
- chore: notecli rev を develop マージ後の commit に再 pin
- fix(streaming): リアルタイムモードの永続設定を起動時にバックエンドへ適用する (#1004)

## 内容

**リアルタイムモードの永続設定が効くようになった (#1004)**
モードの永続値は UI 表示にしか反映されず、バックエンドは常に realtime で動いていた。起動時・オフラインモード解除時に永続モードを適用し、polling 稼働中の `connect` が WebSocket を復活させないよう notecli 側でガードした (notecli#59)。

**ポーリングモードで通知・メンション・チャットが更新されるようになった (#1003 / #1008)**
ポーリングループの対象がノート系購読だけで、main チャンネル (通知/メンション) とチャット購読の取得経路が存在しなかった。notecli の polling loop が両者を定期取得し、WS と同じイベント種別で配るようにした (notecli#60 / #61)。下流の配送・OS 通知・未読バッジは WS モードと共通のまま動く。初回サイクルはカーソル確立のみで配信しないので、切替直後に過去分が OS 通知として大量発火することはない。通知カラムにもノート系カラムと同じ「ポーリング」バナーを出した。

**cross-account 通知カラムの取りこぼし (#1005)**
再接続補完の監視がアカウント指定ありの場合しか機能しておらず、アカウント追加時の購読開始も無かった。全アカウントの stream health を監視し、token 持ちアカウントの集合変化で購読を張り直すようにした。

**復帰直後の通知重複 (#1006)**
復帰時の REST 補完とライブ到着が交差すると同じ通知が 2 件並んだ。マージ規則 (ID 一意・createdAt 降順・limit) を services へ抽出してユニットテストを付け、REST 経路とライブ経路の両方が同じ規則を通るようにした。

## 既知の残作業

- 実機確認 (ポーリング設定で再起動 → バナー表示と通知/チャットのライブ更新、cross-account でのアカウント追加反映)
- チャットの既読・リアクション・削除の polling 追随は未対応 (#1008 のスコープ外として据え置き)

Closes #1003
Closes #1004
Closes #1005
Closes #1006
Closes #1008

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer realtime, polling, and offline-mode status indicators.
  * Restored the selected realtime or polling mode automatically when reconnecting or leaving offline mode.
  * Improved notification synchronization across multiple accounts and reconnects.

* **Bug Fixes**
  * Prevented duplicate notifications and improved ordering when combining live and restored notifications.
  * Improved notification recovery after connection interruptions.

* **Chores**
  * Updated the application version to 1.42.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->