### PR TITLE
ci: @claude メンションで Claude Code を起動する workflow を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,44 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      actions: read # Required for Claude to read CI results on PRs
+      id-token: write # Required for Workload Identity Federation
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Workload Identity Federation (静的 API キー不使用)
+          anthropic_federation_rule_id: "fdrl_01XmTCNgSr5YdBhPwL22znA2"
+          anthropic_organization_id: "8efe77da-6956-4af6-968f-24a2e7e4e120"
+          anthropic_service_account_id: "svac_014W2EA4SWK66ARcbouqCHom"
+          anthropic_workspace_id: "wrkspc_018YcfbNWfTrzJv65boCYKiG"
+          claude_args: "--model claude-opus-4-8"
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## What
Issue / PR コメントで `@claude` をメンションすると Claude Code がレビュー・作業するワークフロー（`claude.yml`）を追加する。

## Why
Claude GitHub App は org にインストール済みだが、実行側のワークフローが無く「👀 リアクションは付くが何も起きない」状態だった。コメント系イベントのワークフローは default branch (main) 上の定義から実行されるため、main に入れば既存 PR でも即有効になる。

## Additional info
- 認証は Workload Identity Federation（GitHub Actions OIDC → 短期トークン、静的 API キー不使用）。使い捨てブランチで token exchange の疎通確認済み（access_token 発行・scope workspace:developer）
- federation rule は `repo:notedeck-dev@306020467/notedeck@1132415138:*`（任意 ref・任意イベント）に一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/notedeck-dev/notedeck/pull/1082" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Claude Code assistance for qualifying issue and pull request interactions.
  * Supports requests from comments, reviews, and issue descriptions that include the designated trigger.
  * Uses secure identity-based authentication and read-only repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->