### PR TITLE
Release v1.43.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.43.0",
+  "version": "1.43.1",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.43.0"
+version = "1.43.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.43.0"
+version = "1.43.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.43.0"
+    "version": "1.43.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.43.0",
+  "version": "1.43.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/deck/DeckColumn.vue
+++ b/src/components/deck/DeckColumn.vue
@@ -169,6 +169,18 @@ async function returnToDeck() {
   await getCurrentWindow().close()
 }
 
+/** 縦分割グループの一員かどうか (分割を解除できるのはこのときだけ) */
+const isStacked = computed(() => {
+  const group = deckStore.layout.find((ids) => ids.includes(props.columnId))
+  return (group?.length ?? 0) > 1
+})
+
+/** 縦分割から抜けて独立した 1 本のカラムに戻す */
+function unstack() {
+  closeMenu()
+  deckStore.unstackColumn(props.columnId)
+}
+
 function popOut() {
   closeMenu()
   popOutColumnToWindow(props.columnId)
@@ -339,6 +351,10 @@ function openAsPip() {
         <button v-if="webUiUrl" class="_popupItem" @click="onOpenWebUi">
           <i class="ti ti-external-link" />
           <span>Web UIで開く</span>
+        </button>
+        <button v-if="isStacked" class="_popupItem" @click="unstack">
+          <i class="ti ti-layout-columns" />
+          <span>分割を解除</span>
         </button>
         <button v-if="canPopOut" class="_popupItem" @click="popOut">
           <i class="ti ti-app-window" />

--- a/src/components/deck/DeckColumnsArea.vue
+++ b/src/components/deck/DeckColumnsArea.vue
@@ -10,6 +10,7 @@ import * as snapshotStore from '@/composables/useSnapshotStore'
 import { useDeckStore } from '@/stores/deck'
 import { useIsCompactLayout } from '@/stores/ui'
 import { accountsCacheKeyDeps, columnCacheKey } from '@/utils/columnCacheKey'
+import { isInsertNoop } from '@/utils/deckLayout'
 import { COLUMN_SELECTOR } from '@/utils/themeVars'
 import DeckStackCell from './DeckStackCell.vue'
 
@@ -155,16 +156,8 @@ const dropInsertIndex = computed(() => {
   const dt = columnDrag.dropTarget.value
   if (!dt || !('insertIndex' in dt)) return -1
   const dragId = columnDrag.dragColumnId.value
-  if (dragId) {
-    const fromIdx = deckStore.windowLayout.findIndex((ids) =>
-      ids.includes(dragId),
-    )
-    if (
-      fromIdx >= 0 &&
-      (dt.insertIndex === fromIdx || dt.insertIndex === fromIdx + 1)
-    )
-      return -1
-  }
+  if (dragId && isInsertNoop(deckStore.windowLayout, dragId, dt.insertIndex))
+    return -1
   return dt.insertIndex
 })
 

--- a/src/composables/useColumnDrag.ts
+++ b/src/composables/useColumnDrag.ts
@@ -1,5 +1,6 @@
 import { nextTick, ref } from 'vue'
 import type { useDeckStore } from '@/stores/deck'
+import { isInsertNoop } from '@/utils/deckLayout'
 import { hapticLight, hapticMedium } from '@/utils/haptics'
 import { emitTauri } from '@/utils/tauriEvents'
 
@@ -195,14 +196,11 @@ export function useColumnDrag(
       return
     }
 
-    // Helper: inserting at fromIdx or fromIdx+1 is a no-op (same position)
-    function isInsertNoop(insertIndex: number): boolean {
+    // Helper: dropping back at the same position changes nothing
+    function isNoop(insertIndex: number): boolean {
       const dragId = dragColumnId.value
-      if (!dragId || !groupIndexMap) return false
-      const fromIdx = groupIndexMap.get(dragId) ?? -1
-      return (
-        fromIdx >= 0 && (insertIndex === fromIdx || insertIndex === fromIdx + 1)
-      )
+      if (!dragId) return false
+      return isInsertNoop(deckStore.layout, dragId, insertIndex)
     }
 
     // Check if hovering over a resize handle or gap between columns
@@ -226,7 +224,7 @@ export function useColumnDrag(
         }
       }
 
-      dropTarget.value = isInsertNoop(insertIndex)
+      dropTarget.value = isNoop(insertIndex)
         ? null
         : { insertIndex, position: 'insert' }
       return
@@ -253,7 +251,7 @@ export function useColumnDrag(
         }
       }
 
-      dropTarget.value = isInsertNoop(insertIndex)
+      dropTarget.value = isNoop(insertIndex)
         ? null
         : { insertIndex, position: 'insert' }
       return

--- a/src/composables/useColumnDrag.ts
+++ b/src/composables/useColumnDrag.ts
@@ -1,6 +1,6 @@
 import { nextTick, ref } from 'vue'
 import type { useDeckStore } from '@/stores/deck'
-import { isInsertNoop } from '@/utils/deckLayout'
+import { isInsertNoop, toGlobalInsertIndex } from '@/utils/deckLayout'
 import { hapticLight, hapticMedium } from '@/utils/haptics'
 import { emitTauri } from '@/utils/tauriEvents'
 
@@ -196,11 +196,13 @@ export function useColumnDrag(
       return
     }
 
-    // Helper: dropping back at the same position changes nothing
+    // Helper: dropping back at the same position changes nothing.
+    // 挿入位置は画面に並んでいるカラムを数えて決まるので、判定も現ウィンドウの
+    // 並びで行う (デッキ全体の並びとは index がずれる — #1027)
     function isNoop(insertIndex: number): boolean {
       const dragId = dragColumnId.value
       if (!dragId) return false
-      return isInsertNoop(deckStore.layout, dragId, insertIndex)
+      return isInsertNoop(deckStore.windowLayout, dragId, insertIndex)
     }
 
     // Check if hovering over a resize handle or gap between columns
@@ -317,7 +319,14 @@ export function useColumnDrag(
       void animateColumnFlip(() => {
         if (target.position === 'insert') {
           // Drop between columns — unstack / move to position
-          deckStore.insertColumnAt(dragId, target.insertIndex)
+          deckStore.insertColumnAt(
+            dragId,
+            toGlobalInsertIndex(
+              deckStore.layout,
+              deckStore.windowLayout,
+              target.insertIndex,
+            ),
+          )
         } else {
           const { columnId: targetId, position } = target
           const fromIdx = deckStore.layout.findIndex((ids) =>

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -750,18 +750,25 @@ export const useDeckStore = defineStore('deck', () => {
 
   // --- Multi-window column management ---
 
-  /** Layout groups visible in the current window */
+  /**
+   * Layout groups visible in the current window.
+   *
+   * 所属ウィンドウはカラム 1 枚ごとに持つので、絞り込みもカラム単位で行う。
+   * グループ単位で絞ると、分割グループの 1 枚だけが別ウィンドウにある場合に
+   * 同じグループが両方のウィンドウに現れる (#1027)。
+   */
   const windowLayout = computed(() => {
     const wid = currentWindowId.value
     const colMap = columnMap.value
-    return layout.value.filter((group) =>
-      group.some((colId) => {
-        const col = colMap.get(colId)
-        if (!col) return false
-        if (!wid) return !col.windowId
-        return col.windowId === wid
-      }),
-    )
+    const belongsHere = (colId: string) => {
+      const col = colMap.get(colId)
+      if (!col) return false
+      if (!wid) return !col.windowId
+      return col.windowId === wid
+    }
+    return layout.value
+      .map((group) => group.filter(belongsHere))
+      .filter((group) => group.length > 0)
   })
 
   function popOutColumn(columnId: string, windowId: string) {
@@ -795,6 +802,8 @@ export const useDeckStore = defineStore('deck', () => {
   function moveColumnToWindow(columnId: string, targetWindowId: string | null) {
     const col = getColumn(columnId)
     if (!col) return
+    // 分割したまま移すとグループがウィンドウをまたいでしまう (#1027)
+    unstackColumn(columnId)
     col.windowId = targetWindowId || undefined
     save()
   }

--- a/src/utils/deckLayout.ts
+++ b/src/utils/deckLayout.ts
@@ -82,6 +82,24 @@ export function swapInGroup(
   return result
 }
 
+/**
+ * Whether moving a column to `targetIndex` would leave the layout unchanged.
+ *
+ * スタック中のカラムは、自分のグループのすぐ隣に挿入してもグループから
+ * 抜けるという変化が起きるので no-op ではない (#1026)。
+ */
+export function isInsertNoop(
+  layout: string[][],
+  id: string,
+  targetIndex: number,
+): boolean {
+  const groupIdx = groupIndexOf(layout, id)
+  if (groupIdx < 0) return false
+  const group = layout[groupIdx]
+  if (!group || group.length > 1) return false
+  return targetIndex === groupIdx || targetIndex === groupIdx + 1
+}
+
 /** Move a column to a new group at the target index. Returns null on failure. */
 export function insertColumnAt(
   layout: string[][],
@@ -93,7 +111,7 @@ export function insertColumnAt(
   const group = layout[groupIdx]
   if (!group) return null
 
-  if (group.length === 1 && groupIdx === targetIndex) return null
+  if (isInsertNoop(layout, id, targetIndex)) return null
 
   const newGroup = group.filter((colId) => colId !== id)
   const newLayout = [...layout]

--- a/src/utils/deckLayout.ts
+++ b/src/utils/deckLayout.ts
@@ -130,6 +130,31 @@ export function insertColumnAt(
   return newLayout
 }
 
+/**
+ * Convert an insert index counted on a per-window layout into an index on the
+ * full deck layout.
+ *
+ * ドラッグの挿入位置は画面に並んでいるカラム (= 現ウィンドウ分) を数えて
+ * 決まるが、レイアウトの書き換えはデッキ全体に対して行う。別ウィンドウへ
+ * 切り出したカラムがあると 2 つの並びは長さが違うので、そのまま渡すと
+ * 位置がずれる (#1027)。
+ */
+export function toGlobalInsertIndex(
+  layout: string[][],
+  windowLayout: string[][],
+  windowIndex: number,
+): number {
+  if (windowLayout.length === 0) return layout.length
+  const clamped = Math.max(0, Math.min(windowIndex, windowLayout.length))
+
+  // 末尾に落としたときは「このウィンドウの最後のカラムの直後」
+  const atEnd = clamped === windowLayout.length
+  const anchor = windowLayout[atEnd ? windowLayout.length - 1 : clamped]?.[0]
+  const anchorIdx = anchor ? groupIndexOf(layout, anchor) : -1
+  if (anchorIdx < 0) return layout.length
+  return atEnd ? anchorIdx + 1 : anchorIdx
+}
+
 /** Remove a column from its group into its own new group. Returns null on failure. */
 export function unstackColumn(
   layout: string[][],

--- a/tests/stores/deck.test.ts
+++ b/tests/stores/deck.test.ts
@@ -698,6 +698,46 @@ describe('deck store', () => {
     })
   })
 
+  describe('multi-window layout', () => {
+    /** 2 本のカラムを 1 グループに縦分割して返す */
+    function stackedPair() {
+      const deck = useDeckStore()
+      const col1 = deck.addColumn({
+        type: 'timeline',
+        name: 'A',
+        width: 400,
+        accountId: null,
+      })
+      const col2 = deck.addColumn({
+        type: 'notifications',
+        name: 'B',
+        width: 400,
+        accountId: null,
+      })
+      deck.stackColumn(col2.id, col1.id, 'below')
+      return { deck, col1, col2 }
+    }
+
+    it('moveColumnToWindow は分割を解除してから移す', () => {
+      const { deck, col1, col2 } = stackedPair()
+
+      deck.moveColumnToWindow(col2.id, 'w1')
+
+      expect(deck.layout).toEqual([[col1.id], [col2.id]])
+    })
+
+    it('windowLayout は同じグループ内の他ウィンドウのカラムを含めない', () => {
+      const { deck, col1, col2 } = stackedPair()
+      // 分割したまま移された旧データ相当の状態を直接作る
+      deck.updateColumn(col2.id, { windowId: 'w1' })
+
+      expect(deck.windowLayout).toEqual([[col1.id]])
+
+      deck.currentWindowId = 'w1'
+      expect(deck.windowLayout).toEqual([[col2.id]])
+    })
+  })
+
   describe('deck wallpaper', () => {
     it('setWallpaper sets wallpaper URL', () => {
       const deck = useDeckStore()

--- a/tests/utils/deckLayout.test.ts
+++ b/tests/utils/deckLayout.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { insertColumnAt, isInsertNoop } from '@/utils/deckLayout'
+
+describe('isInsertNoop', () => {
+  it('単独カラムを自分の位置へ挿入すると no-op', () => {
+    expect(isInsertNoop([['a'], ['b']], 'a', 0)).toBe(true)
+  })
+
+  it('単独カラムを自分のすぐ右の隙間へ挿入すると no-op', () => {
+    expect(isInsertNoop([['a'], ['b']], 'a', 1)).toBe(true)
+  })
+
+  it('単独カラムを離れた位置へ挿入するのは no-op ではない', () => {
+    expect(isInsertNoop([['a'], ['b']], 'a', 2)).toBe(false)
+  })
+
+  it('スタック中のカラムを自分のグループの隣へ挿入するのは no-op ではない', () => {
+    // グループから抜けて単独カラムになるので変化がある
+    expect(isInsertNoop([['a', 'b'], ['c']], 'b', 0)).toBe(false)
+    expect(isInsertNoop([['a', 'b'], ['c']], 'b', 1)).toBe(false)
+  })
+
+  it('レイアウトに存在しないカラムは no-op ではない', () => {
+    expect(isInsertNoop([['a']], 'zzz', 0)).toBe(false)
+  })
+})
+
+describe('insertColumnAt', () => {
+  it('スタック中のカラムを自分のグループの右隣へ出すと単独カラムになる', () => {
+    expect(insertColumnAt([['a', 'b'], ['c']], 'b', 1)).toEqual([
+      ['a'],
+      ['b'],
+      ['c'],
+    ])
+  })
+
+  it('デッキが分割グループ 1 つだけでも取り出せる', () => {
+    expect(insertColumnAt([['a', 'b']], 'b', 1)).toEqual([['a'], ['b']])
+    expect(insertColumnAt([['a', 'b']], 'b', 0)).toEqual([['b'], ['a']])
+  })
+
+  it('単独カラムを同じ位置へ挿入しても何も起きない', () => {
+    expect(insertColumnAt([['a'], ['b']], 'a', 0)).toBeNull()
+    expect(insertColumnAt([['a'], ['b']], 'a', 1)).toBeNull()
+  })
+})

--- a/tests/utils/deckLayout.test.ts
+++ b/tests/utils/deckLayout.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { insertColumnAt, isInsertNoop } from '@/utils/deckLayout'
+import {
+  insertColumnAt,
+  isInsertNoop,
+  toGlobalInsertIndex,
+} from '@/utils/deckLayout'
 
 describe('isInsertNoop', () => {
   it('単独カラムを自分の位置へ挿入すると no-op', () => {
@@ -42,5 +46,32 @@ describe('insertColumnAt', () => {
   it('単独カラムを同じ位置へ挿入しても何も起きない', () => {
     expect(insertColumnAt([['a'], ['b']], 'a', 0)).toBeNull()
     expect(insertColumnAt([['a'], ['b']], 'a', 1)).toBeNull()
+  })
+})
+
+describe('toGlobalInsertIndex', () => {
+  // b は別ウィンドウに切り出し済み: 画面に見えているのは a, c だけ
+  const layout = [['a'], ['b'], ['c']]
+  const windowLayout = [['a'], ['c']]
+
+  it('ウィンドウ内の先頭はデッキ全体でも先頭', () => {
+    expect(toGlobalInsertIndex(layout, windowLayout, 0)).toBe(0)
+  })
+
+  it('見えているカラムの間は、そのカラムの全体での位置になる', () => {
+    expect(toGlobalInsertIndex(layout, windowLayout, 1)).toBe(2)
+  })
+
+  it('ウィンドウ内の末尾は、最後に見えているカラムの直後', () => {
+    expect(toGlobalInsertIndex(layout, windowLayout, 2)).toBe(3)
+  })
+
+  it('切り出したカラムがなければ位置は変わらない', () => {
+    expect(toGlobalInsertIndex(layout, layout, 1)).toBe(1)
+    expect(toGlobalInsertIndex(layout, layout, 3)).toBe(3)
+  })
+
+  it('このウィンドウにカラムがなければ末尾', () => {
+    expect(toGlobalInsertIndex(layout, [], 0)).toBe(3)
   })
 })


### PR DESCRIPTION
デッキのカラム操作のバグ修正 2 件。

## 変更

- fix(deck): 縦分割カラムを隣の隙間に出せるようにする (#1026)
- fix(deck): サブウィンドウがあるときの挿入位置のずれを直す (#1027)

### #1026 — 縦分割カラムを取り出せない

ドラッグ中の挿入位置の no-op 判定がグループ単位だったため、スタック中のカラムを自分のグループのすぐ左右へ落とす操作まで「移動していない」と見なして捨てていた。デッキが分割グループ 1 つだけのときは落とせる隙間がその 2 箇所しかなく、手で取り出す手段が存在しなかった。

- no-op 判定を単独カラムのときだけに限定。ドラッグ層とドロップ先インジケータで二重実装されていた同じ判定も 1 本に寄せた
- ドラッグ以外の経路として、カラムメニューに「分割を解除」を追加（分割中のカラムでのみ表示）

### #1027 — サブウィンドウがあると挿入位置がずれる

挿入位置は画面に並んでいるカラム（現ウィンドウ分）を数えて決まるのに、レイアウトの書き換えはデッキ全体の並びに対して行っていた。別ウィンドウに切り出したカラムがあると 2 つの並びは長さが違うので、意図した位置と違う場所に入っていた。

- 判定を現ウィンドウの並びに統一し、確定時にデッキ全体の位置へ変換する
- ウィンドウごとの絞り込みをカラム単位にする（分割グループの 1 枚だけが別ウィンドウにあると、同じグループが両方のウィンドウに現れていた）
- ウィンドウ間の移動は移す前に分割を解除する

## テスト

`tests/utils/deckLayout.test.ts` を新設（挿入位置の判定とウィンドウ内 index の変換）、`tests/stores/deck.test.ts` にウィンドウ間移動の 2 件を追加。全 2686 件通過。

## 未確認

実機でのドラッグ操作は未確認（デスクトップ: #866 / #867 / #871）。

Closes #1026
Closes #1027


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to unstack columns from vertical split groups.
  * Improved column dragging and insertion across multiple windows.

* **Bug Fixes**
  * Corrected layout filtering so each window displays only its assigned columns.
  * Moving columns between windows now automatically removes unintended stacking.
  * Prevented unnecessary drop placeholders and unchanged insert operations.

* **Chores**
  * Updated the application and API version to 1.43.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->