### PR TITLE
Release v1.53.1

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,37 @@
+language: "ja-JP"
+tone_instructions: "日本語で簡潔に。指摘では問題点・影響・根拠を明確にし、具体的な修正案を添えてください。不確実な事項は推測と明示してください。重大なバグ・セキュリティ上の懸念は重要度と根拠を明確に伝えてください。"
+reviews:
+  profile: "chill"
+  high_level_summary: false
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "develop"
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        【レビュー対象外】
+        - フォーマット・型・lint の問題 (biome / vue-tsc / cargo clippy / cargo fmt で検出可能なもの) は CI でチェック済みのため指摘しない。
+
+        【注力してほしい観点】
+        - ビジネスロジックの不備、セキュリティ (permission/capability 境界、シークレットの扱い)、パフォーマンス、設計の適切性。
+        - PR のタイトル・説明に照らして明らかにスコープ外の変更が混入していないか。判断に迷う場合は指摘しない。
+    - path: "src/**/*.vue"
+      instructions: |
+        - Vue Vapor モード互換 (#52) の維持: <script setup> 必須 / h()・JSX 禁止 / カスタムディレクティブ・mixins・getCurrentInstance() 禁止 / <Transition>・<Teleport> は useVaporTransition / usePortal で代替。違反は指摘する。
+        - スタイルは <style module lang="scss"> + $style 参照 (CSS Modules)。モバイル/デスクトップ切替は v-if (CSS display ではない)。
+    - path: "src/stores/**"
+      instructions: |
+        - 正規化・マイグレーション・マージ規則などの純ロジックが store に直接書かれていたら src/services/ への分離を提案する (#782)。store は「購読 + キャッシュ + UI 状態」のみ。
+        - 無制限に成長しうるキャッシュ・Map・配列には上限 (bounded cache 不変条件 #987) があるか確認する。
+    - path: "src-tauri/**"
+      instructions: |
+        - 公開 API は get_credentials_or_anon()、認証必須 API は get_credentials() を使う (ゲスト・ログアウト対応)。
+        - ウィンドウ操作は #[cfg(desktop)] ガード必須 (Android ビルドはタグ push まで CI で検出されない)。
+        - Misskey トークン・外部サービスのシークレットは OS キーチェーン / Secret Vault 経由のみ。フロントに本体を渡すコードは指摘する。
+  path_filters:
+    - "!**/__snapshots__/**"
+    - "!src-tauri/openapi.json"
+    - "!src-tauri/gen/**"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "notedeck",
   "description": "Misskey Pro — integrated deck environment (IDE) for Misskey power users",
   "private": true,
-  "version": "1.53.0",
+  "version": "1.53.1",
   "type": "module",
   "packageManager": "pnpm@11.18.0",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3197,7 +3197,7 @@ dependencies = [
 
 [[package]]
 name = "notedeck"
-version = "1.53.0"
+version = "1.53.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notedeck"
-version = "1.53.0"
+version = "1.53.1"
 description = "Misskey Pro — integrated deck environment (IDE) for Misskey power users"
 edition = "2021"
 license = "AGPL-3.0-only"

--- a/src-tauri/openapi.json
+++ b/src-tauri/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": "MIT"
     },
-    "version": "1.53.0"
+    "version": "1.53.1"
   },
   "paths": {
     "/api": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "NoteDeck",
-  "version": "1.53.0",
+  "version": "1.53.1",
   "identifier": "com.notedeck.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -394,12 +394,17 @@ const reactionUrls = computed(() => reactionsData.value.urls)
 
 // 数え直しの初回取得中はチップを渡さない (#1081): 未フィルタのカウントを
 // 一瞬でも描画すると、抹消したはずのリアクションの存在が見えてしまう。
+// 自分のリアクションだけは対象外 — 0 件のノートに押した直後は楽観的更新で
+// pending になるため、隠すと押したチップが RTT の間消える。
 // エリア自体は reactionsAreaPending が高さを予約して押し下げを防ぐ
-const reactionsWithId = computed(() =>
-  recountPending.value
-    ? []
-    : sortedReactions.value.map((r) => ({ ...r, id: r.reaction })),
-)
+const reactionsWithId = computed(() => {
+  const base = recountPending.value
+    ? sortedReactions.value.filter(
+        (r) => r.reaction === effectiveNote.value.myReaction,
+      )
+    : sortedReactions.value
+  return base.map((r) => ({ ...r, id: r.reaction }))
+})
 const {
   rendered: renderedReactions,
   enteringIds: reactionEnteringIds,

--- a/src/components/common/MkNote.vue
+++ b/src/components/common/MkNote.vue
@@ -352,10 +352,8 @@ const reactionsData = computed(() =>
 
 // #575: ミュート・凍結ユーザーのリアクション抹消。数え直し済みカウントが
 // あれば count を差し替え、0 になった絵文字は行ごと消す
-const { counts: recountedCounts } = useVisibleReactionCounts(
-  () => effectiveNote.value,
-  reactionsVisible,
-)
+const { counts: recountedCounts, pending: recountPending } =
+  useVisibleReactionCounts(() => effectiveNote.value, reactionsVisible)
 
 // #630: リモート絵文字リアクションに相乗りできるサーバーか
 const serversStore = useServersStore()
@@ -394,8 +392,13 @@ const sortedReactions = computed(() => {
 })
 const reactionUrls = computed(() => reactionsData.value.urls)
 
+// 数え直しの初回取得中はチップを渡さない (#1081): 未フィルタのカウントを
+// 一瞬でも描画すると、抹消したはずのリアクションの存在が見えてしまう。
+// エリア自体は reactionsAreaPending が高さを予約して押し下げを防ぐ
 const reactionsWithId = computed(() =>
-  sortedReactions.value.map((r) => ({ ...r, id: r.reaction })),
+  recountPending.value
+    ? []
+    : sortedReactions.value.map((r) => ({ ...r, id: r.reaction })),
 )
 const {
   rendered: renderedReactions,
@@ -883,7 +886,7 @@ function handlePickerReaction(reaction: string) {
         </div>
 
         <!-- Reactions -->
-        <div v-if="sortedReactions.length > 0 && !embedded && !softMuteCollapsed" ref="reactionsAreaRef" :class="[$style.reactionsArea, !reactionsVisible && $style.reactionsAreaPending]">
+        <div v-if="sortedReactions.length > 0 && !embedded && !softMuteCollapsed" ref="reactionsAreaRef" :class="[$style.reactionsArea, (!reactionsVisible || recountPending) && $style.reactionsAreaPending]">
           <div
             v-if="reactionsVisible"
             :class="$style.reactions"

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -71,18 +71,17 @@ const reactionTab = ref<string | null>(null)
 const { counts: recountedCounts, pending: recountPending } =
   useVisibleReactionCounts(() => note.value)
 const visibleReactionCounts = computed<Record<string, number>>(() => {
+  if (!note.value) return {}
   // 数え直しの初回取得中は描画を保留 (#1081): 未フィルタのカウントを
-  // 一瞬でも見せない
-  if (!note.value || recountPending.value) return {}
+  // 一瞬でも見せない。自分のリアクションだけは楽観的更新を壊さないよう残す
+  if (recountPending.value) {
+    const my = note.value.myReaction
+    const count = my ? note.value.reactions[my] : undefined
+    return my && count ? { [my]: count } : {}
+  }
   return recountedCounts.value ?? note.value.reactions
 })
 const reactionTypes = computed(() => Object.keys(visibleReactionCounts.value))
-// 抹消でチップが消えたら選択タブを追従させる
-watch(reactionTypes, (types) => {
-  if (reactionTab.value && !types.includes(reactionTab.value)) {
-    reactionTab.value = types[0] ?? null
-  }
-})
 const isLoading = ref(true)
 const error = ref<AppError | null>(null)
 const myUserId = ref<string | undefined>()
@@ -212,6 +211,16 @@ watch(activeTab, async (tab) => {
     }
   } catch (e) {
     console.warn('[NoteDetail] failed to load tab:', tab, e)
+  }
+})
+
+// 抹消でチップが消えたら選択タブを追従させる。数え直しの保留中 (#1081) に
+// タブを開くと未選択のままになるので、種別が現れたときも先頭を選ぶ
+watch(reactionTypes, (types) => {
+  if (!reactionTab.value) {
+    if (loadedTabs.value.has('reactions')) reactionTab.value = types[0] ?? null
+  } else if (!types.includes(reactionTab.value)) {
+    reactionTab.value = types[0] ?? null
   }
 })
 

--- a/src/components/window/NoteDetailContent.vue
+++ b/src/components/window/NoteDetailContent.vue
@@ -68,9 +68,12 @@ const reactionUsers = ref<NoteReaction[]>([])
 // 本家準拠: リアクション種別チップで絞り込んでユーザー一覧を表示する
 const reactionTab = ref<string | null>(null)
 // #575: ミュート・凍結ユーザーのリアクションを抹消した表示用カウント
-const { counts: recountedCounts } = useVisibleReactionCounts(() => note.value)
+const { counts: recountedCounts, pending: recountPending } =
+  useVisibleReactionCounts(() => note.value)
 const visibleReactionCounts = computed<Record<string, number>>(() => {
-  if (!note.value) return {}
+  // 数え直しの初回取得中は描画を保留 (#1081): 未フィルタのカウントを
+  // 一瞬でも見せない
+  if (!note.value || recountPending.value) return {}
   return recountedCounts.value ?? note.value.reactions
 })
 const reactionTypes = computed(() => Object.keys(visibleReactionCounts.value))

--- a/src/composables/useVisibleReactionCounts.test.ts
+++ b/src/composables/useVisibleReactionCounts.test.ts
@@ -1,0 +1,89 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+import { useVisibleReactionCounts } from '@/composables/useVisibleReactionCounts'
+import { useReactionRecountsStore } from '@/stores/reactionRecounts'
+
+const api = vi.hoisted(() => ({ getNoteReactions: vi.fn() }))
+const state = vi.hoisted(() => ({ hideMuted: true }))
+
+vi.mock('@/adapters/factory', () => ({
+  initAdapterFor: () =>
+    Promise.resolve({
+      adapter: { api: { getNoteReactions: api.getNoteReactions } },
+    }),
+}))
+
+vi.mock('@/stores/accounts', () => ({
+  useAccountsStore: () => ({
+    accounts: [{ id: 'acc1', host: 'example.com', hasToken: true }],
+  }),
+}))
+
+vi.mock('@/stores/settings', () => ({
+  useSettingsStore: () => ({
+    get: (key: string) =>
+      key === 'mute.hideMutedUserReactions' ? state.hideMuted : undefined,
+  }),
+}))
+
+vi.mock('@/bindings', () => ({
+  commands: new Proxy(
+    {},
+    {
+      get: (_t, name: string) => {
+        // suspensions の probe は「応答から欠落 = 凍結」判定なので全員生存を返す
+        if (name === 'apiProbeUsersSuspended') {
+          return (_acc: string, ids: string[]) =>
+            Promise.resolve({
+              status: 'ok',
+              data: ids.map((id) => ({ id, isSuspended: false })),
+            })
+        }
+        return () => Promise.resolve({ status: 'ok', data: [] })
+      },
+    },
+  ),
+}))
+
+const NOTE = { id: 'n1', reactions: { '❤': 2 }, _accountId: 'acc1' }
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  api.getNoteReactions.mockReset()
+  api.getNoteReactions.mockResolvedValue([
+    { type: '❤', user: { id: 'u1' } },
+    { type: '❤', user: { id: 'u2' } },
+  ])
+  state.hideMuted = true
+})
+
+describe('useVisibleReactionCounts (#1081)', () => {
+  it('マウント時は pending、列挙取得が終わると解けて counts が返る', async () => {
+    const { pending, counts } = useVisibleReactionCounts(() => NOTE)
+    expect(pending.value).toBe(true)
+    expect(counts.value).toBeNull()
+    await vi.waitFor(() => expect(pending.value).toBe(false))
+    expect(counts.value).toEqual({ '❤': 2 })
+  })
+
+  it('トグル OFF なら pending にならない (サーバー集計を即表示)', () => {
+    state.hideMuted = false
+    const { pending } = useVisibleReactionCounts(() => NOTE)
+    expect(pending.value).toBe(false)
+  })
+
+  it('エントリが破棄されて pending に戻ったら列挙を取り直す (LRU 破棄・purge)', async () => {
+    const recountsStore = useReactionRecountsStore()
+    const { pending } = useVisibleReactionCounts(() => NOTE)
+    await vi.waitFor(() => expect(pending.value).toBe(false))
+    expect(api.getNoteReactions).toHaveBeenCalledTimes(1)
+
+    // LRU 破棄と同じ「エントリ消滅」を purgeAll で再現する
+    // (mutedUsersRemovalVersion は変えず、pending 復帰だけで駆動されることを確認)
+    recountsStore.purgeAll()
+    await nextTick()
+    await vi.waitFor(() => expect(pending.value).toBe(false))
+    expect(api.getNoteReactions).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/composables/useVisibleReactionCounts.test.ts
+++ b/src/composables/useVisibleReactionCounts.test.ts
@@ -73,14 +73,13 @@ describe('useVisibleReactionCounts (#1081)', () => {
     expect(pending.value).toBe(false)
   })
 
-  it('エントリが破棄されて pending に戻ったら列挙を取り直す (LRU 破棄・purge)', async () => {
+  it('purge で pending に戻ったら列挙を取り直す (保留のまま固まらない)', async () => {
     const recountsStore = useReactionRecountsStore()
     const { pending } = useVisibleReactionCounts(() => NOTE)
     await vi.waitFor(() => expect(pending.value).toBe(false))
     expect(api.getNoteReactions).toHaveBeenCalledTimes(1)
 
-    // LRU 破棄と同じ「エントリ消滅」を purgeAll で再現する
-    // (mutedUsersRemovalVersion は変えず、pending 復帰だけで駆動されることを確認)
+    // mutedUsersRemovalVersion は変えず、pending 復帰だけで駆動されることを確認
     recountsStore.purgeAll()
     await nextTick()
     await vi.waitFor(() => expect(pending.value).toBe(false))

--- a/src/composables/useVisibleReactionCounts.ts
+++ b/src/composables/useVisibleReactionCounts.ts
@@ -48,6 +48,9 @@ export function useVisibleReactionCounts(
       () => note()?.reactions,
       // ミュート解除 (縮小方向) は purge されるので取り直しを駆動する
       () => mutesStore.mutedUsersRemovalVersion,
+      // purge や CACHE_CAP の LRU 破棄でエントリが消えると pending に戻る。
+      // 放置するとチップが保留 (非表示) のまま固まるので取り直しを駆動する
+      pending,
     ],
     () => {
       const n = note()

--- a/src/composables/useVisibleReactionCounts.ts
+++ b/src/composables/useVisibleReactionCounts.ts
@@ -48,8 +48,9 @@ export function useVisibleReactionCounts(
       () => note()?.reactions,
       // ミュート解除 (縮小方向) は purge されるので取り直しを駆動する
       () => mutesStore.mutedUsersRemovalVersion,
-      // purge や CACHE_CAP の LRU 破棄でエントリが消えると pending に戻る。
-      // 放置するとチップが保留 (非表示) のまま固まるので取り直しを駆動する
+      // purge でエントリが消えると pending に戻る。放置するとチップが
+      // 保留 (非表示) のまま固まるので取り直しを駆動する。LRU 破棄は
+      // pending に戻らない (ストア側の settled 履歴がフォールバックさせる)
       pending,
     ],
     () => {

--- a/src/composables/useVisibleReactionCounts.ts
+++ b/src/composables/useVisibleReactionCounts.ts
@@ -7,7 +7,8 @@ import { useSettingsStore } from '@/stores/settings'
 /**
  * ミュート・凍結ユーザーのリアクションを抹消した表示用カウント (#575)。
  * リアクションバーを持つ面 (MkNote / ノート詳細) から使う。
- * `counts` が null の間はサーバー集計のまま表示する。
+ * `pending` の間は描画を保留し、それ以外で `counts` が null なら
+ * サーバー集計のまま表示する (対象外・取得失敗のフォールバック)。
  *
  * トグル (`mute.hideMutedUserReactions`) 自体がオプトインなので、ON なら
  * ミュート/凍結の有無を問わず列挙を取得する — 凍結はサーバー側の除外に
@@ -31,6 +32,14 @@ export function useVisibleReactionCounts(
     return recountsStore.get(n._accountId, n.id, n.reactions)
   })
 
+  // 列挙の初回取得待ち (#1081)。true の間は未フィルタのサーバー集計を
+  // 描画せず保留する — キャッシュ表示で「見えてから消える」のを防ぐ
+  const pending = computed(() => {
+    const n = note()
+    if (!enabled.value || !n) return false
+    return recountsStore.isPending(n.id, n.reactions)
+  })
+
   watch(
     [
       enabled,
@@ -48,5 +57,5 @@ export function useVisibleReactionCounts(
     { immediate: true },
   )
 
-  return { enabled, counts }
+  return { enabled, counts, pending }
 }

--- a/src/stores/reactionRecounts.test.ts
+++ b/src/stores/reactionRecounts.test.ts
@@ -1,0 +1,87 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  RECOUNT_MAX_TOTAL,
+  useReactionRecountsStore,
+} from '@/stores/reactionRecounts'
+
+const api = vi.hoisted(() => ({ getNoteReactions: vi.fn() }))
+
+vi.mock('@/adapters/factory', () => ({
+  initAdapterFor: () =>
+    Promise.resolve({
+      adapter: { api: { getNoteReactions: api.getNoteReactions } },
+    }),
+}))
+
+vi.mock('@/stores/accounts', () => ({
+  useAccountsStore: () => ({
+    accounts: [{ id: 'acc1', host: 'example.com', hasToken: true }],
+  }),
+}))
+
+vi.mock('@/bindings', () => ({
+  commands: new Proxy(
+    {},
+    {
+      get: (_t, name: string) => {
+        // suspensions の probe は「応答から欠落 = 凍結」判定なので、
+        // 全員生存を返して誤って凍結扱いされないようにする
+        if (name === 'apiProbeUsersSuspended') {
+          return (_acc: string, ids: string[]) =>
+            Promise.resolve({
+              status: 'ok',
+              data: ids.map((id) => ({ id, isSuspended: false })),
+            })
+        }
+        return () => Promise.resolve({ status: 'ok', data: [] })
+      },
+    },
+  ),
+}))
+
+function reactor(type: string, userId: string) {
+  return { type, user: { id: userId } }
+}
+
+let store: ReturnType<typeof useReactionRecountsStore>
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  api.getNoteReactions.mockReset()
+  store = useReactionRecountsStore()
+})
+
+describe('useReactionRecountsStore.isPending (#1081)', () => {
+  it('未取得の対象ノートは pending — 描画を保留させる', () => {
+    expect(store.isPending('n1', { '❤': 2 })).toBe(true)
+  })
+
+  it('リアクション 0 件は取得対象外なので pending にならない', () => {
+    expect(store.isPending('n1', {})).toBe(false)
+  })
+
+  it('総数が上限を超えるノートは対象外なので pending にならない', () => {
+    expect(store.isPending('n1', { '❤': RECOUNT_MAX_TOTAL + 1 })).toBe(false)
+  })
+
+  it('取得成功で pending が解け、数え直し値が返る', async () => {
+    api.getNoteReactions.mockResolvedValue([reactor('❤', 'u1')])
+    await store.ensure('acc1', 'n1', { '❤': 2 })
+    expect(store.isPending('n1', { '❤': 2 })).toBe(false)
+    expect(store.get('acc1', 'n1', { '❤': 2 })).toEqual({ '❤': 1 })
+  })
+
+  it('取得失敗でも pending が解け、サーバー集計へフォールバックする', async () => {
+    api.getNoteReactions.mockRejectedValue(new Error('network'))
+    await store.ensure('acc1', 'n1', { '❤': 2 })
+    expect(store.isPending('n1', { '❤': 2 })).toBe(false)
+    expect(store.get('acc1', 'n1', { '❤': 2 })).toBeNull()
+  })
+
+  it('アカウント不明でも pending が解ける (フォールバック確定)', async () => {
+    await store.ensure('acc-gone', 'n1', { '❤': 1 })
+    expect(store.isPending('n1', { '❤': 1 })).toBe(false)
+    expect(store.get('acc-gone', 'n1', { '❤': 1 })).toBeNull()
+  })
+})

--- a/src/stores/reactionRecounts.test.ts
+++ b/src/stores/reactionRecounts.test.ts
@@ -1,6 +1,7 @@
 import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  RECOUNT_CACHE_CAP,
   RECOUNT_MAX_TOTAL,
   useReactionRecountsStore,
 } from '@/stores/reactionRecounts'
@@ -83,5 +84,26 @@ describe('useReactionRecountsStore.isPending (#1081)', () => {
     await store.ensure('acc-gone', 'n1', { '❤': 1 })
     expect(store.isPending('n1', { '❤': 1 })).toBe(false)
     expect(store.get('acc-gone', 'n1', { '❤': 1 })).toBeNull()
+  })
+
+  it('LRU 破棄されたノートは pending に戻らない (サーバー集計へフォールバック)', async () => {
+    api.getNoteReactions.mockResolvedValue([reactor('❤', 'u1')])
+    await store.ensure('acc1', 'n0', { '❤': 1 })
+    // キャッシュを溢れさせて n0 を追い出す
+    for (let i = 1; i <= RECOUNT_CACHE_CAP; i++) {
+      await store.ensure('acc1', `spill-${i}`, { '❤': 1 })
+    }
+    expect(store.get('acc1', 'n0', { '❤': 1 })).toBeNull()
+    // pending に戻すと evict → refetch → evict の自己増幅ループになるため、
+    // 一度取得が完了したノートは集計表示へフォールバックする
+    expect(store.isPending('n0', { '❤': 1 })).toBe(false)
+  })
+
+  it('purgeAll は settled 履歴ごと消して pending に戻す (ミュート解除の取り直し)', async () => {
+    api.getNoteReactions.mockResolvedValue([reactor('❤', 'u1')])
+    await store.ensure('acc1', 'n1', { '❤': 1 })
+    expect(store.isPending('n1', { '❤': 1 })).toBe(false)
+    store.purgeAll()
+    expect(store.isPending('n1', { '❤': 1 })).toBe(true)
   })
 })

--- a/src/stores/reactionRecounts.ts
+++ b/src/stores/reactionRecounts.ts
@@ -34,8 +34,11 @@ const REFETCH_COOLDOWN_MS = 5000
 interface RecountEntry {
   /** serverCounts の JSON。リアクション増減の検知に使う */
   signature: string
-  /** 取得時点の可視リアクション列挙 (縮約)。カウントは get 時に照合込みで数える */
-  records: VisibleReactionRecord[]
+  /**
+   * 取得時点の可視リアクション列挙 (縮約)。カウントは get 時に照合込みで
+   * 数える。null は取得失敗 = サーバー集計へのフォールバックで確定 (#1081)
+   */
+  records: VisibleReactionRecord[] | null
   /** 取得時刻 (epoch ms)。連射抑制の判定に使う */
   fetchedAt: number
 }
@@ -80,7 +83,7 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
     serverCounts: Record<string, number>,
   ): Record<string, number> | null {
     const entry = cache.value.get(noteId)
-    if (!entry) return null
+    if (!entry?.records) return null
     // 総数が取得上限を超えたら stale を使い続けず、サーバー集計に戻す
     if (totalReactionCount(serverCounts) > RECOUNT_MAX_TOTAL) return null
     return recountVisibleReactions(
@@ -90,6 +93,20 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
         mutesStore.isUserMuted(accountId, userId) ||
         suspensionsStore.isSuspended(accountId, userId),
     )
+  }
+
+  /**
+   * 列挙の初回取得がまだ終わっていないか (#1081)。true の間は未フィルタの
+   * サーバー集計を描画せず保留する (見えてから消えるのを防ぐ)。
+   * 対象外 (0 件 / 総数超過) と取得失敗 (フォールバック確定) は false。
+   */
+  function isPending(
+    noteId: string,
+    serverCounts: Record<string, number>,
+  ): boolean {
+    const total = totalReactionCount(serverCounts)
+    if (total === 0 || total > RECOUNT_MAX_TOTAL) return false
+    return !cache.value.has(noteId)
   }
 
   /** 同時フェッチ上限。トグル ON 直後の TL 表示で一斉に飛ぶのを抑える */
@@ -164,6 +181,19 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
     }
   }
 
+  function setEntry(
+    noteId: string,
+    signature: string,
+    records: VisibleReactionRecord[] | null,
+  ): void {
+    if (cache.value.size >= CACHE_CAP) {
+      const oldest = cache.value.keys().next().value
+      if (oldest !== undefined) cache.value.delete(oldest)
+    }
+    cache.value.set(noteId, { signature, records, fetchedAt: Date.now() })
+    triggerRef(cache)
+  }
+
   async function fetchAndStore(
     accountId: string,
     noteId: string,
@@ -173,36 +203,36 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
       const account = useAccountsStore().accounts.find(
         (a) => a.id === accountId,
       )
-      if (!account) return
-      const { adapter } = await initAdapterFor(account.host, account.id, {
-        pinnedReactions: false,
-        hasToken: account.hasToken,
-      })
-      const reactions = await adapter.api.getNoteReactions(
-        noteId,
-        undefined,
-        RECOUNT_MAX_TOTAL,
-      )
-      if (cache.value.size >= CACHE_CAP) {
-        const oldest = cache.value.keys().next().value
-        if (oldest !== undefined) cache.value.delete(oldest)
+      if (account) {
+        const { adapter } = await initAdapterFor(account.host, account.id, {
+          pinnedReactions: false,
+          hasToken: account.hasToken,
+        })
+        const reactions = await adapter.api.getNoteReactions(
+          noteId,
+          undefined,
+          RECOUNT_MAX_TOTAL,
+        )
+        setEntry(
+          noteId,
+          signature,
+          reactions.map((r) => ({ type: r.type, userId: r.user.id })),
+        )
+        // サーバーは凍結ユーザーを列挙から除外しないため、リアクターを
+        // 凍結検知 (#828) に回す。検知されれば get の照合で reactive に消える
+        suspensionsStore.probe(
+          accountId,
+          reactions.map((r) => r.user.id),
+        )
+        return
       }
-      cache.value.set(noteId, {
-        signature,
-        records: reactions.map((r) => ({ type: r.type, userId: r.user.id })),
-        fetchedAt: Date.now(),
-      })
-      triggerRef(cache)
-      // サーバーは凍結ユーザーを列挙から除外しないため、リアクターを
-      // 凍結検知 (#828) に回す。検知されれば get の照合で reactive に消える
-      suspensionsStore.probe(
-        accountId,
-        reactions.map((r) => r.user.id),
-      )
     } catch (e) {
       // 非クリティカル: 取得失敗時はサーバー集計のまま (原因は診断できるよう残す)
       console.warn('[reaction-recount] fetch failed:', noteId, e)
     }
+    // 取得できなかったノートもエントリで確定させる (#1081): isPending を
+    // 解いてサーバー集計を表示させ、隠したまま固まるのを防ぐ
+    setEntry(noteId, signature, null)
   }
 
   function purgeAll(): void {
@@ -211,5 +241,5 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
     triggerRef(cache)
   }
 
-  return { get, ensure, purgeAll }
+  return { get, isPending, ensure, purgeAll }
 })

--- a/src/stores/reactionRecounts.ts
+++ b/src/stores/reactionRecounts.ts
@@ -18,7 +18,10 @@ import { useSuspensionsStore } from '@/stores/suspensions'
 export const RECOUNT_MAX_TOTAL = 100
 
 /** キャッシュ肥大の上限 (ノート数)。超えたら古いものから捨てる。 */
-const CACHE_CAP = 500
+export const RECOUNT_CACHE_CAP = 500
+
+/** settled 履歴の上限。noteId 文字列のみなのでキャッシュ本体より緩くてよい */
+const SETTLED_CAP = 5000
 
 /**
  * 同じノートの列挙を取り直すまでの最短間隔。
@@ -55,6 +58,14 @@ interface RecountEntry {
 export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
   const cache = shallowRef(new Map<string, RecountEntry>())
   const inflight = new Set<string>()
+  /**
+   * 一度でも取得が完了 (成功・失敗とも) したノート (#1084 レビュー)。
+   * LRU 破棄でエントリが消えたノートを pending に戻すと、可視ノートが
+   * CACHE_CAP を超えたとき evict → 再取得 → evict の自己増幅ループに
+   * なるため、破棄後はサーバー集計へのフォールバックで受ける。
+   * 変更は必ず cache の triggerRef と同時に行う (reactive 化はしない)。
+   */
+  const settledOnce = new Set<string>()
 
   const mutesStore = useMutesStore()
   const suspensionsStore = useSuspensionsStore()
@@ -98,7 +109,8 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
   /**
    * 列挙の初回取得がまだ終わっていないか (#1081)。true の間は未フィルタの
    * サーバー集計を描画せず保留する (見えてから消えるのを防ぐ)。
-   * 対象外 (0 件 / 総数超過) と取得失敗 (フォールバック確定) は false。
+   * 対象外 (0 件 / 総数超過)・取得失敗 (フォールバック確定)・取得後に
+   * LRU 破棄されたノートは false。
    */
   function isPending(
     noteId: string,
@@ -106,7 +118,7 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
   ): boolean {
     const total = totalReactionCount(serverCounts)
     if (total === 0 || total > RECOUNT_MAX_TOTAL) return false
-    return !cache.value.has(noteId)
+    return !cache.value.has(noteId) && !settledOnce.has(noteId)
   }
 
   /** 同時フェッチ上限。トグル ON 直後の TL 表示で一斉に飛ぶのを抑える */
@@ -186,9 +198,15 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
     signature: string,
     records: VisibleReactionRecord[] | null,
   ): void {
-    if (cache.value.size >= CACHE_CAP) {
+    // 既存エントリの取り直しでは他のノートを追い出さない
+    if (!cache.value.has(noteId) && cache.value.size >= RECOUNT_CACHE_CAP) {
       const oldest = cache.value.keys().next().value
       if (oldest !== undefined) cache.value.delete(oldest)
+    }
+    settledOnce.add(noteId)
+    if (settledOnce.size > SETTLED_CAP) {
+      const oldest = settledOnce.values().next().value
+      if (oldest !== undefined) settledOnce.delete(oldest)
     }
     cache.value.set(noteId, { signature, records, fetchedAt: Date.now() })
     triggerRef(cache)
@@ -236,7 +254,10 @@ export const useReactionRecountsStore = defineStore('reactionRecounts', () => {
   }
 
   function purgeAll(): void {
-    if (cache.value.size === 0) return
+    if (cache.value.size === 0 && settledOnce.size === 0) return
+    // settled 履歴ごと消して pending に戻す: ミュート解除の取り直し中に
+    // 古い列挙由来の値やサーバー集計を見せない (隠しすぎ側に倒す)
+    settledOnce.clear()
     cache.value.clear()
     triggerRef(cache)
   }


### PR DESCRIPTION
## 変更内容

- fix(mute): リアクション抹消の数え直し中は未フィルタ集計を描画しない (#1081)
- fix(mute): recount エントリ消滅時にリアクションが保留のまま固まるのを防ぐ (#1081)
- chore: bump version to 1.53.1

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/notedeck-dev/notedeck/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction counts no longer briefly display unfiltered values while updated counts are being calculated.
  * Reaction areas maintain their layout while counts are loading.
  * Failed or unavailable recount requests now resolve cleanly and preserve server-provided counts as a fallback.

* **Tests**
  * Added coverage for loading, filtering, cache invalidation, successful recounts, failures, and unavailable accounts.

* **Chores**
  * Updated the application version to 1.53.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->