### PR TITLE
Release v1.51.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.50.0",
+  "version": "1.51.0",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.50.0"
+version = "1.51.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.50.0"
+version = "1.51.0"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.50.0"
+    "version": "1.51.0"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -734,7 +734,7 @@ export function buildColumnDefaults(
   const spec = COLUMN_REGISTRY[type]
   return {
     name: spec?.label ?? type,
-    width: spec?.defaultWidth ?? 360,
+    width: spec?.defaultWidth ?? 330,
     accountId,
     active: true,
     ...spec?.defaultProps,

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -722,6 +722,13 @@ export function unregisterColumnType(type: string): void {
 }
 
 /**
+ * カラムの既定幅。ナビバーをアイコンのみ (80px) に畳んだ 1920px 幅の画面で、
+ * カラムが 5 本並んでも横スクロールが出ない値にしている:
+ * 80 + 左右 padding 12 + gap 6×9 + 列リサイズハンドル 4×5 + 350×5 = 1916px。
+ */
+export const DEFAULT_COLUMN_WIDTH = 350
+
+/**
  * カラム追加時の共通デフォルト。呼び出し側は type/accountId を指定するだけでよい。
  * `defaultProps` が `accountId` を含む場合はそれが優先される (accountIndependent 用)。
  */
@@ -734,7 +741,7 @@ export function buildColumnDefaults(
   const spec = COLUMN_REGISTRY[type]
   return {
     name: spec?.label ?? type,
-    width: spec?.defaultWidth ?? 360,
+    width: spec?.defaultWidth ?? DEFAULT_COLUMN_WIDTH,
     accountId,
     active: true,
     ...spec?.defaultProps,

--- a/src/columns/registry.ts
+++ b/src/columns/registry.ts
@@ -734,7 +734,7 @@ export function buildColumnDefaults(
   const spec = COLUMN_REGISTRY[type]
   return {
     name: spec?.label ?? type,
-    width: spec?.defaultWidth ?? 330,
+    width: spec?.defaultWidth ?? 360,
     accountId,
     active: true,
     ...spec?.defaultProps,

--- a/src/components/common/AccountPickerRow.vue
+++ b/src/components/common/AccountPickerRow.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+/**
+ * アカウント選択の 1 行 (#1018)。
+ *
+ * 正本はナビバーのアカウント一覧の見た目 — アバター (サーバーバッジ付き) +
+ * ラベル + 次段がある場合の chevron。ノートの「別のアカウントで…」/ ウィジェット
+ * の実行アカウント選択 / カラム追加のアカウント選択がそれぞれ別の見た目だった
+ * のを、この行に揃える。
+ *
+ * アバターは slot — ナビバーのオンライン状態インジケータのように、面ごとに
+ * 重ねたいものがあるため。省略時は呼び出し側が AccountAvatar を渡す。
+ */
+defineProps<{
+  label: string
+  /** 選択中 / 展開中の行を示す */
+  active?: boolean
+  /** この行を選ぶと次の段がある (chevron を出す) */
+  hasNext?: boolean
+  disabled?: boolean
+}>()
+</script>
+
+<template>
+  <button
+    class="_button"
+    :class="[$style.row, active && $style.rowActive]"
+    :disabled="disabled"
+  >
+    <slot name="avatar" />
+    <span :class="$style.label">{{ label }}</span>
+    <slot name="trailing">
+      <i v-if="hasNext" class="ti ti-chevron-right" :class="$style.chevron" />
+    </slot>
+  </button>
+</template>
+
+<style lang="scss" module>
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 12px;
+  min-height: 44px;
+  width: 100%;
+  font-size: 0.85em;
+  color: var(--nd-fg);
+  white-space: nowrap;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--nd-duration-fast);
+
+  &:hover {
+    background: var(--nd-buttonHoverBg);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.rowActive {
+  background: var(--nd-buttonHoverBg);
+  color: var(--nd-fgHighlighted);
+}
+
+.label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chevron {
+  margin-left: auto;
+  font-size: 0.75em;
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/common/AccountPickerSheet.vue
+++ b/src/components/common/AccountPickerSheet.vue
@@ -1,0 +1,155 @@
+<script setup lang="ts">
+/**
+ * アカウント選択のボトムシート (#1018)。コンパクト表示専用。
+ *
+ * ナビバーのアカウント一覧が唯一まともなアカウント選択 UI だったので、それを
+ * 共通化した。中央ダイアログやコマンドパレットで選ばせていた面も、コンパクト
+ * 表示ではこのシートに寄せる。
+ *
+ * 2 段選択 (アカウント → 操作) は `stage` で切り替える。段が変わってもシートは
+ * 開いたままなので、開き直しのアニメーションが挟まらない。
+ */
+import { computed, ref, toRef } from 'vue'
+import AccountAvatar from '@/components/common/AccountAvatar.vue'
+import AccountPickerRow from '@/components/common/AccountPickerRow.vue'
+import { useBackButton } from '@/composables/useBackButton'
+import { useNativeDialog } from '@/composables/useNativeDialog'
+import { useVaporTransition } from '@/composables/useVaporTransition'
+import {
+  type Account,
+  getAccountAvatarUrl,
+  getAccountLabel,
+} from '@/stores/accounts'
+
+const props = defineProps<{
+  show: boolean
+  accounts: Account[]
+  /** シート見出し。省略すると見出し行を出さない (ナビバーの一覧など) */
+  title?: string
+  /** 何のために選ぶのか。title の下に小さく出す */
+  description?: string
+  /** 展開中のアカウント (ナビバーのように行から次のメニューを開く面で使う) */
+  activeId?: string | null
+  /** 行に chevron を出す (選ぶと次の段がある) */
+  hasNext?: boolean
+  /** 行ごとの追加クラス (ナビバーの AI Spotlight リングなど) */
+  rowClass?: (accountId: string) => unknown
+  /** 'detail' なら一覧の代わりに #detail を出す (2 段選択の 2 段目) */
+  stage?: 'accounts' | 'detail'
+}>()
+
+const emit = defineEmits<{
+  select: [accountId: string]
+  close: []
+}>()
+
+const { visible, leaving } = useVaporTransition(toRef(props, 'show'), {
+  enterDuration: 200,
+  leaveDuration: 200,
+})
+
+const dialogRef = ref<HTMLDialogElement | null>(null)
+
+useNativeDialog(
+  dialogRef,
+  computed(() => visible.value),
+  {
+    onCancel: () => emit('close'),
+    leaveDuration: 200,
+  },
+)
+
+useBackButton(
+  computed(() => props.show),
+  () => emit('close'),
+)
+</script>
+
+<template>
+  <dialog
+    v-if="visible"
+    ref="dialogRef"
+    class="_nativeDialog"
+    :class="[$style.mobileBackdrop, leaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+  >
+    <!-- シート内のクリックは外に漏らさない (ナビバーの document click ハンドラ
+         のような「外側クリックで閉じる」処理に拾われないように) -->
+    <div
+      autofocus
+      tabindex="-1"
+      :class="[$style.sheet, leaving ? $style.sheetContentLeave : $style.sheetContentEnter]"
+      @click.stop
+    >
+      <div v-if="title || description" :class="$style.header">
+        <div v-if="title" :class="$style.title">{{ title }}</div>
+        <div v-if="description" :class="$style.description">{{ description }}</div>
+      </div>
+
+      <slot v-if="stage === 'detail'" name="detail" />
+      <template v-else>
+        <AccountPickerRow
+          v-for="account in accounts"
+          :key="account.id"
+          :class="rowClass?.(account.id)"
+          :label="getAccountLabel(account)"
+          :active="activeId === account.id"
+          :has-next="hasNext"
+          @click="emit('select', account.id)"
+        >
+          <template #avatar>
+            <slot name="avatar" :account="account">
+              <AccountAvatar
+                :src="getAccountAvatarUrl(account)"
+                :host="account.host"
+                :size="32"
+                show-server
+                badge-background="var(--nd-navBg)"
+              />
+            </slot>
+          </template>
+        </AccountPickerRow>
+        <slot name="footer" />
+      </template>
+    </div>
+  </dialog>
+</template>
+
+<style lang="scss" module>
+@use '@/styles/navMenu';
+
+.sheet {
+  width: 100%;
+  margin: 0;
+  padding: 8px 0 calc(8px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
+  border-radius: 16px 16px 0 0;
+  background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+  max-height: 80vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+
+  &:focus,
+  &:focus-visible {
+    outline: none;
+  }
+}
+
+.header {
+  padding: 6px 16px 8px;
+}
+
+.title {
+  font-size: 0.9em;
+  font-weight: bold;
+  color: var(--nd-fg);
+}
+
+.description {
+  margin-top: 2px;
+  font-size: 0.78em;
+  color: var(--nd-fg);
+  opacity: 0.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+</style>

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -1772,14 +1772,12 @@ function handlePickerReaction(reaction: string) {
 }
 
 /* Container query responsive breakpoints */
-/* アバターはカラム幅に応じて縮める (本家と同じ 58 → 50 → 46 → 44)。
-   MkAvatar は --avatar-size をインライン style で持っていて外から変数を
-   上書きできないので、寸法を直接指定する。MkAvatar 側の width/height と
-   同じ特異度だと読み込み順に依存するため (0,2,0) に上げる (#1045) */
+/* アバターはカラム幅で縮めない (#1045)。本家は 58 → 50 → 46 → 44 と
+   縮めるが、デッキの狭いカラムでは顔が小さくなって見分けにくくなるので
+   58px 固定のままにする */
 @container (max-width: 580px) {
   .noteRoot { font-size: 0.95em; }
   .article { padding: 24px 26px; }
-  .avatar.avatar { width: 50px; height: 50px; }
   .renoteInfo { padding: 12px 26px 6px 26px; }
   .pinnedInfo { padding: 10px 26px 0 26px; }
   .replyTo { padding: 10px 26px 0 26px; }
@@ -1804,7 +1802,6 @@ function handlePickerReaction(reaction: string) {
 
 @container (max-width: 450px) {
   .avatar { margin: 0 10px 0 0; }
-  .avatar.avatar { width: 46px; height: 46px; }
 }
 
 @container (max-width: 400px) {
@@ -1817,7 +1814,6 @@ function handlePickerReaction(reaction: string) {
 }
 
 @container (max-width: 300px) {
-  .avatar.avatar { width: 44px; height: 44px; }
   .footerButton { margin-right: 8px; }
   .reaction { height: 32px; font-size: 1em; border-radius: 4px; }
   .reaction .count { font-size: 0.9em; line-height: 32px; }

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -1772,9 +1772,14 @@ function handlePickerReaction(reaction: string) {
 }
 
 /* Container query responsive breakpoints */
+/* アバターはカラム幅に応じて縮める (本家と同じ 58 → 50 → 46 → 44)。
+   MkAvatar は --avatar-size をインライン style で持っていて外から変数を
+   上書きできないので、寸法を直接指定する。MkAvatar 側の width/height と
+   同じ特異度だと読み込み順に依存するため (0,2,0) に上げる (#1045) */
 @container (max-width: 580px) {
   .noteRoot { font-size: 0.95em; }
   .article { padding: 24px 26px; }
+  .avatar.avatar { width: 50px; height: 50px; }
   .renoteInfo { padding: 12px 26px 6px 26px; }
   .pinnedInfo { padding: 10px 26px 0 26px; }
   .replyTo { padding: 10px 26px 0 26px; }
@@ -1799,6 +1804,7 @@ function handlePickerReaction(reaction: string) {
 
 @container (max-width: 450px) {
   .avatar { margin: 0 10px 0 0; }
+  .avatar.avatar { width: 46px; height: 46px; }
 }
 
 @container (max-width: 400px) {
@@ -1811,6 +1817,7 @@ function handlePickerReaction(reaction: string) {
 }
 
 @container (max-width: 300px) {
+  .avatar.avatar { width: 44px; height: 44px; }
   .footerButton { margin-right: 8px; }
   .reaction { height: 32px; font-size: 1em; border-radius: 4px; }
   .reaction .count { font-size: 0.9em; line-height: 32px; }

--- a/src/components/common/NoteMoreMenu.vue
+++ b/src/components/common/NoteMoreMenu.vue
@@ -26,6 +26,7 @@ import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { getNoteShareUrl } from '@/utils/noteUrl'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import { isWindowExposed } from '@/windows/exposure'
+import AccountPickerSheet from './AccountPickerSheet.vue'
 import PopupMenu from './PopupMenu.vue'
 
 const props = defineProps<{
@@ -58,27 +59,20 @@ const popupMenuRef = ref<InstanceType<typeof PopupMenu>>()
 const showDeleteConfirm = ref(false)
 const showDeleteAndEditConfirm = ref(false)
 const showReportForm = ref(false)
-// compact ではコマンドパレットが無いので、シート内で 2 段選択する (#627)
+// compact ではコマンドパレットが無いので、アカウント選択シートで 2 段選択する
+// (#627 / #1018 — 選ばせ方はナビバーのアカウント一覧に揃える)
 const showActAs = ref(false)
 const actAsAccountId = ref<string | null>(null)
 const reportComment = ref('')
 const localIsFavorited = ref(props.isFavorited)
 const localIsPinned = ref(props.isPinned)
 
-type MenuView =
-  | 'main'
-  | 'deleteConfirm'
-  | 'deleteAndEditConfirm'
-  | 'reportForm'
-  | 'actAsAccounts'
-  | 'actAsOperations'
+type MenuView = 'main' | 'deleteConfirm' | 'deleteAndEditConfirm' | 'reportForm'
 
 const currentView = computed<MenuView>(() => {
   if (showDeleteConfirm.value) return 'deleteConfirm'
   if (showDeleteAndEditConfirm.value) return 'deleteAndEditConfirm'
   if (showReportForm.value) return 'reportForm'
-  if (showActAs.value)
-    return actAsAccountId.value ? 'actAsOperations' : 'actAsAccounts'
   return 'main'
 })
 
@@ -114,9 +108,22 @@ function resetSubViews() {
   showDeleteConfirm.value = false
   showDeleteAndEditConfirm.value = false
   showReportForm.value = false
+  reportComment.value = ''
+}
+
+/** アカウント選択シートを閉じる (メニュー本体は既に閉じている) */
+function closeActAs() {
   showActAs.value = false
   actAsAccountId.value = null
-  reportComment.value = ''
+}
+
+function actAs(op: 'reactAs' | 'renoteAs' | 'quoteAs') {
+  const accountId = actAsAccountId.value
+  closeActAs()
+  if (!accountId) return
+  if (op === 'reactAs') emit('reactAs', accountId)
+  else if (op === 'renoteAs') emit('renoteAs', accountId)
+  else emit('quoteAs', accountId)
 }
 
 function backToMain() {
@@ -267,10 +274,14 @@ function actAsOperations(accountId: string) {
 }
 
 function openActAs() {
-  // compact はコマンドパレットが無い (TitleBar ごと非表示) ので
-  // ボトムシートの中で同じ 2 段選択を再現する
+  // compact はコマンドパレットが無い (TitleBar ごと非表示) ので、共通の
+  // アカウント選択シートで同じ 2 段選択を再現する。メニュー自身もシートなので、
+  // 閉じ切ってから開く (dialog が重ならないように)
   if (isCompact.value) {
-    showActAs.value = true
+    close()
+    setTimeout(() => {
+      showActAs.value = true
+    }, 200)
     return
   }
   close()
@@ -369,45 +380,6 @@ defineExpose({ open })
     </template>
 
 
-
-    <!-- 別のアカウントで… (compact のみ): アカウント選択 -->
-    <template v-else-if="currentView === 'actAsAccounts'">
-      <div class="_popupConfirmText">別のアカウントで…</div>
-      <button
-        v-for="acc in actAsCandidates"
-        :key="acc.id"
-        class="_popupItem"
-        @click="actAsAccountId = acc.id"
-      >
-        <img :src="proxyThumbUrl(getAccountAvatarUrl(acc), 18)" :class="$style.actAsAvatar" alt="" />
-        {{ getAccountLabel(acc) }}
-      </button>
-      <button class="_popupItem" @click="backToMain">
-        <i class="ti ti-arrow-left" />
-        戻る
-      </button>
-    </template>
-
-    <!-- 別のアカウントで… (compact のみ): 操作選択 -->
-    <template v-else-if="currentView === 'actAsOperations'">
-      <div class="_popupConfirmText">{{ actAsAccountLabel }}</div>
-      <button class="_popupItem" @click="emit('reactAs', actAsAccountId!); close()">
-        <i class="ti ti-mood-plus" />
-        リアクション
-      </button>
-      <button class="_popupItem" @click="emit('renoteAs', actAsAccountId!); close()">
-        <i class="ti ti-repeat" />
-        リノート
-      </button>
-      <button class="_popupItem" @click="emit('quoteAs', actAsAccountId!); close()">
-        <i class="ti ti-quote" />
-        引用
-      </button>
-      <button class="_popupItem" @click="actAsAccountId = null">
-        <i class="ti ti-arrow-left" />
-        戻る
-      </button>
-    </template>
 
     <!-- Report form -->
     <template v-else-if="currentView === 'reportForm'">
@@ -516,15 +488,35 @@ defineExpose({ open })
       </template>
     </template>
   </PopupMenu>
-</template>
 
-<style lang="scss" module>
-// 「別のアカウントで…」のアカウント行アバター (._popupItem .ti と同じ幅に揃える)
-.actAsAvatar {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  object-fit: cover;
-}
-</style>
+  <!-- 別のアカウントで… (compact のみ): アカウント選択 → 操作選択の 2 段 -->
+  <AccountPickerSheet
+    :show="showActAs"
+    :accounts="actAsCandidates"
+    :title="actAsAccountId ? actAsAccountLabel : '別のアカウントで…'"
+    :description="actAsAccountId ? undefined : 'このノートを操作するアカウント'"
+    :stage="actAsAccountId ? 'detail' : 'accounts'"
+    has-next
+    @select="actAsAccountId = $event"
+    @close="closeActAs"
+  >
+    <template #detail>
+      <button class="_popupItem" @click="actAs('reactAs')">
+        <i class="ti ti-mood-plus" />
+        リアクション
+      </button>
+      <button class="_popupItem" @click="actAs('renoteAs')">
+        <i class="ti ti-repeat" />
+        リノート
+      </button>
+      <button class="_popupItem" @click="actAs('quoteAs')">
+        <i class="ti ti-quote" />
+        引用
+      </button>
+      <button class="_popupItem" @click="actAsAccountId = null">
+        <i class="ti ti-arrow-left" />
+        戻る
+      </button>
+    </template>
+  </AccountPickerSheet>
+</template>

--- a/src/components/common/TitleBar.vue
+++ b/src/components/common/TitleBar.vue
@@ -14,7 +14,7 @@ import { openPipWindow } from '@/composables/usePipWindow'
 import { isExposed } from '@/settings/exposure'
 import { useAccountsStore } from '@/stores/accounts'
 import { useDeckStore } from '@/stores/deck'
-import { useIsCompactLayout, useUiStore } from '@/stores/ui'
+import { MOBILE_WINDOW_SIZE, useIsCompactLayout, useUiStore } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
 import { buildWindowUri } from '@/windows/registry'
 
@@ -64,9 +64,6 @@ const titleBarText = computed(() => {
   return `NoteDeck${suffix}`
 })
 const isMaximized = ref(false)
-
-const MOBILE_WIDTH = 420
-const MOBILE_HEIGHT = 780
 
 let savedDesktopSize: { width: number; height: number } | null = null
 
@@ -122,7 +119,9 @@ async function toggleMobileSize() {
       width: window.innerWidth,
       height: window.innerHeight,
     }
-    await appWindow.setSize(new LogicalSize(MOBILE_WIDTH, MOBILE_HEIGHT))
+    await appWindow.setSize(
+      new LogicalSize(MOBILE_WINDOW_SIZE.width, MOBILE_WINDOW_SIZE.height),
+    )
   }
   await appWindow.center()
 }

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -284,7 +284,7 @@ async function createNewItem() {
     finalizeColumn({
       type: config.type,
       name: colName,
-      width: 360,
+      width: 330,
       accountId,
       [config.spec.idKey]: created.id,
       active: true,
@@ -306,7 +306,7 @@ function addSelectableColumn(item: SelectableItem) {
   finalizeColumn({
     type: config.type,
     name,
-    width: 360,
+    width: 330,
     accountId,
     [config.spec.idKey]: item.id,
     active: true,

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -9,6 +9,7 @@ import {
   COLUMN_LABELS,
   COLUMN_REGISTRY,
   CROSS_ACCOUNT_TYPES,
+  DEFAULT_COLUMN_WIDTH,
   GUEST_ALLOWED_TYPES,
   type SelectableItem,
   type SelectableSpec,
@@ -284,7 +285,7 @@ async function createNewItem() {
     finalizeColumn({
       type: config.type,
       name: colName,
-      width: 360,
+      width: DEFAULT_COLUMN_WIDTH,
       accountId,
       [config.spec.idKey]: created.id,
       active: true,
@@ -306,7 +307,7 @@ function addSelectableColumn(item: SelectableItem) {
   finalizeColumn({
     type: config.type,
     name,
-    width: 360,
+    width: DEFAULT_COLUMN_WIDTH,
     accountId,
     [config.spec.idKey]: item.id,
     active: true,

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -284,7 +284,7 @@ async function createNewItem() {
     finalizeColumn({
       type: config.type,
       name: colName,
-      width: 330,
+      width: 360,
       accountId,
       [config.spec.idKey]: created.id,
       active: true,
@@ -306,7 +306,7 @@ function addSelectableColumn(item: SelectableItem) {
   finalizeColumn({
     type: config.type,
     name,
-    width: 330,
+    width: 360,
     accountId,
     [config.spec.idKey]: item.id,
     active: true,

--- a/src/components/deck/AddColumnDialog.vue
+++ b/src/components/deck/AddColumnDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch, watchEffect } from 'vue'
+import { computed, nextTick, reactive, ref, watch, watchEffect } from 'vue'
 import { exposedColumnGroups } from '@/columns/exposure'
 import {
   ACCOUNT_INDEPENDENT_TYPES,
@@ -14,6 +14,7 @@ import {
   type SelectableSpec,
 } from '@/columns/registry'
 import AccountAvatar from '@/components/common/AccountAvatar.vue'
+import AccountPickerRow from '@/components/common/AccountPickerRow.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import { showLoginPrompt } from '@/composables/useLoginPrompt'
 import { useNativeDialog } from '@/composables/useNativeDialog'
@@ -31,6 +32,7 @@ import {
 import type { ColumnType, DeckColumn } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
 import { useToast } from '@/stores/toast'
+import { useIsCompactLayout } from '@/stores/ui'
 import { logWarn } from '@/utils/logger'
 import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
@@ -62,8 +64,20 @@ const columnGroups = computed(() => exposedColumnGroups())
 
 const expandedCategories = reactive<Record<string, boolean>>({})
 
-function toggleCategory(key: string) {
-  expandedCategories[key] = !expandedCategories[key]
+/**
+ * カテゴリの開閉。シート表示は高さが限られるので、開いたカテゴリに場所を譲る —
+ * 他のカテゴリを畳んだうえで、見出しがシート上端に来るようスクロールする。
+ * (デスクトップは高さに余裕があるので複数開いたままにできる)
+ */
+function toggleCategory(key: string, event: MouseEvent) {
+  const open = !expandedCategories[key]
+  if (isSheet.value && open) {
+    for (const g of columnGroups.value) expandedCategories[g.group] = false
+  }
+  expandedCategories[key] = open
+  if (!open || !isSheet.value) return
+  const el = event.currentTarget as HTMLElement | null
+  nextTick(() => el?.scrollIntoView({ behavior: 'smooth', block: 'start' }))
 }
 
 // spotlight (チュートリアル) が特定のカラム種別を指しているときは、その種別を
@@ -302,6 +316,11 @@ function addSelectableColumn(item: SelectableItem) {
 const dialogRef = ref<HTMLDialogElement | null>(null)
 const showDialog = ref(true)
 
+// コンパクト表示では他のメニュー同様ボトムシートで出す (#1018)。PiP は
+// カラムの中身として埋め込まれるので対象外
+const isCompact = useIsCompactLayout()
+const isSheet = computed(() => isCompact.value && props.mode !== 'pip')
+
 if (props.mode !== 'pip') {
   useNativeDialog(dialogRef, showDialog, {
     onCancel: () => close(),
@@ -317,9 +336,9 @@ function close() {
   <component
     :is="mode !== 'pip' ? 'dialog' : 'div'"
     ref="dialogRef"
-    :class="[mode === 'pip' ? $style.addInline : [$style.addOverlay, '_nativeDialog']]"
+    :class="[mode === 'pip' ? $style.addInline : [$style.addOverlay, '_nativeDialog', isSheet && $style.mobileBackdrop]]"
   >
-    <div :class="mode === 'pip' ? $style.addPopupInline : $style.addPopup">
+    <div :class="[mode === 'pip' ? $style.addPopupInline : $style.addPopup, isSheet && [$style.addSheet, $style.sheetContentEnter]]">
       <div v-if="!(mode === 'pip' && !addColumnType && !selectConfig)" :class="[$style.addPopupHeader, mode === 'pip' && $style.addPopupHeaderPip]">
         <button v-if="addColumnType && !selectConfig" class="_button" :class="$style.addBackBtn" @click="addColumnType = null">
           <i class="ti ti-chevron-left" />
@@ -339,7 +358,7 @@ function close() {
           :key="g.group"
           :class="$style.addCategorySection"
         >
-          <button class="_button" :class="$style.addCategoryLabel" @click="toggleCategory(g.group)">
+          <button class="_button" :class="$style.addCategoryLabel" @click="toggleCategory(g.group, $event)">
             <i class="ti" :class="`ti-${g.icon}`" />
             {{ g.label }}
             <i class="ti ti-chevron-down" :class="[$style.chevron, { [$style.chevronOpen]: expandedCategories[g.group] }]" />
@@ -419,54 +438,55 @@ function close() {
         </button>
       </template>
 
-      <!-- Step 2: Account selection -->
+      <!-- Step 2: Account selection (行はナビバーのアカウント一覧に揃える #1018) -->
       <template v-else>
         <!-- 全アカウント: 0 件でも開ける (ナビバーのデフォルト項目がトグルで
              開けることとの整合)。1 件のときだけ per-account 選択に譲って非表示 -->
-        <button
+        <AccountPickerRow
           v-if="addColumnType && CROSS_ACCOUNT_TYPES.has(addColumnType) && accountsStore.accounts.length !== 1"
-          class="_button"
-          :class="$style.addAccountBtn"
+          label="全アカウント"
           @click="addColumnForAccount(null)"
         >
           <!-- カラムヘッダーと同じ記号で示す (#1018)。誰が含まれるかは可変な
                ので顔は並べない -->
-          <i class="ti ti-user" style="font-size: 28px;" />
-          <span>全アカウント</span>
-        </button>
-        <button
+          <template #avatar>
+            <i class="ti ti-user" :class="$style.addAccountIcon" />
+          </template>
+        </AccountPickerRow>
+        <AccountPickerRow
           v-if="addColumnType && ACCOUNT_OPTIONAL_TYPES.has(addColumnType)"
-          class="_button"
-          :class="$style.addAccountBtn"
+          label="アカウントなし"
           @click="addColumnForAccount(null)"
         >
-          <i class="ti ti-circle-off" style="font-size: 28px; opacity: 0.5;" />
-          <span>アカウントなし</span>
-        </button>
-        <button
+          <template #avatar>
+            <i class="ti ti-circle-off" :class="[$style.addAccountIcon, $style.addAccountIconMuted]" />
+          </template>
+        </AccountPickerRow>
+        <AccountPickerRow
           v-for="account in accountsStore.accounts"
           :key="account.id"
-          class="_button"
-          :class="[$style.addAccountBtn, { [$style.addAccountDisabled]: isGuestAccount(account) && requiresAuth }]"
+          :label="getAccountLabel(account)"
           :disabled="isGuestAccount(account) && requiresAuth"
           :title="isGuestAccount(account) && requiresAuth ? 'ゲストアカウントではこのカラムを使えません' : ''"
           @click="(!account.hasToken && requiresAuth) ? showLoginPrompt() : addColumnForAccount(account.id)"
         >
-          <AccountAvatar
-            :src="getAccountAvatarUrl(account)"
-            :host="account.host"
-            :size="28"
-            show-server
-            badge-background="var(--nd-popup)"
-          />
-          <span>{{ getAccountLabel(account) }}</span>
-        </button>
+          <template #avatar>
+            <AccountAvatar
+              :src="getAccountAvatarUrl(account)"
+              :host="account.host"
+              :size="32"
+              show-server
+              badge-background="var(--nd-navBg)"
+            />
+          </template>
+        </AccountPickerRow>
       </template>
     </div>
   </component>
 </template>
 
 <style lang="scss" module>
+@use '@/styles/navMenu';
 @use '@/styles/spotlight' as *;
 
 .addOverlay {
@@ -475,7 +495,8 @@ function close() {
   }
 
   @media (prefers-reduced-motion: no-preference) {
-    > .addPopup {
+    // シート表示は下からのスライド (sheetContentEnter) に任せる
+    > .addPopup:not(.addSheet) {
       animation: addPopupIn 0.2s var(--nd-ease-spring);
     }
   }
@@ -489,6 +510,17 @@ function close() {
   max-width: 480px;
   max-height: 90vh;
   overflow-y: auto;
+}
+
+/* コンパクト表示: 画面下からのシート (他のメニューと同じ形) */
+.addSheet {
+  width: 100%;
+  max-width: none;
+  max-height: 80vh;
+  border-radius: 16px 16px 0 0;
+  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
+  padding-bottom: var(--nd-safe-area-bottom, env(safe-area-inset-bottom));
+  overscroll-behavior: contain;
 }
 
 .addInline {
@@ -546,39 +578,19 @@ function close() {
   padding: 2rem;
 }
 
-.addAccountBtn {
+/* 「全アカウント」「アカウントなし」の記号。アバターと同じ枠に収める */
+.addAccountIcon {
   display: flex;
   align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 12px 24px;
-  font-size: 0.85em;
-  font-weight: bold;
-  color: var(--nd-fgHighlighted);
-  transition: background var(--nd-duration-base);
-
-  &:hover {
-    background: var(--nd-buttonHoverBg);
-  }
-
-  & + & {
-    border-top: 1px solid var(--nd-divider);
-  }
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  font-size: 24px;
+  flex-shrink: 0;
 }
 
-.addAccountDisabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-
-  &:hover {
-    background: transparent;
-  }
-}
-
-.addAccountAvatar {
-  width: 28px;
-  height: 28px;
-  border-radius: 50%;
+.addAccountIconMuted {
+  opacity: 0.5;
 }
 
 .addBackBtn {

--- a/src/components/deck/DeckBottomBar.vue
+++ b/src/components/deck/DeckBottomBar.vue
@@ -141,10 +141,10 @@ const {
   flex: 0 0 auto;
   display: flex;
   align-items: stretch;
-  margin-left: calc(-1 * (var(--nd-nav-resize-handle) + var(--nd-nav-border)));
-  padding-left: calc(var(--nd-nav-resize-handle) + var(--nd-nav-border));
+  margin-left: calc(-1 * var(--nd-nav-resize-handle));
+  padding-left: var(--nd-nav-resize-handle);
+  // 本家のボトムバーもナビバーも境界線を持たない。面は背景色だけで分ける (#1045)
   background: color-mix(in srgb, var(--nd-navBg) 50%, var(--nd-deckBg, #1a1a1a));
-  box-shadow: 0 -0.5px 0 0 var(--nd-divider);
 }
 
 .left {

--- a/src/components/deck/DeckLaunchPad.vue
+++ b/src/components/deck/DeckLaunchPad.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { computed, nextTick, ref, useCssModule, watch } from 'vue'
-import { getAccountScope } from '@/columns/accountScope'
 import { exposedColumnTypes } from '@/columns/exposure'
 import {
   ACCOUNT_INDEPENDENT_TYPES,
@@ -58,24 +57,6 @@ const items = computed<ColumnType[]>(() =>
     return CROSS_ACCOUNT_TYPES.has(t) || ACCOUNT_INDEPENDENT_TYPES.has(t)
   }),
 )
-
-/**
- * 「全アカウント」と「アカウントなし」を別の見出しで出す (#1018)。
- * 1 グループにまとめていたので、束ねるカラムとアカウントに紐づかないカラムの
- * 区別がここから伝わらなかった。
- */
-const sections = computed(() => {
-  const groups: Record<'all' | 'none', ColumnType[]> = { all: [], none: [] }
-  for (const t of items.value) {
-    const scope = getAccountScope({ type: t, accountId: null })
-    if (scope === 'all') groups.all.push(t)
-    else groups.none.push(t)
-  }
-  return [
-    { key: 'all', label: '全アカウント', types: groups.all },
-    { key: 'none', label: 'アカウントなし', types: groups.none },
-  ].filter((s) => s.types.length > 0)
-})
 
 const contentClass = computed(() => {
   if (isCompact.value) {
@@ -154,21 +135,18 @@ function close() {
       :class="contentClass"
       :style="popupStyle"
     >
-      <template v-for="section in sections" :key="section.key">
-        <div :class="$style.sectionLabel">{{ section.label }}</div>
-        <div :class="$style.grid">
-          <button
-            v-for="t in section.types"
-            :key="t"
-            class="_button"
-            :class="$style.item"
-            @click="selectItem(t)"
-          >
-            <i class="ti" :class="[$style.icon, `ti-${COLUMN_ICONS[t]}`]" />
-            <span :class="$style.label">{{ COLUMN_LABELS[t] }}</span>
-          </button>
-        </div>
-      </template>
+      <div :class="$style.grid">
+        <button
+          v-for="t in items"
+          :key="t"
+          class="_button"
+          :class="$style.item"
+          @click="selectItem(t)"
+        >
+          <i class="ti" :class="[$style.icon, `ti-${COLUMN_ICONS[t]}`]" />
+          <span :class="$style.label">{{ COLUMN_LABELS[t] }}</span>
+        </button>
+      </div>
     </div>
   </dialog>
 </template>
@@ -214,16 +192,6 @@ dialog.overlay::backdrop {
     border-radius: 16px 16px 0 0;
     box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
     padding-bottom: max(20px, var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
-  }
-}
-
-.sectionLabel {
-  font-size: 0.75em;
-  opacity: 0.6;
-  padding: 6px 4px 2px;
-
-  &:first-child {
-    padding-top: 0;
   }
 }
 

--- a/src/components/deck/DeckMemoColumn.vue
+++ b/src/components/deck/DeckMemoColumn.vue
@@ -14,7 +14,6 @@ import {
 import { type Account, useAccountsStore } from '@/stores/accounts'
 import { useConfirm } from '@/stores/confirm'
 import type { DeckColumn as DeckColumnType } from '@/stores/deck'
-import { useServersStore } from '@/stores/servers'
 import { useToast } from '@/stores/toast'
 import { useWindowsStore } from '@/stores/windows'
 import { formatScheduleAbsolute } from '@/utils/scheduleFormat'
@@ -29,7 +28,6 @@ const props = defineProps<{
 }>()
 
 const accountsStore = useAccountsStore()
-const serversStore = useServersStore()
 const windowsStore = useWindowsStore()
 const { confirm } = useConfirm()
 const toast = useToast()
@@ -44,24 +42,6 @@ const { columnThemeVars } = useColumnTheme(() => props.column)
 const account = computed<Account | undefined>(
   () => accountsStore.activeAccount ?? accountsStore.accounts[0],
 )
-
-const accountById = computed(() => {
-  const map = new Map<string, Account>()
-  for (const a of accountsStore.accounts) map.set(a.id, a)
-  return map
-})
-
-const serverInfoImageUrl = computed(() => {
-  const host = account.value?.host
-  if (!host) return undefined
-  return serversStore.getServer(host)?.infoImageUrl
-})
-
-const serverIconUrl = computed(() => {
-  const host = account.value?.host
-  if (!host) return undefined
-  return serversStore.getServer(host)?.iconUrl
-})
 
 interface MemoContext {
   kind: 'reply' | 'renote' | 'note' | 'channel-note'
@@ -261,10 +241,11 @@ function closeMenu() {
       />
     </div>
 
+    <!-- 空状態はアプリ既定のアイコン。サーバーの infoImageUrl は引かない
+         (メモはアカウント / サーバーに紐づかない — #1018) -->
     <ColumnEmptyState
       v-if="loaded && memoCount === 0"
       message="メモはありません"
-      :image-url="serverInfoImageUrl"
     />
 
     <div v-else :class="$style.list">

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -194,9 +194,12 @@ function onlineStatusClass(accountId: string): string | undefined {
 }
 
 // Navbar resize
-const MIN_WIDTH = 56
-const COLLAPSE_THRESHOLD = 120
-const DEFAULT_WIDTH = 220
+// 幅は本家 Misskey のデッキ UI に合わせる (#1045)。
+// MIN_WIDTH = navbar の --nav-icon-only-width / DEFAULT_WIDTH = --nav-width。
+// ドラッグでのリサイズと上限は NoteDeck 固有 (本家は設定でのトグルのみ)
+const MIN_WIDTH = 80
+const COLLAPSE_THRESHOLD = 140
+const DEFAULT_WIDTH = 250
 const MAX_WIDTH = 400
 const navWidth = ref(
   document.documentElement.clientWidth <= 1279 ? MIN_WIDTH : DEFAULT_WIDTH,
@@ -599,7 +602,7 @@ defineExpose({
           </button>
 
           <!-- Account button -->
-          <div :class="$style.menuWrap">
+          <div :class="[$style.menuWrap, $style.accountWrap]">
             <button
               class="_button"
               :class="$style.item"
@@ -739,11 +742,11 @@ defineExpose({
 // ============================================================
 // Left Navbar — base styles (all sizes)
 // ============================================================
+// 本家のナビバーは deckBg との境界線を持たない (背景色だけで面を分ける #1045)
 .navbar {
   flex: 0 0 auto;
   display: flex;
   background: color-mix(in srgb, var(--nd-navBg) 50%, var(--nd-deckBg, #1a1a1a));
-  border-right: var(--nd-nav-border) solid var(--nd-divider);
   position: relative;
   z-index: 1;
   container-type: inline-size;
@@ -764,12 +767,14 @@ defineExpose({
   }
 }
 
+// 本家 navbar の --top-height: 80px / padding-left: 6px (#1045)
 .top {
   position: sticky;
   top: 0;
   z-index: 1;
   display: flex;
-  height: 36px;
+  height: 80px;
+  padding-left: 6px;
   flex-shrink: 0;
 }
 
@@ -782,9 +787,9 @@ defineExpose({
 }
 
 .instanceIcon {
-  width: 30px;
+  width: 38px;
   aspect-ratio: 1;
-  border-radius: 4px;
+  border-radius: 8px;
   user-select: none;
   -webkit-user-select: none;
 }
@@ -818,20 +823,25 @@ defineExpose({
   }
 }
 
+// 項目の背景 pill は本家と同じく左右 17px インセット (本家は
+// `width: calc(100% - 34px)` の ::before。NoteDeck は item 自体を pill に
+// しているので、section 側の padding で同じ位置に落とす) — #1045
 .section {
   display: flex;
   flex-direction: column;
-  padding: 10px 6px;
+  padding: 0 17px;
 }
 
+// 本家 navbar の .bottom は padding-top: 20px
 .bottomSection {
   flex-shrink: 0;
+  padding-top: 20px;
 }
 
 .divider {
-  height: 1px;
-  background: var(--nd-divider);
-  margin: 10px 6px;
+  height: 0;
+  border-top: solid 0.5px var(--nd-divider);
+  margin: 16px 0;
   align-self: stretch;
 }
 
@@ -839,11 +849,12 @@ defineExpose({
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 14px;
+  // 17px (section) + 13px = 本家のアイコン左端 30px
+  padding: 0 13px;
   line-height: 2.85rem;
   border-radius: var(--nd-radius-full);
   color: var(--nd-navFg, var(--nd-fg));
-  font-size: 0.95em;
+  font-size: 0.9em;
   white-space: nowrap;
   text-decoration: none;
   transition: background var(--nd-duration-base), color var(--nd-duration-base), transform var(--nd-duration-fast) var(--nd-ease-spring);
@@ -1006,12 +1017,14 @@ defineExpose({
 
 
 
+// 本家 navbar の .post: 展開時は高さ 40px の pill (#1045)
 .postBtn {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
-  padding: 10px 14px;
+  height: 40px;
+  padding: 0 13px;
   border-radius: var(--nd-radius-full);
   background: linear-gradient(90deg, var(--nd-buttonGradateA, var(--nd-accent)), var(--nd-buttonGradateB, var(--nd-accentDarken)));
   color: var(--nd-fgOnAccent, #fff);
@@ -1145,6 +1158,12 @@ defineExpose({
   flex-direction: column;
 }
 
+// 本家 navbar の .account は上下 20px の余白を持ち、ノート投稿ボタンから
+// 離れて最下部に落ちる (#1045)
+.accountWrap {
+  margin-top: 20px;
+}
+
 .updateDot { @include update-dot; }
 
 // ============================================================
@@ -1161,35 +1180,44 @@ defineExpose({
     display: none;
   }
 
+  // アイコンのみ表示。寸法は本家 navbar の .root.iconOnly に合わせる (#1045)
   .top {
-    padding-left: 0;
+    height: auto;
+    padding: 20px 0;
     justify-content: center;
   }
 
   .instanceIcon {
     width: 30px;
-    border-radius: 4px;
+    border-radius: 8px;
   }
 
+  // 本家は `padding: 16px 0` の全幅項目に正方形の pill を敷く。
+  // NoteDeck は item 自体を pill にしているので同じ実寸の円で置き換える
   .item {
     justify-content: center;
     padding: 0;
-    width: 44px;
-    height: 44px;
-    margin: 2px auto;
+    width: 52px;
+    height: 52px;
+    margin: 0 auto;
     border-radius: 50%;
 
     :global(.ti) { @include nav-icon; }
   }
 
   .section {
-    padding: 8px 0 0;
+    padding: 0;
     align-items: center;
   }
 
+  .divider {
+    width: calc(100% - 32px);
+    margin: 8px auto;
+  }
+
   .postBtn {
-    width: 44px;
-    height: 44px;
+    width: 52px;
+    height: 52px;
     padding: 0;
     margin: 0 auto;
     border-radius: 50%;

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -859,9 +859,10 @@ defineExpose({
   text-decoration: none;
   transition: background var(--nd-duration-base), color var(--nd-duration-base), transform var(--nd-duration-fast) var(--nd-ease-spring);
 
+  // hover / 選択中はアクセント色 + accentedBg の pill (本家 navbar と同じ)
   &:hover {
-    background: var(--nd-buttonHoverBg);
-    color: var(--nd-fgHighlighted);
+    background: var(--nd-accentedBg);
+    color: var(--nd-accent);
 
     :global(.ti) {
       opacity: 1;
@@ -878,8 +879,8 @@ defineExpose({
 }
 
 .sidebarActive {
-  background: var(--nd-buttonHoverBg);
-  color: var(--nd-fgHighlighted);
+  background: var(--nd-accentedBg);
+  color: var(--nd-accent);
 
   :global(.ti) {
     opacity: 1;

--- a/src/components/deck/DeckNavbar.vue
+++ b/src/components/deck/DeckNavbar.vue
@@ -1,29 +1,22 @@
 <script setup lang="ts">
-import {
-  computed,
-  nextTick,
-  onUnmounted,
-  ref,
-  toRef,
-  useCssModule,
-  watch,
-} from 'vue'
+import { computed, nextTick, onUnmounted, ref, useCssModule, watch } from 'vue'
 import { isColumnExposed } from '@/columns/exposure'
 import { useCommandStore } from '@/commands/registry'
+import AccountAvatar from '@/components/common/AccountAvatar.vue'
+import AccountPickerSheet from '@/components/common/AccountPickerSheet.vue'
 import ColumnBadges from '@/components/common/ColumnBadges.vue'
 import { useAccountActions } from '@/composables/useAccountActions'
 import { useColumnBadge } from '@/composables/useColumnBadge'
 import { COLUMN_ICONS, COLUMN_LABELS } from '@/composables/useColumnTabs'
-import { useNativeDialog } from '@/composables/useNativeDialog'
 import { useNavigation } from '@/composables/useNavigation'
 import {
   accountTargetId,
   navbarTargetId,
   useSpotlightStore,
 } from '@/composables/useSpotlight'
-import { useVaporTransition } from '@/composables/useVaporTransition'
 import {
   type Account,
+  getAccountAvatarUrl,
   getAccountLabel,
   isGuestAccount,
   useAccountsStore,
@@ -32,7 +25,6 @@ import { useConfirm } from '@/stores/confirm'
 import { isNavDivider, type NavItem, useDeckStore } from '@/stores/deck'
 import { useOfflineModeStore } from '@/stores/offlineMode'
 import { useRealtimeModeStore } from '@/stores/realtimeMode'
-import { useServersStore } from '@/stores/servers'
 import { useStreamingStore } from '@/stores/streaming'
 import { useIsCompactLayout } from '@/stores/ui'
 import { useWindowsStore } from '@/stores/windows'
@@ -42,7 +34,6 @@ import {
 } from '@/utils/customTimelines'
 import { AppError } from '@/utils/errors'
 import { hapticLight, hapticMedium } from '@/utils/haptics'
-import { proxyThumbUrl } from '@/utils/mediaProxy'
 import { commands, unwrap } from '@/utils/tauriInvoke'
 import DeckLaunchPad from './DeckLaunchPad.vue'
 import DeckProfileMenu from './DeckProfileMenu.vue'
@@ -175,14 +166,7 @@ function closeDrawerAndDo(fn: () => void) {
   nextTick(fn)
 }
 const accountsStore = useAccountsStore()
-const serversStore = useServersStore()
 const streamingStore = useStreamingStore()
-
-function getServerIconUrl(host: string): string | undefined {
-  const url =
-    serversStore.getServer(host)?.iconUrl || `https://${host}/favicon.ico`
-  return proxyThumbUrl(url, 28)
-}
 
 watch(
   () => accountsStore.accounts.length,
@@ -272,24 +256,6 @@ function toggleSettingsMenu() {
 // Account menu
 const accountMenuId = ref<string | null>(null)
 const showAccountPopup = ref(false)
-const accountDialogRef = ref<HTMLDialogElement | null>(null)
-const { visible: accountPopupVisible, leaving: accountPopupLeaving } =
-  useVaporTransition(toRef(showAccountPopup), {
-    enterDuration: 200,
-    leaveDuration: 200,
-  })
-
-useNativeDialog(
-  accountDialogRef,
-  computed(() => accountPopupVisible.value && isCompact.value),
-  {
-    onCancel: () => {
-      showAccountPopup.value = false
-      accountMenuId.value = null
-    },
-    leaveDuration: 200,
-  },
-)
 
 function toggleAccountPopup() {
   if (showAccountPopup.value) {
@@ -647,66 +613,42 @@ defineExpose({
               </div>
               <span :class="$style.label">アカウント</span>
             </button>
-            <!-- Mobile: bottom sheet via native <dialog> -->
-            <dialog
-              v-if="isCompact && accountPopupVisible"
-              ref="accountDialogRef"
-              class="_nativeDialog"
-              :class="[$style.mobileBackdrop, accountPopupLeaving ? $style.sheetBackdropLeave : $style.sheetBackdropEnter]"
+            <!-- Mobile: bottom sheet (アカウント選択の共通シート #1018) -->
+            <AccountPickerSheet
+              v-if="isCompact"
+              :show="showAccountPopup"
+              :accounts="accountsStore.accounts"
+              :active-id="accountMenuId"
+              :row-class="(id: string) => isAccountSpotlighted(id) ? $style.accountRowSpotlighted : undefined"
+              has-next
+              @select="clearAccountSpotlight($event); toggleAccountMenu($event)"
+              @close="showAccountPopup = false; accountMenuId = null"
             >
-              <div
-                autofocus
-                tabindex="-1"
-                :class="[$style.accountPopup, accountPopupLeaving ? $style.sheetContentLeave : $style.sheetContentEnter]"
-                @click.stop="accountMenuId = null"
-              >
-                <div
-                  v-for="acc in accountsStore.accounts"
-                  :key="acc.id"
-                  :class="[$style.accountPopupItem, { [$style.spotlighted]: isAccountSpotlighted(acc.id) }]"
-                  @mousedown="clearAccountSpotlight(acc.id)"
-                  @click.stop="toggleAccountMenu(acc.id)"
-                >
-                  <div
-                    :class="[$style.accountPopupBtn, { [$style.accountPopupBtnActive]: accountMenuId === acc.id }]"
-                    :title="getAccountLabel(acc)"
-                  >
-                    <div :class="$style.avatarWrap">
-                      <img
-                        v-if="isGuestAccount(acc)"
-                        src="/avatar-guest.svg"
-                        :class="$style.avatar"
-                      />
-                      <img
-                        v-else-if="acc.avatarUrl"
-                        :src="proxyThumbUrl(acc.avatarUrl, 56)"
-                        :class="$style.avatar"
-                      />
-                      <div v-else :class="[$style.avatar, $style.avatarPlaceholder]" />
-                      <img
-                        :src="getServerIconUrl(acc.host)"
-                        :class="$style.serverBadge"
-                        :title="acc.host"
-                      />
-                      <span
-                        :class="[$style.onlineIndicator, onlineStatusClass(acc.id)]"
-                      />
-                    </div>
-                    <span :class="$style.accountPopupName">{{ getAccountLabel(acc) }}</span>
-                    <i class="ti ti-chevron-right" :class="$style.accountPopupChevron" />
-                  </div>
-                </div>
+              <!-- ストリーミング接続状態はナビバーだけの情報なのでここで重ねる -->
+              <template #avatar="{ account }">
+                <span :class="$style.avatarWrap">
+                  <AccountAvatar
+                    :src="getAccountAvatarUrl(account)"
+                    :host="account.host"
+                    :size="32"
+                    show-server
+                    badge-background="var(--nd-navBg)"
+                  />
+                  <span :class="[$style.onlineIndicator, onlineStatusClass(account.id)]" />
+                </span>
+              </template>
+              <template #footer>
                 <div :class="$style.accountPopupDivider" />
                 <button
                   class="_button"
-                  :class="$style.accountPopupBtn"
+                  :class="$style.accountAddBtn"
                   @click="showAccountPopup = false; closeDrawerAndDo(navigateToLogin)"
                 >
                   <div :class="$style.accountPopupIcon"><i class="ti ti-plus" /></div>
                   <span>アカウント追加</span>
                 </button>
-              </div>
-            </dialog>
+              </template>
+            </AccountPickerSheet>
             <NavAccountMenu
               v-if="showAccountPopup && selectedAccount"
               :key="accountMenuId!"
@@ -985,36 +927,19 @@ defineExpose({
 }
 
 // Account popup — bottom sheet inside <dialog class="_nativeDialog">
-.accountPopup {
-  width: 100%;
-  margin: 0;
-  border-radius: 16px 16px 0 0;
-  background: color-mix(in srgb, var(--nd-navBg) 96%, transparent);
-  box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.3);
-  max-height: 80vh;
-  overflow-y: auto;
-  padding: 8px 0 calc(8px + var(--nd-safe-area-bottom, env(safe-area-inset-bottom)));
-
-  &:focus,
-  &:focus-visible {
-    outline: none;
-  }
-}
-
-.accountPopupItem {
-  position: relative;
-}
-
 /* AI Spotlight: account.switch でこの行の外周を光らせる (中身は潰さない) */
-.accountPopupItem.spotlighted {
+.accountRowSpotlighted {
+  position: relative;
   @include spotlight-ring;
 }
 
-.accountPopupBtn {
+/* シート末尾の「アカウント追加」。アカウント行と同じ寸法に揃える */
+.accountAddBtn {
   display: flex;
   align-items: center;
   gap: 8px;
   padding: 4px 12px;
+  min-height: 44px;
   width: 100%;
   font-size: 0.85em;
   color: var(--nd-fg);
@@ -1025,24 +950,6 @@ defineExpose({
   &:hover {
     background: var(--nd-buttonHoverBg);
   }
-}
-
-.accountPopupBtnActive {
-  background: var(--nd-buttonHoverBg);
-  color: var(--nd-fgHighlighted);
-}
-
-.accountPopupChevron {
-  margin-left: auto;
-  font-size: 0.75em;
-  opacity: 0.4;
-  flex-shrink: 0;
-}
-
-.accountPopupName {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  flex: 1;
 }
 
 .accountPopupIcon {
@@ -1066,30 +973,8 @@ defineExpose({
 
 .avatarWrap {
   position: relative;
+  display: inline-flex;
   flex-shrink: 0;
-}
-
-.avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  object-fit: cover;
-  display: block;
-}
-
-.avatarPlaceholder {
-  background: var(--nd-buttonBg);
-}
-
-.serverBadge {
-  position: absolute;
-  top: -2px;
-  right: -4px;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 1.5px solid var(--nd-navBg);
 }
 
 .onlineIndicator {
@@ -1295,14 +1180,6 @@ defineExpose({
     border-radius: 50%;
 
     :global(.ti) { @include nav-icon; }
-  }
-
-  .accountPopup {
-    bottom: 0;
-    left: 100%;
-    right: auto;
-    margin-bottom: 0;
-    margin-left: 4px;
   }
 
   .section {

--- a/src/components/deck/DeckNoteColumn.vue
+++ b/src/components/deck/DeckNoteColumn.vue
@@ -554,6 +554,7 @@ defineExpose({
   align-items: center;
   flex-shrink: 0;
   gap: 2px;
+  margin: auto 0;
   padding: 2px 6px;
   border-radius: var(--nd-radius-full);
   font-size: 0.75em;
@@ -584,9 +585,12 @@ defineExpose({
 
 
 /* フィルタメニュー (#841): サブヘッダ右端の共通トグルボタン */
+// タブ行と同じ面に載せる (#1045)。以前はタブだけが背景と下線を持ち、右端の
+// フィルタ / クエリバッジがその外に浮いて見えていた
 .subHeaderRow {
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  background: var(--nd-bg);
 }
 
 .subHeaderMain {
@@ -598,7 +602,10 @@ defineExpose({
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
   padding: 8px 12px;
+  // タブ行と同じ下線でつなぐ (タブが無いカラムではここだけが行を作る)
+  border-bottom: 1px solid var(--nd-divider);
   opacity: 0.5;
   color: var(--nd-fg);
   transition:

--- a/src/components/deck/DeckNotificationColumn.vue
+++ b/src/components/deck/DeckNotificationColumn.vue
@@ -1493,12 +1493,23 @@ onUnmounted(() => {
 
 .notifItem {
   border-bottom: 1px solid var(--nd-divider);
+  font-size: 0.9em;
 }
 
+// 余白・文字サイズはカラム幅に追随させる (本家 MkNotification と同じ段階)
 .notifLayout {
   display: flex;
-  padding: 12px 16px;
-  gap: 12px;
+  padding: 24px 32px;
+  gap: 8px;
+}
+
+@container (max-width: 600px) {
+  .notifLayout { padding: 16px; }
+}
+
+@container (max-width: 500px) {
+  .notifItem { font-size: 0.85em; }
+  .notifLayout { padding: 12px; }
 }
 
 .notifHead {

--- a/src/components/deck/DeckWidgetColumn.vue
+++ b/src/components/deck/DeckWidgetColumn.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, defineAsyncComponent, ref, useTemplateRef } from 'vue'
 import { isAllAccounts } from '@/columns/accountScope'
+import AccountPickerSheet from '@/components/common/AccountPickerSheet.vue'
 import ColumnEmptyState from '@/components/common/ColumnEmptyState.vue'
 import { useAccountPicker } from '@/composables/useAccountPicker'
 import { useColumnTheme } from '@/composables/useColumnTheme'
@@ -195,7 +196,13 @@ async function openLibraryWidgetEditor(widget: WidgetMeta) {
 }
 
 const { confirm } = useConfirm()
-const { pickAccount, hasPickableAccount } = useAccountPicker()
+const {
+  pickAccount,
+  pickableAccounts,
+  hasPickableAccount,
+  sheetPurpose,
+  resolveSheet,
+} = useAccountPicker()
 
 /** ライブラリから widget 本体を削除 (コードも消える)。
  *  本体削除前に全 widget カラムから参照を剥がして dangling id を残さない
@@ -481,6 +488,16 @@ function handleOpenStoreDetail(entry: StoreWidgetEntry) {
       </template>
     </div>
   </DeckColumn>
+
+  <!-- 実行アカウントの選択 (コンパクト表示のみ。デスクトップはコマンドパレット) -->
+  <AccountPickerSheet
+    :show="sheetPurpose !== null"
+    :accounts="pickableAccounts"
+    title="アカウントを選択"
+    :description="sheetPurpose ?? undefined"
+    @select="resolveSheet($event)"
+    @close="resolveSheet(null)"
+  />
 </template>
 
 <style lang="scss" module>

--- a/src/composables/useAccountPicker.test.ts
+++ b/src/composables/useAccountPicker.test.ts
@@ -2,14 +2,6 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, ref } from 'vue'
 import type { QuickPickStep } from '@/commands/quickPick'
-import type { ConfirmOptions } from '@/stores/confirm'
-
-const confirmWithAction =
-  vi.fn<(opts: ConfirmOptions) => Promise<string | null>>()
-
-vi.mock('@/stores/confirm', () => ({
-  useConfirm: () => ({ confirmWithAction }),
-}))
 
 const isCompact = ref(false)
 vi.mock('@/stores/ui', () => ({
@@ -64,7 +56,6 @@ const TWO = [
 describe('useAccountPicker — 全アカウントカラムからの操作先 (#1018)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
-    confirmWithAction.mockReset()
     isCompact.value = false
     paletteOpen.value = false
     lastStep = null
@@ -72,19 +63,19 @@ describe('useAccountPicker — 全アカウントカラムからの操作先 (#1
 
   it('候補が無ければ何も出さずに null', async () => {
     setAccounts([])
-    const { pickAccount } = useAccountPicker()
+    const { pickAccount, sheetPurpose } = useAccountPicker()
 
     expect(await pickAccount('テスト')).toBeNull()
-    expect(confirmWithAction).not.toHaveBeenCalled()
+    expect(sheetPurpose.value).toBeNull()
     expect(lastStep).toBeNull()
   })
 
   it('候補が 1 つなら選ぶ余地がないので何も出さない', async () => {
     setAccounts([makeAccount({ id: 'only' })])
-    const { pickAccount } = useAccountPicker()
+    const { pickAccount, sheetPurpose } = useAccountPicker()
 
     expect(await pickAccount('テスト')).toBe('only')
-    expect(confirmWithAction).not.toHaveBeenCalled()
+    expect(sheetPurpose.value).toBeNull()
     expect(lastStep).toBeNull()
   })
 
@@ -110,7 +101,6 @@ describe('useAccountPicker — 全アカウントカラムからの操作先 (#1
       await nextTick()
 
       expect(paletteOpen.value).toBe(true)
-      expect(confirmWithAction).not.toHaveBeenCalled()
       expect(lastStep?.placeholder).toBe('どのアカウントで？')
       // アバターとサーバーバッジの材料が渡っている
       expect(lastStep?.items.map((i) => i.serverHost)).toEqual([
@@ -134,31 +124,40 @@ describe('useAccountPicker — 全アカウントカラムからの操作先 (#1
     })
   })
 
-  describe('コンパクト表示 — ダイアログで選ぶ', () => {
+  describe('コンパクト表示 — ボトムシートで選ぶ', () => {
     beforeEach(() => {
       isCompact.value = true
     })
 
-    it('アバター付きの選択肢を出し、選ばれたアカウントを返す', async () => {
+    it('シートを開き、選ばれたアカウントを返す', async () => {
       setAccounts(TWO)
-      confirmWithAction.mockResolvedValue('a2')
-      const { pickAccount } = useAccountPicker()
+      const { pickAccount, pickableAccounts, sheetPurpose, resolveSheet } =
+        useAccountPicker()
 
-      expect(await pickAccount('どのアカウントで？')).toBe('a2')
+      const picked = pickAccount('どのアカウントで？')
+      await nextTick()
+
+      // パレットではなくシートが開く
       expect(lastStep).toBeNull()
+      expect(paletteOpen.value).toBe(false)
+      expect(sheetPurpose.value).toBe('どのアカウントで？')
+      expect(pickableAccounts.value.map((a) => a.id)).toEqual(['a1', 'a2'])
 
-      const actions = confirmWithAction.mock.calls[0]?.[0]?.actions
-      expect(actions?.map((a) => a.value)).toEqual(['a1', 'a2', '__cancel'])
-      expect(actions?.[0]?.avatar?.host).toBe('example.com')
-      expect(actions?.[0]?.description).toBe('example.com')
+      resolveSheet('a2')
+      expect(await picked).toBe('a2')
+      expect(sheetPurpose.value).toBeNull()
     })
 
     it('キャンセルなら null', async () => {
       setAccounts(TWO)
-      confirmWithAction.mockResolvedValue('__cancel')
-      const { pickAccount } = useAccountPicker()
+      const { pickAccount, sheetPurpose, resolveSheet } = useAccountPicker()
 
-      expect(await pickAccount('テスト')).toBeNull()
+      const picked = pickAccount('テスト')
+      await nextTick()
+      resolveSheet(null)
+
+      expect(await picked).toBeNull()
+      expect(sheetPurpose.value).toBeNull()
     })
   })
 })

--- a/src/composables/useAccountPicker.ts
+++ b/src/composables/useAccountPicker.ts
@@ -8,23 +8,23 @@
  *
  * 選ばせ方はレイアウトで変える。デスクトップは既に「候補を絞って選ぶ」場所が
  * コマンドパレットにあるのでそれに乗せ、コンパクト表示ではパレットが画面を
- * 占有してしまうためダイアログを使う。どちらもアバターにサーバーバッジを出す。
+ * 占有してしまうためボトムシート (AccountPickerSheet) を使う。どちらもアバターに
+ * サーバーバッジを出す。
+ *
+ * シートは呼び出し側のテンプレートに置く — `sheetPurpose` が非 null の間だけ
+ * 開き、選択 / キャンセルを `resolveSheet` に渡すと pickAccount が解決する。
  */
 
-import { computed, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useCommandStore } from '@/commands/registry'
 import {
   getAccountAvatarUrl,
   getAccountLabel,
   useAccountsStore,
 } from '@/stores/accounts'
-import { useConfirm } from '@/stores/confirm'
 import { useIsCompactLayout } from '@/stores/ui'
 
-const CANCEL = '__cancel'
-
 export function useAccountPicker() {
-  const { confirmWithAction } = useConfirm()
   const commandStore = useCommandStore()
   const isCompact = useIsCompactLayout()
 
@@ -51,25 +51,26 @@ export function useAccountPicker() {
     if (!only) return null
     if (accounts.length === 1) return only.id
 
-    if (isCompact.value) return pickViaDialog(purpose)
+    if (isCompact.value) return pickViaSheet(purpose)
     return pickViaPalette(purpose)
   }
 
-  function pickViaDialog(purpose: string): Promise<string | null> {
-    return confirmWithAction({
-      title: 'アカウントを選択',
-      message: purpose,
-      icon: 'none',
-      actions: [
-        ...pickableAccounts.value.map((a) => ({
-          value: a.id,
-          label: `@${a.username}`,
-          description: a.host,
-          avatar: { src: getAccountAvatarUrl(a), host: a.host },
-        })),
-        { value: CANCEL, label: 'キャンセル', cancel: true },
-      ],
-    }).then((action) => (action && action !== CANCEL ? action : null))
+  /** シートを開いている間の目的文 (= 開いているかどうか) */
+  const sheetPurpose = ref<string | null>(null)
+  let sheetResolve: ((accountId: string | null) => void) | null = null
+
+  function pickViaSheet(purpose: string): Promise<string | null> {
+    return new Promise((resolve) => {
+      sheetResolve = resolve
+      sheetPurpose.value = purpose
+    })
+  }
+
+  /** シートの選択 / キャンセルを pickAccount 側へ返す */
+  function resolveSheet(accountId: string | null) {
+    sheetPurpose.value = null
+    sheetResolve?.(accountId)
+    sheetResolve = null
   }
 
   function pickViaPalette(purpose: string): Promise<string | null> {
@@ -108,5 +109,11 @@ export function useAccountPicker() {
     })
   }
 
-  return { pickAccount, pickableAccounts, hasPickableAccount }
+  return {
+    pickAccount,
+    pickableAccounts,
+    hasPickableAccount,
+    sheetPurpose,
+    resolveSheet,
+  }
 }

--- a/src/composables/useDeckWindow.ts
+++ b/src/composables/useDeckWindow.ts
@@ -2,6 +2,7 @@ import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { nextTick } from 'vue'
 import type { DeckWindowLayout } from '@/stores/deck'
 import { useDeckStore } from '@/stores/deck'
+import { MOBILE_WINDOW_SIZE } from '@/stores/ui'
 import { emitTauri, listenTauri } from '@/utils/tauriEvents'
 import { withViewTransition } from '@/utils/viewTransition'
 
@@ -127,12 +128,12 @@ export async function popOutColumnToWindow(
   // Flush save synchronously so the sub-window can read the updated profile
   deckStore.flushSave()
 
-  // ポップアウト先はモバイルサイズ表示 (コンパクト判定に入る幅) で使う。
-  // `decorations: false` なのでウィンドウ幅 = 中身の幅で、カラムは全幅描画に
-  // なるため、幅をそのまま渡せばデッキ上のカラムと同じ実寸になる (PiP と同じ)
+  // ポップアウト先はモバイルサイズ表示で使うので、タイトルバーの「モバイル
+  // サイズ」ボタンと同じ寸法で開く (同じスマホ表示なのに窓の大きさが違うと
+  // 見比べられない)
   const result = await openColumnWindow(deckStore.windowProfileId, windowId, {
-    width: col.width,
-    height: 700,
+    width: MOBILE_WINDOW_SIZE.width,
+    height: MOBILE_WINDOW_SIZE.height,
   })
 
   if (!result) {

--- a/src/composables/useDeckWindow.ts
+++ b/src/composables/useDeckWindow.ts
@@ -127,8 +127,11 @@ export async function popOutColumnToWindow(
   // Flush save synchronously so the sub-window can read the updated profile
   deckStore.flushSave()
 
+  // ポップアウト先はモバイルサイズ表示 (コンパクト判定に入る幅) で使う。
+  // `decorations: false` なのでウィンドウ幅 = 中身の幅で、カラムは全幅描画に
+  // なるため、幅をそのまま渡せばデッキ上のカラムと同じ実寸になる (PiP と同じ)
   const result = await openColumnWindow(deckStore.windowProfileId, windowId, {
-    width: col.width + 40,
+    width: col.width,
     height: 700,
   })
 

--- a/src/composables/usePipWindow.ts
+++ b/src/composables/usePipWindow.ts
@@ -11,7 +11,16 @@ import { WINDOW_SIZES } from '@/windows/registry'
  * (420px 以下) で全幅表示されるカラムの実寸もデッキ側と一致する。
  */
 const PIP_WIDTH = DEFAULT_COLUMN_WIDTH
-const PIP_HEIGHT = 640
+
+/**
+ * 高さは既定サイズ (800px) のウィンドウに並ぶカラムと同じ長さにする。カラムは
+ * ウィンドウ高さからタイトルバー (32px)、カラム領域の上下 padding (6px×2)、
+ * ボトムバー (42px) を引いた分:
+ *   800 - 32 - 12 - 42 = 714
+ * PiP はカラムを選んだ後ドラッグバーを出さないので、ウィンドウの高さが
+ * そのままカラムの高さになり、デッキ上のカラムと並べても長さが揃う。
+ */
+const PIP_HEIGHT = 714
 const PIP_MIN_WIDTH = 280
 const PIP_MIN_HEIGHT = 400
 const PIP_WINDOW_MAX_HEIGHT = 900

--- a/src/composables/usePipWindow.ts
+++ b/src/composables/usePipWindow.ts
@@ -1,10 +1,16 @@
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
+import { DEFAULT_COLUMN_WIDTH } from '@/columns/registry'
 import type { DeckColumn } from '@/stores/deck'
 import type { WindowType } from '@/stores/windows'
 import { listenTauri } from '@/utils/tauriEvents'
 import { WINDOW_SIZES } from '@/windows/registry'
 
-const PIP_WIDTH = 360
+/**
+ * PiP はカラム 1 本を切り出した窓なので、幅はデッキのカラムと同じにする。
+ * `decorations: false` なのでウィンドウ幅 = 中身の幅になり、コンパクト表示
+ * (420px 以下) で全幅表示されるカラムの実寸もデッキ側と一致する。
+ */
+const PIP_WIDTH = DEFAULT_COLUMN_WIDTH
 const PIP_HEIGHT = 640
 const PIP_MIN_WIDTH = 280
 const PIP_MIN_HEIGHT = 400

--- a/src/composables/usePostFormState.ts
+++ b/src/composables/usePostFormState.ts
@@ -178,8 +178,15 @@ export function usePostFormState(
   // auto-save が飛んで重複 create されるのを防ぐ。
   let draftCreateInFlight: Promise<string> | null = null
 
+  /**
+   * メモはアカウントに紐づかない (#1018) ので、memo モードではアカウントの
+   * サーバーテーマを乗せずアプリのテーマのままにする (投稿ボタンの色などが
+   * アクティブアカウント依存になるのを避ける)。
+   */
   const formThemeVars = computed(() =>
-    themeStore.getStyleVarsForAccount(activeAccountId.value),
+    memoMode
+      ? undefined
+      : themeStore.getStyleVarsForAccount(activeAccountId.value),
   )
 
   const currentVisibility = computed(

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -417,7 +417,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'chat',
         name: null,
-        width: 330,
+        width: 360,
         accountId: null,
         sidebar: true,
       })
@@ -449,7 +449,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'search',
         name: null,
-        width: 330,
+        width: 360,
         accountId: null,
         sidebar: true,
         query,
@@ -487,7 +487,7 @@ export const useDeckStore = defineStore('deck', () => {
     addColumnAt(0, {
       type,
       name: null,
-      width: 330,
+      width: 360,
       accountId,
       sidebar: true,
       ...extraProps,

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -417,7 +417,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'chat',
         name: null,
-        width: 360,
+        width: 330,
         accountId: null,
         sidebar: true,
       })
@@ -449,7 +449,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'search',
         name: null,
-        width: 360,
+        width: 330,
         accountId: null,
         sidebar: true,
         query,
@@ -487,7 +487,7 @@ export const useDeckStore = defineStore('deck', () => {
     addColumnAt(0, {
       type,
       name: null,
-      width: 360,
+      width: 330,
       accountId,
       sidebar: true,
       ...extraProps,

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -2,6 +2,7 @@ import JSON5 from 'json5'
 import { defineStore } from 'pinia'
 import { computed, nextTick, reactive, ref } from 'vue'
 import type { TimelineFilter, TimelineType } from '@/adapters/types'
+import { DEFAULT_COLUMN_WIDTH } from '@/columns/registry'
 import * as snapshotStore from '@/composables/useSnapshotStore'
 import defaultNavbarJson5 from '@/defaults/navbar.json5?raw'
 import { useAccountsStore } from '@/stores/accounts'
@@ -417,7 +418,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'chat',
         name: null,
-        width: 360,
+        width: DEFAULT_COLUMN_WIDTH,
         accountId: null,
         sidebar: true,
       })
@@ -449,7 +450,7 @@ export const useDeckStore = defineStore('deck', () => {
       addColumnAt(0, {
         type: 'search',
         name: null,
-        width: 360,
+        width: DEFAULT_COLUMN_WIDTH,
         accountId: null,
         sidebar: true,
         query,
@@ -487,7 +488,7 @@ export const useDeckStore = defineStore('deck', () => {
     addColumnAt(0, {
       type,
       name: null,
-      width: 360,
+      width: DEFAULT_COLUMN_WIDTH,
       accountId,
       sidebar: true,
       ...extraProps,

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -31,6 +31,13 @@ const isDesktop = isTauri && !isMobilePlatform
 
 const MOBILE_BREAKPOINT = 420 // 420px 以下をモバイルとみなす（タブレット横持ち等は除外）
 
+/**
+ * モバイルサイズ表示にするときのウィンドウサイズ。タイトルバーの「モバイル
+ * サイズ」ボタンと、カラムのポップアウト先で共有する (同じスマホ表示なのに
+ * 窓の大きさが違うと見比べられない)。幅は MOBILE_BREAKPOINT ちょうど。
+ */
+export const MOBILE_WINDOW_SIZE = { width: MOBILE_BREAKPOINT, height: 780 }
+
 export const useUiStore = defineStore('ui', () => {
   const sidebarOpen = ref(true)
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -160,7 +160,6 @@
   --nd-radius-full: 999px;
   --nd-margin: 10px;
   --nd-nav-resize-handle: 6px;
-  --nd-nav-border: 0.5px;
   --nd-columnGap: 6px;
   --nd-blur: 15px;
   --nd-blur-panel: 10px;


### PR DESCRIPTION
## 概要

デッキ UI の見た目を本家 Misskey に寄せ、アカウント選択の導線をスマホサイズ表示で統一したリリース。

## 変更

### デッキ UI を本家 Misskey に揃える (#1045)

- ナビバー幅 250px / アイコンのみ 80px (本家 `--nav-width` / `--nav-icon-only-width`)
- ナビバー内の余白: 項目の pill を左右 17px インセット、アイコン左端 30px、上部 80px、区切り線 16px、アイコンのみ表示は 52px の円
- ナビバーの右境界線とボトムバーの上境界線を削除 (本家は背景色だけで面を分ける)
- ノート投稿ボタンは高さ 40px、アカウントボタンは 20px 空けて最下部へ
- ナビバーの項目は hover / 選択中にアクセント色 + accentedBg
- 通知の余白と文字サイズをカラム幅に追随 (24px 32px → 16px → 12px)
- タイムラインのフィルタ / クエリバッジをタブ行と同じ面に載せ、行からはみ出して見えていたのを修正

カラムの既定幅とノートのアバターは、情報量が落ちるため本家値を採用せず NoteDeck の値を維持している。

### アカウント選択 UI をボトムシートに統一 (#1018)

一番整っていたナビバーのアカウント一覧を正本に、`AccountPickerRow` (行) と `AccountPickerSheet` (器) を切り出して 4 つの面を揃えた。

- ナビバーのアカウントボタン (接続状態インジケータは従来どおり)
- ノートの「別のアカウントで…」(メニューを閉じてシートで 2 段選択)
- ウィジェットの実行アカウント (中央ダイアログ → シート)
- カラム追加ダイアログ (コンパクト表示ではシート。カテゴリを開くと他を畳んで見出しを上端へ)

### カラムと窓の寸法

- カラムの既定幅を `DEFAULT_COLUMN_WIDTH` (350px) に集約。ナビバーをアイコンのみに畳んだ 1920px の画面でカラム 5 本が横スクロールなしに収まる
- PiP の幅をカラムと同じ 350px、高さを既定ウィンドウでのカラムと同じ 714px に
- カラムのポップアウト先はタイトルバーの「モバイルサイズ」ボタンと同じ 420×780 (`MOBILE_WINDOW_SIZE` として共有)

### その他

- メモカラムがアクティブアカウントのサーバーテーマ / 空状態画像を引かないように (#1018)
- ナビバーの「もっと」のアカウントスコープ別見出しを撤廃

## 確認

- `pnpm typecheck` / `biome check` / `vitest run` (271 files, 3098 tests) いずれもパス
- 見た目の確認は実機待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compact-layout bottom sheets for selecting accounts, including multi-step actions and cancellation support.
  * Introduced reusable account-selection rows across deck and action interfaces.
* **UI Improvements**
  * Refined deck navigation, column layouts, notifications, headers, and bottom-bar styling.
  * Improved responsive behavior for narrow columns and compact windows.
  * Standardized default column width and mobile window dimensions.
* **Bug Fixes**
  * Memo posts no longer apply server-account theme styling.
  * Empty memo columns now use the default application icon.
* **Chores**
  * Updated the application version to 1.51.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->