### PR TITLE
Release v1.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.43.1",
+  "version": "1.44.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.43.1"
+version = "1.44.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.43.1"
+version = "1.44.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.43.1"
+    "version": "1.44.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/src/settings_store.rs
+++ b/src-tauri/src/settings_store.rs
@@ -33,6 +33,9 @@ pub const ALLOWED_ROOT_FILES: &[&str] = &[
     "postform.json5",
     "settings.json5",
     "tasks.json5",
+    // チュートリアルの達成記録 + NoteDeck 独自実績 (#1029)。プロファイル・
+    // アカウントから独立 (アプリ操作の習熟はアカウントに紐づかない)
+    "tutorial.json5",
     // principal 別権限 + 確認スキップ (#712 / #714)。capability 層に write を
     // 公開しない制約はここではなく capability registry 側で担保している
     // (settingsFs の固定名ラッパーのみが本コマンドに到達する)
@@ -413,6 +416,34 @@ mod tests {
         // #714: 権限プロファイル + 確認スキップの保存先。allowlist から漏れると
         // 読み書きもバックアップも黙って失敗する (#712〜v1.5.0 で実際に発生)
         assert!(ALLOWED_ROOT_FILES.contains(&"permissions.json5"));
+    }
+
+    #[test]
+    fn tutorial_json5_is_allowed_root_file() {
+        // #1029: チュートリアルの達成記録と実績の保存先。allowlist から漏れると
+        // 読み書きもバックアップも黙って失敗する
+        assert!(ALLOWED_ROOT_FILES.contains(&"tutorial.json5"));
+    }
+
+    #[test]
+    fn tutorial_json5_is_backed_up() {
+        // #1029: 達成記録はユーザーの習熟の記録なので、設定のバックアップに含める
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        write_root_file(base, "tutorial.json5", r#"{ version: 1 }"#).unwrap();
+
+        let bundle = export_bundle(base).unwrap();
+        assert_eq!(
+            bundle.get("tutorial.json5").map(String::as_str),
+            Some(r#"{ version: 1 }"#)
+        );
+
+        fs::remove_file(base.join("tutorial.json5")).unwrap();
+        import_bundle(base, &bundle).unwrap();
+        assert_eq!(
+            read_root_file(base, "tutorial.json5").unwrap(),
+            r#"{ version: 1 }"#
+        );
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.43.1",
+  "version": "1.44.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/commands/definitions.test.ts
+++ b/src/commands/definitions.test.ts
@@ -8,9 +8,6 @@ vi.mock('@/composables/useEntityCrud', () => ({
   isEntityType: vi.fn(() => false),
   useEntityCrud: vi.fn(),
 }))
-vi.mock('@/composables/useTutorial', () => ({
-  useTutorialStore: vi.fn(() => ({ start: vi.fn() })),
-}))
 vi.mock('@/composables/useDeckWindow', () => ({
   switchProfileWithWindows: vi.fn(),
   popOutColumnToWindow: vi.fn(),
@@ -46,6 +43,7 @@ vi.mock('@/utils/mediaProxy', () => ({ proxyThumbUrl: (u: unknown) => u }))
 import { useDeckStore } from '@/stores/deck'
 import { useThemeStore } from '@/stores/theme'
 import { useUiStore } from '@/stores/ui'
+import { useWindowsStore } from '@/stores/windows'
 import {
   type CommandHandlers,
   refreshProfileCommands,
@@ -233,5 +231,25 @@ describe('refreshProfileCommands', () => {
     refreshProfileCommands()
     expect(store.commands.get('profile-1')).toBeDefined()
     expect(store.commands.get('profile-2')).toBeUndefined()
+  })
+})
+
+describe('チュートリアルコマンド (#1029)', () => {
+  it('コマンドパレットに出る', () => {
+    const store = useCommandStore()
+    registerDefaultCommands(makeHandlers())
+    const cmd = store.commands.get('tutorial')
+    expect(cmd?.label).toBe('チュートリアル')
+    // visible 未指定 = パレットに出る (ショートカット専用にしない)
+    expect(cmd?.visible).not.toBe(false)
+  })
+
+  it('初回ウィザードではなくチェックリストを開く', () => {
+    const open = vi.fn()
+    vi.mocked(useWindowsStore).mockReturnValue({ open } as never)
+    const store = useCommandStore()
+    registerDefaultCommands(makeHandlers())
+    store.commands.get('tutorial')?.execute()
+    expect(open).toHaveBeenCalledWith('tutorialEditor', {})
   })
 })

--- a/src/commands/definitions.ts
+++ b/src/commands/definitions.ts
@@ -2,7 +2,6 @@ import { useCommandStore } from '@/commands/registry'
 import { useAccountActions } from '@/composables/useAccountActions'
 import { isEntityType, useEntityCrud } from '@/composables/useEntityCrud'
 import type { NoteAction } from '@/composables/useNoteFocus'
-import { useTutorialStore } from '@/composables/useTutorial'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
 import { useDeckStore } from '@/stores/deck'
@@ -343,7 +342,9 @@ export function registerDefaultCommands(handlers: CommandHandlers) {
     icon: 'presentation-analytics',
     category: 'general',
     shortcuts: keybindsStore.getShortcuts('tutorial'),
-    execute: () => useTutorialStore().start(),
+    // 初回ウィザードではなくチェックリストを開く。ウィザードを最後まで
+    // やらなかった人 (完走フラグが立たない) もここから続きに入れる (#1029)
+    execute: () => useWindowsStore().open('tutorialEditor', {}),
   })
 
   commandStore.register({

--- a/src/commands/quickPickProviders.test.ts
+++ b/src/commands/quickPickProviders.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/utils/tauriInvoke', () => ({
 
 import { refreshProfileCommands } from '@/commands/definitions'
 import { switchProfileWithWindows } from '@/composables/useDeckWindow'
+import { SETTINGS_SECTIONS } from '@/settings/sections'
 import { useDeckStore } from '@/stores/deck'
 import { useDeckProfileStore } from '@/stores/deckProfile'
 import { useThemeStore } from '@/stores/theme'
@@ -95,6 +96,23 @@ describe('getSettingsItems', () => {
       expect(item.label, item.id).toBeTruthy()
       expect(item.icon, item.id).toBeTruthy()
       expect(typeof item.action, item.id).toBe('function')
+    }
+  })
+
+  it('設定メニュー (SETTINGS_SECTIONS) と同じウィンドウを網羅する', () => {
+    // パレット側とメニュー側で一覧が二重管理になっている。片方に足して
+    // もう片方を忘れると、デスクトップとモバイルで開ける設定がずれる
+    // (実際に tutorialEditor がパレット側から漏れていた)
+    const opened = new Set<string>()
+    windowsMock.open.mockImplementation((w: string) => {
+      opened.add(w)
+    })
+    for (const item of getSettingsItems()) item.action?.()
+    for (const section of SETTINGS_SECTIONS) {
+      expect(
+        opened.has(section.window),
+        `${section.window} がパレットに無い`,
+      ).toBe(true)
     }
   })
 

--- a/src/commands/quickPickProviders.ts
+++ b/src/commands/quickPickProviders.ts
@@ -42,6 +42,12 @@ export function getSettingsItems(): QuickPickItem[] {
   return [
     // 個別操作は並べず、モバイルの設定メニューと同じくウィンドウに集約する
     {
+      id: 'tutorial',
+      label: 'チュートリアル',
+      icon: 'checkbox',
+      action: () => useWindowsStore().open('tutorialEditor'),
+    },
+    {
       id: 'appearance',
       label: 'アピアランス',
       icon: 'brush',

--- a/src/components/common/MkAchievementsGrid.vue
+++ b/src/components/common/MkAchievementsGrid.vue
@@ -1,17 +1,27 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { ACHIEVEMENT_LABELS } from '@/utils/achievementLabels'
-import { ACHIEVEMENT_TYPES, type Achievement } from '@/utils/achievements'
+import {
+  ACHIEVEMENT_TYPES,
+  type Achievement,
+  type AchievementBadge,
+} from '@/utils/achievements'
 
+/**
+ * 種別・バッジ・ラベルは差し替えられる。既定は Misskey サーバーの実績だが、
+ * NoteDeck 独自実績 (#1029) も同じ見た目で出すため (グリッドを 2 つ作らない)。
+ */
 const props = defineProps<{
   achievements: Achievement[]
+  /** 表示する種別と並び。未指定ならサーバー実績の全種別 */
+  types?: readonly string[]
+  /** 種別 → バッジ。未指定ならサーバー実績のバッジ */
+  badges?: Record<string, AchievementBadge>
+  /** 種別 → 表示名。未指定ならサーバー実績のラベル */
+  labels?: Record<string, string>
 }>()
 
-interface BadgeInfo {
-  emoji: string
-  frame: 'bronze' | 'silver' | 'gold' | 'platinum'
-  bg: string | null
-}
+type BadgeInfo = AchievementBadge
 
 const BADGES: Record<string, BadgeInfo> = {
   notes1: {
@@ -386,7 +396,7 @@ const FRAME_COLORS = {
 const sortedAchievements = computed(() => {
   const unlocked: Array<{ name: string; unlockedAt: number | null }> = []
   const locked: Array<{ name: string; unlockedAt: number | null }> = []
-  for (const name of ACHIEVEMENT_TYPES) {
+  for (const name of props.types ?? ACHIEVEMENT_TYPES) {
     const a = props.achievements.find((x) => x.name === name)
     if (a) {
       unlocked.push(a)
@@ -398,7 +408,13 @@ const sortedAchievements = computed(() => {
 })
 
 function getBadge(name: string): BadgeInfo {
-  return BADGES[name] ?? { emoji: '\u{1F3C5}', frame: 'bronze', bg: null }
+  const table = props.badges ?? BADGES
+  return table[name] ?? { emoji: '\u{1F3C5}', frame: 'bronze', bg: null }
+}
+
+function getLabel(name: string): string {
+  const table = props.labels ?? ACHIEVEMENT_LABELS
+  return table[name] ?? name
 }
 
 function formatDate(ts: number): string {
@@ -431,7 +447,7 @@ function formatDate(ts: number): string {
         </div>
       </div>
       <div :class="$style.achievementInfo">
-        <div :class="$style.achievementName">{{ item.unlockedAt ? (ACHIEVEMENT_LABELS[item.name] ?? item.name) : '???' }}</div>
+        <div :class="$style.achievementName">{{ item.unlockedAt ? getLabel(item.name) : '???' }}</div>
         <div v-if="item.unlockedAt" :class="$style.achievementDate">{{ formatDate(item.unlockedAt) }}</div>
       </div>
     </div>

--- a/src/components/deck/DeckAchievementsColumn.vue
+++ b/src/components/deck/DeckAchievementsColumn.vue
@@ -6,12 +6,22 @@ import MkAchievementsGrid from '@/components/common/MkAchievementsGrid.vue'
 import { useColumnPullScroller } from '@/composables/useColumnPullScroller'
 import { useColumnTheme } from '@/composables/useColumnTheme'
 import { useServerImages } from '@/composables/useServerImages'
+import { useTutorialStore } from '@/composables/useTutorial'
+import {
+  TUTORIAL_ACHIEVEMENT_BADGES,
+  TUTORIAL_ACHIEVEMENT_LABELS,
+  TUTORIAL_ACHIEVEMENT_TOTAL,
+  TUTORIAL_ACHIEVEMENT_TYPES,
+  tutorialAchievements,
+} from '@/services/tutorialAchievements'
 import { getAccountAvatarUrl } from '@/stores/accounts'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
 import { ACHIEVEMENT_TOTAL, type Achievement } from '@/utils/achievements'
 import { AppError } from '@/utils/errors'
 import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
+import type { ColumnTabDef } from './ColumnTabs.vue'
+import ColumnTabs from './ColumnTabs.vue'
 import DeckColumn from './DeckColumn.vue'
 
 const props = defineProps<{
@@ -27,7 +37,27 @@ const achievements = ref<Achievement[]>([])
 const loading = ref(false)
 const error = ref<AppError | null>(null)
 
-const unlockedCount = computed(() => achievements.value.length)
+/**
+ * サーバー実績 (Misskey) と NoteDeck 独自実績 (#1029) の切替。
+ * カラムを増やさず、同じグリッドで出し分ける。
+ */
+const SOURCE_TABS: ColumnTabDef[] = [
+  { value: 'server', label: 'サーバー', icon: 'server' },
+  { value: 'notedeck', label: 'NoteDeck', icon: 'checkbox' },
+]
+const source = ref<'server' | 'notedeck'>('server')
+
+const tutorial = useTutorialStore()
+const ownAchievements = computed(() => tutorialAchievements(tutorial.progress))
+
+const isOwn = computed(() => source.value === 'notedeck')
+const shownAchievements = computed(() =>
+  isOwn.value ? ownAchievements.value : achievements.value,
+)
+const unlockedCount = computed(() => shownAchievements.value.length)
+const totalCount = computed(() =>
+  isOwn.value ? TUTORIAL_ACHIEVEMENT_TOTAL : ACHIEVEMENT_TOTAL,
+)
 
 async function fetchAchievements() {
   if (!props.column.accountId) return
@@ -49,6 +79,7 @@ async function fetchAchievements() {
 }
 
 fetchAchievements()
+void tutorial.loadProgress()
 
 const achievementsScrollRef = useTemplateRef<HTMLElement>(
   'achievementsScrollRef',
@@ -67,14 +98,25 @@ function scrollToTop() {
     </template>
 
     <template #header-meta>
-      <span v-if="unlockedCount > 0" :class="$style.headerCount">{{ unlockedCount }}/{{ ACHIEVEMENT_TOTAL }}</span>
+      <span v-if="unlockedCount > 0" :class="$style.headerCount">{{ unlockedCount }}/{{ totalCount }}</span>
       <div v-if="account" :class="$style.headerAccount">
         <img :src="proxyThumbUrl(getAccountAvatarUrl(account), 56)" :class="$style.headerAvatar" />
       </div>
     </template>
 
+    <template #header-extra>
+      <ColumnTabs :tabs="SOURCE_TABS" :model-value="source" compact @update:model-value="source = $event as 'server' | 'notedeck'" />
+    </template>
+
     <div ref="achievementsScrollRef" :class="$style.achievementsScroll">
-      <div v-if="loading && achievements.length === 0 && !isLoggedOut" :class="$style.columnLoading"><LoadingSpinner /></div>
+      <MkAchievementsGrid
+        v-if="isOwn"
+        :achievements="ownAchievements"
+        :types="TUTORIAL_ACHIEVEMENT_TYPES"
+        :badges="TUTORIAL_ACHIEVEMENT_BADGES"
+        :labels="TUTORIAL_ACHIEVEMENT_LABELS"
+      />
+      <div v-else-if="loading && achievements.length === 0 && !isLoggedOut" :class="$style.columnLoading"><LoadingSpinner /></div>
       <ColumnEmptyState
         v-else-if="error && !isLoggedOut"
         :error="error"

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -42,10 +42,16 @@ import { useNoteVisibility } from '@/composables/useNoteVisibility'
 import { usePortal } from '@/composables/usePortal'
 import { useReadMarker } from '@/composables/useReadMarker'
 import { useTabSlide } from '@/composables/useTabSlide'
+import { useTutorialStore } from '@/composables/useTutorial'
 import { getStreamHealth } from '@/core/streamHealth'
 import { createBoundedCache } from '@/services/boundedCache'
 import { mergeNotifications as mergeNotificationLists } from '@/services/notificationMerge'
 import { syncNotificationNotes } from '@/services/notificationNoteSync'
+import { TUTORIAL_ACHIEVEMENT_LABELS } from '@/services/tutorialAchievements'
+import {
+  isTutorialNotificationId,
+  mergeTutorialNotifications,
+} from '@/services/tutorialNotifications'
 import { getAccountAvatarUrl, useAccountsStore } from '@/stores/accounts'
 import { type DeckColumn as DeckColumnType, useDeckStore } from '@/stores/deck'
 import { useNoteStore } from '@/stores/notes'
@@ -384,6 +390,14 @@ function onFilterChange(value: string) {
 // 通知ごと隠す（#575）。一部のみなら当該ユーザーを除いて表示する。
 const { isNotificationHidden, visibleReactions, visibleGroupedUsers } =
   useNoteVisibility()
+
+const tutorial = useTutorialStore()
+void tutorial.loadProgress()
+
+/** サーバー実績と NoteDeck 独自実績のどちらのラベルも引く */
+function achievementLabel(name: string): string {
+  return TUTORIAL_ACHIEVEMENT_LABELS[name] ?? ACHIEVEMENT_LABELS[name] ?? name
+}
 const visibleNotifications = computed(() =>
   notifications.value
     .filter((n) => !isNotificationHidden(n))
@@ -409,10 +423,22 @@ watch(
 )
 
 const filteredNotifications = computed(() => {
-  if (activeFilter.value === 'all') return visibleNotifications.value
-  return visibleNotifications.value.filter(
-    (n) => baseType(n.type) === activeFilter.value,
-  )
+  const base =
+    activeFilter.value === 'all'
+      ? visibleNotifications.value
+      : visibleNotifications.value.filter(
+          (n) => baseType(n.type) === activeFilter.value,
+        )
+  // NoteDeck 独自実績 (#1029) は達成記録から表示時に合成する。notifications
+  // 本体には入れない — 続き読み込みの cursor (untilId) にこの id が渡ると
+  // サーバーが解釈できないため
+  if (
+    activeFilter.value !== 'all' &&
+    activeFilter.value !== 'achievementEarned'
+  ) {
+    return base
+  }
+  return mergeTutorialNotifications(base, tutorial.progress)
 })
 
 const noteScrollerRef = ref<{
@@ -1278,6 +1304,7 @@ onUnmounted(() => {
                   />
                   <template v-else>
                     <img v-if="notif.type === 'app' && notif.icon" :src="notif.icon" :class="[$style.notifFallbackAvatar, $style.notifAppIcon]" alt="" />
+                    <img v-else-if="isTutorialNotificationId(notif.id)" src="/favicon.svg" :class="[$style.notifFallbackAvatar, $style.notifAppIcon]" alt="NoteDeck" />
                     <img v-else-if="resolveNotifAccount(notif)?.avatarUrl" :src="proxyThumbUrl(resolveNotifAccount(notif)!.avatarUrl!, 56)" :class="$style.notifFallbackAvatar" />
                   </template>
                   <img
@@ -1316,7 +1343,7 @@ onUnmounted(() => {
 
                   <!-- Achievement name -->
                   <div v-if="notif.type === 'achievementEarned' && notif.achievement" :class="$style.notifAchievement">
-                    {{ ACHIEVEMENT_LABELS[notif.achievement] ?? notif.achievement }}
+                    {{ achievementLabel(notif.achievement) }}
                   </div>
 
                   <!-- App notification body (外部アプリの notifications/create) -->

--- a/src/components/tutorial/TutorialContent.vue
+++ b/src/components/tutorial/TutorialContent.vue
@@ -12,11 +12,19 @@
 
 import { computed } from 'vue'
 import { useTutorialStore } from '@/composables/useTutorial'
+import { tutorialDocsUrl } from '@/data/tutorialSteps'
+import { openSafeUrl } from '@/utils/url'
 
 const tutorial = useTutorialStore()
 
 const stepCount = computed(() => tutorial.totalSteps)
 const stepIndex = computed(() => tutorial.currentNumber)
+// step ごとの詳しい説明は公式ドキュメントにある。読みたい人はここから開く
+const docsPath = computed(() => tutorial.currentStep?.docsPath ?? null)
+
+function openDocs(path: string): void {
+  openSafeUrl(tutorialDocsUrl(path))
+}
 </script>
 
 <template>
@@ -50,6 +58,16 @@ const stepIndex = computed(() => tutorial.currentNumber)
     <div v-if="tutorial.currentStep" :class="$style.body">
       <div :class="$style.title">{{ tutorial.currentStep.title }}</div>
       <p :class="$style.description">{{ tutorial.currentStep.description }}</p>
+      <button
+        v-if="docsPath"
+        type="button"
+        class="_button"
+        :class="$style.docsLink"
+        @click="openDocs(docsPath)"
+      >
+        <i class="ti ti-book" />
+        詳しく読む
+      </button>
     </div>
 
     <!-- Footer actions -->
@@ -65,6 +83,10 @@ const stepIndex = computed(() => tutorial.currentNumber)
         </button>
       </template>
       <template v-else>
+        <span v-if="tutorial.stepCompleted" :class="$style.doneMark">
+          <i class="ti ti-circle-check-filled" />
+          達成しました
+        </span>
         <button
           type="button"
           class="_button"
@@ -175,12 +197,43 @@ const stepIndex = computed(() => tutorial.currentNumber)
   white-space: pre-line;
 }
 
+.docsLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.88em;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.15s var(--nd-ease-decel), background 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
 .actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--nd-divider);
+}
+
+/* 達成しても自動では進めない (次 step が勝手にウィンドウを開かないように)。
+   代わりに達成をここに出して [次へ] を待つ */
+.doneMark {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-right: auto;
+  font-size: 0.85em;
+  color: var(--nd-accent);
 }
 
 .linkBtn {

--- a/src/components/window/AboutContent.vue
+++ b/src/components/window/AboutContent.vue
@@ -2,7 +2,6 @@
 import { getTauriVersion } from '@tauri-apps/api/app'
 import { computed, onMounted, ref, shallowRef } from 'vue'
 import type { Check, HealthReport, Status } from '@/bindings'
-import { useTutorialStore } from '@/composables/useTutorial'
 import { useUpdater } from '@/composables/useUpdater'
 import { formatHealthDuration, getStreamHealth } from '@/core/streamHealth'
 import { getAccountLabel, useAccountsStore } from '@/stores/accounts'
@@ -23,20 +22,11 @@ const tauriVersion = ref('')
 const rustVersion = ref('')
 const copied = ref(false)
 const uiStore = useUiStore()
-const tutorialStore = useTutorialStore()
 const accountsStore = useAccountsStore()
 
 const REPO_URL = 'https://github.com/notedeck-dev/notedeck'
 const SITE_URL = 'https://notedeck.io'
 const SPONSOR_URL = 'https://github.com/sponsors/hitalin'
-
-// チュートリアル (= ヘルプ/案内) の再実行はここから。設定メニューではなく
-// About に置く (チュートリアルは設定項目ではないため)。ほぼ一度しか使われない
-// 機能なので CTA にはせず、リンク行 (formLink) の1つに置く。起動時に About は閉じる。
-function openTutorial(): void {
-  tutorialStore.start()
-  emit('close')
-}
 
 // バージョン情報テーブルは普段は畳んでおく (必要なのはバグ報告・コピー時で、
 // その2つは表示に依存せず infoRows から本文を生成する)
@@ -421,13 +411,6 @@ function reportBug() {
         <span v-if="isUpToDate">最新</span>
       </button>
       <div v-else :class="$style.aboutVersion">v{{ appVersion }}</div>
-    </div>
-
-    <div :class="$style.aboutLinks">
-      <button type="button" class="_button" :class="$style.pillBtn" @click="openTutorial">
-        <i class="ti ti-presentation-analytics" />
-        チュートリアルを見る
-      </button>
     </div>
 
     <!-- アップデートは hero から切り離した独立セクション (VSCode の

--- a/src/components/window/TutorialEditorContent.vue
+++ b/src/components/window/TutorialEditorContent.vue
@@ -1,0 +1,606 @@
+<script setup lang="ts">
+/**
+ * TutorialEditorContent — チュートリアル (#1029)。
+ *
+ * カテゴリ別のチェックリスト。読むだけのガイドにはせず、実際に操作すると
+ * チェックが付く。カテゴリを完走すると NoteDeck 独自の実績が解除され、
+ * 達成は tutorial.json5 に永続化される。
+ *
+ * カテゴリの区切りと並びは公式ドキュメントのサイドバーに揃えてあり、各項目
+ * から対応するページを開ける (アプリで触る順序 = 読み進める順序)。
+ *
+ * 進捗の見せ方は「今どこまで来たか」に留める。未達成の数を煽らない
+ * (回数・連続日数系の実績を作らないのと同じ理由)。
+ */
+
+import { computed, onMounted, ref, watch } from 'vue'
+import { useDoubleConfirm } from '@/composables/useDoubleConfirm'
+import { useTutorialStore } from '@/composables/useTutorial'
+import {
+  buildTutorialSteps,
+  TUTORIAL_CATEGORIES,
+  type TutorialCategoryId,
+  tutorialDocsUrl,
+} from '@/data/tutorialSteps'
+import { openSafeUrl } from '@/utils/url'
+
+const tutorial = useTutorialStore()
+const resetConfirm = useDoubleConfirm()
+
+/** カテゴリごとの項目と達成状況 */
+const groups = computed(() => {
+  const all = buildTutorialSteps()
+  return TUTORIAL_CATEGORIES.map((category, index) => {
+    const items = all
+      .filter((s) => s.category === category.id)
+      .map((step) => ({
+        id: step.id,
+        title: step.title,
+        docsPath: step.docsPath,
+        done: tutorial.isStepDone(step),
+      }))
+    const doneCount = items.filter((i) => i.done).length
+    return {
+      category,
+      step: index + 1,
+      items,
+      doneCount,
+      complete: doneCount === items.length,
+      unlockedAt: tutorial.progress.achievements[category.id] ?? null,
+    }
+  })
+})
+
+/** 次に手をつけるカテゴリ (先頭の未完了)。順路を 1 つだけ指し示す */
+const nextCategoryId = computed(
+  () => groups.value.find((g) => !g.complete)?.category.id ?? null,
+)
+
+const unlockedCount = computed(
+  () => groups.value.filter((g) => g.unlockedAt != null).length,
+)
+
+/** 解除の知らせに出すカテゴリ */
+const unlockedNotice = computed(() => {
+  const id = tutorial.justUnlocked
+  if (!id) return null
+  return TUTORIAL_CATEGORIES.find((c) => c.id === id) ?? null
+})
+
+/**
+ * 開いているカテゴリ。既定は「次にやる 1 つ」だけ。
+ * 全カテゴリの項目を一度に見せると、やることが多く見えて選べなくなる。
+ */
+const openedId = ref<TutorialCategoryId | null>(null)
+/** ユーザーが自分で開閉したら、以降は既定の追従をやめる */
+const userToggled = ref(false)
+
+function toggleGroup(id: TutorialCategoryId): void {
+  userToggled.value = true
+  openedId.value = openedId.value === id ? null : id
+}
+
+// 達成が進んで「次にやるカテゴリ」が変わったら、そこを開いて示す
+watch(
+  nextCategoryId,
+  (id) => {
+    if (!userToggled.value) openedId.value = id
+  },
+  { immediate: true },
+)
+
+onMounted(async () => {
+  await tutorial.loadProgress()
+  tutorial.syncProgress()
+})
+
+function runCategory(id: TutorialCategoryId): void {
+  tutorial.startCategory(id)
+}
+
+function openDocs(path: string): void {
+  openSafeUrl(tutorialDocsUrl(path))
+}
+
+function formatDate(at: number): string {
+  return new Date(at).toLocaleDateString()
+}
+</script>
+
+<template>
+  <div :class="$style.root">
+    <!-- 実績の解除。トーストは数秒で消えて「習熟の記録」に合わないので、
+         開いている間は残る行として出す -->
+    <div v-if="unlockedNotice" :class="$style.notice">
+      <span :class="$style.noticeEmoji">{{ unlockedNotice.achievementEmoji }}</span>
+      <span :class="$style.noticeText">
+        <strong>{{ unlockedNotice.achievementName }}</strong> を達成しました
+      </span>
+      <button
+        type="button"
+        class="_button"
+        :class="$style.iconBtn"
+        title="閉じる"
+        @click="tutorial.clearJustUnlocked()"
+      >
+        <i class="ti ti-x" />
+      </button>
+    </div>
+
+    <header :class="$style.head">
+      <div :class="$style.trophies">
+        <span
+          v-for="group in groups"
+          :key="group.category.id"
+          :class="[$style.trophy, { [$style.trophyOn]: group.unlockedAt != null }]"
+          :title="group.unlockedAt != null
+            ? `${group.category.achievementName} — ${formatDate(group.unlockedAt)}`
+            : `${group.category.achievementName} (未達成)`"
+        >{{ group.category.achievementEmoji }}</span>
+        <span :class="$style.trophyCount">{{ unlockedCount }} / {{ groups.length }}</span>
+      </div>
+      <p :class="$style.lead">
+        操作するとチェックが付きます。カテゴリを終えると実績になります。
+      </p>
+      <button type="button" class="_button" :class="$style.docsBtn" @click="openDocs('/docs/')">
+        <i class="ti ti-book" />
+        ドキュメントを読む
+      </button>
+    </header>
+
+    <ol :class="$style.groups">
+      <li
+        v-for="group in groups"
+        :key="group.category.id"
+        :class="[
+          $style.group,
+          {
+            [$style.groupNext]: group.category.id === nextCategoryId,
+            [$style.groupDone]: group.complete,
+          },
+        ]"
+      >
+        <button
+          type="button"
+          class="_button"
+          :class="$style.groupHead"
+          :aria-expanded="openedId === group.category.id"
+          @click="toggleGroup(group.category.id)"
+        >
+          <span :class="$style.stepNo">
+            <i v-if="group.complete" class="ti ti-check" />
+            <template v-else>{{ group.step }}</template>
+          </span>
+          <span :class="$style.groupTitles">
+            <span :class="$style.groupTitle">{{ group.category.title }}</span>
+            <span :class="$style.groupDesc">{{ group.category.description }}</span>
+          </span>
+          <span :class="$style.groupCount">{{ group.doneCount }}/{{ group.items.length }}</span>
+          <i
+            :class="[
+              'ti ti-chevron-down',
+              $style.chevron,
+              { [$style.chevronOpen]: openedId === group.category.id },
+            ]"
+          />
+        </button>
+
+        <ul v-if="openedId === group.category.id" :class="$style.items">
+          <li v-for="item in group.items" :key="item.id" :class="$style.item">
+            <i
+              :class="[
+                item.done ? 'ti ti-circle-check-filled' : 'ti ti-circle',
+                $style.check,
+                { [$style.checkDone]: item.done },
+              ]"
+            />
+            <span :class="[$style.itemTitle, { [$style.itemDone]: item.done }]">
+              {{ item.title }}
+            </span>
+            <button
+              v-if="item.docsPath"
+              type="button"
+              class="_button"
+              :class="$style.iconBtn"
+              title="このステップの解説を読む"
+              @click="openDocs(item.docsPath)"
+            >
+              <i class="ti ti-external-link" />
+            </button>
+          </li>
+        </ul>
+
+        <div v-if="openedId === group.category.id" :class="$style.groupFoot">
+          <span v-if="group.unlockedAt != null" :class="$style.award">
+            <span :class="$style.awardEmoji">{{ group.category.achievementEmoji }}</span>
+            {{ group.category.achievementName }}
+            <span :class="$style.awardDate">{{ formatDate(group.unlockedAt) }}</span>
+          </span>
+          <button
+            type="button"
+            class="_button"
+            :class="$style.linkBtn"
+            @click="openDocs(group.category.docsPath)"
+          >
+            読む
+          </button>
+          <button
+            type="button"
+            class="_button"
+            :class="$style.runBtn"
+            @click="runCategory(group.category.id)"
+          >
+            {{ group.complete ? 'もう一度' : group.doneCount === 0 ? 'はじめる' : '続きから' }}
+          </button>
+        </div>
+      </li>
+    </ol>
+
+    <footer :class="$style.footer">
+      <button
+        type="button"
+        class="_button"
+        :class="[$style.resetBtn, { [$style.resetArmed]: resetConfirm.confirming.value }]"
+        @click="resetConfirm.trigger(() => tutorial.resetProgress())"
+      >
+        {{ resetConfirm.confirming.value ? 'もう一度押すと消えます' : '達成記録を消す' }}
+      </button>
+    </footer>
+  </div>
+</template>
+
+<style lang="scss" module>
+.root {
+  display: flex;
+  flex-direction: column;
+  // モバイルはウィンドウが画面高いっぱいに広がるため、中身側でスクロールさせる
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  gap: 12px;
+  padding: 14px 16px 12px;
+  color: var(--nd-fg);
+  font-size: 0.92em;
+}
+
+/* 実績解除の知らせ */
+.notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: var(--nd-accentedBg);
+  color: var(--nd-accent);
+}
+
+.noticeEmoji {
+  font-size: 1.2em;
+  line-height: 1;
+}
+
+.noticeText {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.9em;
+}
+
+/* ヘッダ: 実績の並び + 導入 */
+.head {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--nd-divider);
+}
+
+.trophies {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.trophy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--nd-buttonBg);
+  font-size: 0.95em;
+  line-height: 1;
+  filter: grayscale(1);
+  opacity: 0.4;
+  transition:
+    filter var(--nd-duration, 0.2s) var(--nd-ease-decel),
+    opacity var(--nd-duration, 0.2s) var(--nd-ease-decel);
+}
+
+.trophyOn {
+  filter: none;
+  opacity: 1;
+  background: var(--nd-eventAchievement, var(--nd-accentedBg));
+}
+
+.trophyCount {
+  margin-left: auto;
+  font-size: 0.85em;
+  opacity: 0.6;
+  letter-spacing: 0.04em;
+}
+
+.lead {
+  margin: 0;
+  line-height: 1.6;
+  font-size: 0.88em;
+  opacity: 0.75;
+}
+
+.docsBtn {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 6px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  font-size: 0.85em;
+  color: var(--nd-fg);
+  opacity: 0.75;
+  cursor: pointer;
+  transition:
+    opacity 0.15s var(--nd-ease-decel),
+    background 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+/* カテゴリ */
+.groups {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--nd-divider);
+  border-radius: 10px;
+  transition: border-color 0.2s var(--nd-ease-decel);
+}
+
+/* 次に手をつける 1 つだけを指し示す */
+.groupNext {
+  border-color: var(--nd-accent);
+}
+
+.groupDone {
+  opacity: 0.72;
+}
+
+.groupHead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 0;
+  text-align: left;
+  color: inherit;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: opacity 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+.chevron {
+  flex: none;
+  font-size: 0.95em;
+  opacity: 0.45;
+  transition: transform 0.2s var(--nd-ease-decel);
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.stepNo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 22px;
+  height: 22px;
+  margin-top: 1px;
+  border-radius: 50%;
+  background: var(--nd-buttonBg);
+  font-size: 0.8em;
+  font-weight: 600;
+  opacity: 0.75;
+}
+
+.groupDone .stepNo {
+  background: var(--nd-accentedBg);
+  color: var(--nd-accent);
+  opacity: 1;
+}
+
+.groupTitles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.groupTitle {
+  font-weight: 600;
+  color: var(--nd-fgHighlighted);
+}
+
+.groupDesc {
+  font-size: 0.85em;
+  line-height: 1.4;
+  opacity: 0.65;
+}
+
+.groupCount {
+  flex: none;
+  font-size: 0.82em;
+  opacity: 0.55;
+  letter-spacing: 0.03em;
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0 0 0 32px;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.check {
+  flex: none;
+  font-size: 1.05em;
+  opacity: 0.3;
+}
+
+.checkDone {
+  color: var(--nd-accent);
+  opacity: 1;
+}
+
+.itemTitle {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.92em;
+}
+
+.itemDone {
+  opacity: 0.6;
+}
+
+.iconBtn {
+  flex: none;
+  padding: 3px 6px;
+  border-radius: 5px;
+  color: var(--nd-fg);
+  opacity: 0.45;
+  cursor: pointer;
+  transition:
+    opacity 0.15s var(--nd-ease-decel),
+    background 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.groupFoot {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-left: 32px;
+}
+
+.award {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.82em;
+  color: var(--nd-accent);
+}
+
+.awardEmoji {
+  font-size: 1.05em;
+  line-height: 1;
+}
+
+.awardDate {
+  opacity: 0.6;
+  color: var(--nd-fg);
+}
+
+.linkBtn {
+  margin-left: auto;
+  padding: 5px 12px;
+  font-size: 0.85em;
+  border-radius: 6px;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  cursor: pointer;
+  transition:
+    opacity 0.15s var(--nd-ease-decel),
+    background 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.runBtn {
+  padding: 5px 14px;
+  font-size: 0.85em;
+  font-weight: 600;
+  border-radius: 6px;
+  background: var(--nd-accent);
+  color: var(--nd-fgOnAccent, #fff);
+  cursor: pointer;
+  transition: filter 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    filter: brightness(1.08);
+  }
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 6px;
+  border-top: 1px solid var(--nd-divider);
+}
+
+.resetBtn {
+  padding: 5px 12px;
+  font-size: 0.82em;
+  border-radius: 6px;
+  color: var(--nd-fg);
+  opacity: 0.55;
+  cursor: pointer;
+  transition:
+    opacity 0.15s var(--nd-ease-decel),
+    background 0.15s var(--nd-ease-decel),
+    color 0.15s var(--nd-ease-decel);
+
+  &:hover {
+    opacity: 1;
+    background: var(--nd-buttonHoverBg);
+  }
+}
+
+.resetArmed {
+  opacity: 1;
+  color: var(--nd-error);
+  background: var(--nd-buttonHoverBg);
+}
+</style>

--- a/src/components/window/TutorialEditorContent.vue
+++ b/src/components/window/TutorialEditorContent.vue
@@ -46,7 +46,6 @@ const groups = computed(() => {
       items,
       doneCount,
       complete: doneCount === items.length,
-      unlockedAt: tutorial.progress.achievements[category.id] ?? null,
     }
   })
 })
@@ -55,17 +54,6 @@ const groups = computed(() => {
 const nextCategoryId = computed(
   () => groups.value.find((g) => !g.complete)?.category.id ?? null,
 )
-
-const unlockedCount = computed(
-  () => groups.value.filter((g) => g.unlockedAt != null).length,
-)
-
-/** 解除の知らせに出すカテゴリ */
-const unlockedNotice = computed(() => {
-  const id = tutorial.justUnlocked
-  if (!id) return null
-  return TUTORIAL_CATEGORIES.find((c) => c.id === id) ?? null
-})
 
 /**
  * 開いているカテゴリ。既定は「次にやる 1 つ」だけ。
@@ -101,46 +89,13 @@ function runCategory(id: TutorialCategoryId): void {
 function openDocs(path: string): void {
   openSafeUrl(tutorialDocsUrl(path))
 }
-
-function formatDate(at: number): string {
-  return new Date(at).toLocaleDateString()
-}
 </script>
 
 <template>
   <div :class="$style.root">
-    <!-- 実績の解除。トーストは数秒で消えて「習熟の記録」に合わないので、
-         開いている間は残る行として出す -->
-    <div v-if="unlockedNotice" :class="$style.notice">
-      <span :class="$style.noticeEmoji">{{ unlockedNotice.achievementEmoji }}</span>
-      <span :class="$style.noticeText">
-        <strong>{{ unlockedNotice.achievementName }}</strong> を達成しました
-      </span>
-      <button
-        type="button"
-        class="_button"
-        :class="$style.iconBtn"
-        title="閉じる"
-        @click="tutorial.clearJustUnlocked()"
-      >
-        <i class="ti ti-x" />
-      </button>
-    </div>
-
     <header :class="$style.head">
-      <div :class="$style.trophies">
-        <span
-          v-for="group in groups"
-          :key="group.category.id"
-          :class="[$style.trophy, { [$style.trophyOn]: group.unlockedAt != null }]"
-          :title="group.unlockedAt != null
-            ? `${group.category.achievementName} — ${formatDate(group.unlockedAt)}`
-            : `${group.category.achievementName} (未達成)`"
-        >{{ group.category.achievementEmoji }}</span>
-        <span :class="$style.trophyCount">{{ unlockedCount }} / {{ groups.length }}</span>
-      </div>
       <p :class="$style.lead">
-        操作するとチェックが付きます。カテゴリを終えると実績になります。
+        操作するとチェックが付きます。カテゴリを終えると実績になり、通知に届きます。
       </p>
       <button type="button" class="_button" :class="$style.docsBtn" @click="openDocs('/docs/')">
         <i class="ti ti-book" />
@@ -211,11 +166,6 @@ function formatDate(at: number): string {
         </ul>
 
         <div v-if="openedId === group.category.id" :class="$style.groupFoot">
-          <span v-if="group.unlockedAt != null" :class="$style.award">
-            <span :class="$style.awardEmoji">{{ group.category.achievementEmoji }}</span>
-            {{ group.category.achievementName }}
-            <span :class="$style.awardDate">{{ formatDate(group.unlockedAt) }}</span>
-          </span>
           <button
             type="button"
             class="_button"
@@ -263,29 +213,10 @@ function formatDate(at: number): string {
   font-size: 0.92em;
 }
 
-/* 実績解除の知らせ */
-.notice {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
-  border-radius: 8px;
-  background: var(--nd-accentedBg);
-  color: var(--nd-accent);
-}
 
-.noticeEmoji {
-  font-size: 1.2em;
-  line-height: 1;
-}
 
-.noticeText {
-  flex: 1;
-  min-width: 0;
-  font-size: 0.9em;
-}
 
-/* ヘッダ: 実績の並び + 導入 */
+/* ヘッダ */
 .head {
   display: flex;
   flex-direction: column;
@@ -294,41 +225,9 @@ function formatDate(at: number): string {
   border-bottom: 1px solid var(--nd-divider);
 }
 
-.trophies {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
 
-.trophy {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
-  background: var(--nd-buttonBg);
-  font-size: 0.95em;
-  line-height: 1;
-  filter: grayscale(1);
-  opacity: 0.4;
-  transition:
-    filter var(--nd-duration, 0.2s) var(--nd-ease-decel),
-    opacity var(--nd-duration, 0.2s) var(--nd-ease-decel);
-}
 
-.trophyOn {
-  filter: none;
-  opacity: 1;
-  background: var(--nd-eventAchievement, var(--nd-accentedBg));
-}
 
-.trophyCount {
-  margin-left: auto;
-  font-size: 0.85em;
-  opacity: 0.6;
-  letter-spacing: 0.04em;
-}
 
 .lead {
   margin: 0;
@@ -522,23 +421,8 @@ function formatDate(at: number): string {
   padding-left: 32px;
 }
 
-.award {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  font-size: 0.82em;
-  color: var(--nd-accent);
-}
 
-.awardEmoji {
-  font-size: 1.05em;
-  line-height: 1;
-}
 
-.awardDate {
-  opacity: 0.6;
-  color: var(--nd-fg);
-}
 
 .linkBtn {
   margin-left: auto;

--- a/src/composables/useTutorial.test.ts
+++ b/src/composables/useTutorial.test.ts
@@ -308,7 +308,6 @@ describe('カテゴリ実行と実績 (#1029)', () => {
     }
     store.syncProgress()
     expect(store.progress.achievements['getting-started']).toBeDefined()
-    expect(store.justUnlocked).toBe('getting-started')
   })
 
   it('一部しか満たしていなければ実績は解除されない', () => {

--- a/src/composables/useTutorial.test.ts
+++ b/src/composables/useTutorial.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick } from 'vue'
+import { nextTick, ref } from 'vue'
 import { useWindowsStore } from '@/stores/windows'
 import { useTutorialStore } from './useTutorial'
 
@@ -14,14 +14,21 @@ const mockSteps: Array<{
   id: string
   title: string
   description: string
+  category?: string
+  wizard?: boolean
   onEnter?: () => void
   precheck?: () => 'skip' | 'show'
   completion?: { watch: () => unknown; isComplete: (v: unknown) => boolean }
   isFinal?: boolean
 }> = []
 
+const mockCategories: Array<{ id: string; title: string }> = []
+
 vi.mock('@/data/tutorialSteps', () => ({
   buildTutorialSteps: () => mockSteps.map((s) => ({ ...s })),
+  get TUTORIAL_CATEGORIES() {
+    return mockCategories
+  },
 }))
 
 const settingsSetSpy = vi.fn()
@@ -33,6 +40,7 @@ describe('useTutorialStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     mockSteps.length = 0
+    mockCategories.length = 0
     settingsSetSpy.mockReset()
   })
 
@@ -234,5 +242,141 @@ describe('useTutorialStore', () => {
     store.start() // 既に active なので二重 open しない
     expect(store.currentStep?.id).toBe('b')
     expect(windowsStore.windows.length).toBe(beforeCount)
+  })
+})
+
+describe('カテゴリ実行と実績 (#1029)', () => {
+  const done = ref(false)
+
+  beforeEach(() => {
+    done.value = false
+    setActivePinia(createPinia())
+    mockSteps.length = 0
+    mockCategories.length = 0
+    settingsSetSpy.mockReset()
+    mockCategories.push({ id: 'getting-started', title: 'はじめに' })
+    mockSteps.push(
+      { id: 'welcome', title: 'W', description: '' },
+      {
+        id: 'a',
+        title: 'A',
+        description: '',
+        category: 'getting-started',
+        wizard: false,
+        precheck: () => 'show',
+      },
+      {
+        id: 'b',
+        title: 'B',
+        description: '',
+        category: 'getting-started',
+        wizard: false,
+        precheck: () => 'show',
+      },
+      { id: 'complete', title: 'C', description: '', isFinal: true },
+    )
+  })
+
+  it('初回ウィザードは wizard: false の step を含まない', () => {
+    const store = useTutorialStore()
+    store.start()
+    expect(store.totalSteps).toBe(2) // welcome + complete
+  })
+
+  it('startCategory はそのカテゴリの step だけを積む', () => {
+    const store = useTutorialStore()
+    store.startCategory('getting-started')
+    expect(store.active).toBe(true)
+    expect(store.totalSteps).toBe(2)
+    expect(store.currentStep?.id).toBe('a')
+  })
+
+  it('カテゴリを走り切っても完走フラグは立たない (ウィザードのものなので)', () => {
+    const store = useTutorialStore()
+    store.startCategory('getting-started')
+    store.next()
+    store.next() // 終端
+    expect(store.active).toBe(false)
+    expect(settingsSetSpy).not.toHaveBeenCalled()
+  })
+
+  it('カテゴリの全項目を満たすと実績が解除される', () => {
+    const store = useTutorialStore()
+    // 2 項目とも達成済みの状態にする
+    for (const s of mockSteps) {
+      if (s.category) s.precheck = () => 'skip'
+    }
+    store.syncProgress()
+    expect(store.progress.achievements['getting-started']).toBeDefined()
+    expect(store.justUnlocked).toBe('getting-started')
+  })
+
+  it('一部しか満たしていなければ実績は解除されない', () => {
+    const store = useTutorialStore()
+    const a = mockSteps.find((s) => s.id === 'a')
+    if (a) a.precheck = () => 'skip'
+    store.syncProgress()
+    expect(store.progress.items['a']).toBeDefined()
+    expect(store.progress.achievements['getting-started']).toBeUndefined()
+  })
+
+  it('達成済みの項目は状態が戻っても未達成にならない (latch)', () => {
+    const store = useTutorialStore()
+    const a = mockSteps.find((s) => s.id === 'a')
+    if (a) a.precheck = () => 'skip'
+    store.syncProgress()
+    // カラムを閉じた相当: 状態が false に戻る
+    if (a) a.precheck = () => 'show'
+    expect(store.isStepDone({ id: 'a', title: 'A', description: '' })).toBe(
+      true,
+    )
+  })
+
+  it('完了済みのカテゴリも先頭から見直せる', () => {
+    const store = useTutorialStore()
+    for (const s of mockSteps) {
+      if (s.category) s.precheck = () => 'skip'
+    }
+    store.startCategory('getting-started')
+    expect(store.active).toBe(true)
+    expect(store.currentStep?.id).toBe('a')
+  })
+
+  it('category では達成しても自動で次に進まない (次 step が勝手に開かない)', async () => {
+    let opened = false
+    const a = mockSteps.find((s) => s.id === 'a')
+    const b = mockSteps.find((s) => s.id === 'b')
+    if (a) {
+      a.completion = { watch: () => done.value, isComplete: (v) => v === true }
+    }
+    if (b) {
+      b.onEnter = () => {
+        opened = true
+      }
+    }
+    const store = useTutorialStore()
+    store.startCategory('getting-started')
+    expect(store.currentStep?.id).toBe('a')
+    done.value = true
+    await nextTick()
+    // 達成は記録されるが step は動かない
+    expect(store.stepCompleted).toBe(true)
+    expect(store.currentStep?.id).toBe('a')
+    expect(opened).toBe(false)
+    // ユーザーが [次へ] を押して初めて次の onEnter が走る
+    store.next()
+    expect(store.currentStep?.id).toBe('b')
+    expect(opened).toBe(true)
+  })
+
+  it('resetProgress で達成記録が消える', () => {
+    const store = useTutorialStore()
+    for (const s of mockSteps) {
+      if (s.category) s.precheck = () => 'skip'
+    }
+    store.syncProgress()
+    store.resetProgress()
+    expect(store.progress.items).toEqual({})
+    expect(store.progress.achievements).toEqual({})
   })
 })

--- a/src/composables/useTutorial.ts
+++ b/src/composables/useTutorial.ts
@@ -53,11 +53,6 @@ export const useTutorialStore = defineStore('tutorial', () => {
   const runMode = ref<TutorialRunMode>('wizard')
   const progress = ref<TutorialProgress>(emptyProgress())
   /**
-   * 直近に解除された実績のカテゴリ id。UI が拾って知らせるための一時値で、
-   * 永続化はしない (正本は progress.achievements)。
-   */
-  const justUnlocked = ref<TutorialCategoryId | null>(null)
-  /**
    * category 実行で、今の step の達成条件が満たされたか。カードに達成を出して
    * [次へ] を待つために使う (wizard は自動で進むので常に false)。
    */
@@ -196,18 +191,13 @@ export const useTutorialStore = defineStore('tutorial', () => {
       const members = all.filter((s) => s.category === category.id)
       if (members.length === 0) continue
       if (members.every((s) => next.items[s.id] != null)) {
+        // 解除の知らせは通知欄が達成記録から合成する (#1029)
         next = unlockAchievement(next, category.id, now)
-        justUnlocked.value = category.id
       }
     }
     if (next === progress.value) return
     progress.value = next
     void saveProgress()
-  }
-
-  /** 実績の解除を UI が知らせ終えたら呼ぶ */
-  function clearJustUnlocked(): void {
-    justUnlocked.value = null
   }
 
   /**
@@ -217,7 +207,6 @@ export const useTutorialStore = defineStore('tutorial', () => {
   function resetProgress(): void {
     const cleared = emptyProgress()
     progress.value = cleared
-    justUnlocked.value = null
     if (!isTauri) return
     // saveProgress は保存済みの記録と統合するので、消す時は使えない
     void writeTutorialProgress(serializeTutorialProgress(cleared)).catch(
@@ -388,7 +377,6 @@ export const useTutorialStore = defineStore('tutorial', () => {
     runMode,
     progress,
     stepCompleted,
-    justUnlocked,
     // actions
     start,
     startCategory,
@@ -401,6 +389,5 @@ export const useTutorialStore = defineStore('tutorial', () => {
     syncProgress,
     loadProgress,
     resetProgress,
-    clearJustUnlocked,
   }
 })

--- a/src/composables/useTutorial.ts
+++ b/src/composables/useTutorial.ts
@@ -1,17 +1,19 @@
 /**
- * useTutorial — `/tutorial` コマンドのセットアップ wizard 状態マシン。
+ * useTutorial — チュートリアルの状態マシン。
+ *
+ * 2 つの走らせ方を持つ (#1029):
+ * - **wizard**: 初回起動時の線形セットアップ。完走で `tutorial.completed`
+ * - **category**: チュートリアル設定のチェックリストから選んだカテゴリを
+ *   走らせる。完走しても `tutorial.completed` は触らない (ウィザードの
+ *   完走フラグなので)。案内カードは閉じるが、設定ウィンドウは開いたまま
  *
  * 設計判断:
  * - AI を呼ばない (= AI 未設定でも動くべきチュートリアルなので、AI 依存にできない)
  * - capability dispatcher を経由しない (= step の action は store API を直接叩く)
- * - 状態は system state (vault.connections / accounts) から自動派生するので、
- *   チュートリアル自身の永続セッションは持たない (= flag `tutorial.completed` のみ)
- * - UI は固定 overlay ではなく **DeckWindow として** 表示 (= 他補助 UI と paradigm 統一)。
- *   start() で windows.open('tutorial')、cancel/finish で windows.close
- *
- * 状態フロー:
- *   inactive → start() → window 開く + 最初の未 skip step に遷移 →
- *   next/skip で進む → 最終 step で finish() を呼ぶと completed flag + window close
+ * - 完了判定は system state (vault.connections / accounts / columns) からの導出が
+ *   基本。ただし「カラムを開いた」は閉じると false に戻るため、一度満たしたら
+ *   戻らない latch として tutorial.json5 に残す
+ * - UI は固定 overlay ではなく **DeckWindow として** 表示 (= 他補助 UI と paradigm 統一)
  *
  * 外部閉鎖検出: window が UI 側で閉じられた (= ユーザーがヘッダ [×] や Esc 押下)
  * 場合も watcher で内部状態をリセットする (= 二重 close なし)
@@ -19,14 +21,47 @@
 
 import { defineStore } from 'pinia'
 import { computed, ref, type WatchStopHandle, watch } from 'vue'
-import { buildTutorialSteps, type TutorialStep } from '@/data/tutorialSteps'
+import {
+  buildTutorialSteps,
+  TUTORIAL_CATEGORIES,
+  type TutorialCategoryId,
+  type TutorialStep,
+} from '@/data/tutorialSteps'
+import {
+  emptyProgress,
+  markItemDone,
+  mergeProgress,
+  parseTutorialProgress,
+  serializeTutorialProgress,
+  type TutorialProgress,
+  unlockAchievement,
+} from '@/services/tutorialProgress'
 import { useSettingsStore } from '@/stores/settings'
 import { useWindowsStore } from '@/stores/windows'
+import {
+  isTauri,
+  readTutorialProgress,
+  writeTutorialProgress,
+} from '@/utils/settingsFs'
+
+export type TutorialRunMode = 'wizard' | 'category'
 
 export const useTutorialStore = defineStore('tutorial', () => {
   const steps = ref<TutorialStep[]>([])
   const currentIndex = ref(-1)
   const windowId = ref<string | null>(null)
+  const runMode = ref<TutorialRunMode>('wizard')
+  const progress = ref<TutorialProgress>(emptyProgress())
+  /**
+   * 直近に解除された実績のカテゴリ id。UI が拾って知らせるための一時値で、
+   * 永続化はしない (正本は progress.achievements)。
+   */
+  const justUnlocked = ref<TutorialCategoryId | null>(null)
+  /**
+   * category 実行で、今の step の達成条件が満たされたか。カードに達成を出して
+   * [次へ] を待つために使う (wizard は自動で進むので常に false)。
+   */
+  const stepCompleted = ref(false)
   const active = computed(() => windowId.value !== null)
   const currentStep = computed<TutorialStep | null>(() => {
     if (currentIndex.value < 0 || currentIndex.value >= steps.value.length) {
@@ -51,7 +86,22 @@ export const useTutorialStore = defineStore('tutorial', () => {
     if (!step?.completion) return
     const { watch: getValue, isComplete } = step.completion
     stopStepWatcher = watch(getValue, (value) => {
-      if (isComplete(value)) next()
+      if (!isComplete(value)) return
+      // 達成の瞬間に記録する。カラムを閉じると状態は false に戻るので、
+      // ここで latch しないと「開いた」ことが失われる
+      const done = currentStep.value
+      if (done?.category) {
+        progress.value = markItemDone(progress.value, done.id, Date.now())
+      }
+      syncProgress()
+      if (runMode.value === 'wizard') {
+        next()
+        return
+      }
+      // category では自動で次に進めない。次 step の onEnter (ウィンドウや
+      // カラム追加 UI を開く) がユーザーの操作なしに連鎖してしまうため、
+      // 達成を見せて [次へ] を待つ
+      stepCompleted.value = true
     })
   }
 
@@ -90,6 +140,91 @@ export const useTutorialStore = defineStore('tutorial', () => {
     currentIndex.value = -1
     steps.value = []
     windowId.value = null
+    stepCompleted.value = false
+  }
+
+  // --- 達成記録 (tutorial.json5) ---
+
+  /** 保存済みの達成記録を読む。ブラウザ (非 Tauri) では何もしない */
+  async function loadProgress(): Promise<void> {
+    if (!isTauri) return
+    try {
+      progress.value = parseTutorialProgress(await readTutorialProgress())
+    } catch (e) {
+      console.warn('[tutorial] failed to read tutorial.json5 (ignored):', e)
+    }
+  }
+
+  /**
+   * 達成記録を保存する。別ウィンドウが書いた分を消さないよう、
+   * 直前の保存内容と統合してから書く。
+   */
+  async function saveProgress(): Promise<void> {
+    if (!isTauri) return
+    try {
+      const stored = parseTutorialProgress(await readTutorialProgress())
+      const merged = mergeProgress(stored, progress.value)
+      progress.value = merged
+      await writeTutorialProgress(serializeTutorialProgress(merged))
+    } catch (e) {
+      console.warn('[tutorial] failed to write tutorial.json5 (ignored):', e)
+    }
+  }
+
+  /** step が達成済みか。記録済み (latch) か、今の状態で満たされていれば true */
+  function isStepDone(step: TutorialStep): boolean {
+    if (progress.value.items[step.id] != null) return true
+    return step.precheck?.() === 'skip'
+  }
+
+  /**
+   * 全 step の達成状況を評価して記録に反映し、カテゴリを完走していれば
+   * 実績を解除する。チェックリスト表示時と step 完了時に呼ぶ。
+   */
+  function syncProgress(): void {
+    const all = buildTutorialSteps()
+    const now = Date.now()
+    let next = progress.value
+    for (const step of all) {
+      if (!step.category) continue
+      if (next.items[step.id] == null && step.precheck?.() === 'skip') {
+        next = markItemDone(next, step.id, now)
+      }
+    }
+    for (const category of TUTORIAL_CATEGORIES) {
+      if (next.achievements[category.id] != null) continue
+      const members = all.filter((s) => s.category === category.id)
+      if (members.length === 0) continue
+      if (members.every((s) => next.items[s.id] != null)) {
+        next = unlockAchievement(next, category.id, now)
+        justUnlocked.value = category.id
+      }
+    }
+    if (next === progress.value) return
+    progress.value = next
+    void saveProgress()
+  }
+
+  /** 実績の解除を UI が知らせ終えたら呼ぶ */
+  function clearJustUnlocked(): void {
+    justUnlocked.value = null
+  }
+
+  /**
+   * 達成記録をすべて消す。状態から導出できる項目 (ログイン済みなど) は
+   * 次の評価で戻るが、latch していた項目 (カラムを開いた) は未達成に戻る。
+   */
+  function resetProgress(): void {
+    const cleared = emptyProgress()
+    progress.value = cleared
+    justUnlocked.value = null
+    if (!isTauri) return
+    // saveProgress は保存済みの記録と統合するので、消す時は使えない
+    void writeTutorialProgress(serializeTutorialProgress(cleared)).catch(
+      (e) => {
+        console.warn('[tutorial] failed to reset tutorial.json5 (ignored):', e)
+      },
+    )
   }
 
   /** index `i` から始めて、precheck=skip を満たさない最初の step の index を返す */
@@ -105,6 +240,7 @@ export const useTutorialStore = defineStore('tutorial', () => {
 
   function enterStep(i: number): void {
     teardownStepWatcher()
+    stepCompleted.value = false
     currentIndex.value = i
     const step = currentStep.value
     if (!step) return
@@ -126,7 +262,10 @@ export const useTutorialStore = defineStore('tutorial', () => {
     enterStep(index)
   }
 
-  /** チュートリアルを開始。window を開いて最初に show すべき step に遷移する */
+  /**
+   * 初回セットアップのウィザードを開始する。API キーを要する step は
+   * 必須線に含めない (#1012)。
+   */
   function start(): void {
     if (active.value) {
       // 既に開いていれば最前面に持ってくる
@@ -134,7 +273,9 @@ export const useTutorialStore = defineStore('tutorial', () => {
       if (id) useWindowsStore().bringToFront(id)
       return
     }
-    steps.value = buildTutorialSteps()
+    void loadProgress()
+    steps.value = buildTutorialSteps().filter((s) => s.wizard !== false)
+    runMode.value = 'wizard'
     windowId.value = useWindowsStore().open('tutorial', {})
     installWindowWatcher()
     const startIdx = findNextShowable(0)
@@ -148,6 +289,30 @@ export const useTutorialStore = defineStore('tutorial', () => {
   }
 
   /**
+   * チェックリスト (チュートリアル設定) から 1 カテゴリを走らせる。
+   * 案内カードは wizard と同じウィンドウを使い、終わったら閉じる。
+   * チュートリアル設定ウィンドウは開いたまま残る。
+   */
+  function startCategory(categoryId: TutorialCategoryId): void {
+    const members = buildTutorialSteps().filter(
+      (s) => s.category === categoryId,
+    )
+    if (members.length === 0) return
+    // 走行中なら差し替える (別カテゴリをクリックした場合)
+    teardownStepWatcher()
+    steps.value = members
+    runMode.value = 'category'
+    // 全て達成済みなら先頭から見直す (完了したカテゴリをもう一度やれる)
+    const found = findNextShowable(0)
+    const startIdx = found >= steps.value.length ? 0 : found
+    if (!active.value) {
+      windowId.value = useWindowsStore().open('tutorial', {})
+      installWindowWatcher()
+    }
+    enterStep(startIdx)
+  }
+
+  /**
    * 次の step へ進む。途中 step を超えて isFinal の step に到達したら finish()。
    * 既に最終 step に居て呼ばれた場合も finish() で締める。
    */
@@ -155,15 +320,28 @@ export const useTutorialStore = defineStore('tutorial', () => {
     const step = currentStep.value
     if (!step) return
     if (step.isFinal) {
-      finish()
+      endRun()
       return
     }
     const nextIdx = findNextShowable(currentIndex.value + 1)
     if (nextIdx >= steps.value.length) {
-      finish()
+      endRun()
       return
     }
     enterStep(nextIdx)
+  }
+
+  /**
+   * run の終端。wizard は完走フラグを立てて閉じる。category は達成を記録して
+   * カードを閉じるだけ (完走フラグはウィザードのものなので触らない)。
+   */
+  function endRun(): void {
+    if (runMode.value === 'wizard') {
+      finish()
+      return
+    }
+    syncProgress()
+    cancel()
   }
 
   /**
@@ -173,16 +351,16 @@ export const useTutorialStore = defineStore('tutorial', () => {
   function skip(): void {
     const step = currentStep.value
     if (!step) return
-    if (step.isFinal) {
+    const isLast =
+      step.isFinal ||
+      findNextShowable(currentIndex.value + 1) >= steps.value.length
+    if (isLast) {
+      // wizard / category いずれも完走扱いにはせずカードを閉じる
+      if (runMode.value === 'category') syncProgress()
       cancel()
       return
     }
-    const nextIdx = findNextShowable(currentIndex.value + 1)
-    if (nextIdx >= steps.value.length) {
-      cancel()
-      return
-    }
-    enterStep(nextIdx)
+    enterStep(findNextShowable(currentIndex.value + 1))
   }
 
   /** チュートリアルを途中で閉じる。completed flag は立てない */
@@ -207,12 +385,22 @@ export const useTutorialStore = defineStore('tutorial', () => {
     currentNumber,
     totalSteps,
     windowId,
+    runMode,
+    progress,
+    stepCompleted,
+    justUnlocked,
     // actions
     start,
+    startCategory,
     next,
     skip,
     cancel,
     finish,
     goToStep,
+    isStepDone,
+    syncProgress,
+    loadProgress,
+    resetProgress,
+    clearJustUnlocked,
   }
 })

--- a/src/data/tutorialSteps.test.ts
+++ b/src/data/tutorialSteps.test.ts
@@ -1,0 +1,114 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  buildTutorialSteps,
+  TUTORIAL_CATEGORIES,
+  type TutorialStep,
+  tutorialDocsUrl,
+} from './tutorialSteps'
+
+/** docs のパスに対応する markdown が site/ に実在するか */
+function docsFileExists(docsPath: string): boolean {
+  const rel = docsPath.replace(/^\//, '')
+  const base = resolve(__dirname, '../../site')
+  const candidates = docsPath.endsWith('/')
+    ? [`${rel}index.md`]
+    : [`${rel}.md`, `${rel}/index.md`]
+  return candidates.some((c) => existsSync(resolve(base, c)))
+}
+
+/** 初回ウィザードに出る step (wizard 未指定は既定 true) */
+function wizardSteps(steps: TutorialStep[]): TutorialStep[] {
+  return steps.filter((s) => s.wizard !== false)
+}
+
+describe('buildTutorialSteps', () => {
+  it('初回ウィザードは API キー不要の範囲だけで完走できる (#1012)', () => {
+    const ids = wizardSteps(buildTutorialSteps()).map((s) => s.id)
+    expect(ids).toEqual([
+      'welcome',
+      'account-login',
+      'add-first-column',
+      'open-notifications',
+      'complete',
+    ])
+  })
+
+  it('AI の step は任意線 (「使いこなす」カテゴリのみ) に置かれる', () => {
+    const ai = buildTutorialSteps().filter((s) => s.category === 'mastery')
+    expect(ai.map((s) => s.id)).toEqual([
+      'ai-setup',
+      'ai-select-provider',
+      'ai-column',
+    ])
+    expect(ai.every((s) => s.wizard === false)).toBe(true)
+  })
+
+  it('最終 step だけが isFinal を持つ', () => {
+    const steps = buildTutorialSteps()
+    expect(steps.filter((s) => s.isFinal).map((s) => s.id)).toEqual([
+      'complete',
+    ])
+  })
+
+  it('カテゴリ付き step はすべて完了検知を持つ (チェックリストに出るため)', () => {
+    for (const step of buildTutorialSteps()) {
+      if (!step.category) continue
+      expect(step.completion, `${step.id} に completion がない`).toBeDefined()
+      expect(step.precheck, `${step.id} に precheck がない`).toBeDefined()
+    }
+  })
+
+  it('step の category はすべて定義済みカテゴリを指す', () => {
+    const known = new Set(TUTORIAL_CATEGORIES.map((c) => c.id))
+    for (const step of buildTutorialSteps()) {
+      if (!step.category) continue
+      expect(known.has(step.category), `${step.id} の category が未定義`).toBe(
+        true,
+      )
+    }
+  })
+
+  it('各カテゴリに step が 1 つ以上ある (空の実績を作らない)', () => {
+    const steps = buildTutorialSteps()
+    for (const category of TUTORIAL_CATEGORIES) {
+      const members = steps.filter((s) => s.category === category.id)
+      expect(members.length, `${category.id} が空`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('ドキュメントとの対応', () => {
+  it('カテゴリの docsPath は site/ に実在するページを指す', () => {
+    for (const category of TUTORIAL_CATEGORIES) {
+      expect(
+        docsFileExists(category.docsPath),
+        `${category.id} の ${category.docsPath} が無い`,
+      ).toBe(true)
+    }
+  })
+
+  it('step の docsPath は site/ に実在するページを指す', () => {
+    for (const step of buildTutorialSteps()) {
+      if (!step.docsPath) continue
+      expect(
+        docsFileExists(step.docsPath),
+        `${step.id} の ${step.docsPath} が無い`,
+      ).toBe(true)
+    }
+  })
+
+  it('カテゴリ付き step はすべてドキュメントに紐づく', () => {
+    for (const step of buildTutorialSteps()) {
+      if (!step.category) continue
+      expect(step.docsPath, `${step.id} に docsPath がない`).toBeDefined()
+    }
+  })
+
+  it('docs の URL は公式サイトを指す', () => {
+    expect(tutorialDocsUrl('/docs/first-run')).toBe(
+      'https://notedeck.io/docs/first-run',
+    )
+  })
+})

--- a/src/data/tutorialSteps.ts
+++ b/src/data/tutorialSteps.ts
@@ -22,7 +22,7 @@ import {
 } from '@/composables/useSpotlight'
 import { useVault } from '@/composables/useVault'
 import { useAccountsStore } from '@/stores/accounts'
-import { useDeckStore } from '@/stores/deck'
+import { type ColumnType, useDeckStore } from '@/stores/deck'
 import { useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { WINDOW_LABELS } from '@/windows/registry'
@@ -44,6 +44,31 @@ export interface TutorialCompletionWatcher {
   isComplete: (value: unknown) => boolean
 }
 
+/**
+ * チュートリアルのカテゴリ。チェックリストの見出し単位であり、
+ * 完走すると NoteDeck 独自実績が 1 つ解除される単位でもある (#1029)。
+ *
+ * 並びと区切りは公式ドキュメント (site/ の VitePress) のサイドバーに合わせて
+ * ある。ドキュメントを読み進める順序と、アプリを触って覚える順序が同じもの
+ * になるようにするため。カテゴリと step はそれぞれ対応するページを持ち、
+ * チュートリアルから直接開ける。
+ */
+export type TutorialCategoryId = 'getting-started' | 'mastery' | 'extend'
+
+export interface TutorialCategory {
+  id: TutorialCategoryId
+  /** チェックリストの見出し。ドキュメントのセクション名に揃える */
+  title: string
+  /** 見出し下の 1 行説明 */
+  description: string
+  /** カテゴリ完走で解除される実績の表示名 */
+  achievementName: string
+  /** 実績バッジの絵文字 */
+  achievementEmoji: string
+  /** 対応するドキュメントのパス */
+  docsPath: string
+}
+
 export interface TutorialStep {
   /** step id (kebab-case)。テスト・デバッグ用 */
   id: string
@@ -51,6 +76,18 @@ export interface TutorialStep {
   title: string
   /** カード本文。改行を含んでよい */
   description: string
+  /**
+   * 所属カテゴリ。未指定 = チェックリストに出さない (welcome / complete like
+   * な、完了検知を持たない wizard 専用カード)。
+   */
+  category?: TutorialCategoryId
+  /** この step を詳しく説明しているドキュメントのパス */
+  docsPath?: string
+  /**
+   * 初回ウィザードの必須線に含めるか。既定 true。
+   * API キーを要する AI などは false にして任意線 (カテゴリ) に置く (#1012)。
+   */
+  wizard?: boolean
   /** step に入った時に一度だけ呼ばれるアクション (windows.open など) */
   onEnter?: () => void
   /** 既に満たされていれば skip するかを返す。未指定 = 常に show */
@@ -67,15 +104,6 @@ export interface TutorialStep {
   isFinal?: boolean
 }
 
-/**
- * 接続のうち、AI プロバイダ (protocol 付き) のものが 1 件以上あるか判定。
- * Vault は AI 用接続 / 一般 fetch 用接続を同居させているので、protocol 有無で
- * AI 用かどうかを判別する。
- */
-function hasAnyAiConnection(): boolean {
-  return useVault().connections.value.some((c) => c.protocol != null)
-}
-
 /** hasToken (= 実認証) 済みの実アカウントが 1 件以上あるか */
 function hasAuthenticatedAccount(): boolean {
   return useAccountsStore().accounts.some((a) => a.hasToken)
@@ -86,9 +114,39 @@ function hasAnyColumn(): boolean {
   return useDeckStore().columns.length > 0
 }
 
-/** AI チャットカラム (sidebar スロット) が今開いているか */
-function isAiColumnOpen(): boolean {
-  return useDeckStore().columns.some((c) => c.sidebar && c.type === 'ai')
+/** 通知カラム (sidebar スロット) が今開いているか */
+function isNotificationsColumnOpen(): boolean {
+  return useDeckStore().columns.some(
+    (c) => c.sidebar && c.type === 'notifications',
+  )
+}
+
+/** 指定種別のカラムが今開いているか */
+function isColumnOpen(type: ColumnType): boolean {
+  return useDeckStore().columns.some((c) => c.type === type)
+}
+
+/**
+ * カラム追加 UI を開き、指定種別の項目を spotlight で指し示す。
+ * desktop はコマンドパレット (+ モード)、compact は AddColumnDialog。どちらも
+ * add-column コマンド (toggleAddMenu) 経由で開く。dialog は遅延ロードなので
+ * duration を長めに取る。
+ */
+function openAddColumnAndPoint(type: ColumnType, label: string): void {
+  useCommandStore().execute('add-column')
+  useSpotlightStore().highlight(commandItemTargetId(`col-${type}`), {
+    label: `チュートリアルが${label}の項目を示しています`,
+    durationMs: 6000,
+  })
+}
+
+/**
+ * 接続のうち、AI プロバイダ (protocol 付き) のものが 1 件以上あるか判定。
+ * Vault は AI 用接続 / 一般 fetch 用接続を同居させているので、protocol 有無で
+ * AI 用かどうかを判別する。
+ */
+function hasAnyAiConnection(): boolean {
+  return useVault().connections.value.some((c) => c.protocol != null)
 }
 
 /** AI プロバイダ (アクティブ接続) が選択・解決済みか */
@@ -97,17 +155,61 @@ function hasResolvedAiProvider(): boolean {
   return resolveAiConnection(config.value, useVault().connections.value) != null
 }
 
+/** AI チャットカラム (sidebar スロット) が今開いているか */
+function isAiColumnOpen(): boolean {
+  return useDeckStore().columns.some((c) => c.sidebar && c.type === 'ai')
+}
+
+/**
+ * カテゴリ定義。表示順がそのまま学習の順序になる。
+ * ドキュメントのサイドバー (はじめに → 使いこなす → 拡張をつくる) と
+ * 同じ区切り・同じ並び。デッキを組む工程は初回に必ず通るので「はじめに」に
+ * まとめている。
+ */
+export const TUTORIAL_CATEGORIES: TutorialCategory[] = [
+  {
+    id: 'getting-started',
+    title: 'はじめに',
+    description: 'アカウントをつなぎ、カラムを並べて使い始める',
+    achievementName: 'はじめの一歩',
+    achievementEmoji: '🎴',
+    docsPath: '/docs/first-run',
+  },
+  {
+    id: 'mastery',
+    title: '使いこなす',
+    description: '外部の AI をつないで自分の環境を動かす',
+    achievementName: '使い手',
+    achievementEmoji: '⌨️',
+    docsPath: '/docs/guide/ai',
+  },
+  {
+    id: 'extend',
+    title: '拡張をつくる',
+    description: 'プロトコルを覗き、自分だけのカラムを組み立てる',
+    achievementName: '拡張の作者',
+    achievementEmoji: '🔧',
+    docsPath: '/docs/dev/',
+  },
+]
+
+/** ドキュメントのパスから公開 URL を作る */
+export function tutorialDocsUrl(docsPath: string): string {
+  return `https://notedeck.io${docsPath}`
+}
+
 /**
  * チュートリアル step リスト。順序がそのままユーザー体験の順序になる。
- * 最小限で「ログイン → カラム → AI 接続/プロバイダ選択 → AIカラム」まで通す。
  *
- * 1. welcome          — NoteDeck の趣旨を一言
- * 2. account-login    — Misskey にログイン
- * 3. add-first-column — 最初のカラム (ホーム TL) を追加 = デッキを体得
- * 4. ai-setup         — AI プロバイダの API キーを Vault に登録
- * 5. ai-select-provider — AI 設定で接続をプロバイダとして選択
- * 6. ai-column        — サイドバーの AI ボタン (spotlight) から AI カラムを開く
- * 7. complete         — 完了カード
+ * AI の設定は初回ウィザードの必須線に置かない (#1012)。API キーを持たない
+ * 利用者がここで止まるため、ウィザードは API キー不要の範囲 (wizard: true)
+ * だけで完走できるようにする。AI は任意線として「使いこなす」に置き、
+ * チェックリストから後で出会う。
+ *
+ * 初回ウィザード (wizard: true):
+ *   welcome → account-login → add-first-column → open-notifications → complete
+ *
+ * チェックリスト (category 付き): はじめに → 使いこなす → 拡張をつくる
  */
 export function buildTutorialSteps(): TutorialStep[] {
   return [
@@ -115,13 +217,15 @@ export function buildTutorialSteps(): TutorialStep[] {
       id: 'welcome',
       title: 'NoteDeck へようこそ',
       description:
-        'NoteDeck は Misskey を、カラムを並べたデッキ・コマンドパレット・AI で' +
+        'NoteDeck は Misskey を、カラムを並べたデッキとコマンドパレットで' +
         '統合した環境です。基本を数ステップで案内します。' +
         '途中でやめても、設定済みの内容は保たれます。',
     },
 
     {
       id: 'account-login',
+      category: 'getting-started',
+      docsPath: '/docs/first-run',
       title: 'Misskey アカウントを追加',
       description:
         'ログインウィンドウで Misskey サーバーのホスト名' +
@@ -143,23 +247,15 @@ export function buildTutorialSteps(): TutorialStep[] {
 
     {
       id: 'add-first-column',
+      category: 'getting-started',
+      docsPath: '/docs/deck/columns',
       title: '最初のカラムを追加',
       description:
         'NoteDeck はカラムを並べて使います。カラム追加 (＋) から' +
         '「タイムライン」を選ぶとホームタイムラインが表示されます。' +
         '追加すると自動で次へ進みます。',
       precheck: () => (hasAnyColumn() ? 'skip' : 'show'),
-      onEnter: () => {
-        // カラム追加 UI を開く: desktop はコマンドパレット (+ モード)、compact は
-        // AddColumnDialog。どちらも add-column コマンド (toggleAddMenu) 経由で開く。
-        // 開いた UI の「タイムライン」項目を spotlight で指し示す (palette/dialog
-        // 共通ターゲット)。dialog は遅延ロードなので duration を長めに取る。
-        useCommandStore().execute('add-column')
-        useSpotlightStore().highlight(commandItemTargetId('col-timeline'), {
-          label: 'チュートリアルがタイムラインの項目を示しています',
-          durationMs: 6000,
-        })
-      },
+      onEnter: () => openAddColumnAndPoint('timeline', 'タイムライン'),
       completion: {
         watch: () => useDeckStore().columns.length,
         isComplete: () => hasAnyColumn(),
@@ -167,7 +263,96 @@ export function buildTutorialSteps(): TutorialStep[] {
     },
 
     {
+      id: 'open-notifications',
+      category: 'getting-started',
+      docsPath: '/docs/deck/navbar',
+      title: '通知をサイドバーに開く',
+      description:
+        'ナビバーの通知ボタン (光っています) を押してみましょう。' +
+        'ナビバーのボタンは、カラムをサイドバーに開いたり閉じたりします。' +
+        '開くと自動で次へ進みます。',
+      precheck: () => (isNotificationsColumnOpen() ? 'skip' : 'show'),
+      onEnter: () => {
+        // compact (スマホ) は navbar がドロワーなので、まず開いて通知ボタンを
+        // 画面にかぶせて見せる (desktop は navbar 常時表示なので不要)。
+        if (useUiStore().isCompactLayout) {
+          useUiStore().mobileDrawerOpen = true
+        }
+        // ナビバーの通知ボタンを spotlight で指し示す (クリックで自動 clear)。
+        // 開く動作はユーザーに任せ、completion で開いたことを検知する。
+        useSpotlightStore().highlight(navbarTargetId('notifications', null), {
+          label: 'チュートリアルが通知カラムのボタンを示しています',
+        })
+      },
+      completion: {
+        watch: () => isNotificationsColumnOpen(),
+        isComplete: () => isNotificationsColumnOpen(),
+      },
+    },
+
+    // --- 拡張をつくる (任意線) ---
+    // API キー不要で効く差別化。AI と並列に最初から見えるようにする (#1012)。
+
+    {
+      id: 'open-stream-inspector',
+      category: 'extend',
+      docsPath: '/docs/dev/',
+      wizard: false,
+      title: 'Stream Inspector を開く',
+      description:
+        'カラム追加から「Stream Inspector」を開くと、Misskey との' +
+        'WebSocket イベントが流れるまま見えます。',
+      precheck: () => (isColumnOpen('streamInspector') ? 'skip' : 'show'),
+      onEnter: () =>
+        openAddColumnAndPoint('streamInspector', 'Stream Inspector'),
+      completion: {
+        watch: () => isColumnOpen('streamInspector'),
+        isComplete: () => isColumnOpen('streamInspector'),
+      },
+    },
+
+    {
+      id: 'open-api-console',
+      category: 'extend',
+      docsPath: '/docs/dev/',
+      wizard: false,
+      title: 'API コンソールを開く',
+      description:
+        'カラム追加から「API コンソール」を開くと、Misskey の API を' +
+        '直接叩いて応答を確かめられます。',
+      precheck: () => (isColumnOpen('apiConsole') ? 'skip' : 'show'),
+      onEnter: () => openAddColumnAndPoint('apiConsole', 'API コンソール'),
+      completion: {
+        watch: () => isColumnOpen('apiConsole'),
+        isComplete: () => isColumnOpen('apiConsole'),
+      },
+    },
+
+    {
+      id: 'open-query-manager',
+      category: 'extend',
+      docsPath: '/docs/dev/query',
+      wizard: false,
+      title: 'カラムクエリを開く',
+      description:
+        'カラム追加から「カラムクエリ」を開くと、AiScript で' +
+        '自分だけのタイムラインを組み立てられます。',
+      precheck: () => (isColumnOpen('queryManager') ? 'skip' : 'show'),
+      onEnter: () => openAddColumnAndPoint('queryManager', 'カラムクエリ'),
+      completion: {
+        watch: () => isColumnOpen('queryManager'),
+        isComplete: () => isColumnOpen('queryManager'),
+      },
+    },
+
+    // --- 使いこなす (任意線) ---
+    // 外部 LLM の API キーを要するため、初回ウィザードには置かない (#1012)。
+
+    {
       id: 'ai-setup',
+      category: 'mastery',
+      docsPath: '/docs/guide/ai',
+      wizard: false,
       title: 'AI 接続を追加',
       description:
         '接続管理ウィンドウで、Anthropic / OpenAI など' +
@@ -193,6 +378,9 @@ export function buildTutorialSteps(): TutorialStep[] {
 
     {
       id: 'ai-select-provider',
+      category: 'mastery',
+      docsPath: '/docs/guide/ai',
+      wizard: false,
       title: 'AI プロバイダを選択',
       description:
         'エージェント設定を開きました。登録した接続を AI プロバイダとして選んでください。' +
@@ -212,9 +400,12 @@ export function buildTutorialSteps(): TutorialStep[] {
 
     {
       id: 'ai-column',
+      category: 'mastery',
+      docsPath: '/docs/guide/ai',
+      wizard: false,
       title: 'AI カラムを開く',
       description:
-        'サイドバーの AI ボタン (光っています) から AI カラムを開いて' +
+        'ナビバーの AI ボタン (光っています) から AI カラムを開いて' +
         'みましょう。ここで AI と対話できます。',
       precheck: () => (isAiColumnOpen() ? 'skip' : 'show'),
       onEnter: () => {

--- a/src/services/tutorialAchievements.ts
+++ b/src/services/tutorialAchievements.ts
@@ -1,0 +1,67 @@
+/**
+ * NoteDeck 独自実績の表示データ (#1029)。
+ *
+ * 実績はチュートリアルのカテゴリと 1 対 1 で、達成記録 (tutorial.json5) から
+ * 導出する。サーバー実績と同じグリッド・同じ通知欄に流すため、Misskey の
+ * `Achievement` と同じ形に変換する。
+ *
+ * サーバーには書かない。NoteDeck の操作習熟は Misskey の実績とは無関係で、
+ * アカウントにも紐づかない。
+ */
+
+import {
+  TUTORIAL_CATEGORIES,
+  type TutorialCategoryId,
+} from '@/data/tutorialSteps'
+import type { TutorialProgress } from '@/services/tutorialProgress'
+import type { Achievement, AchievementBadge } from '@/utils/achievements'
+
+/** 通知・実績欄で NoteDeck 実績を識別する接頭辞 */
+const PREFIX = 'notedeck:'
+
+export function tutorialAchievementName(id: TutorialCategoryId): string {
+  return `${PREFIX}${id}`
+}
+
+/** グリッドに並べる種別と順序 (カテゴリの並び = 学習の順序) */
+export const TUTORIAL_ACHIEVEMENT_TYPES: readonly string[] =
+  TUTORIAL_CATEGORIES.map((c) => tutorialAchievementName(c.id))
+
+export const TUTORIAL_ACHIEVEMENT_TOTAL = TUTORIAL_ACHIEVEMENT_TYPES.length
+
+/**
+ * バッジ。段階が進むほど格を上げる (bronze → silver → gold) ことで、
+ * グリッドを見ただけでどこまで来たかが分かる。
+ */
+export const TUTORIAL_ACHIEVEMENT_BADGES: Record<string, AchievementBadge> =
+  Object.fromEntries(
+    TUTORIAL_CATEGORIES.map((category, index) => [
+      tutorialAchievementName(category.id),
+      {
+        emoji: category.achievementEmoji,
+        frame: (['bronze', 'silver', 'gold'] as const)[index] ?? 'gold',
+        bg: null,
+      },
+    ]),
+  )
+
+export const TUTORIAL_ACHIEVEMENT_LABELS: Record<string, string> =
+  Object.fromEntries(
+    TUTORIAL_CATEGORIES.map((c) => [
+      tutorialAchievementName(c.id),
+      c.achievementName,
+    ]),
+  )
+
+/** 達成記録から、解除済みの実績だけを取り出す */
+export function tutorialAchievements(
+  progress: TutorialProgress,
+): Achievement[] {
+  const out: Achievement[] = []
+  for (const category of TUTORIAL_CATEGORIES) {
+    const at = progress.achievements[category.id]
+    if (at == null) continue
+    out.push({ name: tutorialAchievementName(category.id), unlockedAt: at })
+  }
+  return out
+}

--- a/src/services/tutorialNotifications.test.ts
+++ b/src/services/tutorialNotifications.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import type { NormalizedNotification } from '@/adapters/types'
+import {
+  isTutorialNotificationId,
+  mergeTutorialNotifications,
+} from './tutorialNotifications'
+import { emptyProgress, unlockAchievement } from './tutorialProgress'
+
+function notif(id: string, createdAt: string): NormalizedNotification {
+  return {
+    id,
+    _accountId: 'acc-1',
+    _serverHost: 'example.com',
+    createdAt,
+    type: 'reaction',
+  }
+}
+
+describe('mergeTutorialNotifications', () => {
+  it('解除した実績を achievementEarned として差し込む', () => {
+    const progress = unlockAchievement(
+      emptyProgress(),
+      'getting-started',
+      Date.parse('2026-08-05T00:00:00Z'),
+    )
+    const merged = mergeTutorialNotifications([], progress)
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.type).toBe('achievementEarned')
+    expect(merged[0]?.achievement).toBe('notedeck:getting-started')
+  })
+
+  it('未解除の実績は出さない', () => {
+    expect(mergeTutorialNotifications([], emptyProgress())).toEqual([])
+  })
+
+  it('解除時刻の順にサーバー通知と混ぜる (新しい順)', () => {
+    const progress = unlockAchievement(
+      emptyProgress(),
+      'getting-started',
+      Date.parse('2026-08-05T12:00:00Z'),
+    )
+    const merged = mergeTutorialNotifications(
+      [notif('a', '2026-08-06T00:00:00Z'), notif('b', '2026-08-05T00:00:00Z')],
+      progress,
+    )
+    expect(merged.map((n) => n.id)).toEqual([
+      'a',
+      'notedeck-achievement:getting-started',
+      'b',
+    ])
+  })
+
+  it('サーバー通知が空でも落ちない', () => {
+    const progress = unlockAchievement(emptyProgress(), 'extend', 100)
+    expect(mergeTutorialNotifications([], progress)).toHaveLength(1)
+  })
+
+  it('元の配列を書き換えない', () => {
+    const base = [notif('a', '2026-08-06T00:00:00Z')]
+    const progress = unlockAchievement(emptyProgress(), 'extend', 100)
+    mergeTutorialNotifications(base, progress)
+    expect(base).toHaveLength(1)
+  })
+})
+
+describe('isTutorialNotificationId', () => {
+  it('合成通知の id を見分けられる (ページングの cursor に混ぜないため)', () => {
+    expect(isTutorialNotificationId('notedeck-achievement:extend')).toBe(true)
+    expect(isTutorialNotificationId('9abc123')).toBe(false)
+  })
+})

--- a/src/services/tutorialNotifications.ts
+++ b/src/services/tutorialNotifications.ts
@@ -1,0 +1,57 @@
+/**
+ * NoteDeck 独自実績の解除を通知欄に流す (#1029)。
+ *
+ * Misskey 本家がサーバー実績を通知ストリームで届けるので、「実績は通知に出る」
+ * はユーザーの既存のメンタルモデルどおり。トーストは数秒で消えてしまい
+ * 「習熟の記録」に合わないので、遡って見返せる通知欄を使う。
+ *
+ * 通知エントリはサーバーにも通知キャッシュにも書かず、達成記録 (正本) から
+ * 表示時に合成する。正本が別にあるので重複・不整合が構造的に起きない。
+ * 未読バッジも増やさない (煽らない)。
+ */
+
+import type { NormalizedNotification } from '@/adapters/types'
+import { TUTORIAL_CATEGORIES } from '@/data/tutorialSteps'
+import { tutorialAchievementName } from '@/services/tutorialAchievements'
+import type { TutorialProgress } from '@/services/tutorialProgress'
+
+const ID_PREFIX = 'notedeck-achievement:'
+
+/**
+ * 合成した通知か。用途は 2 つ:
+ * - ページングの cursor (untilId) にこの id を渡すとサーバーが解釈できない
+ * - アカウントに紐づかずアバターが引けないので、描画側でアプリアイコンに
+ *   差し替える
+ */
+export function isTutorialNotificationId(id: string): boolean {
+  return id.startsWith(ID_PREFIX)
+}
+
+/**
+ * 解除済みの実績を achievementEarned 通知として、サーバー通知に時系列で
+ * 混ぜた新しい配列を返す。表示専用で、元の配列は書き換えない。
+ */
+export function mergeTutorialNotifications(
+  notifications: readonly NormalizedNotification[],
+  progress: TutorialProgress,
+): NormalizedNotification[] {
+  const synthesized: NormalizedNotification[] = []
+  for (const category of TUTORIAL_CATEGORIES) {
+    const at = progress.achievements[category.id]
+    if (at == null) continue
+    synthesized.push({
+      id: `${ID_PREFIX}${category.id}`,
+      // アプリ操作の習熟はアカウントに紐づかない。cross-account でも 1 件
+      _accountId: '',
+      _serverHost: '',
+      createdAt: new Date(at).toISOString(),
+      type: 'achievementEarned',
+      achievement: tutorialAchievementName(category.id),
+    })
+  }
+  if (synthesized.length === 0) return [...notifications]
+
+  return [...notifications, ...synthesized].sort(
+    (a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt),
+  )
+}

--- a/src/services/tutorialProgress.test.ts
+++ b/src/services/tutorialProgress.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  emptyProgress,
+  markItemDone,
+  mergeProgress,
+  parseTutorialProgress,
+  serializeTutorialProgress,
+  unlockAchievement,
+} from './tutorialProgress'
+
+describe('parseTutorialProgress', () => {
+  it('serialize したものを読み戻せる', () => {
+    const p = markItemDone(emptyProgress(), 'account-login', 100)
+    expect(parseTutorialProgress(serializeTutorialProgress(p))).toEqual(p)
+  })
+
+  it('空文字・壊れた JSON5・型違いは空の進捗に倒す', () => {
+    expect(parseTutorialProgress('')).toEqual(emptyProgress())
+    expect(parseTutorialProgress('{ items: ')).toEqual(emptyProgress())
+    expect(parseTutorialProgress('[]')).toEqual(emptyProgress())
+    expect(parseTutorialProgress('{ items: 3 }')).toEqual(emptyProgress())
+  })
+
+  it('数値でない達成時刻は捨てる', () => {
+    const p = parseTutorialProgress(
+      '{ version: 1, items: { a: 100, b: "x", c: null } }',
+    )
+    expect(p.items).toEqual({ a: 100 })
+  })
+})
+
+describe('markItemDone', () => {
+  it('達成時刻を記録する', () => {
+    const p = markItemDone(emptyProgress(), 'account-login', 100)
+    expect(p.items['account-login']).toBe(100)
+  })
+
+  it('記録済みの項目は上書きしない (最初の達成時刻を残す)', () => {
+    let p = markItemDone(emptyProgress(), 'account-login', 100)
+    p = markItemDone(p, 'account-login', 200)
+    expect(p.items['account-login']).toBe(100)
+  })
+
+  it('元の進捗を書き換えない', () => {
+    const before = emptyProgress()
+    markItemDone(before, 'account-login', 100)
+    expect(before.items).toEqual({})
+  })
+})
+
+describe('unlockAchievement', () => {
+  it('カテゴリ実績の解除時刻を記録する', () => {
+    const p = unlockAchievement(emptyProgress(), 'first-steps', 100)
+    expect(p.achievements['first-steps']).toBe(100)
+  })
+
+  it('解除済みなら時刻を上書きしない', () => {
+    let p = unlockAchievement(emptyProgress(), 'first-steps', 100)
+    p = unlockAchievement(p, 'first-steps', 200)
+    expect(p.achievements['first-steps']).toBe(100)
+  })
+})
+
+describe('mergeProgress', () => {
+  it('両者の項目を統合する', () => {
+    const a = markItemDone(emptyProgress(), 'a', 100)
+    const b = markItemDone(emptyProgress(), 'b', 200)
+    expect(mergeProgress(a, b).items).toEqual({ a: 100, b: 200 })
+  })
+
+  it('衝突した達成時刻は早い方を残す (別ウィンドウの書き込みで巻き戻さない)', () => {
+    const a = markItemDone(emptyProgress(), 'a', 200)
+    const b = markItemDone(emptyProgress(), 'a', 100)
+    expect(mergeProgress(a, b).items['a']).toBe(100)
+  })
+
+  it('実績も同様に統合する', () => {
+    const a = unlockAchievement(emptyProgress(), 'ide', 200)
+    const b = unlockAchievement(emptyProgress(), 'ai', 100)
+    const merged = mergeProgress(a, b)
+    expect(merged.achievements).toEqual({ ide: 200, ai: 100 })
+  })
+})

--- a/src/services/tutorialProgress.ts
+++ b/src/services/tutorialProgress.ts
@@ -1,0 +1,115 @@
+/**
+ * tutorial.json5 の codec (#1029)。
+ *
+ * チュートリアルの達成記録を保持する。プロファイル・アカウントからは独立して
+ * いる (アプリ操作の習熟はアカウントに紐づかない)。
+ *
+ * 記録が要る理由: 完了検知はシステム状態からの導出が基本だが、「Stream
+ * Inspector を開いた」のようにカラムを閉じると false に戻るものがある。
+ * 一度達成したら戻らない latch としてここに残す。
+ */
+
+import JSON5 from 'json5'
+
+/** step id / カテゴリ id → 達成時刻 (epoch ms) */
+type Unlocks = Record<string, number>
+
+export interface TutorialProgress {
+  version: 1
+  /** step 単位の達成記録 */
+  items: Unlocks
+  /** カテゴリ完走で解除される実績 */
+  achievements: Unlocks
+}
+
+export function emptyProgress(): TutorialProgress {
+  return { version: 1, items: {}, achievements: {} }
+}
+
+/** 達成時刻の map として妥当なエントリだけを拾う */
+function sanitizeUnlocks(value: unknown): Unlocks {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return {}
+  }
+  const out: Unlocks = {}
+  for (const [key, at] of Object.entries(value)) {
+    if (typeof at === 'number' && Number.isFinite(at)) out[key] = at
+  }
+  return out
+}
+
+/**
+ * 保存内容を読む。壊れていても例外を投げず空の進捗に倒す
+ * (達成記録が読めないだけでチュートリアルが開けなくなることは避ける)。
+ */
+export function parseTutorialProgress(content: string): TutorialProgress {
+  let raw: unknown
+  try {
+    raw = JSON5.parse(content)
+  } catch {
+    return emptyProgress()
+  }
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return emptyProgress()
+  }
+  const obj = raw as Record<string, unknown>
+  return {
+    version: 1,
+    items: sanitizeUnlocks(obj.items),
+    achievements: sanitizeUnlocks(obj.achievements),
+  }
+}
+
+export function serializeTutorialProgress(progress: TutorialProgress): string {
+  return `${JSON5.stringify(progress, null, 2)}\n`
+}
+
+/** 達成時刻を記録する。記録済みなら最初の時刻を残す (冪等) */
+function withUnlock(unlocks: Unlocks, key: string, at: number): Unlocks {
+  if (unlocks[key] != null) return unlocks
+  return { ...unlocks, [key]: at }
+}
+
+export function markItemDone(
+  progress: TutorialProgress,
+  stepId: string,
+  at: number,
+): TutorialProgress {
+  return { ...progress, items: withUnlock(progress.items, stepId, at) }
+}
+
+export function unlockAchievement(
+  progress: TutorialProgress,
+  categoryId: string,
+  at: number,
+): TutorialProgress {
+  return {
+    ...progress,
+    achievements: withUnlock(progress.achievements, categoryId, at),
+  }
+}
+
+/** 衝突したキーは早い達成時刻を残す */
+function mergeUnlocks(a: Unlocks, b: Unlocks): Unlocks {
+  const out: Unlocks = { ...a }
+  for (const [key, at] of Object.entries(b)) {
+    const existing = out[key]
+    out[key] = existing == null ? at : Math.min(existing, at)
+  }
+  return out
+}
+
+/**
+ * 2 つの進捗を統合する。保存は read-merge-write で行い、別ウィンドウが
+ * 書いた達成記録を上書きで消さないようにする。
+ */
+export function mergeProgress(
+  a: TutorialProgress,
+  b: TutorialProgress,
+): TutorialProgress {
+  return {
+    version: 1,
+    items: mergeUnlocks(a.items, b.items),
+    achievements: mergeUnlocks(a.achievements, b.achievements),
+  }
+}

--- a/src/settings/sections.ts
+++ b/src/settings/sections.ts
@@ -27,6 +27,9 @@ export interface SettingsSection {
 
 /** 表示順はこの配列の順 */
 export const SETTINGS_SECTIONS: readonly SettingsSection[] = [
+  // チュートリアルは達成記録を tutorial.json5 に永続化する常設のチェックリスト
+  // (#1029)。他のファイル永続化される設定と同じくここから開く
+  { window: 'tutorialEditor' },
   { window: 'appearanceEditor' },
   { window: 'aiSettings' },
   { window: 'permissions' },

--- a/src/stores/windows.ts
+++ b/src/stores/windows.ts
@@ -42,6 +42,7 @@ export type WindowType =
   | 'connections'
   | 'connectionEdit'
   | 'tutorial'
+  | 'tutorialEditor'
 
 export interface DeckWindow {
   id: string
@@ -119,6 +120,7 @@ export const useWindowsStore = defineStore('windows', () => {
     'snippetsEditor',
     'connections',
     'tutorial',
+    'tutorialEditor',
   ])
 
   // PiP WebView (別 OS ウィンドウ) 内では DeckWindow オーバーレイが存在しないため、

--- a/src/utils/achievements.ts
+++ b/src/utils/achievements.ts
@@ -3,6 +3,17 @@ export interface Achievement {
   unlockedAt: number
 }
 
+/**
+ * バッジの見た目。Misskey サーバー実績と NoteDeck 独自実績 (#1029) で
+ * 同じ描画を共有するため、グリッド側ではなくここに置く。
+ */
+export interface AchievementBadge {
+  emoji: string
+  frame: 'bronze' | 'silver' | 'gold' | 'platinum'
+  /** 解除済みのときの内側の背景。null なら frame の既定色 */
+  bg: string | null
+}
+
 export const ACHIEVEMENT_TYPES = [
   'notes1',
   'notes10',

--- a/src/utils/settingsFs.ts
+++ b/src/utils/settingsFs.ts
@@ -218,6 +218,16 @@ export async function writeTasks(content: string): Promise<void> {
   return writeRootSettingsFile('tasks.json5', content)
 }
 
+// --- Tutorial helpers (#1029) ---
+
+export async function readTutorialProgress(): Promise<string> {
+  return readRootSettingsFile('tutorial.json5')
+}
+
+export async function writeTutorialProgress(content: string): Promise<void> {
+  return writeRootSettingsFile('tutorial.json5', content)
+}
+
 // --- Navbar helpers ---
 
 export async function readNavbar(): Promise<string> {

--- a/src/windows/registry.ts
+++ b/src/windows/registry.ts
@@ -336,6 +336,13 @@ export const WINDOW_REGISTRY: Record<WindowType, WindowSpec> = {
     anchor: 'top-right',
     component: () => import('@/components/tutorial/TutorialContent.vue'),
   },
+  tutorialEditor: {
+    label: 'チュートリアル',
+    icon: 'ti ti-checkbox',
+    width: 500,
+    maxHeight: 700,
+    component: () => import('@/components/window/TutorialEditorContent.vue'),
+  },
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要

チュートリアルをカテゴリ別のチェックリストに育て、初回ウィザードから AI を外すリリース (#1012, #1029)。

API キーを持たない利用者がセットアップの途中で止まっていた問題を解消し、あわせて「何をすればいいか分からない」に対する常設の導線を用意する。

## 変更一覧

- feat(tutorial): 達成記録の保存先 tutorial.json5 を追加する (#1029)
- feat(tutorial): カテゴリ別チェックリストを追加し初回ウィザードから AI を外す (#1012, #1029)
- feat(tutorial): 実績の解除を通知欄に流し、実績カラムに並べる (#1029)
- chore: bump version to 1.44.0

## 主な変更点

### 初回ウィザードから AI を外す (#1012)

必須線は API キー不要の範囲だけで完走できるようになった。

`welcome → account-login → add-first-column → open-notifications → complete`

AI の設定は削除ではなくカテゴリ側へ移し、チェックリストから後で出会う形にした。代わりに入れた open-notifications は、ナビバーのボタンがカラムをサイドバーに開き閉じすることを教える。

### カテゴリ別チェックリストと独自実績 (#1029)

- カテゴリはドキュメント (site/) のサイドバーと同じ区切り・同じ並び。各項目から対応するページを開ける。読み進める順序とアプリを触って覚える順序を揃えるため。リンク切れはテストで検出する
- カテゴリを完走すると NoteDeck 独自の実績が解除される。項目ごとではなくカテゴリ単位にして、実績を「習熟の記録」に留める
- 達成は tutorial.json5 に永続化し、設定のバックアップ対象に含める
- 解除は既存の通知欄と実績カラムで受ける。通知はサーバーにもキャッシュにも書かず達成記録から表示時に合成するので、続き読み込みの cursor には渡らず未読バッジも増やさない

## 確認

- typecheck / docs-lint / biome: 問題なし
- cargo test: 290 件通過 (openapi スナップショット含む)
- vitest: 2724/2725。`mediaProxy.dom.test.ts` の 1 件はフルラン時のみ 5s タイムアウトする既知の flaky で、単独実行では通る。本リリースの変更範囲外
- 実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tutorial checklist editor with categorized steps, progress tracking, resume/replay controls, documentation links, and reset options.
  * Tutorial progress now persists across sessions and settings backups.
  * Added tutorial achievements and notifications, integrated with achievement and notification views.
  * Added documentation links and completion indicators to tutorial steps.
  * Added tutorial access through Settings and the command palette.

* **Updates**
  * Improved achievement displays with configurable badges, labels, and categories.
  * Removed the tutorial restart action from the About window.
  * Updated the application version to 1.44.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->