### PR TITLE
Release v1.49.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.49.0",
+  "version": "1.49.1",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.49.0"
+version = "1.49.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.49.0"
+version = "1.49.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.49.0"
+    "version": "1.49.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/stores/theme.dom.test.ts
+++ b/src/stores/theme.dom.test.ts
@@ -1,5 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DARK_BASE, DARK_THEME } from '@/theme/builtinThemes'
+import { compileMisskeyTheme } from '@/theme/compiler'
 import type { MisskeyTheme } from '@/theme/types'
 import { STORAGE_KEYS } from '@/utils/storage'
 import { useThemeStore } from './theme'
@@ -213,5 +215,52 @@ describe('useThemeStore.unlinkAccountFromTheme — #988', () => {
     const undo = store.unlinkAccountFromTheme(RED.id, 'acc-1')
     expect(undo).toBeUndefined()
     expect(store.installedThemes[0]?.$notedeck?.installedFor).toEqual(['acc-2'])
+  })
+})
+
+describe('useThemeStore.getStyleVarsForAccount — グローバルテーマの適用範囲 (#1046)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  /** グローバルにカスタムテーマ RED を選択した dark モードの状態を作る */
+  function selectRedGlobally() {
+    const store = useThemeStore()
+    store.manualMode = 'dark'
+    store.installedThemes = [RED]
+    store.selectedDarkThemeId = RED.id
+    store.applyCurrentTheme()
+    return store
+  }
+
+  it('per-account テーマが無いアカウントのカラムには組込テーマを当てる', () => {
+    const store = selectRedGlobally()
+
+    const vars = store.getStyleVarsForAccount('acc-no-theme')
+
+    const builtin = compileMisskeyTheme(DARK_THEME, DARK_BASE)
+    expect(vars?.['--nd-bg']).toBe(builtin.bg)
+    expect(vars?.['--nd-bg']).not.toBe(RED.props.bg)
+  })
+
+  it('per-account テーマを持つアカウントのカラムにはそのテーマを当てる', () => {
+    const store = selectRedGlobally()
+    store.accountThemeCache = new Map([['acc-1', { dark: BLUE }]])
+
+    const vars = store.getStyleVarsForAccount('acc-1')
+
+    expect(vars?.['--nd-bg']).toBe(BLUE.props.bg)
+  })
+
+  it('セーフモード中はカラムに何も当てない (組込テーマがグローバルに当たっている)', () => {
+    localStorage.setItem(STORAGE_KEYS.safeMode, 'true')
+    const store = selectRedGlobally()
+
+    expect(store.getStyleVarsForAccount('acc-no-theme')).toBeUndefined()
   })
 })

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -781,17 +781,20 @@ export const useThemeStore = defineStore('theme', () => {
     if (compiledCache.has(cacheKey)) return compiledCache.get(cacheKey) ?? null
 
     const cached = accountThemeCache.value.get(accountId)
-    if (!cached) return null
 
     const dark = isCurrentDark()
     // mode strict: dark モード時は dark のみ、light モード時は light のみ。
     // sync が無ければ meta default を fallback とする (registry sync 削除後も
     // インスタンスデフォルトが残っていれば反映される)。クロスモードの fallback
     // はしない (dark モードで light が当たる混乱を避ける)。
-    const theme = dark
-      ? (cached.dark ?? cached.metaDark)
-      : (cached.light ?? cached.metaLight)
-    if (!theme) return null
+    const accountTheme = dark
+      ? (cached?.dark ?? cached?.metaDark)
+      : (cached?.light ?? cached?.metaLight)
+
+    // per-account テーマが無ければ組込テーマへ落とす (#1046)。グローバルの
+    // カスタムテーマはアカウントに紐づかないカラム (アカウントなし / 全
+    // アカウント) のものなので、アカウントのカラムに継承させない。
+    const theme = accountTheme ?? (dark ? DARK_THEME : LIGHT_THEME)
 
     const base = dark ? DARK_BASE : LIGHT_BASE
     const compiled = compileMisskeyTheme(theme, base)

--- a/tests/stores/theme.test.ts
+++ b/tests/stores/theme.test.ts
@@ -4,7 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Account } from '@/stores/accounts'
 import { useAccountsStore } from '@/stores/accounts'
 import { useThemeStore } from '@/stores/theme'
-import { DARK_THEME, LIGHT_THEME } from '@/theme/builtinThemes'
+import {
+  DARK_BASE,
+  DARK_THEME,
+  LIGHT_BASE,
+  LIGHT_THEME,
+} from '@/theme/builtinThemes'
+import { compileMisskeyTheme } from '@/theme/compiler'
 
 function makeAccount(id: string): Account {
   return {
@@ -206,9 +212,14 @@ describe('theme store', () => {
 
   // --- getCompiledForAccount ---
 
-  it('getCompiledForAccount() returns null for unknown account', () => {
+  it('getCompiledForAccount() falls back to the builtin theme for unknown account', () => {
+    // per-account テーマを持たないアカウントは組込テーマを当てる。グローバルの
+    // カスタムテーマをカラムへ継承させないため (#1046)。
     const store = useThemeStore()
-    expect(store.getCompiledForAccount('unknown-acc')).toBeNull()
+    store.applySource({ kind: 'builtin-dark', theme: DARK_THEME })
+
+    const compiled = store.getCompiledForAccount('unknown-acc')
+    expect(compiled).toEqual(compileMisskeyTheme(DARK_THEME, DARK_BASE))
   })
 
   it('getCompiledForAccount() compiles and caches theme', async () => {
@@ -256,11 +267,11 @@ describe('theme store', () => {
     expect(compiled?.bg).toBe('#eee')
   })
 
-  it('getCompiledForAccount() returns null when current mode theme is missing (no cross-mode fallback)', async () => {
+  it('getCompiledForAccount() falls back to the builtin theme when current mode theme is missing (no cross-mode fallback)', async () => {
     // dark モードで適用するテーマしか持たないアカウント。light モードでは
-    // 該当テーマが無いので null を返す (デッキ全体の builtin にフォールバック)。
-    // 旧実装は cross-mode で dark を当てていたが、dark/light が混在表示される
-    // 混乱を避けるため mode strict 化 (#339)。
+    // 該当テーマが無いので組込テーマを当てる。旧実装は cross-mode で dark を
+    // 当てていたが、dark/light が混在表示される混乱を避けるため mode strict
+    // 化 (#339)。
     mockFetchTheme.mockResolvedValue({
       status: 'ok',
       data: { metaDark: JSON.stringify({ name: 'D', props: { bg: '#222' } }) },
@@ -272,7 +283,7 @@ describe('theme store', () => {
     await store.fetchAccountTheme('acc-fb')
 
     const compiled = store.getCompiledForAccount('acc-fb')
-    expect(compiled).toBeNull()
+    expect(compiled).toEqual(compileMisskeyTheme(LIGHT_THEME, LIGHT_BASE))
   })
 
   it('applySource() clears compiled cache so columns recompile', async () => {


### PR DESCRIPTION
## 変更

v1.49.0 に対する修正リリース。

- fix: グローバルカスタムテーマをアカウントのカラムに継承させない (#1046)
- chore: bump version to 1.49.1

## 修正内容

per-account テーマを持たないアカウントのカラムは CSS 変数を一切当てていなかったため、`:root` に適用されたグローバルのカスタムテーマをそのまま継承していた。`getCompiledForAccount` が per-account テーマ不在時に組込テーマを返すようにして、グローバルのカスタムテーマを `accountId` を持たないカラム (アカウントなし / 全アカウント) に限定する。

mode strict (#339) とセーフモード (#794) の挙動は変えていない。

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme handling by automatically applying the appropriate built-in light or dark theme when no account-specific theme is available.
  * Preserved mode-specific behavior, preventing themes from the wrong display mode from being used.
  * Safe mode continues to avoid applying custom style variables.

* **Tests**
  * Added coverage for built-in theme fallback, account-specific themes, mode matching, and safe mode behavior.

* **Chores**
  * Updated the application and API version to 1.49.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->