### PR TITLE
Release v1.43.0

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -193,18 +193,24 @@ attach モードはデバイス側アプリを終了させず、デッキ操作�
 
 できること:
 
-- **デッキ状態** — カラム一覧、`/api/health` と `/api/openapi.json` の
-  シンタックスハイライト付き表示
+- **デッキ状態** — カラム一覧と、折りたたみで `/api/health` raw・
+  `/api/openapi.json`・起動計測（起動マーク + WebView 固定費、[#985](https://github.com/notedeck-dev/notedeck/issues/985)）・
+  HEARTBEAT 状態（最終 tick / 結末 / 連続失敗、[#411](https://github.com/notedeck-dev/notedeck/issues/411)）・キャッシュ観測
+  （上限つきキャッシュの size / limit 実測、[#987](https://github.com/notedeck-dev/notedeck/issues/987)）・Query Bridge トレース
+  （query 往復の所要時間）。JSON はシンタックスハイライト付き
 - **SSE ライブビューア** — `/api/events` を購読して Rust 側イベントバスの
-  流れをリアルタイム表示。type prefix フィルタ（`note,notification,main-` の
-  ようにカンマ区切り）、切断時自動再接続。行クリックでペイロードを展開
+  流れをリアルタイム表示。type prefix フィルタ・種別チップ（クリックで
+  絞り込み）・流量表示・JSON Lines エクスポート・切断時自動再接続。
+  折りたたみで Inspector 突き合わせ（アダプタ層 vs SSE の種別別カウント）
 - **Capabilities 実行盤** — 登録済み capability の一覧からパラメータを
   JSON で組んで実行。external principal として dispatcher を通るので、
   権限ゲート（[#712](https://github.com/notedeck-dev/notedeck/issues/712)）の deny・確認ダイアログ・DispatchResult → HTTP status の
-  写像をそのまま目視テストできる
-- **Rust ログ tail** — アプリの tracing ログ（`notedeck.log` 日次ローテート）
-  を Vite dev server の `/dev/logs` が SSE で流す。レベル別色分けと部分一致
-  フィルタ付き。ログの所在は `/api` インデックスが開示する `logDir` から解決
+  写像をそのまま目視テストできる。principal 別実効権限マトリクスと
+  実行履歴つき
+- **統合タイムライン** — Rust の tracing ログ（Vite dev server の
+  `/dev/logs` が SSE 配信、所在は `/api` インデックスの `logDir` から解決）
+  + SSE イベント + フロント in-app ログを単一時系列にマージ。
+  「どの層でイベントが消えたか」をソース切替しながら 1 画面で追える
 - **Scalar API ドキュメント** — `/api/docs` へのリンク
 
 仕組み: Vite の dev proxy（`vite.config.ts`）が `/api` と `/proxy` を

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.42.8",
+  "version": "1.43.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.42.8"
+version = "1.43.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.42.8"
+version = "1.43.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -360,6 +360,34 @@
         ]
       }
     },
+    "/api/heartbeat/status": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_heartbeat_status",
+        "responses": {
+          "200": {
+            "description": "HEARTBEAT daemon snapshot (last tick, outcome, failure counter) and config"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/openapi.json": {
       "get": {
         "tags": [

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -373,6 +373,62 @@
         }
       }
     },
+    "/api/permissions/resolved": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_permissions_resolved",
+        "responses": {
+          "200": {
+            "description": "Effective permission grants per profiled principal (#712)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/startup/trace": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_startup_trace",
+        "responses": {
+          "200": {
+            "description": "Frontend startup trace marks (navigation-origin ms) and WebView fixed cost"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/{host}/note": {
       "post": {
         "tags": [

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -388,6 +388,62 @@
         ]
       }
     },
+    "/api/inspector/recent": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_inspector_recent",
+        "responses": {
+          "200": {
+            "description": "Stream Inspector (adapter-layer raw WS) event counts by kind, for cross-checking against the SSE stream"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/logs/recent": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_logs_recent",
+        "responses": {
+          "200": {
+            "description": "Frontend in-app log ring (console.warn/error wrap)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/openapi.json": {
       "get": {
         "tags": [
@@ -401,6 +457,34 @@
         }
       }
     },
+    "/api/perf/caches": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_perf_caches",
+        "responses": {
+          "200": {
+            "description": "Bounded cache registry stats (name / size / limit, #987)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
     "/api/permissions/resolved": {
       "get": {
         "tags": [
@@ -410,6 +494,34 @@
         "responses": {
           "200": {
             "description": "Effective permission grants per profiled principal (#712)"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/querybridge/trace": {
+      "get": {
+        "tags": [
+          "dev"
+        ],
+        "operationId": "get_querybridge_trace",
+        "responses": {
+          "200": {
+            "description": "Recent query-bridge round trips with duration (IPC visibility)"
           },
           "401": {
             "description": "Unauthorized",

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.42.8"
+    "version": "1.43.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -430,6 +430,46 @@ async fn list_commands(State(state): State<DeckState>) -> Result<Json<Value>, Ap
     Ok(Json(data))
 }
 
+// --- dev ダッシュボード向け読み取り診断 (#977) ---
+// ephemeral トークンで読む前提の面。永続トークン (external principal) には
+// permissions_gate::route_rule が既定 Deny を返す (マッピング未登録 = 閉)。
+
+#[utoipa::path(get, path = "/api/startup/trace", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Frontend startup trace marks (navigation-origin ms) and WebView fixed cost"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_startup_trace(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "startup/trace", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
+#[utoipa::path(get, path = "/api/permissions/resolved", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Effective permission grants per profiled principal (#712)"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_permissions_resolved(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "permissions/resolved", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
 // --- Capability API (#709: 外部アプリ向け操作面) ---
 // カラム追加/削除・コマンド実行の旧ルートは #711 で削除した。外部からの操作は
 // すべて POST /api/capabilities/{id}/execute (= 権限判定を通る dispatcher) を使う。
@@ -596,6 +636,8 @@ fn deck_openapi_router() -> OpenApiRouter<DeckState> {
         .routes(routes!(list_capabilities))
         .routes(routes!(execute_capability))
         .routes(routes!(get_health))
+        .routes(routes!(get_startup_trace))
+        .routes(routes!(get_permissions_resolved))
 }
 
 /// Public image-proxy route, as an [`OpenApiRouter`].

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -452,6 +452,24 @@ async fn get_startup_trace(State(state): State<DeckState>) -> Result<Json<Value>
     Ok(Json(data))
 }
 
+#[utoipa::path(get, path = "/api/heartbeat/status", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "HEARTBEAT daemon snapshot (last tick, outcome, failure counter) and config"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_heartbeat_status(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "heartbeat/status", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
 #[utoipa::path(get, path = "/api/permissions/resolved", tag = "dev",
     security(("bearer_auth" = [])),
     responses(
@@ -638,6 +656,7 @@ fn deck_openapi_router() -> OpenApiRouter<DeckState> {
         .routes(routes!(get_health))
         .routes(routes!(get_startup_trace))
         .routes(routes!(get_permissions_resolved))
+        .routes(routes!(get_heartbeat_status))
 }
 
 /// Public image-proxy route, as an [`OpenApiRouter`].

--- a/src-tauri/src/http_server.rs
+++ b/src-tauri/src/http_server.rs
@@ -452,6 +452,78 @@ async fn get_startup_trace(State(state): State<DeckState>) -> Result<Json<Value>
     Ok(Json(data))
 }
 
+#[utoipa::path(get, path = "/api/perf/caches", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Bounded cache registry stats (name / size / limit, #987)"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_perf_caches(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "perf/caches", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
+#[utoipa::path(get, path = "/api/logs/recent", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Frontend in-app log ring (console.warn/error wrap)"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_logs_recent(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "logs/recent", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
+#[utoipa::path(get, path = "/api/querybridge/trace", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Recent query-bridge round trips with duration (IPC visibility)"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_querybridge_trace(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "querybridge/trace", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
+#[utoipa::path(get, path = "/api/inspector/recent", tag = "dev",
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Stream Inspector (adapter-layer raw WS) event counts by kind, for cross-checking against the SSE stream"),
+        (status = 401, description = "Unauthorized", body = ApiErrorResponse),
+    )
+)]
+async fn get_inspector_recent(State(state): State<DeckState>) -> Result<Json<Value>, ApiError> {
+    let data = query_bridge::query_frontend(&state.app_handle, "inspector/recent", json!({}))
+        .await
+        .map_err(|e| ApiError {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "QUERY_FAILED".to_string(),
+            message: e,
+        })?;
+    Ok(Json(data))
+}
+
 #[utoipa::path(get, path = "/api/heartbeat/status", tag = "dev",
     security(("bearer_auth" = [])),
     responses(
@@ -657,6 +729,10 @@ fn deck_openapi_router() -> OpenApiRouter<DeckState> {
         .routes(routes!(get_startup_trace))
         .routes(routes!(get_permissions_resolved))
         .routes(routes!(get_heartbeat_status))
+        .routes(routes!(get_perf_caches))
+        .routes(routes!(get_logs_recent))
+        .routes(routes!(get_querybridge_trace))
+        .routes(routes!(get_inspector_recent))
 }
 
 /// Public image-proxy route, as an [`OpenApiRouter`].

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.42.8",
+  "version": "1.43.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -464,8 +464,9 @@ function flushRafBuffer() {
 // キーは通知 ID を含むので、流れてきた通知の数だけ増える。通知カラムは
 // 開きっぱなしにされる面なので上限を持たせる (#987)。保持している通知の
 // 数を超えて覚えていても引かれることはない
-const reactionUrlLookup = createBoundedCache<string, string | null>(() =>
-  perfStore.get('maxNotifications'),
+const reactionUrlLookup = createBoundedCache<string, string | null>(
+  () => perfStore.get('maxNotifications'),
+  'notification:reaction-url',
 )
 // 絵文字そのものがキー (Unicode 絵文字の種類ぶん) なので通知数では増えない
 const twemojiUrlLookup = new Map<string, string | null>()

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -45,6 +45,81 @@ const CodeEditor = defineAsyncComponent(
 )
 const lang = jsonLang()
 
+// --- OpenClaw Control UI 流のビュー切替 (サイドバー + 単一ペイン) ---
+
+type ViewId =
+  | 'overview'
+  | 'sse'
+  | 'timeline'
+  | 'inspector'
+  | 'caps'
+  | 'perms'
+  | 'startup'
+  | 'heartbeat'
+  | 'caches'
+  | 'qbtrace'
+
+const activeView = ref<ViewId>('overview')
+
+const NAV_GROUPS: {
+  label: string
+  items: { id: ViewId; icon: string; label: string }[]
+}[] = [
+  {
+    label: '観測',
+    items: [
+      { id: 'overview', icon: 'ti ti-layout-columns', label: '概要' },
+      { id: 'sse', icon: 'ti ti-broadcast', label: 'SSE イベント' },
+      { id: 'timeline', icon: 'ti ti-terminal-2', label: '統合タイムライン' },
+      { id: 'inspector', icon: 'ti ti-search', label: 'Inspector 照合' },
+    ],
+  },
+  {
+    label: '実行',
+    items: [
+      { id: 'caps', icon: 'ti ti-bolt', label: 'Capabilities' },
+      { id: 'perms', icon: 'ti ti-shield-lock', label: '実効権限' },
+    ],
+  },
+  {
+    label: '診断',
+    items: [
+      { id: 'startup', icon: 'ti ti-rocket', label: '起動計測' },
+      { id: 'heartbeat', icon: 'ti ti-heartbeat', label: 'HEARTBEAT' },
+      { id: 'caches', icon: 'ti ti-database', label: 'キャッシュ' },
+      { id: 'qbtrace', icon: 'ti ti-arrows-left-right', label: 'Query Bridge' },
+    ],
+  },
+]
+
+function selectView(id: ViewId) {
+  activeView.value = id
+  // 開いたときに取得する遅延ロード系ビュー
+  if (id === 'startup') fetchStartup()
+  if (id === 'perms') fetchPerms()
+  if (id === 'caches') fetchCaches()
+  if (id === 'qbtrace') fetchQbTrace()
+  if (id === 'inspector') fetchInspector()
+}
+
+/** アプリ (19820) への到達性。切断時は OpenClaw 流のアンバーピルを出す */
+const appReachable = ref(true)
+
+// ナビの開閉 (Misskey ナビバー式)。folded は幅 56px のアイコン列になる
+const navCollapsed = ref(localStorage.getItem('nd-control-nav') === 'collapsed')
+
+function toggleNav() {
+  navCollapsed.value = !navCollapsed.value
+  try {
+    localStorage.setItem(
+      'nd-control-nav',
+      navCollapsed.value ? 'collapsed' : 'open',
+    )
+  } catch {
+    // localStorage 不可なら永続化だけ諦める
+  }
+}
+
 const app = ref<ApiIndex | null>(null)
 const columns = ref<DeckColumn[]>([])
 const health = ref('')
@@ -73,7 +148,6 @@ interface StartupTrace {
   webviewFixedCost: number | null
 }
 
-const showStartup = ref(false)
 const startup = ref<StartupTrace | null>(null)
 
 const startupRows = computed(() => {
@@ -89,9 +163,7 @@ const startupMaxDelta = computed(() =>
   Math.max(1, ...startupRows.value.map((r) => r.delta)),
 )
 
-async function toggleStartup() {
-  showStartup.value = !showStartup.value
-  if (!showStartup.value) return
+async function fetchStartup() {
   try {
     const res = await fetch('/api/startup/trace')
     if (res.ok) startup.value = await res.json()
@@ -119,14 +191,9 @@ interface HeartbeatStatusView {
   }
 }
 
-const showHeartbeat = ref(false)
 // heartbeat の中身は refreshStatus の 5 秒ポーリングが埋める
-// (ステータスバーにも常時出すため折りたたみ開閉と独立に取得する)
+// (ステータスバーにも常時出すためビュー表示と独立に取得する)
 const heartbeat = ref<HeartbeatStatusView | null>(null)
-
-function toggleHeartbeat() {
-  showHeartbeat.value = !showHeartbeat.value
-}
 
 function relativeTime(epochMs: number | null): string {
   if (epochMs === null) return '—'
@@ -172,6 +239,7 @@ async function refreshStatus() {
       fetch('/api/health'),
       fetch('/api/heartbeat/status'),
     ])
+    appReachable.value = indexRes.ok
     if (indexRes.ok) app.value = await indexRes.json()
     if (colsRes.ok) {
       const data: unknown = await colsRes.json()
@@ -182,6 +250,7 @@ async function refreshStatus() {
     if (hbRes.ok) heartbeat.value = await hbRes.json()
   } catch {
     // アプリ再起動中など — 次の周期更新で回復する
+    appReachable.value = false
   }
 }
 
@@ -431,12 +500,9 @@ interface ResolvedPermissions {
 
 const PERM_PRINCIPALS = ['ai.chat', 'ai.heartbeat', 'plugin', 'external']
 
-const showPerms = ref(false)
 const perms = ref<ResolvedPermissions | null>(null)
 
-async function togglePerms() {
-  showPerms.value = !showPerms.value
-  if (!showPerms.value) return
+async function fetchPerms() {
   try {
     const res = await fetch('/api/permissions/resolved')
     if (res.ok) perms.value = await res.json()
@@ -670,12 +736,9 @@ interface CacheStat {
   limit: number
 }
 
-const showCaches = ref(false)
 const caches = ref<CacheStat[]>([])
 
-async function toggleCaches() {
-  showCaches.value = !showCaches.value
-  if (!showCaches.value) return
+async function fetchCaches() {
   try {
     const res = await fetch('/api/perf/caches')
     if (res.ok) {
@@ -694,12 +757,9 @@ interface QbTraceRow {
   error: boolean
 }
 
-const showQbTrace = ref(false)
 const qbTrace = ref<QbTraceRow[]>([])
 
-async function toggleQbTrace() {
-  showQbTrace.value = !showQbTrace.value
-  if (!showQbTrace.value) return
+async function fetchQbTrace() {
   try {
     const res = await fetch('/api/querybridge/trace')
     if (res.ok) {
@@ -717,12 +777,9 @@ interface InspectorRecent {
   oldestTs: number | null
 }
 
-const showInspector = ref(false)
 const inspector = ref<InspectorRecent | null>(null)
 
-async function toggleInspector() {
-  showInspector.value = !showInspector.value
-  if (!showInspector.value) return
+async function fetchInspector() {
   try {
     const res = await fetch('/api/inspector/recent')
     if (res.ok) inspector.value = await res.json()
@@ -732,6 +789,7 @@ async function toggleInspector() {
 }
 
 onMounted(() => {
+  document.title = 'NoteDeck Control'
   refreshStatus()
   statusTimer = setInterval(refreshStatus, 5000)
   connectSse()
@@ -752,6 +810,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  document.title = 'NoteDeck'
   if (statusTimer) clearInterval(statusTimer)
   if (frontTimer) clearInterval(frontTimer)
   if (tickTimer) clearInterval(tickTimer)
@@ -761,195 +820,319 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div :class="$style.dashboard">
-    <header :class="$style.header">
-      <img
-        src="/favicon.svg"
-        alt=""
-        :class="[$style.logo, sseState === 'open' && $style.logoLive]"
-      />
-      <div :class="$style.headText">
-        <h1 :class="$style.title">
-          NoteDeck <span :class="$style.titleAccent">Dev Dashboard</span>
-        </h1>
-        <p :class="$style.subtitle">
-          <span :class="[$style.led, sseState === 'open' && $style.ledOpen]" />
-          <span :class="$style.mono">{{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}</span>
-          · 127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template>
-        </p>
-      </div>
-      <nav :class="$style.links">
-        <a href="/api/docs" target="_blank" rel="noopener">
-          <i class="ti ti-book-2" /> API ドキュメント
-        </a>
-      </nav>
-    </header>
+  <div :class="$style.control">
+    <div v-if="!appReachable" :class="$style.reconnectPill">
+      <i class="ti ti-plug-x" /> アプリ接続なし — 再接続待ち…
+    </div>
 
-    <div :class="$style.grid">
-      <section :class="[$style.panel, $style.gridDeck]">
-        <h2 :class="$style.panelTitle">
-          <i class="ti ti-layout-columns" :class="$style.panelIcon" />
-          デッキ状態 — カラム {{ columns.length }} 本
-        </h2>
-        <div :class="$style.tableWrap">
-          <table :class="$style.table">
-            <thead>
-              <tr><th>type</th><th>id</th><th>account</th></tr>
-            </thead>
-            <tbody>
-              <tr v-for="col in columns" :key="col.id">
-                <td>{{ col.type }}</td>
-                <td :class="$style.mono">{{ col.id }}</td>
-                <td :class="$style.mono">{{ col.accountId ?? '(cross-account)' }}</td>
-              </tr>
-            </tbody>
-          </table>
+    <div :class="$style.body">
+      <aside :class="[$style.sidebar, navCollapsed && $style.sidebarCollapsed]">
+        <div :class="$style.sidebarHead">
+          <img
+            src="/favicon.svg"
+            alt=""
+            :class="[$style.brandLogo, sseState === 'open' && $style.logoLive]"
+            :title="sseState === 'open' ? 'LIVE' : sseState"
+          />
+          <span v-if="!navCollapsed" :class="$style.brandName">NoteDeck</span>
+          <button
+            type="button"
+            :class="$style.navToggle"
+            :title="navCollapsed ? 'ナビゲーションを開く' : 'ナビゲーションを畳む'"
+            @click="toggleNav"
+          >
+            <i :class="navCollapsed ? 'ti ti-chevrons-right' : 'ti ti-chevrons-left'" />
+          </button>
         </div>
-        <button
-          type="button"
-          :class="$style.summary"
-          @click="showHealth = !showHealth"
-        >
-          <i :class="showHealth ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          /api/health raw
-        </button>
-        <CodeEditor
-          v-if="showHealth && health"
-          :model-value="health"
-          :language="lang"
-          read-only
-          auto-height
-        />
-        <button type="button" :class="$style.summary" @click="toggleSpec">
-          <i :class="showSpec ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          /api/openapi.json
-        </button>
-        <CodeEditor
-          v-if="showSpec && spec"
-          :model-value="spec"
-          :language="lang"
-          read-only
-          max-height="48vh"
-        />
-        <button type="button" :class="$style.summary" @click="toggleStartup">
-          <i :class="showStartup ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          起動計測 (#985)
-        </button>
-        <template v-if="showStartup && startup">
-          <p v-if="startup.webviewFixedCost !== null" :class="$style.capDesc">
-            WebView 起動固定費 ~{{ startup.webviewFixedCost }}ms
-          </p>
+        <nav :class="$style.nav">
+          <div
+            v-for="group in NAV_GROUPS"
+            :key="group.label"
+            :class="$style.navGroup"
+          >
+            <p v-if="!navCollapsed" :class="$style.navGroupLabel">{{ group.label }}</p>
+            <button
+              v-for="item in group.items"
+              :key="item.id"
+              type="button"
+              :class="[
+                $style.navItem,
+                activeView === item.id && $style.navItemActive,
+              ]"
+              :title="item.label"
+              @click="selectView(item.id)"
+            >
+              <i :class="item.icon" />
+              <span v-if="!navCollapsed" :class="$style.navLabel">{{ item.label }}</span>
+              <i
+                v-if="
+                  item.id === 'heartbeat' &&
+                  heartbeat?.config.enabled &&
+                  !navCollapsed
+                "
+                class="ti ti-heartbeat"
+                :class="[$style.beat, $style.navItemSuffix]"
+              />
+            </button>
+          </div>
+          <div :class="$style.navGroup">
+            <p v-if="!navCollapsed" :class="$style.navGroupLabel">リソース</p>
+            <a
+              :class="$style.navItem"
+              href="/api/docs"
+              target="_blank"
+              rel="noopener"
+              title="API ドキュメント"
+            >
+              <i class="ti ti-book-2" />
+              <span v-if="!navCollapsed" :class="$style.navLabel">API ドキュメント</span>
+            </a>
+          </div>
+        </nav>
+      </aside>
+
+      <main :class="$style.content">
+        <section v-if="activeView === 'overview'" :class="$style.view">
+          <div :class="$style.statCards">
+            <div :class="$style.statCard">
+              <span :class="$style.statValue">{{ sseCount }}</span>
+              <span :class="$style.statLabel">events</span>
+            </div>
+            <div :class="$style.statCard">
+              <span :class="$style.statValue">{{ sseRatePerMin }}</span>
+              <span :class="$style.statLabel">events/min</span>
+            </div>
+            <div :class="$style.statCard">
+              <span :class="[$style.statValue, timelineErrorCount > 0 && $style.statusErr]">{{ timelineErrorCount }}</span>
+              <span :class="$style.statLabel">errors</span>
+            </div>
+            <div :class="$style.statCard">
+              <span :class="[$style.statValue, timelineWarnCount > 0 && $style.statusWarn]">{{ timelineWarnCount }}</span>
+              <span :class="$style.statLabel">warnings</span>
+            </div>
+            <div :class="$style.statCard">
+              <span :class="$style.statValue">{{ columns.length }}</span>
+              <span :class="$style.statLabel">columns</span>
+            </div>
+            <div :class="$style.statCard">
+              <span :class="$style.statValue">{{ capabilities.length }}</span>
+              <span :class="$style.statLabel">capabilities</span>
+            </div>
+          </div>
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-layout-columns" :class="$style.panelIcon" />
+            デッキ状態 — カラム {{ columns.length }} 本
+          </h2>
           <div :class="$style.tableWrap">
             <table :class="$style.table">
               <thead>
-                <tr><th>mark</th><th>at</th><th>+Δ</th><th /></tr>
+                <tr><th>type</th><th>id</th><th>account</th></tr>
               </thead>
               <tbody>
-                <tr v-for="row in startupRows" :key="row.name">
-                  <td :class="$style.mono">{{ row.name }}</td>
-                  <td :class="$style.mono">{{ Math.round(row.at) }}ms</td>
-                  <td :class="$style.mono">+{{ Math.round(row.delta) }}ms</td>
+                <tr v-for="col in columns" :key="col.id">
+                  <td>{{ col.type }}</td>
+                  <td :class="$style.mono">{{ col.id }}</td>
+                  <td :class="$style.mono">{{ col.accountId ?? '(cross-account)' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <button
+            type="button"
+            :class="$style.summary"
+            @click="showHealth = !showHealth"
+          >
+            <i :class="showHealth ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+            /api/health raw
+          </button>
+          <CodeEditor
+            v-if="showHealth && health"
+            :model-value="health"
+            :language="lang"
+            read-only
+            auto-height
+          />
+          <button type="button" :class="$style.summary" @click="toggleSpec">
+            <i :class="showSpec ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+            /api/openapi.json
+          </button>
+          <CodeEditor
+            v-if="showSpec && spec"
+            :model-value="spec"
+            :language="lang"
+            read-only
+            max-height="48vh"
+          />
+        </section>
+
+        <section v-if="activeView === 'startup'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-rocket" :class="$style.panelIcon" />
+            起動計測 (#985)
+            <button type="button" :class="$style.btn" @click="fetchStartup">更新</button>
+          </h2>
+          <template v-if="startup">
+            <p v-if="startup.webviewFixedCost !== null" :class="$style.capDesc">
+              WebView 起動固定費 ~{{ startup.webviewFixedCost }}ms
+            </p>
+            <div :class="$style.tableWrap">
+              <table :class="$style.table">
+                <thead>
+                  <tr><th>mark</th><th>at</th><th>+Δ</th><th /></tr>
+                </thead>
+                <tbody>
+                  <tr v-for="row in startupRows" :key="row.name">
+                    <td :class="$style.mono">{{ row.name }}</td>
+                    <td :class="$style.mono">{{ Math.round(row.at) }}ms</td>
+                    <td :class="$style.mono">+{{ Math.round(row.delta) }}ms</td>
+                    <td :class="$style.barCell">
+                      <span
+                        :class="$style.bar"
+                        :style="{ width: `${(row.delta / startupMaxDelta) * 100}%` }"
+                      />
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </template>
+        </section>
+
+        <section v-if="activeView === 'heartbeat'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-heartbeat" :class="$style.panelIcon" />
+            HEARTBEAT 状態 (#411)
+            <i
+              v-if="heartbeat?.config.enabled"
+              class="ti ti-heartbeat"
+              :class="$style.beat"
+            />
+          </h2>
+          <div v-if="heartbeat" :class="$style.tableWrap">
+            <table :class="$style.table">
+              <tbody>
+                <tr>
+                  <td>daemon</td>
+                  <td :class="$style.mono">
+                    {{ heartbeat.mounted ? (heartbeat.config.enabled ? 'enabled' : 'disabled') : 'not mounted' }}{{ heartbeat.running ? ' (tick 実行中)' : '' }}
+                  </td>
+                </tr>
+                <tr>
+                  <td>interval / target</td>
+                  <td :class="$style.mono">{{ heartbeat.config.intervalMinutes }} 分 / {{ heartbeat.config.target }}</td>
+                </tr>
+                <tr>
+                  <td>最終 tick</td>
+                  <td :class="$style.mono">
+                    {{ relativeTime(heartbeat.lastTickAt) }}<template v-if="heartbeat.lastTickSource"> ({{ heartbeat.lastTickSource }})</template>
+                  </td>
+                </tr>
+                <tr>
+                  <td>直近の結末</td>
+                  <td :class="$style.mono">{{ heartbeat.lastOutcome ?? '—' }}</td>
+                </tr>
+                <tr>
+                  <td>連続失敗</td>
+                  <td :class="$style.mono">{{ heartbeat.consecutiveFailures }}</td>
+                </tr>
+                <tr>
+                  <td>本日の AI 起動</td>
+                  <td :class="$style.mono">{{ heartbeat.dailyCount }} / {{ heartbeat.config.dailyMaxAiRuns }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section v-if="activeView === 'caches'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-database" :class="$style.panelIcon" />
+            キャッシュ観測 (#987)
+            <button type="button" :class="$style.btn" @click="fetchCaches">更新</button>
+          </h2>
+          <div :class="$style.tableWrap">
+            <table v-if="caches.length" :class="$style.table">
+              <thead>
+                <tr><th>name</th><th>size</th><th>limit</th><th /></tr>
+              </thead>
+              <tbody>
+                <tr v-for="(c, i) in caches" :key="`${c.name}-${i}`">
+                  <td :class="$style.mono">{{ c.name }}</td>
+                  <td :class="$style.mono">{{ c.size }}</td>
+                  <td :class="$style.mono">{{ c.limit }}</td>
                   <td :class="$style.barCell">
                     <span
-                      :class="$style.bar"
-                      :style="{ width: `${(row.delta / startupMaxDelta) * 100}%` }"
+                      :class="[$style.bar, c.size / c.limit > 0.9 && $style.barHot]"
+                      :style="{ width: `${Math.min(100, (c.size / Math.max(1, c.limit)) * 100)}%` }"
                     />
                   </td>
                 </tr>
               </tbody>
             </table>
+            <p v-else :class="$style.capDesc">登録済みキャッシュなし</p>
           </div>
-        </template>
-        <button type="button" :class="$style.summary" @click="toggleHeartbeat">
-          <i :class="showHeartbeat ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          HEARTBEAT 状態 (#411)
-          <i
-            v-if="heartbeat?.config.enabled"
-            class="ti ti-heartbeat"
-            :class="$style.beat"
-          />
-        </button>
-        <div v-if="showHeartbeat && heartbeat" :class="$style.tableWrap">
-          <table :class="$style.table">
-            <tbody>
-              <tr>
-                <td>daemon</td>
-                <td :class="$style.mono">
-                  {{ heartbeat.mounted ? (heartbeat.config.enabled ? 'enabled' : 'disabled') : 'not mounted' }}{{ heartbeat.running ? ' (tick 実行中)' : '' }}
-                </td>
-              </tr>
-              <tr>
-                <td>interval / target</td>
-                <td :class="$style.mono">{{ heartbeat.config.intervalMinutes }} 分 / {{ heartbeat.config.target }}</td>
-              </tr>
-              <tr>
-                <td>最終 tick</td>
-                <td :class="$style.mono">
-                  {{ relativeTime(heartbeat.lastTickAt) }}<template v-if="heartbeat.lastTickSource"> ({{ heartbeat.lastTickSource }})</template>
-                </td>
-              </tr>
-              <tr>
-                <td>直近の結末</td>
-                <td :class="$style.mono">{{ heartbeat.lastOutcome ?? '—' }}</td>
-              </tr>
-              <tr>
-                <td>連続失敗</td>
-                <td :class="$style.mono">{{ heartbeat.consecutiveFailures }}</td>
-              </tr>
-              <tr>
-                <td>本日の AI 起動</td>
-                <td :class="$style.mono">{{ heartbeat.dailyCount }} / {{ heartbeat.config.dailyMaxAiRuns }}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <button type="button" :class="$style.summary" @click="toggleCaches">
-          <i :class="showCaches ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          キャッシュ観測 (#987)
-        </button>
-        <div v-if="showCaches" :class="$style.tableWrap">
-          <table v-if="caches.length" :class="$style.table">
-            <thead>
-              <tr><th>name</th><th>size</th><th>limit</th><th /></tr>
-            </thead>
-            <tbody>
-              <tr v-for="(c, i) in caches" :key="`${c.name}-${i}`">
-                <td :class="$style.mono">{{ c.name }}</td>
-                <td :class="$style.mono">{{ c.size }}</td>
-                <td :class="$style.mono">{{ c.limit }}</td>
-                <td :class="$style.barCell">
-                  <span
-                    :class="[$style.bar, c.size / c.limit > 0.9 && $style.barHot]"
-                    :style="{ width: `${Math.min(100, (c.size / Math.max(1, c.limit)) * 100)}%` }"
-                  />
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <p v-else :class="$style.capDesc">登録済みキャッシュなし</p>
-        </div>
-        <button type="button" :class="$style.summary" @click="toggleQbTrace">
-          <i :class="showQbTrace ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          Query Bridge トレース
-        </button>
-        <div v-if="showQbTrace" :class="$style.tableWrap">
-          <table v-if="qbTrace.length" :class="$style.table">
-            <thead>
-              <tr><th>time</th><th>type</th><th>ms</th></tr>
-            </thead>
-            <tbody>
-              <tr v-for="(t, i) in qbTrace" :key="`${t.at}-${i}`">
-                <td :class="$style.mono">{{ new Date(t.at).toLocaleTimeString('ja-JP', { hour12: false }) }}</td>
-                <td :class="[$style.mono, t.error && $style.logError]">{{ t.type }}</td>
-                <td :class="$style.mono">{{ t.ms }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <p v-else :class="$style.capDesc">まだ記録なし</p>
-        </div>
-      </section>
+        </section>
 
-      <section :class="[$style.panel, $style.ssePanel, $style.gridSse]">
+        <section v-if="activeView === 'qbtrace'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-arrows-left-right" :class="$style.panelIcon" />
+            Query Bridge トレース
+            <button type="button" :class="$style.btn" @click="fetchQbTrace">更新</button>
+          </h2>
+          <div :class="$style.tableWrap">
+            <table v-if="qbTrace.length" :class="$style.table">
+              <thead>
+                <tr><th>time</th><th>type</th><th>ms</th></tr>
+              </thead>
+              <tbody>
+                <tr v-for="(t, i) in qbTrace" :key="`${t.at}-${i}`">
+                  <td :class="$style.mono">{{ new Date(t.at).toLocaleTimeString('ja-JP', { hour12: false }) }}</td>
+                  <td :class="[$style.mono, t.error && $style.logError]">{{ t.type }}</td>
+                  <td :class="$style.mono">{{ t.ms }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <p v-else :class="$style.capDesc">まだ記録なし</p>
+          </div>
+        </section>
+
+        <section v-if="activeView === 'inspector'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-search" :class="$style.panelIcon" />
+            Inspector 突き合わせ (アダプタ層 vs SSE)
+            <button type="button" :class="$style.btn" @click="fetchInspector">更新</button>
+          </h2>
+          <div :class="$style.inspectorCompare">
+            <div :class="$style.tableWrap">
+              <p :class="$style.capDesc">アダプタ層 (Misskey WS raw)</p>
+              <table v-if="inspector?.total" :class="$style.table">
+                <tbody>
+                  <tr v-for="(n, kind) in inspector.counts" :key="kind">
+                    <td :class="$style.mono">{{ kind }}</td>
+                    <td :class="$style.mono">{{ n }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else :class="$style.capDesc">
+                バッファ空 — Stream Inspector カラムを開くと流入します
+              </p>
+            </div>
+            <div :class="$style.tableWrap">
+              <p :class="$style.capDesc">SSE (Rust イベントバス)</p>
+              <table v-if="sseTopTypes.length" :class="$style.table">
+                <tbody>
+                  <tr v-for="[t, n] in sseTopTypes" :key="t">
+                    <td :class="$style.mono">{{ t }}</td>
+                    <td :class="$style.mono">{{ n }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p v-else :class="$style.capDesc">受信なし</p>
+            </div>
+          </div>
+        </section>
+
+        <section v-if="activeView === 'sse'" :class="[$style.view, $style.viewStream]">
         <h2 :class="$style.panelTitle">
           <i class="ti ti-broadcast" :class="$style.panelIcon" />
           SSE ライブビューア (/api/events)
@@ -998,38 +1181,6 @@ onUnmounted(() => {
             {{ t }} ×{{ n }}
           </button>
         </div>
-        <button type="button" :class="$style.summary" @click="toggleInspector">
-          <i :class="showInspector ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          Inspector 突き合わせ (アダプタ層 vs SSE)
-        </button>
-        <div v-if="showInspector" :class="$style.inspectorCompare">
-          <div :class="$style.tableWrap">
-            <p :class="$style.capDesc">アダプタ層 (Misskey WS raw)</p>
-            <table v-if="inspector?.total" :class="$style.table">
-              <tbody>
-                <tr v-for="(n, kind) in inspector.counts" :key="kind">
-                  <td :class="$style.mono">{{ kind }}</td>
-                  <td :class="$style.mono">{{ n }}</td>
-                </tr>
-              </tbody>
-            </table>
-            <p v-else :class="$style.capDesc">
-              バッファ空 — Stream Inspector カラムを開くと流入します
-            </p>
-          </div>
-          <div :class="$style.tableWrap">
-            <p :class="$style.capDesc">SSE (Rust イベントバス)</p>
-            <table v-if="sseTopTypes.length" :class="$style.table">
-              <tbody>
-                <tr v-for="[t, n] in sseTopTypes" :key="t">
-                  <td :class="$style.mono">{{ t }}</td>
-                  <td :class="$style.mono">{{ n }}</td>
-                </tr>
-              </tbody>
-            </table>
-            <p v-else :class="$style.capDesc">受信なし</p>
-          </div>
-        </div>
         <div :class="$style.sseList">
           <div
             v-for="row in sseRows"
@@ -1059,7 +1210,7 @@ onUnmounted(() => {
         </div>
       </section>
 
-      <section :class="[$style.panel, $style.gridCaps]">
+        <section v-if="activeView === 'caps'" :class="$style.view">
         <h2 :class="$style.panelTitle">
           <i class="ti ti-bolt" :class="$style.panelIcon" />
           Capabilities 実行盤
@@ -1160,39 +1311,46 @@ onUnmounted(() => {
             >{{ h.status ?? 'ERR' }}</span>
           </button>
         </div>
-        <button type="button" :class="$style.summary" @click="togglePerms">
-          <i :class="showPerms ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
-          principal 別実効権限 (#712)
-        </button>
-        <div v-if="showPerms && perms" :class="$style.tableWrap">
-          <table :class="$style.table">
-            <thead>
-              <tr>
-                <th>permission</th>
-                <th v-for="p in PERM_PRINCIPALS" :key="p">{{ p }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="key in perms.keys"
-                :key="key"
-                :class="selectedCap?.permissions.includes(key) && $style.permRowRelevant"
-              >
-                <td :class="$style.mono">{{ key }}</td>
-                <td
-                  v-for="p in PERM_PRINCIPALS"
-                  :key="p"
-                  :class="perms.principals[p]?.[key] ? $style.permOk : $style.permNo"
-                >
-                  {{ perms.principals[p]?.[key] ? '✓' : '–' }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
       </section>
 
-      <section :class="[$style.panel, $style.ssePanel, $style.gridLogs]">
+        <section v-if="activeView === 'perms'" :class="$style.view">
+          <h2 :class="$style.panelTitle">
+            <i class="ti ti-shield-lock" :class="$style.panelIcon" />
+            principal 別実効権限 (#712)
+            <button type="button" :class="$style.btn" @click="fetchPerms">更新</button>
+          </h2>
+          <p v-if="selectedCap" :class="$style.capDesc">
+            選択中の capability ({{ selectedCap.id }}) の要求キー行をハイライト表示
+          </p>
+          <div v-if="perms" :class="$style.tableWrap">
+            <table :class="$style.table">
+              <thead>
+                <tr>
+                  <th>permission</th>
+                  <th v-for="p in PERM_PRINCIPALS" :key="p">{{ p }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="key in perms.keys"
+                  :key="key"
+                  :class="selectedCap?.permissions.includes(key) && $style.permRowRelevant"
+                >
+                  <td :class="$style.mono">{{ key }}</td>
+                  <td
+                    v-for="p in PERM_PRINCIPALS"
+                    :key="p"
+                    :class="perms.principals[p]?.[key] ? $style.permOk : $style.permNo"
+                  >
+                    {{ perms.principals[p]?.[key] ? '✓' : '–' }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section v-if="activeView === 'timeline'" :class="[$style.view, $style.viewStream]">
         <h2 :class="$style.panelTitle">
           <i class="ti ti-terminal-2" :class="$style.panelIcon" />
           統合タイムライン
@@ -1273,132 +1431,118 @@ onUnmounted(() => {
           </p>
         </div>
       </section>
+      </main>
     </div>
 
-    <footer :class="$style.statusBar">
-      <button
-        type="button"
-        :class="[$style.statusSeg, $style.statusSegBtn, $style.statusRemote]"
-        :title="sseState === 'stopped' ? 'クリックで SSE 接続' : 'クリックで SSE 停止'"
-        @click="sseState === 'stopped' ? connectSse() : stopSse()"
-      >
-        <i :class="sseState === 'open' ? 'ti ti-bolt' : 'ti ti-plug-x'" />
-        {{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}
-      </button>
-      <button
-        type="button"
-        :class="[
-          $style.statusSeg,
-          $style.statusSegBtn,
-          logWarnOnly && $style.statusSegActive,
-        ]"
-        title="クリックで WARN+ フィルタを切り替え"
-        @click="logWarnOnly = !logWarnOnly"
-      >
-        <i class="ti ti-circle-x" :class="timelineErrorCount > 0 && $style.statusErrIcon" /> {{ timelineErrorCount }}
-        <i class="ti ti-alert-triangle" :class="timelineWarnCount > 0 && $style.statusWarnIcon" /> {{ timelineWarnCount }}
-      </button>
-      <button
-        type="button"
-        :class="[$style.statusSeg, $style.statusSegBtn]"
-        title="クリックで SSE バッファを JSON Lines エクスポート"
-        @click="exportSse"
-      >
-        <i class="ti ti-broadcast" /> {{ sseRatePerMin }}/min · {{ sseCount }} events
-      </button>
-      <button
-        type="button"
-        :class="[$style.statusSeg, $style.statusSegBtn]"
-        title="クリックで状態を今すぐ更新"
-        @click="refreshStatus"
-      >
-        <i class="ti ti-layout-columns" /> {{ columns.length }} columns
-      </button>
-      <span :class="$style.statusSpacer" />
-      <button
-        v-if="heartbeat?.config.enabled"
-        type="button"
-        :class="[$style.statusSeg, $style.statusSegBtn]"
-        title="クリックで HEARTBEAT 状態を開閉"
-        @click="toggleHeartbeat"
-      >
-        <i class="ti ti-heartbeat" :class="$style.beat" />
-        {{ heartbeat.dailyCount }}/{{ heartbeat.config.dailyMaxAiRuns }}
-      </button>
-      <a
-        :class="[$style.statusSeg, $style.statusSegBtn]"
-        href="/api/docs"
-        target="_blank"
-        rel="noopener"
-        title="API ドキュメント (Scalar) を開く"
-      >127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template></a>
-    </footer>
   </div>
 </template>
 
 <style lang="scss" module>
-.dashboard {
+.control {
+  position: relative;
   height: 100%;
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 20px 24px 0;
   background: var(--nd-bg);
   color: var(--nd-fg);
   overflow: hidden;
 }
 
-/* VSCode 風ステータスバー。地はパネル色に抑え、左端の LIVE ブロック
-   (remote インジケータの意匠) だけアクセントで差す */
-.statusBar {
+.body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+/* OpenClaw Control UI 流のサイドバー: グループ分けナビ + 下部 identity カード */
+.sidebar {
+  flex: none;
+  width: 248px;
+  display: flex;
+  flex-direction: column;
+  background: var(--nd-panel);
+  border-right: 1px solid var(--nd-divider);
+}
+
+/* アイコンのみの折りたたみ。寸法は本体ナビバーの折りたたみ (44px 円形 +
+   margin 2px auto) を踏襲 */
+.sidebarCollapsed {
+  width: 56px;
+
+  .sidebarHead {
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px 0 10px;
+  }
+
+  .navItem {
+    justify-content: center;
+    padding: 0;
+    width: 44px;
+    height: 44px;
+    margin: 2px auto;
+    border-radius: 50%;
+    line-height: 1;
+
+    i {
+      width: auto;
+    }
+  }
+
+  .navGroup {
+    margin-bottom: 8px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--nd-divider);
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+/* identity はサイドバー上部 (OpenClaw Control UI の配置) */
+.sidebarHead {
   flex: none;
   display: flex;
-  align-items: stretch;
-  margin: 0 -24px;
-  height: 26px;
-  background: var(--nd-panel);
-  border-top: 1px solid var(--nd-divider);
-  color: var(--nd-fg);
-  font-family: var(--nd-font-mono);
-  font-size: 0.72rem;
-  user-select: none;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 12px 10px;
+  border-bottom: 1px solid var(--nd-divider);
 }
 
-.statusSeg {
+.brandLogo {
+  width: 30px;
+  height: 30px;
+  border-radius: 8px;
+  transition: filter 250ms ease-out;
+}
+
+.brandName {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.92rem;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--nd-fgHighlighted);
+}
+
+.navToggle {
+  flex: none;
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 0 10px;
-  white-space: nowrap;
-  opacity: 0.85;
-
-  i {
-    font-size: 0.85rem;
-  }
-}
-
-.statusRemote {
-  background: var(--nd-accentDarken);
-  color: #fff;
-  font-weight: 700;
-  opacity: 1;
-
-  &:hover {
-    background: var(--nd-accent);
-  }
-}
-
-.statusSegBtn {
+  justify-content: center;
+  width: 26px;
+  height: 26px;
   border: none;
+  border-radius: var(--nd-radius-sm, 6px);
   background: none;
-  color: inherit;
-  font: inherit;
-  text-decoration: none;
+  color: var(--nd-fg);
+  opacity: 0.6;
   cursor: pointer;
   transition: background 150ms ease-out;
 
   &:hover {
-    background: var(--nd-buttonHoverBg, rgba(255, 255, 255, 0.08));
+    background: var(--nd-buttonBg);
     opacity: 1;
   }
 
@@ -1408,63 +1552,194 @@ onUnmounted(() => {
   }
 }
 
-.statusSegActive {
-  background: var(--nd-accentedBg);
-  opacity: 1;
-}
-
-.statusErrIcon {
-  color: var(--nd-error);
-}
-
-.statusWarnIcon {
-  color: var(--nd-warn);
-}
-
-.statusSpacer {
+.navLabel {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.header {
+.nav {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--nd-divider) transparent;
+}
+
+.navGroup {
+  margin-bottom: 14px;
+}
+
+.navGroupLabel {
+  padding: 0 10px 4px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.45;
+  user-select: none;
+}
+
+/* 寸法は本体ナビバー (DeckNavbar) を踏襲 */
+.navItem {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 8px;
+  width: 100%;
+  padding: 0 14px;
+  line-height: 2.85rem;
+  border: none;
+  border-radius: var(--nd-radius-full);
+  background: none;
+  color: var(--nd-fg);
+  font-size: 0.95em;
+  white-space: nowrap;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 150ms ease-out, color 150ms ease-out;
+
+  i {
+    flex-shrink: 0;
+    width: 32px;
+    font-size: 22px;
+    text-align: center;
+    opacity: 0.7;
+  }
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+    color: var(--nd-fgHighlighted);
+
+    i {
+      opacity: 1;
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--nd-focusRing);
+    outline-offset: -2px;
+  }
+}
+
+.navItemActive {
+  background: var(--nd-buttonHoverBg);
+  color: var(--nd-fgHighlighted);
+
+  i {
+    opacity: 1;
+  }
+}
+
+.navItemSuffix {
+  margin-left: auto;
+  width: auto;
+}
+
+.footText {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.footName {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--nd-fgHighlighted);
+}
+
+.footMeta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--nd-font-mono);
+  font-size: 0.65rem;
+  opacity: 0.6;
+}
+
+.content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  /* 全角はアプリ既定スタックのうち最も一般的なもの (mac=Hiragino Sans /
+     Win=BIZ UDGothic) を明示。等幅データは --nd-font-mono のまま */
+  font-family: 'Hiragino Sans', 'BIZ UDGothic', 'Segoe UI', sans-serif;
+  font-size: 14px;
+}
+
+.view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 20px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--nd-divider) transparent;
+}
+
+/* ストリーム系ビューは内側のリストが唯一のスクロール面 */
+.viewStream {
+  overflow: hidden;
+}
+
+/* 切断時のアンバーピル (OpenClaw の "Gateway connection lost" の意匠) */
+.reconnectPill {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 14px;
+  border-radius: 999px;
+  background: var(--nd-warn);
+  color: #1a1a1a;
+  font-size: 0.78rem;
+  font-weight: 600;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+}
+
+.statCards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
   flex: none;
 }
 
-.logo {
-  width: 40px;
-  height: 40px;
-  border-radius: 10px;
-  transition: filter 250ms ease-out;
+.statCard {
+  display: flex;
+  flex-direction: column;
+  min-width: 92px;
+  padding: 8px 14px;
+  border: 1px solid var(--nd-divider);
+  border-radius: var(--nd-radius-md);
+  background: var(--nd-panel);
+}
+
+.statValue {
+  font-family: var(--nd-font-mono);
+  font-size: 1.15rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--nd-fgHighlighted);
+}
+
+.statLabel {
+  font-size: 0.66rem;
+  opacity: 0.55;
 }
 
 .logoLive {
   filter: drop-shadow(0 0 8px color-mix(in srgb, var(--nd-accent) 55%, transparent));
-}
-
-.headText {
-  flex: 1;
-  min-width: 0;
-}
-
-.title {
-  font-size: 1.25rem;
-  font-weight: 800;
-  letter-spacing: -0.01em;
-  color: var(--nd-fgHighlighted);
-}
-
-.titleAccent {
-  color: var(--nd-accent);
-}
-
-.subtitle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  opacity: 0.7;
 }
 
 .led {
@@ -1490,69 +1765,6 @@ onUnmounted(() => {
   }
   50% {
     box-shadow: 0 0 8px var(--nd-success);
-  }
-}
-
-.links {
-  display: flex;
-  gap: 16px;
-
-  a {
-    color: var(--nd-accent);
-    font-size: 0.85rem;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.grid {
-  flex: 1;
-  min-height: 0;
-  display: grid;
-  grid-template-columns: minmax(300px, 1fr) minmax(0, 1.6fr);
-  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
-  grid-template-areas:
-    'deck sse'
-    'caps logs';
-  gap: 16px;
-}
-
-.gridDeck {
-  grid-area: deck;
-}
-
-.gridSse {
-  grid-area: sse;
-}
-
-.gridCaps {
-  grid-area: caps;
-}
-
-.gridLogs {
-  grid-area: logs;
-}
-
-.panel {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  min-height: 0;
-  padding: 14px 16px;
-  border: 1px solid var(--nd-divider);
-  border-radius: var(--nd-radius);
-  background:
-    linear-gradient(var(--nd-panelHighlight), transparent 48px),
-    var(--nd-panel);
-  overflow: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--nd-divider) transparent;
-  transition: border-color 150ms ease-out;
-
-  &:hover {
-    border-color: color-mix(in srgb, var(--nd-accent) 25%, var(--nd-divider));
   }
 }
 
@@ -1593,7 +1805,7 @@ onUnmounted(() => {
 .table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.8rem;
+  font-size: 0.86rem;
 
   th,
   td {
@@ -1623,16 +1835,12 @@ onUnmounted(() => {
   background: none;
   color: var(--nd-fg);
   cursor: pointer;
-  font-size: 0.8rem;
+  font-size: 0.86rem;
   opacity: 0.7;
 
   &:hover {
     opacity: 1;
   }
-}
-
-.ssePanel {
-  overflow: hidden;
 }
 
 .sseBadge {
@@ -1792,7 +2000,7 @@ onUnmounted(() => {
 }
 
 .capDesc {
-  font-size: 0.8rem;
+  font-size: 0.86rem;
   opacity: 0.75;
 }
 
@@ -2072,8 +2280,8 @@ onUnmounted(() => {
 
   .sparkBar,
   .bar,
-  .logo,
-  .panel,
+  .brandLogo,
+  .navItem,
   .btn,
   .filterInput {
     transition: none;

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -84,6 +84,11 @@ const startupRows = computed(() => {
   }))
 })
 
+/** ウォーターフォールバーの正規化基準 (最長区間 = 100%) */
+const startupMaxDelta = computed(() =>
+  Math.max(1, ...startupRows.value.map((r) => r.delta)),
+)
+
 async function toggleStartup() {
   showStartup.value = !showStartup.value
   if (!showStartup.value) return
@@ -489,6 +494,34 @@ const timelineSources = ref({ rust: true, sse: true, front: true })
 const frontRows = ref<FrontLogEntry[]>([])
 let frontTimer: ReturnType<typeof setInterval> | null = null
 
+// --- 見た目まわり (#977 UI 磨き) ---
+
+/** SSE 流量スパークライン用の 1 秒 tick (バケット再計算の駆動) */
+const nowTick = ref(Date.now())
+let tickTimer: ReturnType<typeof setInterval> | null = null
+
+const SPARK_BUCKETS = 30
+const SPARK_BUCKET_MS = 2000
+
+/** 直近 60 秒の到着数を 2 秒バケットに畳んだ正規化列 (0..1) */
+const sparkBars = computed(() => {
+  const now = nowTick.value
+  const buckets = new Array(SPARK_BUCKETS).fill(0) as number[]
+  for (const t of sseRecentTimes) {
+    const idx = SPARK_BUCKETS - 1 - Math.floor((now - t) / SPARK_BUCKET_MS)
+    if (idx >= 0 && idx < SPARK_BUCKETS) buckets[idx] = (buckets[idx] ?? 0) + 1
+  }
+  const max = Math.max(1, ...buckets)
+  return buckets.map((n) => n / max)
+})
+
+/** イベント種別 → 安定した色相 (同じ種別は常に同じ色で追える) */
+function typeColor(type: string): string {
+  let h = 0
+  for (let i = 0; i < type.length; i++) h = (h * 31 + type.charCodeAt(i)) % 360
+  return `hsl(${h} 65% 62%)`
+}
+
 async function refreshFrontLogs() {
   try {
     const res = await fetch('/api/logs/recent')
@@ -671,11 +704,22 @@ onMounted(() => {
   connectLogs()
   refreshFrontLogs()
   frontTimer = setInterval(refreshFrontLogs, 3000)
+  // スパークラインの時間窓を進め、静かな期間も流量表示を減衰させる
+  tickTimer = setInterval(() => {
+    nowTick.value = Date.now()
+    while (
+      sseRecentTimes.length &&
+      nowTick.value - (sseRecentTimes[0] ?? 0) > 60_000
+    )
+      sseRecentTimes.shift()
+    sseRatePerMin.value = sseRecentTimes.length
+  }, 1000)
 })
 
 onUnmounted(() => {
   if (statusTimer) clearInterval(statusTimer)
   if (frontTimer) clearInterval(frontTimer)
+  if (tickTimer) clearInterval(tickTimer)
   stopSse()
   stopLogs()
 })
@@ -684,21 +728,34 @@ onUnmounted(() => {
 <template>
   <div :class="$style.dashboard">
     <header :class="$style.header">
-      <img src="/favicon.svg" alt="" :class="$style.logo" />
+      <img
+        src="/favicon.svg"
+        alt=""
+        :class="[$style.logo, sseState === 'open' && $style.logoLive]"
+      />
       <div :class="$style.headText">
-        <h1 :class="$style.title">NoteDeck Dev Dashboard</h1>
+        <h1 :class="$style.title">
+          NoteDeck <span :class="$style.titleAccent">Dev Dashboard</span>
+        </h1>
         <p :class="$style.subtitle">
-          実行中のアプリ (127.0.0.1:19820) に接続中<template v-if="app?.version"> — v{{ app.version }}</template>
+          <span :class="[$style.led, sseState === 'open' && $style.ledOpen]" />
+          <span :class="$style.mono">{{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}</span>
+          · 127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template>
         </p>
       </div>
       <nav :class="$style.links">
-        <a href="/api/docs" target="_blank" rel="noopener">API ドキュメント</a>
+        <a href="/api/docs" target="_blank" rel="noopener">
+          <i class="ti ti-book-2" /> API ドキュメント
+        </a>
       </nav>
     </header>
 
     <div :class="$style.grid">
       <section :class="[$style.panel, $style.gridDeck]">
-        <h2 :class="$style.panelTitle">デッキ状態 — カラム {{ columns.length }} 本</h2>
+        <h2 :class="$style.panelTitle">
+          <i class="ti ti-layout-columns" :class="$style.panelIcon" />
+          デッキ状態 — カラム {{ columns.length }} 本
+        </h2>
         <div :class="$style.tableWrap">
           <table :class="$style.table">
             <thead>
@@ -750,13 +807,19 @@ onUnmounted(() => {
           <div :class="$style.tableWrap">
             <table :class="$style.table">
               <thead>
-                <tr><th>mark</th><th>at</th><th>+Δ</th></tr>
+                <tr><th>mark</th><th>at</th><th>+Δ</th><th /></tr>
               </thead>
               <tbody>
                 <tr v-for="row in startupRows" :key="row.name">
                   <td :class="$style.mono">{{ row.name }}</td>
                   <td :class="$style.mono">{{ Math.round(row.at) }}ms</td>
                   <td :class="$style.mono">+{{ Math.round(row.delta) }}ms</td>
+                  <td :class="$style.barCell">
+                    <span
+                      :class="$style.bar"
+                      :style="{ width: `${(row.delta / startupMaxDelta) * 100}%` }"
+                    />
+                  </td>
                 </tr>
               </tbody>
             </table>
@@ -765,6 +828,11 @@ onUnmounted(() => {
         <button type="button" :class="$style.summary" @click="toggleHeartbeat">
           <i :class="showHeartbeat ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
           HEARTBEAT 状態 (#411)
+          <i
+            v-if="heartbeat?.config.enabled"
+            class="ti ti-heartbeat"
+            :class="$style.beat"
+          />
         </button>
         <div v-if="showHeartbeat && heartbeat" :class="$style.tableWrap">
           <table :class="$style.table">
@@ -807,13 +875,19 @@ onUnmounted(() => {
         <div v-if="showCaches" :class="$style.tableWrap">
           <table v-if="caches.length" :class="$style.table">
             <thead>
-              <tr><th>name</th><th>size</th><th>limit</th></tr>
+              <tr><th>name</th><th>size</th><th>limit</th><th /></tr>
             </thead>
             <tbody>
               <tr v-for="(c, i) in caches" :key="`${c.name}-${i}`">
                 <td :class="$style.mono">{{ c.name }}</td>
                 <td :class="$style.mono">{{ c.size }}</td>
                 <td :class="$style.mono">{{ c.limit }}</td>
+                <td :class="$style.barCell">
+                  <span
+                    :class="[$style.bar, c.size / c.limit > 0.9 && $style.barHot]"
+                    :style="{ width: `${Math.min(100, (c.size / Math.max(1, c.limit)) * 100)}%` }"
+                  />
+                </td>
               </tr>
             </tbody>
           </table>
@@ -842,9 +916,18 @@ onUnmounted(() => {
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridSse]">
         <h2 :class="$style.panelTitle">
+          <i class="ti ti-broadcast" :class="$style.panelIcon" />
           SSE ライブビューア (/api/events)
           <span :class="[$style.sseBadge, sseState === 'open' && $style.sseOpen]">{{ sseState }}</span>
           <span :class="$style.sseCount">{{ sseCount }} events</span>
+          <span :class="$style.spark" title="直近 60 秒の流量">
+            <span
+              v-for="(h, i) in sparkBars"
+              :key="i"
+              :class="$style.sparkBar"
+              :style="{ height: `${Math.max(8, h * 100)}%`, opacity: h > 0 ? 1 : 0.25 }"
+            />
+          </span>
         </h2>
         <div :class="$style.sseControls">
           <input
@@ -863,7 +946,7 @@ onUnmounted(() => {
             title="バッファを JSON Lines でダウンロード"
             @click="exportSse"
           >
-            <i class="ti ti-download" />
+            <i class="ti ti-download" /> JSONL
           </button>
         </div>
         <div v-if="sseTopTypes.length" :class="$style.chipRow">
@@ -873,6 +956,7 @@ onUnmounted(() => {
             :key="t"
             type="button"
             :class="$style.typeChip"
+            :style="{ color: typeColor(t) }"
             title="クリックでこの種別に絞る"
             @click="filterByType(t)"
           >
@@ -912,14 +996,18 @@ onUnmounted(() => {
           </div>
         </div>
         <div :class="$style.sseList">
-          <div v-for="row in sseRows" :key="row.seq" :class="$style.sseRow">
+          <div
+            v-for="row in sseRows"
+            :key="row.seq"
+            :class="[$style.sseRow, nowTick - row.ts < 1200 && $style.rowNew]"
+          >
             <button
               type="button"
               :class="$style.sseRowHead"
               @click="toggleRow(row)"
             >
               <span :class="$style.sseTime">{{ row.time }}</span>
-              <span :class="$style.sseType">{{ row.type }}</span>
+              <span :class="$style.sseType" :style="{ color: typeColor(row.type) }">{{ row.type }}</span>
               <code :class="$style.sseData">{{ row.data }}</code>
             </button>
             <CodeEditor
@@ -938,6 +1026,7 @@ onUnmounted(() => {
 
       <section :class="[$style.panel, $style.gridCaps]">
         <h2 :class="$style.panelTitle">
+          <i class="ti ti-bolt" :class="$style.panelIcon" />
           Capabilities 実行盤
           <span :class="$style.sseCount">{{ capabilities.length }} 件</span>
         </h2>
@@ -991,7 +1080,17 @@ onUnmounted(() => {
             >
               {{ capRunning ? '実行中…' : '実行' }}
             </button>
-            <span v-if="capStatus !== null" :class="$style.capStatus">
+            <span
+              v-if="capStatus !== null"
+              :class="[
+                $style.capStatus,
+                capStatus < 300
+                  ? $style.statusOk
+                  : capStatus < 500
+                    ? $style.statusWarn
+                    : $style.statusErr,
+              ]"
+            >
               HTTP {{ capStatus }}
             </span>
           </div>
@@ -1014,7 +1113,16 @@ onUnmounted(() => {
           >
             <span :class="$style.sseTime">{{ h.time }}</span>
             <span :class="[$style.mono, $style.capHistoryId]">{{ h.capId }}</span>
-            <span :class="$style.capStatus">{{ h.status ?? 'ERR' }}</span>
+            <span
+              :class="[
+                $style.capStatus,
+                h.status !== null && h.status < 300
+                  ? $style.statusOk
+                  : h.status !== null && h.status < 500
+                    ? $style.statusWarn
+                    : $style.statusErr,
+              ]"
+            >{{ h.status ?? 'ERR' }}</span>
           </button>
         </div>
         <button type="button" :class="$style.summary" @click="togglePerms">
@@ -1051,6 +1159,7 @@ onUnmounted(() => {
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridLogs]">
         <h2 :class="$style.panelTitle">
+          <i class="ti ti-terminal-2" :class="$style.panelIcon" />
           統合タイムライン
           <span :class="[$style.sseBadge, logState === 'open' && $style.sseOpen]">rust: {{ logState }}</span>
         </h2>
@@ -1088,6 +1197,7 @@ onUnmounted(() => {
             :key="row.key"
             :class="[
               $style.logLine,
+              nowTick - row.ts < 1200 && $style.rowNew,
               row.level === 'error'
                 ? $style.logError
                 : row.level === 'warn'
@@ -1103,7 +1213,7 @@ onUnmounted(() => {
                   ? $style.sourceFront
                   : $style.sourceRust,
             ]"
-          >{{ row.source }}</span> <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span> <span :class="$style.sseType">{{ row.label }}</span> {{ row.text }}</div>
+          >{{ row.source }}</span> <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span> <span :class="$style.sseType" :style="row.source === 'sse' ? { color: typeColor(row.label) } : undefined">{{ row.label }}</span> {{ row.text }}</div>
           <p v-if="!unifiedRows.length" :class="$style.sseEmpty">
             待機中 — Rust ログ / SSE イベント / フロントログがここに時系列で流れます
           </p>
@@ -1136,6 +1246,11 @@ onUnmounted(() => {
   width: 40px;
   height: 40px;
   border-radius: 10px;
+  transition: filter 250ms ease-out;
+}
+
+.logoLive {
+  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--nd-accent) 55%, transparent));
 }
 
 .headText {
@@ -1150,9 +1265,42 @@ onUnmounted(() => {
   color: var(--nd-fgHighlighted);
 }
 
+.titleAccent {
+  color: var(--nd-accent);
+}
+
 .subtitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 0.8rem;
-  opacity: 0.6;
+  opacity: 0.7;
+}
+
+.led {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--nd-fg);
+  opacity: 0.3;
+  flex: none;
+  transition: background 150ms ease-out;
+}
+
+.ledOpen {
+  background: var(--nd-success);
+  opacity: 1;
+  animation: ledPulse 2s ease-out infinite;
+}
+
+@keyframes ledPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 2px var(--nd-success);
+  }
+  50% {
+    box-shadow: 0 0 8px var(--nd-success);
+  }
 }
 
 .links {
@@ -1205,8 +1353,17 @@ onUnmounted(() => {
   padding: 14px 16px;
   border: 1px solid var(--nd-divider);
   border-radius: var(--nd-radius);
-  background: var(--nd-panel);
+  background:
+    linear-gradient(var(--nd-panelHighlight), transparent 48px),
+    var(--nd-panel);
   overflow: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--nd-divider) transparent;
+  transition: border-color 150ms ease-out;
+
+  &:hover {
+    border-color: color-mix(in srgb, var(--nd-accent) 25%, var(--nd-divider));
+  }
 }
 
 .panelTitle {
@@ -1216,6 +1373,27 @@ onUnmounted(() => {
   font-size: 0.95rem;
   font-weight: 700;
   color: var(--nd-fgHighlighted);
+}
+
+.panelIcon {
+  color: var(--nd-accent);
+  font-size: 1rem;
+}
+
+.spark {
+  display: flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 16px;
+  margin-left: auto;
+  flex: none;
+}
+
+.sparkBar {
+  width: 3px;
+  border-radius: 1px;
+  background: var(--nd-accent);
+  transition: height 250ms ease-out;
 }
 
 .tableWrap {
@@ -1305,6 +1483,12 @@ onUnmounted(() => {
   color: var(--nd-fg);
   font-family: var(--nd-font-mono);
   font-size: 0.8rem;
+  transition: border-color 150ms ease-out;
+
+  &:focus-visible {
+    outline: none;
+    border-color: var(--nd-focusRing);
+  }
 }
 
 .btn {
@@ -1315,9 +1499,23 @@ onUnmounted(() => {
   color: var(--nd-fg);
   font-size: 0.8rem;
   cursor: pointer;
+  transition:
+    background 150ms ease-out,
+    border-color 150ms ease-out;
 
   &:hover {
     background: var(--nd-buttonHoverBg, var(--nd-buttonBg));
+    border-color: color-mix(in srgb, var(--nd-accent) 35%, var(--nd-divider));
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--nd-focusRing);
+    outline-offset: 1px;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: default;
   }
 }
 
@@ -1327,10 +1525,20 @@ onUnmounted(() => {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  scrollbar-width: thin;
+  scrollbar-color: var(--nd-divider) transparent;
+}
+
+/* 新着ハイライト: 到着 1 秒間だけ着色し transition で退色する。
+   CSS animation だと行挿入のたびに既存行でも再始動してしまうため、
+   recency クラス + transition で表現する */
+.rowNew {
+  background: var(--nd-accentedBg);
 }
 
 .sseRow {
   border-bottom: 1px solid var(--nd-divider);
+  transition: background 250ms ease-out;
 }
 
 .sseRowHead {
@@ -1435,6 +1643,7 @@ onUnmounted(() => {
   white-space: pre-wrap;
   word-break: break-all;
   border-bottom: 1px solid var(--nd-divider);
+  transition: background 250ms ease-out;
 }
 
 .logError {
@@ -1569,5 +1778,92 @@ onUnmounted(() => {
   flex: none;
   max-height: 40%;
   overflow-y: auto;
+}
+
+.barCell {
+  width: 30%;
+  min-width: 60px;
+}
+
+.bar {
+  display: block;
+  height: 6px;
+  min-width: 2px;
+  border-radius: 3px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--nd-accent) 55%, transparent),
+    var(--nd-accent)
+  );
+  transition: width 250ms ease-out;
+}
+
+.barHot {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--nd-warn) 55%, transparent),
+    var(--nd-warn)
+  );
+}
+
+.statusOk {
+  color: var(--nd-success);
+}
+
+.statusWarn {
+  color: var(--nd-warn);
+}
+
+.statusErr {
+  color: var(--nd-error);
+}
+
+/* HEARTBEAT 有効時の鼓動 (スプラッシュの nd-heartbeat と同じリズム) */
+.beat {
+  display: inline-block;
+  color: var(--nd-accent);
+  animation: beat 1.4s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  transform-origin: center;
+}
+
+@keyframes beat {
+  0%,
+  55%,
+  100% {
+    transform: scale(1);
+  }
+  10% {
+    transform: scale(1.25);
+  }
+  22% {
+    transform: scale(1);
+  }
+  32% {
+    transform: scale(1.12);
+  }
+  44% {
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ledOpen,
+  .beat {
+    animation: none;
+  }
+
+  .sseRow,
+  .logLine {
+    transition: none;
+  }
+
+  .sparkBar,
+  .bar,
+  .logo,
+  .panel,
+  .btn,
+  .filterInput {
+    transition: none;
+  }
 }
 </style>

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -94,6 +94,47 @@ async function toggleStartup() {
   }
 }
 
+// --- HEARTBEAT 状態 (#411) ---
+// daemon の silent fail 防止機構 (連続失敗 auto-disable) の観測面
+
+interface HeartbeatStatusView {
+  mounted: boolean
+  running: boolean
+  lastTickAt: number | null
+  lastTickSource: string | null
+  lastOutcome: string | null
+  consecutiveFailures: number
+  dailyCount: number
+  config: {
+    enabled: boolean
+    intervalMinutes: number
+    target: string
+    dailyMaxAiRuns: number
+  }
+}
+
+const showHeartbeat = ref(false)
+const heartbeat = ref<HeartbeatStatusView | null>(null)
+
+async function toggleHeartbeat() {
+  showHeartbeat.value = !showHeartbeat.value
+  if (!showHeartbeat.value) return
+  try {
+    const res = await fetch('/api/heartbeat/status')
+    if (res.ok) heartbeat.value = await res.json()
+  } catch {
+    // アプリ未起動
+  }
+}
+
+function relativeTime(epochMs: number | null): string {
+  if (epochMs === null) return '—'
+  const mins = Math.floor((Date.now() - epochMs) / 60_000)
+  if (mins >= 60) return `${Math.floor(mins / 60)} 時間前`
+  if (mins >= 1) return `${mins} 分前`
+  return 'たった今'
+}
+
 // SSE ビューア。EventSource は event: 名ごとの addEventListener が必要で
 // 動的な main-{eventType} を受けられないため、fetch + ReadableStream で
 // SSE をパースする (Authorization は proxy が注入するので相対 fetch でよい)
@@ -102,10 +143,25 @@ const sseRows = ref<SseRow[]>([])
 const sseState = ref<'stopped' | 'connecting' | 'open'>('stopped')
 const sseFilter = ref('')
 const sseCount = ref(0)
+const sseTypeCounts = ref<Record<string, number>>({})
+const sseRatePerMin = ref(0)
+let sseRecentTimes: number[] = []
 let sseAbort: AbortController | null = null
 let sseSeq = 0
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null
 let statusTimer: ReturnType<typeof setInterval> | null = null
+
+/** 到着数の多い順の種別チップ (クリックでフィルタ適用) */
+const sseTopTypes = computed(() =>
+  Object.entries(sseTypeCounts.value)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 6),
+)
+
+function filterByType(type: string) {
+  sseFilter.value = type
+  connectSse()
+}
 
 async function refreshStatus() {
   try {
@@ -128,6 +184,12 @@ async function refreshStatus() {
 
 function pushRow(type: string, data: string) {
   sseCount.value++
+  sseTypeCounts.value[type] = (sseTypeCounts.value[type] ?? 0) + 1
+  const now = Date.now()
+  sseRecentTimes.push(now)
+  while (sseRecentTimes.length && now - (sseRecentTimes[0] ?? now) > 60_000)
+    sseRecentTimes.shift()
+  sseRatePerMin.value = sseRecentTimes.length
   sseRows.value.unshift({
     seq: ++sseSeq,
     time: new Date().toLocaleTimeString('ja-JP', { hour12: false }),
@@ -197,6 +259,40 @@ function stopSse() {
 function clearSse() {
   sseRows.value = []
   sseCount.value = 0
+  sseTypeCounts.value = {}
+  sseRecentTimes = []
+  sseRatePerMin.value = 0
+}
+
+/** バッファを古い順の JSON Lines でダウンロード (バグ報告への添付用) */
+function exportSse() {
+  const lines = [...sseRows.value].reverse().map((r) =>
+    JSON.stringify({
+      time: r.time,
+      type: r.type,
+      data: tryParseJson(r.data),
+    }),
+  )
+  downloadText(`sse-events-${Date.now()}.jsonl`, lines.join('\n'))
+}
+
+function tryParseJson(text: string): unknown {
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+function downloadText(filename: string, text: string) {
+  const url = URL.createObjectURL(
+    new Blob([text], { type: 'application/x-ndjson' }),
+  )
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
 }
 
 function toggleRow(row: SseRow) {
@@ -264,6 +360,26 @@ function onSelectCap() {
   capParams.value = '{}'
 }
 
+// 実行履歴 (直近 20 件)。クリックで結果を呼び戻せる
+interface CapHistoryEntry {
+  seq: number
+  time: string
+  capId: string
+  status: number | null
+  result: string
+}
+
+const CAP_HISTORY_MAX = 20
+const capHistory = ref<CapHistoryEntry[]>([])
+let capHistSeq = 0
+
+function restoreCapHistory(entry: CapHistoryEntry) {
+  if (capabilities.value.some((c) => c.id === entry.capId))
+    selectedCapId.value = entry.capId
+  capStatus.value = entry.status
+  capResult.value = entry.result
+}
+
 async function executeCap() {
   const cap = selectedCap.value
   if (!cap || capRunning.value) return
@@ -288,6 +404,15 @@ async function executeCap() {
     capResult.value = String(e)
   } finally {
     capRunning.value = false
+    capHistory.value.unshift({
+      seq: ++capHistSeq,
+      time: new Date().toLocaleTimeString('ja-JP', { hour12: false }),
+      capId: cap.id,
+      status: capStatus.value,
+      result: capResult.value,
+    })
+    if (capHistory.value.length > CAP_HISTORY_MAX)
+      capHistory.value.length = CAP_HISTORY_MAX
   }
 }
 
@@ -330,13 +455,17 @@ const LOG_BUFFER_MAX = 500
 const logRows = ref<LogRow[]>([])
 const logState = ref<'stopped' | 'connecting' | 'open'>('stopped')
 const logFilter = ref('')
+const logWarnOnly = ref(false)
 let logEs: EventSource | null = null
 let logSeq = 0
 
 const filteredLogRows = computed(() => {
   const q = logFilter.value.trim().toLowerCase()
-  if (!q) return logRows.value
-  return logRows.value.filter((r) => r.line.toLowerCase().includes(q))
+  return logRows.value.filter((r) => {
+    if (logWarnOnly.value && r.level !== 'error' && r.level !== 'warn')
+      return false
+    return !q || r.line.toLowerCase().includes(q)
+  })
 })
 
 function detectLevel(line: string): LogRow['level'] {
@@ -475,6 +604,44 @@ onUnmounted(() => {
             </table>
           </div>
         </template>
+        <button type="button" :class="$style.summary" @click="toggleHeartbeat">
+          <i :class="showHeartbeat ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          HEARTBEAT 状態 (#411)
+        </button>
+        <div v-if="showHeartbeat && heartbeat" :class="$style.tableWrap">
+          <table :class="$style.table">
+            <tbody>
+              <tr>
+                <td>daemon</td>
+                <td :class="$style.mono">
+                  {{ heartbeat.mounted ? (heartbeat.config.enabled ? 'enabled' : 'disabled') : 'not mounted' }}{{ heartbeat.running ? ' (tick 実行中)' : '' }}
+                </td>
+              </tr>
+              <tr>
+                <td>interval / target</td>
+                <td :class="$style.mono">{{ heartbeat.config.intervalMinutes }} 分 / {{ heartbeat.config.target }}</td>
+              </tr>
+              <tr>
+                <td>最終 tick</td>
+                <td :class="$style.mono">
+                  {{ relativeTime(heartbeat.lastTickAt) }}<template v-if="heartbeat.lastTickSource"> ({{ heartbeat.lastTickSource }})</template>
+                </td>
+              </tr>
+              <tr>
+                <td>直近の結末</td>
+                <td :class="$style.mono">{{ heartbeat.lastOutcome ?? '—' }}</td>
+              </tr>
+              <tr>
+                <td>連続失敗</td>
+                <td :class="$style.mono">{{ heartbeat.consecutiveFailures }}</td>
+              </tr>
+              <tr>
+                <td>本日の AI 起動</td>
+                <td :class="$style.mono">{{ heartbeat.dailyCount }} / {{ heartbeat.config.dailyMaxAiRuns }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridSse]">
@@ -493,6 +660,28 @@ onUnmounted(() => {
           <button type="button" :class="$style.btn" @click="connectSse">適用 / 再接続</button>
           <button type="button" :class="$style.btn" @click="stopSse">停止</button>
           <button type="button" :class="$style.btn" @click="clearSse">クリア</button>
+          <button
+            type="button"
+            :class="$style.btn"
+            :disabled="!sseRows.length"
+            title="バッファを JSON Lines でダウンロード"
+            @click="exportSse"
+          >
+            <i class="ti ti-download" />
+          </button>
+        </div>
+        <div v-if="sseTopTypes.length" :class="$style.chipRow">
+          <span :class="$style.rateChip">{{ sseRatePerMin }}/min</span>
+          <button
+            v-for="[t, n] in sseTopTypes"
+            :key="t"
+            type="button"
+            :class="$style.typeChip"
+            title="クリックでこの種別に絞る"
+            @click="filterByType(t)"
+          >
+            {{ t }} ×{{ n }}
+          </button>
         </div>
         <div :class="$style.sseList">
           <div v-for="row in sseRows" :key="row.seq" :class="$style.sseRow">
@@ -586,6 +775,20 @@ onUnmounted(() => {
             auto-height
           />
         </template>
+        <div v-if="capHistory.length" :class="$style.capHistory">
+          <button
+            v-for="h in capHistory"
+            :key="h.seq"
+            type="button"
+            :class="$style.capHistoryRow"
+            title="クリックで結果を呼び戻す"
+            @click="restoreCapHistory(h)"
+          >
+            <span :class="$style.sseTime">{{ h.time }}</span>
+            <span :class="[$style.mono, $style.capHistoryId]">{{ h.capId }}</span>
+            <span :class="$style.capStatus">{{ h.status ?? 'ERR' }}</span>
+          </button>
+        </div>
         <button type="button" :class="$style.summary" @click="togglePerms">
           <i :class="showPerms ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
           principal 別実効権限 (#712)
@@ -629,6 +832,14 @@ onUnmounted(() => {
             :class="$style.filterInput"
             placeholder="絞り込み (部分一致)"
           />
+          <button
+            type="button"
+            :class="[$style.btn, logWarnOnly && $style.btnActive]"
+            title="WARN 以上のみ表示"
+            @click="logWarnOnly = !logWarnOnly"
+          >
+            WARN+
+          </button>
           <button type="button" :class="$style.btn" @click="connectLogs">再接続</button>
           <button type="button" :class="$style.btn" @click="stopLogs">停止</button>
           <button type="button" :class="$style.btn" @click="clearLogs">クリア</button>
@@ -997,5 +1208,75 @@ onUnmounted(() => {
 
 .permRowRelevant {
   background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
+}
+
+.btnActive {
+  background: var(--nd-accent);
+  color: #fff;
+  border-color: var(--nd-accent);
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+
+.rateChip {
+  font-family: var(--nd-font-mono);
+  font-size: 0.7rem;
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+}
+
+.typeChip {
+  padding: 2px 8px;
+  border: none;
+  border-radius: 999px;
+  background: var(--nd-buttonBg);
+  color: var(--nd-accent);
+  font-family: var(--nd-font-mono);
+  font-size: 0.7rem;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--nd-buttonHoverBg, var(--nd-buttonBg));
+  }
+}
+
+.capHistory {
+  display: flex;
+  flex-direction: column;
+  flex: none;
+  max-height: 130px;
+  overflow-y: auto;
+  border-top: 1px solid var(--nd-divider);
+}
+
+.capHistoryRow {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 2px 6px;
+  border: none;
+  background: none;
+  color: var(--nd-fg);
+  text-align: left;
+  font-size: 0.75rem;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--nd-buttonBg);
+  }
+}
+
+.capHistoryId {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 </style>

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -63,6 +63,37 @@ async function toggleSpec() {
   }
 }
 
+// --- 起動計測 (#985) ---
+// About ウィンドウにしか出ていなかった startupTrace の露出面。
+// 開くたびに取り直す (アプリ再起動をまたいでも古い値を見せない)
+
+interface StartupTrace {
+  entries: { name: string; at: number }[]
+  webviewFixedCost: number | null
+}
+
+const showStartup = ref(false)
+const startup = ref<StartupTrace | null>(null)
+
+const startupRows = computed(() => {
+  const entries = startup.value?.entries ?? []
+  return entries.map((m, i) => ({
+    ...m,
+    delta: i > 0 ? m.at - (entries[i - 1]?.at ?? 0) : 0,
+  }))
+})
+
+async function toggleStartup() {
+  showStartup.value = !showStartup.value
+  if (!showStartup.value) return
+  try {
+    const res = await fetch('/api/startup/trace')
+    if (res.ok) startup.value = await res.json()
+  } catch {
+    // アプリ未起動
+  }
+}
+
 // SSE ビューア。EventSource は event: 名ごとの addEventListener が必要で
 // 動的な main-{eventType} を受けられないため、fetch + ReadableStream で
 // SSE をパースする (Authorization は proxy が注入するので相対 fetch でよい)
@@ -260,6 +291,31 @@ async function executeCap() {
   }
 }
 
+// --- principal 別実効権限 (#712) ---
+// 実行盤で 403 が返ったとき「なぜ deny か」をその場で照合するための
+// 読み取りマトリクス。選択中 capability の要求キー行をハイライトする
+
+interface ResolvedPermissions {
+  keys: string[]
+  principals: Record<string, Record<string, boolean>>
+}
+
+const PERM_PRINCIPALS = ['ai.chat', 'ai.heartbeat', 'plugin', 'external']
+
+const showPerms = ref(false)
+const perms = ref<ResolvedPermissions | null>(null)
+
+async function togglePerms() {
+  showPerms.value = !showPerms.value
+  if (!showPerms.value) return
+  try {
+    const res = await fetch('/api/permissions/resolved')
+    if (res.ok) perms.value = await res.json()
+  } catch {
+    // アプリ未起動
+  }
+}
+
 // --- Rust ログ tail ---
 // /dev/logs は Vite dev server の面 (vite.config.ts)。tracing の
 // 日次ローテートログを SSE で流してくる。イベント名なしなので EventSource でよい
@@ -396,6 +452,29 @@ onUnmounted(() => {
           read-only
           max-height="48vh"
         />
+        <button type="button" :class="$style.summary" @click="toggleStartup">
+          <i :class="showStartup ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          起動計測 (#985)
+        </button>
+        <template v-if="showStartup && startup">
+          <p v-if="startup.webviewFixedCost !== null" :class="$style.capDesc">
+            WebView 起動固定費 ~{{ startup.webviewFixedCost }}ms
+          </p>
+          <div :class="$style.tableWrap">
+            <table :class="$style.table">
+              <thead>
+                <tr><th>mark</th><th>at</th><th>+Δ</th></tr>
+              </thead>
+              <tbody>
+                <tr v-for="row in startupRows" :key="row.name">
+                  <td :class="$style.mono">{{ row.name }}</td>
+                  <td :class="$style.mono">{{ Math.round(row.at) }}ms</td>
+                  <td :class="$style.mono">+{{ Math.round(row.delta) }}ms</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </template>
       </section>
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridSse]">
@@ -507,6 +586,36 @@ onUnmounted(() => {
             auto-height
           />
         </template>
+        <button type="button" :class="$style.summary" @click="togglePerms">
+          <i :class="showPerms ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          principal 別実効権限 (#712)
+        </button>
+        <div v-if="showPerms && perms" :class="$style.tableWrap">
+          <table :class="$style.table">
+            <thead>
+              <tr>
+                <th>permission</th>
+                <th v-for="p in PERM_PRINCIPALS" :key="p">{{ p }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="key in perms.keys"
+                :key="key"
+                :class="selectedCap?.permissions.includes(key) && $style.permRowRelevant"
+              >
+                <td :class="$style.mono">{{ key }}</td>
+                <td
+                  v-for="p in PERM_PRINCIPALS"
+                  :key="p"
+                  :class="perms.principals[p]?.[key] ? $style.permOk : $style.permNo"
+                >
+                  {{ perms.principals[p]?.[key] ? '✓' : '–' }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </section>
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridLogs]">
@@ -876,5 +985,17 @@ onUnmounted(() => {
 
 .logWarn {
   color: #da3;
+}
+
+.permOk {
+  color: var(--nd-success, #6c6);
+}
+
+.permNo {
+  opacity: 0.35;
+}
+
+.permRowRelevant {
+  background: color-mix(in srgb, var(--nd-accent) 12%, transparent);
 }
 </style>

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -32,6 +32,7 @@ interface DeckColumn {
 
 interface SseRow {
   seq: number
+  ts: number
   time: string
   type: string
   data: string
@@ -192,7 +193,8 @@ function pushRow(type: string, data: string) {
   sseRatePerMin.value = sseRecentTimes.length
   sseRows.value.unshift({
     seq: ++sseSeq,
-    time: new Date().toLocaleTimeString('ja-JP', { hour12: false }),
+    ts: now,
+    time: new Date(now).toLocaleTimeString('ja-JP', { hour12: false }),
     type,
     data,
     expanded: false,
@@ -447,6 +449,7 @@ async function togglePerms() {
 
 interface LogRow {
   seq: number
+  ts: number
   line: string
   level: 'error' | 'warn' | 'info' | 'debug'
 }
@@ -459,13 +462,94 @@ const logWarnOnly = ref(false)
 let logEs: EventSource | null = null
 let logSeq = 0
 
-const filteredLogRows = computed(() => {
+// tracing 行頭の ISO タイムスタンプ (統合タイムラインのソート基準)
+const LOG_ISO_RE = /^(\d{4}-\d{2}-\d{2}T[0-9:.]+Z)/
+
+// --- 統合タイムライン ---
+// Rust ログ (SSE tail) + Rust イベントバス (SSE) + フロント in-app ログを
+// 単一時系列にマージし、「どの層でイベントが消えたか」を 1 画面で追う
+
+interface FrontLogEntry {
+  at: number
+  level: 'warn' | 'error'
+  scope?: string
+  message: string
+}
+
+interface UnifiedRow {
+  key: string
+  ts: number
+  source: 'rust' | 'sse' | 'front'
+  label: string
+  text: string
+  level: 'error' | 'warn' | 'info' | 'debug'
+}
+
+const timelineSources = ref({ rust: true, sse: true, front: true })
+const frontRows = ref<FrontLogEntry[]>([])
+let frontTimer: ReturnType<typeof setInterval> | null = null
+
+async function refreshFrontLogs() {
+  try {
+    const res = await fetch('/api/logs/recent')
+    if (res.ok) {
+      const data: unknown = await res.json()
+      if (Array.isArray(data)) frontRows.value = data as FrontLogEntry[]
+    }
+  } catch {
+    // アプリ再起動中など — 次の周期更新で回復する
+  }
+}
+
+const unifiedRows = computed<UnifiedRow[]>(() => {
   const q = logFilter.value.trim().toLowerCase()
-  return logRows.value.filter((r) => {
-    if (logWarnOnly.value && r.level !== 'error' && r.level !== 'warn')
-      return false
-    return !q || r.line.toLowerCase().includes(q)
+  const warnOnly = logWarnOnly.value
+  const src = timelineSources.value
+  const rows: UnifiedRow[] = []
+  if (src.rust) {
+    for (const r of logRows.value)
+      rows.push({
+        key: `r${r.seq}`,
+        ts: r.ts,
+        source: 'rust',
+        label: r.level.toUpperCase(),
+        text: r.line,
+        level: r.level,
+      })
+  }
+  if (src.sse) {
+    for (const r of sseRows.value)
+      rows.push({
+        key: `s${r.seq}`,
+        ts: r.ts,
+        source: 'sse',
+        label: r.type,
+        text: r.data,
+        level: 'info',
+      })
+  }
+  if (src.front) {
+    for (const [i, e] of frontRows.value.entries()) {
+      rows.push({
+        key: `f${e.at}-${i}`,
+        ts: e.at,
+        source: 'front',
+        label: e.level.toUpperCase(),
+        text: (e.scope ? `[${e.scope}] ` : '') + e.message,
+        level: e.level,
+      })
+    }
+  }
+  const filtered = rows.filter((r) => {
+    if (warnOnly && r.level !== 'error' && r.level !== 'warn') return false
+    return (
+      !q ||
+      r.text.toLowerCase().includes(q) ||
+      r.label.toLowerCase().includes(q)
+    )
   })
+  filtered.sort((a, b) => b.ts - a.ts)
+  return filtered.slice(0, LOG_BUFFER_MAX)
 })
 
 function detectLevel(line: string): LogRow['level'] {
@@ -484,8 +568,10 @@ function connectLogs() {
     logState.value = 'open'
   }
   es.onmessage = (e) => {
+    const iso = e.data.match(LOG_ISO_RE)?.[1]
     logRows.value.unshift({
       seq: ++logSeq,
+      ts: iso ? Date.parse(iso) : Date.now(),
       line: e.data,
       level: detectLevel(e.data),
     })
@@ -508,16 +594,88 @@ function clearLogs() {
   logRows.value = []
 }
 
+// --- キャッシュ観測 (#987) / Query Bridge トレース / Inspector 突き合わせ ---
+
+interface CacheStat {
+  name: string
+  size: number
+  limit: number
+}
+
+const showCaches = ref(false)
+const caches = ref<CacheStat[]>([])
+
+async function toggleCaches() {
+  showCaches.value = !showCaches.value
+  if (!showCaches.value) return
+  try {
+    const res = await fetch('/api/perf/caches')
+    if (res.ok) {
+      const data: unknown = await res.json()
+      if (Array.isArray(data)) caches.value = data as CacheStat[]
+    }
+  } catch {
+    // アプリ未起動
+  }
+}
+
+interface QbTraceRow {
+  at: number
+  type: string
+  ms: number
+  error: boolean
+}
+
+const showQbTrace = ref(false)
+const qbTrace = ref<QbTraceRow[]>([])
+
+async function toggleQbTrace() {
+  showQbTrace.value = !showQbTrace.value
+  if (!showQbTrace.value) return
+  try {
+    const res = await fetch('/api/querybridge/trace')
+    if (res.ok) {
+      const data: unknown = await res.json()
+      if (Array.isArray(data)) qbTrace.value = data as QbTraceRow[]
+    }
+  } catch {
+    // アプリ未起動
+  }
+}
+
+interface InspectorRecent {
+  total: number
+  counts: Record<string, number>
+  oldestTs: number | null
+}
+
+const showInspector = ref(false)
+const inspector = ref<InspectorRecent | null>(null)
+
+async function toggleInspector() {
+  showInspector.value = !showInspector.value
+  if (!showInspector.value) return
+  try {
+    const res = await fetch('/api/inspector/recent')
+    if (res.ok) inspector.value = await res.json()
+  } catch {
+    // アプリ未起動
+  }
+}
+
 onMounted(() => {
   refreshStatus()
   statusTimer = setInterval(refreshStatus, 5000)
   connectSse()
   loadCapabilities()
   connectLogs()
+  refreshFrontLogs()
+  frontTimer = setInterval(refreshFrontLogs, 3000)
 })
 
 onUnmounted(() => {
   if (statusTimer) clearInterval(statusTimer)
+  if (frontTimer) clearInterval(frontTimer)
   stopSse()
   stopLogs()
 })
@@ -642,6 +800,44 @@ onUnmounted(() => {
             </tbody>
           </table>
         </div>
+        <button type="button" :class="$style.summary" @click="toggleCaches">
+          <i :class="showCaches ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          キャッシュ観測 (#987)
+        </button>
+        <div v-if="showCaches" :class="$style.tableWrap">
+          <table v-if="caches.length" :class="$style.table">
+            <thead>
+              <tr><th>name</th><th>size</th><th>limit</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(c, i) in caches" :key="`${c.name}-${i}`">
+                <td :class="$style.mono">{{ c.name }}</td>
+                <td :class="$style.mono">{{ c.size }}</td>
+                <td :class="$style.mono">{{ c.limit }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else :class="$style.capDesc">登録済みキャッシュなし</p>
+        </div>
+        <button type="button" :class="$style.summary" @click="toggleQbTrace">
+          <i :class="showQbTrace ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          Query Bridge トレース
+        </button>
+        <div v-if="showQbTrace" :class="$style.tableWrap">
+          <table v-if="qbTrace.length" :class="$style.table">
+            <thead>
+              <tr><th>time</th><th>type</th><th>ms</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(t, i) in qbTrace" :key="`${t.at}-${i}`">
+                <td :class="$style.mono">{{ new Date(t.at).toLocaleTimeString('ja-JP', { hour12: false }) }}</td>
+                <td :class="[$style.mono, t.error && $style.logError]">{{ t.type }}</td>
+                <td :class="$style.mono">{{ t.ms }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p v-else :class="$style.capDesc">まだ記録なし</p>
+        </div>
       </section>
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridSse]">
@@ -682,6 +878,38 @@ onUnmounted(() => {
           >
             {{ t }} ×{{ n }}
           </button>
+        </div>
+        <button type="button" :class="$style.summary" @click="toggleInspector">
+          <i :class="showInspector ? 'ti ti-chevron-down' : 'ti ti-chevron-right'" />
+          Inspector 突き合わせ (アダプタ層 vs SSE)
+        </button>
+        <div v-if="showInspector" :class="$style.inspectorCompare">
+          <div :class="$style.tableWrap">
+            <p :class="$style.capDesc">アダプタ層 (Misskey WS raw)</p>
+            <table v-if="inspector?.total" :class="$style.table">
+              <tbody>
+                <tr v-for="(n, kind) in inspector.counts" :key="kind">
+                  <td :class="$style.mono">{{ kind }}</td>
+                  <td :class="$style.mono">{{ n }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <p v-else :class="$style.capDesc">
+              バッファ空 — Stream Inspector カラムを開くと流入します
+            </p>
+          </div>
+          <div :class="$style.tableWrap">
+            <p :class="$style.capDesc">SSE (Rust イベントバス)</p>
+            <table v-if="sseTopTypes.length" :class="$style.table">
+              <tbody>
+                <tr v-for="[t, n] in sseTopTypes" :key="t">
+                  <td :class="$style.mono">{{ t }}</td>
+                  <td :class="$style.mono">{{ n }}</td>
+                </tr>
+              </tbody>
+            </table>
+            <p v-else :class="$style.capDesc">受信なし</p>
+          </div>
         </div>
         <div :class="$style.sseList">
           <div v-for="row in sseRows" :key="row.seq" :class="$style.sseRow">
@@ -823,8 +1051,8 @@ onUnmounted(() => {
 
       <section :class="[$style.panel, $style.ssePanel, $style.gridLogs]">
         <h2 :class="$style.panelTitle">
-          Rust ログ tail (notedeck.log)
-          <span :class="[$style.sseBadge, logState === 'open' && $style.sseOpen]">{{ logState }}</span>
+          統合タイムライン
+          <span :class="[$style.sseBadge, logState === 'open' && $style.sseOpen]">rust: {{ logState }}</span>
         </h2>
         <div :class="$style.sseControls">
           <input
@@ -835,7 +1063,7 @@ onUnmounted(() => {
           <button
             type="button"
             :class="[$style.btn, logWarnOnly && $style.btnActive]"
-            title="WARN 以上のみ表示"
+            title="WARN 以上のみ表示 (SSE イベントも隠れる)"
             @click="logWarnOnly = !logWarnOnly"
           >
             WARN+
@@ -844,10 +1072,20 @@ onUnmounted(() => {
           <button type="button" :class="$style.btn" @click="stopLogs">停止</button>
           <button type="button" :class="$style.btn" @click="clearLogs">クリア</button>
         </div>
+        <div :class="$style.chipRow">
+          <label
+            v-for="(label, key) in { rust: 'Rust ログ', sse: 'SSE', front: 'フロント' }"
+            :key="key"
+            :class="$style.sourceToggle"
+          >
+            <input v-model="timelineSources[key]" type="checkbox" />
+            {{ label }}
+          </label>
+        </div>
         <div :class="$style.sseList">
           <div
-            v-for="row in filteredLogRows"
-            :key="row.seq"
+            v-for="row in unifiedRows"
+            :key="row.key"
             :class="[
               $style.logLine,
               row.level === 'error'
@@ -856,9 +1094,18 @@ onUnmounted(() => {
                   ? $style.logWarn
                   : '',
             ]"
-          >{{ row.line }}</div>
-          <p v-if="!filteredLogRows.length" :class="$style.sseEmpty">
-            ログ待機中 — アプリ側の tracing 出力がここに流れます
+          ><span
+            :class="[
+              $style.sourceBadge,
+              row.source === 'sse'
+                ? $style.sourceSse
+                : row.source === 'front'
+                  ? $style.sourceFront
+                  : $style.sourceRust,
+            ]"
+          >{{ row.source }}</span> <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span> <span :class="$style.sseType">{{ row.label }}</span> {{ row.text }}</div>
+          <p v-if="!unifiedRows.length" :class="$style.sseEmpty">
+            待機中 — Rust ログ / SSE イベント / フロントログがここに時系列で流れます
           </p>
         </div>
       </section>
@@ -1278,5 +1525,49 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.sourceToggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.75rem;
+  opacity: 0.8;
+  cursor: pointer;
+  user-select: none;
+}
+
+.sourceBadge {
+  display: inline-block;
+  min-width: 40px;
+  text-align: center;
+  padding: 0 6px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+.sourceRust {
+  background: var(--nd-buttonBg);
+  opacity: 0.8;
+}
+
+.sourceSse {
+  background: color-mix(in srgb, var(--nd-accent) 25%, transparent);
+  color: var(--nd-accent);
+}
+
+.sourceFront {
+  background: color-mix(in srgb, #4a9eda 25%, transparent);
+  color: #4a9eda;
+}
+
+.inspectorCompare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  flex: none;
+  max-height: 40%;
+  overflow-y: auto;
 }
 </style>

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -120,17 +120,12 @@ interface HeartbeatStatusView {
 }
 
 const showHeartbeat = ref(false)
+// heartbeat の中身は refreshStatus の 5 秒ポーリングが埋める
+// (ステータスバーにも常時出すため折りたたみ開閉と独立に取得する)
 const heartbeat = ref<HeartbeatStatusView | null>(null)
 
-async function toggleHeartbeat() {
+function toggleHeartbeat() {
   showHeartbeat.value = !showHeartbeat.value
-  if (!showHeartbeat.value) return
-  try {
-    const res = await fetch('/api/heartbeat/status')
-    if (res.ok) heartbeat.value = await res.json()
-  } catch {
-    // アプリ未起動
-  }
 }
 
 function relativeTime(epochMs: number | null): string {
@@ -171,10 +166,11 @@ function filterByType(type: string) {
 
 async function refreshStatus() {
   try {
-    const [indexRes, colsRes, healthRes] = await Promise.all([
+    const [indexRes, colsRes, healthRes, hbRes] = await Promise.all([
       fetch('/api'),
       fetch('/api/deck/columns'),
       fetch('/api/health'),
+      fetch('/api/heartbeat/status'),
     ])
     if (indexRes.ok) app.value = await indexRes.json()
     if (colsRes.ok) {
@@ -183,6 +179,7 @@ async function refreshStatus() {
     }
     if (healthRes.ok)
       health.value = JSON.stringify(await healthRes.json(), null, 2)
+    if (hbRes.ok) heartbeat.value = await hbRes.json()
   } catch {
     // アプリ再起動中など — 次の周期更新で回復する
   }
@@ -521,6 +518,21 @@ function typeColor(type: string): string {
   for (let i = 0; i < type.length; i++) h = (h * 31 + type.charCodeAt(i)) % 360
   return `hsl(${h} 65% 62%)`
 }
+
+// VSCode 風ステータスバーのカウント (統合タイムラインの Rust + フロント分)
+const timelineErrorCount = computed(() => {
+  let n = 0
+  for (const r of logRows.value) if (r.level === 'error') n++
+  for (const e of frontRows.value) if (e.level === 'error') n++
+  return n
+})
+
+const timelineWarnCount = computed(() => {
+  let n = 0
+  for (const r of logRows.value) if (r.level === 'warn') n++
+  for (const e of frontRows.value) if (e.level === 'warn') n++
+  return n
+})
 
 async function refreshFrontLogs() {
   try {
@@ -1220,6 +1232,34 @@ onUnmounted(() => {
         </div>
       </section>
     </div>
+
+    <footer :class="$style.statusBar">
+      <span :class="[$style.statusSeg, $style.statusRemote]">
+        <i :class="sseState === 'open' ? 'ti ti-bolt' : 'ti ti-plug-x'" />
+        {{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}
+      </span>
+      <button
+        type="button"
+        :class="[$style.statusSeg, $style.statusSegBtn]"
+        title="クリックで WARN+ フィルタを切り替え"
+        @click="logWarnOnly = !logWarnOnly"
+      >
+        <i class="ti ti-circle-x" /> {{ timelineErrorCount }}
+        <i class="ti ti-alert-triangle" /> {{ timelineWarnCount }}
+      </button>
+      <span :class="$style.statusSeg">
+        <i class="ti ti-broadcast" /> {{ sseRatePerMin }}/min · {{ sseCount }} events
+      </span>
+      <span :class="$style.statusSeg">
+        <i class="ti ti-layout-columns" /> {{ columns.length }} columns
+      </span>
+      <span :class="$style.statusSpacer" />
+      <span v-if="heartbeat?.config.enabled" :class="$style.statusSeg" title="HEARTBEAT 有効">
+        <i class="ti ti-heartbeat" :class="$style.beat" />
+        {{ heartbeat.dailyCount }}/{{ heartbeat.config.dailyMaxAiRuns }}
+      </span>
+      <span :class="$style.statusSeg">127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template></span>
+    </footer>
   </div>
 </template>
 
@@ -1229,10 +1269,63 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 20px 24px;
+  padding: 20px 24px 0;
   background: var(--nd-bg);
   color: var(--nd-fg);
   overflow: hidden;
+}
+
+/* VSCode 風ステータスバー。左端の LIVE ブロックは remote インジケータの意匠 */
+.statusBar {
+  flex: none;
+  display: flex;
+  align-items: stretch;
+  margin: 0 -24px;
+  height: 26px;
+  background: var(--nd-accentDarken);
+  color: #fff;
+  font-family: var(--nd-font-mono);
+  font-size: 0.72rem;
+  user-select: none;
+}
+
+.statusSeg {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  white-space: nowrap;
+
+  i {
+    font-size: 0.85rem;
+  }
+}
+
+.statusRemote {
+  background: var(--nd-accent);
+  font-weight: 700;
+}
+
+.statusSegBtn {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 150ms ease-out;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--nd-focusRing);
+    outline-offset: -2px;
+  }
+}
+
+.statusSpacer {
+  flex: 1;
 }
 
 .header {

--- a/src/components/dev/DevDashboard.vue
+++ b/src/components/dev/DevDashboard.vue
@@ -546,6 +546,29 @@ async function refreshFrontLogs() {
   }
 }
 
+// SSE 行の開閉状態 (unifiedRows は computed で作り直されるため外に持つ)。
+// バッファ落ちした行のキーが残るが、上限で丸ごと捨てて有界にする
+const expandedUnified = ref<Set<string>>(new Set())
+
+function toggleUnifiedRow(row: UnifiedRow) {
+  if (row.source !== 'sse') return
+  const next = new Set(expandedUnified.value)
+  if (next.has(row.key)) next.delete(row.key)
+  else {
+    if (next.size > 50) next.clear()
+    next.add(row.key)
+  }
+  expandedUnified.value = next
+}
+
+function prettyText(text: string): string {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2)
+  } catch {
+    return text
+  }
+}
+
 const unifiedRows = computed<UnifiedRow[]>(() => {
   const q = logFilter.value.trim().toLowerCase()
   const warnOnly = logWarnOnly.value
@@ -1216,16 +1239,35 @@ onUnmounted(() => {
                   ? $style.logWarn
                   : '',
             ]"
-          ><span
-            :class="[
-              $style.sourceBadge,
-              row.source === 'sse'
-                ? $style.sourceSse
-                : row.source === 'front'
-                  ? $style.sourceFront
-                  : $style.sourceRust,
-            ]"
-          >{{ row.source }}</span> <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span> <span :class="$style.sseType" :style="row.source === 'sse' ? { color: typeColor(row.label) } : undefined">{{ row.label }}</span> {{ row.text }}</div>
+          >
+            <!-- SSE 行はペイロードが長いのでデフォルト 1 行、クリックで展開 -->
+            <button
+              v-if="row.source === 'sse'"
+              type="button"
+              :class="$style.unifiedRowHead"
+              @click="toggleUnifiedRow(row)"
+            >
+              <span :class="[$style.sourceBadge, $style.sourceSse]">{{ row.source }}</span>
+              <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span>
+              <span :class="$style.sseType" :style="{ color: typeColor(row.label) }">{{ row.label }}</span>
+              <span :class="$style.unifiedSseText">{{ row.text }}</span>
+            </button>
+            <template v-else>
+              <span
+                :class="[
+                  $style.sourceBadge,
+                  row.source === 'front' ? $style.sourceFront : $style.sourceRust,
+                ]"
+              >{{ row.source }}</span> <span :class="$style.sseTime">{{ new Date(row.ts).toLocaleTimeString('ja-JP', { hour12: false }) }}</span> <span :class="$style.sseType">{{ row.label }}</span> {{ row.text }}
+            </template>
+            <CodeEditor
+              v-if="row.source === 'sse' && expandedUnified.has(row.key)"
+              :model-value="prettyText(row.text)"
+              :language="lang"
+              read-only
+              auto-height
+            />
+          </div>
           <p v-if="!unifiedRows.length" :class="$style.sseEmpty">
             待機中 — Rust ログ / SSE イベント / フロントログがここに時系列で流れます
           </p>
@@ -1234,31 +1276,62 @@ onUnmounted(() => {
     </div>
 
     <footer :class="$style.statusBar">
-      <span :class="[$style.statusSeg, $style.statusRemote]">
-        <i :class="sseState === 'open' ? 'ti ti-bolt' : 'ti ti-plug-x'" />
-        {{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}
-      </span>
       <button
         type="button"
-        :class="[$style.statusSeg, $style.statusSegBtn]"
+        :class="[$style.statusSeg, $style.statusSegBtn, $style.statusRemote]"
+        :title="sseState === 'stopped' ? 'クリックで SSE 接続' : 'クリックで SSE 停止'"
+        @click="sseState === 'stopped' ? connectSse() : stopSse()"
+      >
+        <i :class="sseState === 'open' ? 'ti ti-bolt' : 'ti ti-plug-x'" />
+        {{ sseState === 'open' ? 'LIVE' : sseState.toUpperCase() }}
+      </button>
+      <button
+        type="button"
+        :class="[
+          $style.statusSeg,
+          $style.statusSegBtn,
+          logWarnOnly && $style.statusSegActive,
+        ]"
         title="クリックで WARN+ フィルタを切り替え"
         @click="logWarnOnly = !logWarnOnly"
       >
-        <i class="ti ti-circle-x" /> {{ timelineErrorCount }}
-        <i class="ti ti-alert-triangle" /> {{ timelineWarnCount }}
+        <i class="ti ti-circle-x" :class="timelineErrorCount > 0 && $style.statusErrIcon" /> {{ timelineErrorCount }}
+        <i class="ti ti-alert-triangle" :class="timelineWarnCount > 0 && $style.statusWarnIcon" /> {{ timelineWarnCount }}
       </button>
-      <span :class="$style.statusSeg">
+      <button
+        type="button"
+        :class="[$style.statusSeg, $style.statusSegBtn]"
+        title="クリックで SSE バッファを JSON Lines エクスポート"
+        @click="exportSse"
+      >
         <i class="ti ti-broadcast" /> {{ sseRatePerMin }}/min · {{ sseCount }} events
-      </span>
-      <span :class="$style.statusSeg">
+      </button>
+      <button
+        type="button"
+        :class="[$style.statusSeg, $style.statusSegBtn]"
+        title="クリックで状態を今すぐ更新"
+        @click="refreshStatus"
+      >
         <i class="ti ti-layout-columns" /> {{ columns.length }} columns
-      </span>
+      </button>
       <span :class="$style.statusSpacer" />
-      <span v-if="heartbeat?.config.enabled" :class="$style.statusSeg" title="HEARTBEAT 有効">
+      <button
+        v-if="heartbeat?.config.enabled"
+        type="button"
+        :class="[$style.statusSeg, $style.statusSegBtn]"
+        title="クリックで HEARTBEAT 状態を開閉"
+        @click="toggleHeartbeat"
+      >
         <i class="ti ti-heartbeat" :class="$style.beat" />
         {{ heartbeat.dailyCount }}/{{ heartbeat.config.dailyMaxAiRuns }}
-      </span>
-      <span :class="$style.statusSeg">127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template></span>
+      </button>
+      <a
+        :class="[$style.statusSeg, $style.statusSegBtn]"
+        href="/api/docs"
+        target="_blank"
+        rel="noopener"
+        title="API ドキュメント (Scalar) を開く"
+      >127.0.0.1:19820<template v-if="app?.version"> · v{{ app.version }}</template></a>
     </footer>
   </div>
 </template>
@@ -1275,15 +1348,17 @@ onUnmounted(() => {
   overflow: hidden;
 }
 
-/* VSCode 風ステータスバー。左端の LIVE ブロックは remote インジケータの意匠 */
+/* VSCode 風ステータスバー。地はパネル色に抑え、左端の LIVE ブロック
+   (remote インジケータの意匠) だけアクセントで差す */
 .statusBar {
   flex: none;
   display: flex;
   align-items: stretch;
   margin: 0 -24px;
   height: 26px;
-  background: var(--nd-accentDarken);
-  color: #fff;
+  background: var(--nd-panel);
+  border-top: 1px solid var(--nd-divider);
+  color: var(--nd-fg);
   font-family: var(--nd-font-mono);
   font-size: 0.72rem;
   user-select: none;
@@ -1295,6 +1370,7 @@ onUnmounted(() => {
   gap: 5px;
   padding: 0 10px;
   white-space: nowrap;
+  opacity: 0.85;
 
   i {
     font-size: 0.85rem;
@@ -1302,8 +1378,14 @@ onUnmounted(() => {
 }
 
 .statusRemote {
-  background: var(--nd-accent);
+  background: var(--nd-accentDarken);
+  color: #fff;
   font-weight: 700;
+  opacity: 1;
+
+  &:hover {
+    background: var(--nd-accent);
+  }
 }
 
 .statusSegBtn {
@@ -1311,17 +1393,32 @@ onUnmounted(() => {
   background: none;
   color: inherit;
   font: inherit;
+  text-decoration: none;
   cursor: pointer;
   transition: background 150ms ease-out;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.12);
+    background: var(--nd-buttonHoverBg, rgba(255, 255, 255, 0.08));
+    opacity: 1;
   }
 
   &:focus-visible {
     outline: 2px solid var(--nd-focusRing);
     outline-offset: -2px;
   }
+}
+
+.statusSegActive {
+  background: var(--nd-accentedBg);
+  opacity: 1;
+}
+
+.statusErrIcon {
+  color: var(--nd-error);
+}
+
+.statusWarnIcon {
+  color: var(--nd-warn);
 }
 
 .statusSpacer {
@@ -1827,6 +1924,29 @@ onUnmounted(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.unifiedRowHead {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.unifiedSseText {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  opacity: 0.75;
 }
 
 .sourceToggle {

--- a/src/composables/useHeartbeatDaemon.ts
+++ b/src/composables/useHeartbeatDaemon.ts
@@ -358,6 +358,26 @@ async function resolveTargetSession(
 }
 
 /**
+ * dev ダッシュボード (#977) 向けの読み取りスナップショット。daemon は
+ * App.vue で 1 mount の global singleton なので module スコープに置き、
+ * apiBridge の query handler ('heartbeat/status') がここを読む。
+ * silent fail 防止機構 (連続失敗 auto-disable) の観測面。
+ */
+export const heartbeatStatus = {
+  /** daemon が mount 済みか (セーフモード・非 Tauri では false のまま) */
+  mounted: false,
+  /** tick 本処理が実行中か */
+  running: false,
+  lastTickAt: null as number | null,
+  lastTickSource: null as string | null,
+  /** 直近 tick の結末 (skip:<理由> / suppressed / reported / error) */
+  lastOutcome: null as string | null,
+  consecutiveFailures: 0,
+  /** 本日の AI 起動回数 (日次上限のカウンタ) */
+  dailyCount: 0,
+}
+
+/**
  * HEARTBEAT session 専用 AI タイトル生成 system prompt。
  * (DeckAiColumn.vue の chat session 用 prompt と同じ shape、文脈だけ heartbeat 向け)
  */
@@ -369,6 +389,7 @@ export function useHeartbeatDaemon() {
   // 第三者コードと同格に止める。App.vue の mount より手前で抜けるので
   // Rust scheduler への configure も listen も一切行われない
   if (readSafeMode()) return
+  heartbeatStatus.mounted = true
 
   const { config } = useAiConfig()
   const sessionsStore = useAiSessionsStore()
@@ -534,19 +555,26 @@ export function useHeartbeatDaemon() {
   // --- tick listener (App lifecycle で 1 度だけ) ---
   ;(async () => {
     unlisten = await listenTauri('nd:ai-heartbeat-tick', (tick) => {
+      heartbeatStatus.lastTickAt = Date.now()
+      heartbeatStatus.lastTickSource = tick.source
       if (isRunning.value) {
         console.debug(
           `[heartbeat] skip (already running) source=${tick.source}`,
         )
+        heartbeatStatus.lastOutcome = 'skip:already-running'
         return
       }
       isRunning.value = true
+      heartbeatStatus.running = true
       runOnce(tick)
         .catch((e) => {
           console.warn('[heartbeat] daemon error:', e)
+          heartbeatStatus.lastOutcome = 'error'
         })
         .finally(() => {
           isRunning.value = false
+          heartbeatStatus.running = false
+          heartbeatStatus.consecutiveFailures = consecutiveFailures
         })
     })
   })()
@@ -560,12 +588,16 @@ export function useHeartbeatDaemon() {
 
   async function runOnce(payload: HeartbeatTickPayload): Promise<void> {
     const cfg = config.value.heartbeat
-    if (!cfg.enabled) return
+    if (!cfg.enabled) {
+      heartbeatStatus.lastOutcome = 'skip:disabled'
+      return
+    }
 
     // active account がいない (= 未ログイン) なら skip。アカウント context
     // 自体は capability 側で必要なものだけ参照する。
     if (!accountsStore.activeAccountId) {
       console.debug('[heartbeat] no active account, skip')
+      heartbeatStatus.lastOutcome = 'skip:no-account'
       return
     }
 
@@ -574,6 +606,7 @@ export function useHeartbeatDaemon() {
     const heartbeatSkills = skillsStore.heartbeatSkills
     if (heartbeatSkills.length === 0) {
       console.debug('[heartbeat] no skills tagged as heartbeat, skip')
+      heartbeatStatus.lastOutcome = 'skip:no-skills'
       return
     }
     const skillBodies: string[] = []
@@ -584,6 +617,7 @@ export function useHeartbeatDaemon() {
     }
     if (skillBodies.length === 0) {
       console.debug('[heartbeat] heartbeat-tagged skills have empty body, skip')
+      heartbeatStatus.lastOutcome = 'skip:no-skills'
       return
     }
 
@@ -599,6 +633,7 @@ export function useHeartbeatDaemon() {
       console.debug(
         `[heartbeat] cheap-check skip AI (reason=${decision.reason}, source=${payload.source})`,
       )
+      heartbeatStatus.lastOutcome = `skip:cheap-check:${decision.reason}`
       // skip 時も hash は最新化 (= 次 tick で「変化あり」を検知できるように)。
       // lastAiRunAt は更新しない (= maxSkipHours は AI 起動時のみ更新)。
       saveCheapCheckState({
@@ -616,8 +651,10 @@ export function useHeartbeatDaemon() {
     //   'warn'    = toast 出して継続 (= AI 呼んで進める)
     //   'disable' = toast + heartbeat.enabled=false で daemon 停止
     const counter = tickDailyCounter(now)
+    heartbeatStatus.dailyCount = counter.count
     if (counter.count > cfg.dailyMaxAiRuns) {
       if (cfg.onDailyLimit === 'disable') {
+        heartbeatStatus.lastOutcome = 'skip:daily-limit-disable'
         config.value.heartbeat.enabled = false
         toast.show(
           `HEARTBEAT を停止しました (本日 ${cfg.dailyMaxAiRuns} 回の AI 起動上限に到達)`,
@@ -655,6 +692,7 @@ export function useHeartbeatDaemon() {
       })
     } catch (e) {
       consecutiveFailures += 1
+      heartbeatStatus.lastOutcome = 'error'
       const errMsg = e instanceof Error ? e.message : String(e)
       console.warn(
         `[heartbeat] inference failed (${consecutiveFailures}/${MAX_CONSECUTIVE_FAILURES}):`,
@@ -671,15 +709,20 @@ export function useHeartbeatDaemon() {
       }
       return
     }
-    if (responseText === null) return
+    if (responseText === null) {
+      heartbeatStatus.lastOutcome = 'skip:no-response'
+      return
+    }
 
     const visible = applyHeartbeatSuppression(responseText)
     if (visible === null) {
       console.debug(
         `[heartbeat] AI returned OK / short-ack, suppress (source=${payload.source})`,
       )
+      heartbeatStatus.lastOutcome = 'suppressed'
       return
     }
+    heartbeatStatus.lastOutcome = 'reported'
 
     // target session に append (target='none' なら log のみ)
     const resolvedConn = resolveAiConnection(

--- a/src/core/apiBridge.ts
+++ b/src/core/apiBridge.ts
@@ -4,7 +4,11 @@ import { sanitizeToolName } from '@/capabilities/identifier'
 import { listCapabilities } from '@/capabilities/registry'
 import { useCommandStore } from '@/commands/registry'
 import { listStreamHealth } from '@/core/streamHealth'
+import type { ProfiledPrincipalId } from '@/permissions/principal'
+import { PERMISSION_KEYS } from '@/permissions/schema'
+import { resolveForProfiled } from '@/permissions/store'
 import { useDeckStore } from '@/stores/deck'
+import { getStartupEntries, getWebviewFixedCost } from '@/utils/startupTrace'
 import { listenTauri } from '@/utils/tauriEvents'
 
 export interface QueryRequest {
@@ -43,6 +47,30 @@ const handlers: Record<string, QueryHandler> = {
 
   // /api/health のフロント側パート: WebView 死活の証明 + ストリーム接続状態
   'health/streams': () => listStreamHealth(),
+
+  // --- dev ダッシュボード向け読み取り診断 (#977) ---
+  // ephemeral トークン (dev) 前提。永続トークン (external principal) には
+  // permissions_gate の route_rule が既定 Deny を返すので開かない
+
+  'startup/trace': () => ({
+    entries: getStartupEntries(),
+    webviewFixedCost: getWebviewFixedCost(),
+  }),
+
+  'permissions/resolved': () => {
+    const principals: ProfiledPrincipalId[] = [
+      'ai.chat',
+      'ai.heartbeat',
+      'plugin',
+      'external',
+    ]
+    return {
+      keys: PERMISSION_KEYS,
+      principals: Object.fromEntries(
+        principals.map((id) => [id, resolveForProfiled(id)]),
+      ),
+    }
+  },
 
   // --- 外部アプリ向け capability 面 (#709) ---
   // 権限は external principal のプロファイルで gate される (dispatcher が照合)。

--- a/src/core/apiBridge.ts
+++ b/src/core/apiBridge.ts
@@ -9,7 +9,10 @@ import { listStreamHealth } from '@/core/streamHealth'
 import type { ProfiledPrincipalId } from '@/permissions/principal'
 import { PERMISSION_KEYS } from '@/permissions/schema'
 import { resolveForProfiled } from '@/permissions/store'
+import { listBoundedCacheStats } from '@/services/boundedCache'
 import { useDeckStore } from '@/stores/deck'
+import { useLogsStore } from '@/stores/logs'
+import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { getStartupEntries, getWebviewFixedCost } from '@/utils/startupTrace'
 import { listenTauri } from '@/utils/tauriEvents'
 
@@ -20,6 +23,30 @@ export interface QueryRequest {
 }
 
 type QueryHandler = (params: Record<string, unknown>) => unknown
+
+/**
+ * Query Bridge トレース (#977 / #897 の IPC 可視化)。往復ごとに種別と
+ * 所要時間を記録するリングバッファ。'querybridge/trace' 自身は記録しない
+ * (自己汚染防止)。
+ */
+const QUERY_TRACE_MAX = 100
+const queryTrace: { at: number; type: string; ms: number; error: boolean }[] =
+  []
+
+function recordQueryTrace(type: string, ms: number, result: unknown) {
+  if (type === 'querybridge/trace') return
+  queryTrace.unshift({
+    at: Date.now(),
+    type,
+    ms: Math.round(ms * 10) / 10,
+    error:
+      typeof result === 'object' &&
+      result !== null &&
+      !Array.isArray(result) &&
+      'error' in result,
+  })
+  if (queryTrace.length > QUERY_TRACE_MAX) queryTrace.length = QUERY_TRACE_MAX
+}
 
 const handlers: Record<string, QueryHandler> = {
   'deck/columns': () => {
@@ -88,6 +115,31 @@ const handlers: Record<string, QueryHandler> = {
     }
   },
 
+  // 上限つきキャッシュ (#987) の実測一覧 — 「必ず上限」不変条件の観測面
+  'perf/caches': () => listBoundedCacheStats(),
+
+  // フロント in-app ログ (console.warn/error のリング)。統合タイムラインが
+  // Rust ログ・SSE とマージして表示する
+  'logs/recent': () => useLogsStore().entries,
+
+  'querybridge/trace': () => queryTrace,
+
+  // Stream Inspector (アダプタ層の raw WS イベント) の種別別カウント。
+  // SSE 側 (Rust イベントバス) との突き合わせ用。Inspector カラムが
+  // 開いているときだけ流入する
+  'inspector/recent': () => {
+    const buffer = useStreamInspectorStore().buffer
+    const counts: Record<string, number> = {}
+    for (const entry of buffer) {
+      counts[entry.kind] = (counts[entry.kind] ?? 0) + 1
+    }
+    return {
+      total: buffer.length,
+      counts,
+      oldestTs: buffer.length ? (buffer[buffer.length - 1]?.ts ?? null) : null,
+    }
+  },
+
   // --- 外部アプリ向け capability 面 (#709) ---
   // 権限は external principal のプロファイルで gate される (dispatcher が照合)。
   // カラム追加/削除・コマンド実行の旧 store 直叩きハンドラは #711 で削除済み —
@@ -143,7 +195,9 @@ export async function initApiBridge() {
   const unlistenFn = await listenTauri(
     'nd:query-request',
     async ({ id, type, params }) => {
+      const started = performance.now()
       const result = await handleQuery(type, params)
+      recordQueryTrace(type, performance.now() - started, result)
 
       // 動的イベント名なので TauriEventPayloads の対象外 (型付け不可)
       await emit(`nd:query-response-${id}`, result)

--- a/src/core/apiBridge.ts
+++ b/src/core/apiBridge.ts
@@ -3,6 +3,8 @@ import { dispatchCapability } from '@/capabilities/dispatcher'
 import { sanitizeToolName } from '@/capabilities/identifier'
 import { listCapabilities } from '@/capabilities/registry'
 import { useCommandStore } from '@/commands/registry'
+import { useAiConfig } from '@/composables/useAiConfig'
+import { heartbeatStatus } from '@/composables/useHeartbeatDaemon'
 import { listStreamHealth } from '@/core/streamHealth'
 import type { ProfiledPrincipalId } from '@/permissions/principal'
 import { PERMISSION_KEYS } from '@/permissions/schema'
@@ -56,6 +58,20 @@ const handlers: Record<string, QueryHandler> = {
     entries: getStartupEntries(),
     webviewFixedCost: getWebviewFixedCost(),
   }),
+
+  'heartbeat/status': () => {
+    const { config } = useAiConfig()
+    const hb = config.value.heartbeat
+    return {
+      ...heartbeatStatus,
+      config: {
+        enabled: hb.enabled,
+        intervalMinutes: hb.intervalMinutes,
+        target: hb.target,
+        dailyMaxAiRuns: hb.dailyMaxAiRuns,
+      },
+    }
+  },
 
   'permissions/resolved': () => {
     const principals: ProfiledPrincipalId[] = [

--- a/src/services/boundedCache.test.ts
+++ b/src/services/boundedCache.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { createBoundedCache } from '@/services/boundedCache'
+import {
+  createBoundedCache,
+  listBoundedCacheStats,
+} from '@/services/boundedCache'
 
 describe('createBoundedCache', () => {
   it('上限を超えたら最も古いエントリから捨てる', () => {
@@ -108,5 +111,22 @@ describe('createBoundedCache', () => {
       ['c', 3],
       ['a', 1],
     ])
+  })
+
+  it('名前付きで生成すると観測レジストリに size/limit が載る (#977)', () => {
+    const cache = createBoundedCache<string, number>(5, 'test:stats-cache')
+    cache.set('a', 1)
+    cache.set('b', 2)
+
+    const stat = listBoundedCacheStats().find(
+      (s) => s.name === 'test:stats-cache',
+    )
+    expect(stat).toEqual({ name: 'test:stats-cache', size: 2, limit: 5 })
+  })
+
+  it('名前なしで生成するとレジストリに載らない', () => {
+    const before = listBoundedCacheStats().length
+    createBoundedCache<string, number>(5)
+    expect(listBoundedCacheStats().length).toBe(before)
   })
 })

--- a/src/services/boundedCache.ts
+++ b/src/services/boundedCache.ts
@@ -26,8 +26,46 @@ export interface BoundedCache<K, V> {
   readonly size: number
 }
 
+export interface BoundedCacheStat {
+  name: string
+  size: number
+  limit: number
+}
+
+/**
+ * 観測レジストリ (#977 / #987)。名前付きで生成されたキャッシュを WeakRef で
+ * 保持し、dev ダッシュボードが size / limit を一覧する。「必ず上限」の
+ * 不変条件が実測で見える面。WeakRef なのでコンポーネント寿命のキャッシュ
+ * (カラム単位等) は GC されれば自動で一覧から消える (レジストリが寿命を
+ * 延ばさない)。
+ */
+const registry = new Map<
+  number,
+  {
+    name: string
+    ref: WeakRef<BoundedCache<unknown, unknown>>
+    maxOf: () => number
+  }
+>()
+let registrySeq = 0
+
+export function listBoundedCacheStats(): BoundedCacheStat[] {
+  const stats: BoundedCacheStat[] = []
+  for (const [id, entry] of registry) {
+    const cache = entry.ref.deref()
+    if (!cache) {
+      registry.delete(id)
+      continue
+    }
+    stats.push({ name: entry.name, size: cache.size, limit: entry.maxOf() })
+  }
+  return stats
+}
+
 export function createBoundedCache<K, V>(
   max: number | (() => number),
+  /** 観測レジストリに載せる名前。省略時は非登録 */
+  name?: string,
 ): BoundedCache<K, V> {
   const map = new Map<K, V>()
   // 0 以下は「キャッシュ無効」ではなく 1 に丸める。設定ミスで毎回の
@@ -40,7 +78,7 @@ export function createBoundedCache<K, V>(
     return Number.isFinite(value) ? Math.max(1, value) : 1
   }
 
-  return {
+  const cache: BoundedCache<K, V> = {
     get(key) {
       if (!map.has(key)) return undefined
       const value = map.get(key) as V
@@ -68,4 +106,19 @@ export function createBoundedCache<K, V>(
       return map.size
     },
   }
+
+  if (name) {
+    // 死んだ WeakRef は登録時にも掃除する — 一覧が読まれなくても
+    // エントリ数が「生きているキャッシュの数」を超えて育たない (#987)
+    for (const [id, entry] of registry) {
+      if (!entry.ref.deref()) registry.delete(id)
+    }
+    registry.set(++registrySeq, {
+      name,
+      ref: new WeakRef(cache as BoundedCache<unknown, unknown>),
+      maxOf,
+    })
+  }
+
+  return cache
 }

--- a/src/utils/blurhashDataUrl.ts
+++ b/src/utils/blurhashDataUrl.ts
@@ -10,7 +10,7 @@ const cache = createBoundedCache<string, string | null>(() => {
   } catch {
     return 256
   }
-})
+}, 'blurhash-data-url')
 
 /**
  * blurhash を data URL (32x32 PNG) にデコードする。

--- a/tests/core/apiBridge.test.ts
+++ b/tests/core/apiBridge.test.ts
@@ -9,11 +9,16 @@ import type { Command } from '@/commands/registry'
 import { handleQuery } from '@/core/apiBridge'
 import { recordStreamHealth } from '@/core/streamHealth'
 import type { ProfiledPrincipalId } from '@/permissions/principal'
-import { setPermissionPreset } from '@/permissions/schema'
+import {
+  EXTERNAL_READ_FLOOR,
+  PERMISSION_KEYS,
+  setPermissionPreset,
+} from '@/permissions/schema'
 import {
   _resetPermissionsForTest,
   usePermissionsConfig,
 } from '@/permissions/store'
+import { markStartup } from '@/utils/startupTrace'
 
 function makeCapability(overrides: Partial<Command> = {}): Command {
   return {
@@ -156,6 +161,59 @@ describe('handleQuery: health/streams', () => {
     const acc1 = result.find((r) => r.accountId === 'acc1')
     expect(acc1?.state).toBe('connected')
     expect(acc1?.since).toBeGreaterThan(0)
+  })
+})
+
+describe('handleQuery: startup/trace (#977)', () => {
+  it('記録済みの起動マークを entries として返す', async () => {
+    markStartup('test-mark')
+    const result = (await handleQuery('startup/trace', {})) as {
+      entries: { name: string; at: number }[]
+      webviewFixedCost: number | null
+    }
+    const mark = result.entries.find((e) => e.name === 'test-mark')
+    expect(mark?.at).toBeGreaterThan(0)
+    // happy-dom には navigation entry が無いので null (実機では数値)
+    expect(
+      result.webviewFixedCost === null ||
+        typeof result.webviewFixedCost === 'number',
+    ).toBe(true)
+  })
+})
+
+describe('handleQuery: permissions/resolved (#977)', () => {
+  it('4 principal の granted map と全 permission キーを返す', async () => {
+    const result = (await handleQuery('permissions/resolved', {})) as {
+      keys: string[]
+      principals: Record<string, Record<string, boolean>>
+    }
+    expect(result.keys).toEqual([...PERMISSION_KEYS])
+    for (const id of ['ai.chat', 'ai.heartbeat', 'plugin', 'external']) {
+      const map = result.principals[id]
+      expect(map, id).toBeDefined()
+      for (const key of PERMISSION_KEYS) {
+        expect(typeof map?.[key], `${id}.${key}`).toBe('boolean')
+      }
+    }
+  })
+
+  it('external の既定は READ_FLOOR のみ true で write 系は false', async () => {
+    const result = (await handleQuery('permissions/resolved', {})) as {
+      principals: Record<string, Record<string, boolean>>
+    }
+    const external = result.principals.external
+    for (const key of EXTERNAL_READ_FLOOR) {
+      expect(external?.[key], key).toBe(true)
+    }
+    expect(external?.['notes.write']).toBe(false)
+  })
+
+  it('preset 変更が解決結果に反映される', async () => {
+    setPrincipalPreset('external', 'full')
+    const result = (await handleQuery('permissions/resolved', {})) as {
+      principals: Record<string, Record<string, boolean>>
+    }
+    expect(result.principals.external?.['notes.write']).toBe(true)
   })
 })
 

--- a/tests/core/apiBridge.test.ts
+++ b/tests/core/apiBridge.test.ts
@@ -18,6 +18,8 @@ import {
   _resetPermissionsForTest,
   usePermissionsConfig,
 } from '@/permissions/store'
+import { createBoundedCache } from '@/services/boundedCache'
+import { useStreamInspectorStore } from '@/stores/streamInspector'
 import { markStartup } from '@/utils/startupTrace'
 
 function makeCapability(overrides: Partial<Command> = {}): Command {
@@ -231,6 +233,67 @@ describe('handleQuery: heartbeat/status (#977)', () => {
     expect(typeof result.config.enabled).toBe('boolean')
     expect(typeof result.config.intervalMinutes).toBe('number')
     expect(typeof result.config.target).toBe('string')
+  })
+})
+
+describe('handleQuery: perf/caches (#977/#987)', () => {
+  it('名前付き boundedCache の size/limit を返す', async () => {
+    const cache = createBoundedCache<string, number>(7, 'test:api-bridge')
+    cache.set('x', 1)
+    const result = (await handleQuery('perf/caches', {})) as Array<{
+      name: string
+      size: number
+      limit: number
+    }>
+    const stat = result.find((s) => s.name === 'test:api-bridge')
+    expect(stat).toEqual({ name: 'test:api-bridge', size: 1, limit: 7 })
+  })
+})
+
+describe('handleQuery: inspector/recent (#977)', () => {
+  it('アダプタ層バッファを kind 別カウントに集計する', async () => {
+    const inspector = useStreamInspectorStore()
+    const badge = { avatar: null, serverIcon: null }
+    inspector.buffer = [
+      {
+        id: 1,
+        ts: 100,
+        kind: 'stream-note',
+        accountId: 'a',
+        observer: badge,
+        subject: null,
+        payload: {},
+      },
+      {
+        id: 2,
+        ts: 50,
+        kind: 'stream-note',
+        accountId: 'a',
+        observer: badge,
+        subject: null,
+        payload: {},
+      },
+      {
+        id: 3,
+        ts: 10,
+        kind: 'stream-notification',
+        accountId: 'a',
+        observer: badge,
+        subject: null,
+        payload: {},
+      },
+    ]
+    const result = (await handleQuery('inspector/recent', {})) as {
+      total: number
+      counts: Record<string, number>
+      oldestTs: number | null
+    }
+    expect(result.total).toBe(3)
+    expect(result.counts).toEqual({
+      'stream-note': 2,
+      'stream-notification': 1,
+    })
+    expect(result.oldestTs).toBe(10)
   })
 })
 

--- a/tests/core/apiBridge.test.ts
+++ b/tests/core/apiBridge.test.ts
@@ -217,6 +217,23 @@ describe('handleQuery: permissions/resolved (#977)', () => {
   })
 })
 
+describe('handleQuery: heartbeat/status (#977)', () => {
+  it('daemon スナップショットと config を返す (テスト環境では未 mount)', async () => {
+    const result = (await handleQuery('heartbeat/status', {})) as {
+      mounted: boolean
+      running: boolean
+      consecutiveFailures: number
+      config: { enabled: boolean; intervalMinutes: number; target: string }
+    }
+    expect(result.mounted).toBe(false)
+    expect(result.running).toBe(false)
+    expect(typeof result.consecutiveFailures).toBe('number')
+    expect(typeof result.config.enabled).toBe('boolean')
+    expect(typeof result.config.intervalMinutes).toBe('number')
+    expect(typeof result.config.target).toBe('string')
+  })
+})
+
 describe('handleQuery: 共通挙動', () => {
   it('未知の query type は error envelope を返す', async () => {
     const result = (await handleQuery('nope/nothing', {})) as {

--- a/tests/lint/moduleCaches.test.ts
+++ b/tests/lint/moduleCaches.test.ts
@@ -47,6 +47,8 @@ const ALLOWED: Record<string, string> = {
     'bounded: MAX_CACHE_ENTRIES',
 
   // lifecycle — 完了・解除・発火で消える
+  'src/services/boundedCache.ts:registry':
+    'lifecycle: WeakRef 保持 — 参照切れは登録時と一覧読み取り時に掃除 (#977 観測レジストリ)',
   'src/utils/dedup.ts:inflight': 'lifecycle: finally で削除',
   'src/utils/highlight.ts:pendingLangs': 'lifecycle: ロード完了で削除',
   'src/composables/useOgpPreview.ts:pendingRequests':

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -269,20 +269,34 @@ let ndTokenPath: string | null = null
 let ndLogDir: string | null = null
 let ndTokenPathResolving: Promise<void> | null = null
 
+// アプリ停止検知 (null = 稼働中とみなす)。停止中はミドルウェアが proxy に
+// 渡さず即 503 を返す — ダッシュボードの自動再接続が Rust ビルド中ずっと
+// 「http proxy error: ECONNREFUSED」をターミナルに撒くのを防ぐ
+let ndAppDownSince: number | null = null
+const ND_DOWN_RECHECK_MS = 2000
+
 function resolveNdTokenPath(): Promise<void> {
   ndTokenPathResolving ??= fetch(`${ND_APP_ORIGIN}/api`)
     .then(async (r) => {
       const index = (await r.json()) as { tokenPath?: string; logDir?: string }
       ndTokenPath = index.tokenPath ?? null
       ndLogDir = index.logDir ?? null
+      ndAppDownSince = null
     })
     .catch(() => {
-      // アプリ未起動 — 次のリクエストで再解決する
+      // アプリ未起動 (ビルド中など) — 次のリクエストで再解決する
+      ndAppDownSince = Date.now()
     })
     .finally(() => {
       ndTokenPathResolving = null
     })
   return ndTokenPathResolving
+}
+
+function ndRespondAppDown(res: import('node:http').ServerResponse): void {
+  res.statusCode = 503
+  res.setHeader('Content-Type', 'application/json')
+  res.end('{"error":"NoteDeck app is not running (building or stopped)"}')
 }
 
 /** proxy より先に走る middleware で tokenPath 解決を待ち、初回リクエストの注入漏れを防ぐ */
@@ -291,8 +305,20 @@ function ndApiBridge(): Plugin {
     name: 'nd-api-bridge',
     apply: 'serve',
     configureServer(server) {
-      server.middlewares.use('/api', async (_req, _res, next) => {
-        if (!ndTokenPath) await resolveNdTokenPath()
+      server.middlewares.use('/api', async (_req, res, next) => {
+        // 停止直後の再確認は 2 秒に 1 回まで — その間は proxy に渡さず 503
+        if (
+          ndAppDownSince &&
+          Date.now() - ndAppDownSince < ND_DOWN_RECHECK_MS
+        ) {
+          ndRespondAppDown(res)
+          return
+        }
+        if (!ndTokenPath || ndAppDownSince) await resolveNdTokenPath()
+        if (ndAppDownSince) {
+          ndRespondAppDown(res)
+          return
+        }
         next()
       })
 
@@ -375,6 +401,11 @@ function ndApiProxy(): Record<string, ProxyOptions> {
       target: ND_APP_ORIGIN,
       changeOrigin: true,
       configure(proxy) {
+        // 稼働中に落ちた場合の検知 (Vite のエラーログはこの 1 回だけ出る —
+        // 以降はミドルウェアが 503 で止める)
+        proxy.on('error', () => {
+          ndAppDownSince = Date.now()
+        })
         proxy.on('proxyReq', (proxyReq) => {
           if (!ndTokenPath) return
           if (proxyReq.getHeader('authorization')) return


### PR DESCRIPTION
## 概要

Dev Dashboard (#977) の Tier A / Tier B を実装し、`pnpm tauri:dev` 中の Vite dev server (5173) が「実行中のアプリを外から覗く開発者ダッシュボード」として使えるようになった。あわせて boundedCache (#987) に観測レジストリを足し、「キャッシュには必ず上限」不変条件の実測面を用意した。

エンドユーザー向けの挙動変更はなく、開発者向けの面の追加が中心。

## 変更一覧

- chore: regenerate openapi.json for 1.43.0
- chore: bump version to 1.43.0
- fix(dev): タイムラインの SSE 行を 1 行折りたたみに + ステータスバー調整 (#977)
- feat(dev): VSCode 風ステータスバーを Dev Dashboard に足す (#977)
- feat(dev): Dev Dashboard の UI/UX を磨く (#977)
- fix(dev): アプリ停止中の proxy エラーノイズを止める
- feat(dev): 統合タイムラインほか Tier B パネル (#977)
- feat(perf): boundedCache に観測レジストリを足す (#987 / #977 Tier B)
- feat(dev): HEARTBEAT 状態パネルと UX 小改善 (#977 Tier A 完)
- feat(dev): 権限解決ビューアと起動計測パネル (#977 Tier A)

## Related

- #977 — Tier A / Tier B 完了。Tier C (MCP テストベンチ・本番配信版) は #940 の前提待ちのため継続
- #987 — 観測レジストリで実測面を追加 (issue 自体はクローズ済み)

## 検証

- `pnpm lint` / `pnpm typecheck` / `pnpm test` (239 ファイル / 2671 テスト) すべて通過
- Dev Dashboard の実機疎通は `pnpm tauri:dev` 時に確認済み (headless ブラウザでの描画確認を含む)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the Developer Dashboard with startup, heartbeat, cache, permissions, capability history, and Query Bridge diagnostics.
  * Added a unified timeline combining application events, live-stream activity, and logs.
  * Added event filtering, traffic metrics, sparklines, JSON Lines export, and Inspector comparisons.
  * Added authenticated diagnostic endpoints for accessing detailed development telemetry.

* **Bug Fixes**
  * API requests now return clear temporary-unavailable responses when the application is offline, with throttled recovery checks.

* **Documentation**
  * Updated Developer Dashboard documentation to cover the new diagnostics and monitoring tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->