### PR TITLE
コード署名の壁と Star 導線をランディングに追加

### DIFF
--- a/site/.vitepress/theme/components/landing/LandingDownload.vue
+++ b/site/.vitepress/theme/components/landing/LandingDownload.vue
@@ -73,6 +73,11 @@ onUnmounted(() => clearTimeout(resetTimer))
         </a>
       </div>
 
+      <p class="unsigned-note" data-fade>
+        Windows / macOS 版はまだコード署名なしで配布しているため、初回起動時に「発行元不明」の警告が出ます。
+        <a href="#store-distribution">警告をなくすために、協力をお願いしています</a>
+      </p>
+
       <div class="install-alt acrylic" data-fade>
         <h3>パッケージマネージャー</h3>
         <button
@@ -113,16 +118,28 @@ onUnmounted(() => clearTimeout(resetTimer))
         </button>
       </div>
 
-      <!-- Mobile Store Distribution -->
+      <!-- 配布の壁（署名 / ストア）と、協力のお願い -->
       <div id="store-distribution" class="store-distribution" data-fade>
         <h3 class="store-distribution-title">
-          <b class="u-line">スマホ版を、ストアで届けるために</b>
+          <b class="u-line">警告なしで、ストアから届けるために</b>
         </h3>
         <p class="store-distribution-lead">
-          Google Play / App Store
-          への正式配布には、開発者アカウントの登録費とクローズドテストの参加者が必要です。需要があれば、コミュニティの皆さんと一緒に進めたいと思っています。
+          デスクトップ版の「発行元不明」警告も、Google Play / App
+          Store への正式配布も、残っているのは技術ではなく手続きの壁です。プロジェクトが知られていることと、開発者アカウントの費用。コミュニティの皆さんと一緒に越えたいと思っています。
         </p>
         <div class="store-cta-grid">
+          <div class="store-cta">
+            <h4>GitHub で Star をつける</h4>
+            <p>
+              Windows 向けの OSS 無料コード署名（SignPath
+              Foundation）は「誰も知らないソースコードには署名できない」として、実際に使われている実績を審査で見ています。Star
+              とダウンロード数がそのまま材料になります。クリック 1 回でできる、いちばん手軽な後押しです。
+            </p>
+            <a href="https://github.com/notedeck-dev/notedeck" class="btn btn-accent shadow">
+              <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2l2.9 6.26 6.86.72-5.12 4.6 1.45 6.72L12 16.9l-6.09 3.4 1.45-6.72-5.12-4.6 6.86-.72L12 2z" /></svg>
+              GitHub で Star
+            </a>
+          </div>
           <div class="store-cta">
             <h4>ベータテスター募集</h4>
             <p>
@@ -140,9 +157,10 @@ onUnmounted(() => clearTimeout(resetTimer))
           <div class="store-cta">
             <h4>開発を支援する</h4>
             <p>
-              Google Play（登録費 $25）/ Apple Developer Program（$99/年）のアカウント費用、テスト機材の調達、継続的な配布作業の維持にあてさせていただきます。
+              Google Play（登録費 $25）/ Apple Developer Program（$99/年）のアカウント費用、テスト機材の調達、継続的な配布作業の維持にあてさせていただきます。macOS
+              の Gatekeeper 警告をなくす公証（notarization）にも、同じ Apple Developer Program が要ります。
             </p>
-            <a href="https://github.com/sponsors/hitalin" class="btn btn-accent shadow">
+            <a href="https://github.com/sponsors/hitalin" class="btn btn-plain shadow">
               GitHub Sponsor
             </a>
           </div>

--- a/site/.vitepress/theme/landing.css
+++ b/site/.vitepress/theme/landing.css
@@ -537,6 +537,13 @@
   letter-spacing: 0.03em; white-space: nowrap;
 }
 
+.unsigned-note {
+  margin-top: var(--space-md);
+  text-align: center;
+  color: var(--text-muted); font-size: var(--text-xs);
+  max-width: 68ch; margin-inline: auto;
+}
+
 .install-alt { margin-top: var(--space-md); padding: var(--space-lg); }
 .install-alt h3 {
   font-size: var(--text-sm); font-weight: 700;
@@ -592,9 +599,10 @@
   max-width: 62ch; margin-inline: auto;
 }
 .store-cta-grid {
-  display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-md); margin-top: var(--space-lg);
 }
+@media (max-width: 1000px) { .store-cta-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
 @media (max-width: 800px) { .store-cta-grid { grid-template-columns: minmax(0, 1fr); } }
 .store-cta {
   background: var(--tint);
@@ -611,6 +619,10 @@
 }
 .store-cta p { font-size: var(--text-sm); flex: 1; }
 .store-cta .btn { margin-top: var(--space-md); }
+.btn-icon {
+  width: 16px; height: 16px; fill: currentColor;
+  margin-right: var(--space-2xs); flex: none;
+}
 
 /* ===== Reduced motion ===== */
 @media (prefers-reduced-motion: reduce) {

--- a/site/docs/install.md
+++ b/site/docs/install.md
@@ -27,6 +27,17 @@ nix run github:notedeck-dev/notedeck
 
 :::
 
+## 初回起動時の警告
+
+Windows / macOS 版はまだコード署名なしで配布しているため、初回起動時に「発行元不明」の警告が出ます。
+
+- **Windows**: SmartScreen の画面で「詳細情報」→「実行」
+- **macOS**: Finder でアプリを右クリック →「開く」→ もう一度「開く」（システム設定 →「プライバシーとセキュリティ」から許可する方法もあります）
+
+署名がないのはコストと審査の問題で、悪意のあるコードが入っているわけではありません。配布物は GitHub Actions が公開リポジトリのソースからビルドしており、`SHA256SUMS.txt` でハッシュを検証できます。
+
+警告をなくすには、Windows は OSS 向け無料コード署名（[SignPath Foundation](https://signpath.org/)）の審査を通すこと、macOS は Apple Developer Program での公証（notarization）が必要です。SignPath Foundation は「誰も知らないソースコードには署名できない」として実際に使われている実績を見るため、[GitHub の Star](https://github.com/notedeck-dev/notedeck) とダウンロード数がそのまま材料になります。協力できる方は[ダウンロードページ下部の案内](/#store-distribution)を見てください。
+
 ## モバイル
 
 Android は `.apk` を直接インストールします。提供元不明のアプリのインストール許可を求められたら、許可してください。


### PR DESCRIPTION
## なぜ

Windows / macOS 版は未署名で配布しているため初回起動で「発行元不明」の警告が出るが、ランディングにもドキュメントにもその事実と、解消に向けた導線がなかった。

Windows 向けの OSS 無料コード署名（[SignPath Foundation](https://signpath.org/terms.html)）は「誰も知らないソースコードには署名できない」として、実際に使われている実績を審査で見ている（形式的な Star 数の閾値はない）。つまり Star とダウンロード数がそのまま材料になる。

一方 macOS の公証は Apple Developer Program の年会費のみが壁で、こちらは Star ではなく Sponsor が効く。Google Play / App Store の「Coming soon」カードが `#store-distribution` に飛ばしているのと同じ形で、デスクトップ側にも導線を用意した。

## 変更

- **ダウンロード**: プラットフォーム一覧の下に未署名の注記を追加し、`#store-distribution` へ飛ばす
- **`#store-distribution`**: ストア配布専用から「配布の壁」全般に一般化。`GitHub で Star` カードを追加して 3 カラム化し、primary CTA を Star に移動（Sponsor は plain に降格）。Sponsor カードに macOS 公証の話を追記
- **`site/docs/install.md`**: 「初回起動時の警告」節を追加（SmartScreen / Gatekeeper の回避手順、ビルドの検証可能性、Star 導線）

アンカー ID `#store-distribution` は既存リンクのため据え置き。

## 確認

- `pnpm docs:build` 成功
- pre-commit（docs-lint / biome / typecheck）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear Windows and macOS warnings for unsigned downloads, with guidance for proceeding safely.
  * Expanded distribution information to cover desktop code signing, mobile stores, and macOS notarization.
  * Added a GitHub Star call to action and updated support options.
* **Documentation**
  * Added instructions for handling first-launch signing warnings, verifying downloads, and understanding signing requirements.
* **Style**
  * Improved distribution card layout across screen sizes and refined button and icon styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->